### PR TITLE
feat: Added numerous trigonometric UDFs

### DIFF
--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -18,6 +18,30 @@ Returns the absolute value of `col1`.
 
 ---
 
+### **`ACOS`**
+
+```sql title="Since: 0.27.0"
+ACOS(col1)
+```
+
+Returns the inverse (arc) cosine of `col1` in radians. Use [DEGREES](#degrees) to convert the output to degrees if necessary.
+
+Note that this function will return `NaN` for any input outside [-1, 1].
+
+---
+
+### **`ASIN`**
+
+```sql title="Since: 0.27.0"
+ASIN(col1)
+```
+
+Returns the inverse (arc) sine of `col1` in radians. Use [DEGREES](#degrees) to convert the output to degrees if necessary.
+
+Note that this function will return `NaN` for any input outside [-1, 1].
+
+---
+
 ### **`AS_VALUE`**
 
 ```sql title="Since: 0.9.0"
@@ -38,6 +62,28 @@ CREATE TABLE AGG AS
 
 !!! Tip "See AS_VALUE in action"
     - [Understand user behavior with clickstream data](https://developer.confluent.io/tutorials/clickstream/confluent.html#execute-ksqldb-code)
+
+---
+
+### **`ATAN`**
+
+```sql title="Since: 0.27.0"
+ATAN(col1)
+```
+
+Returns the inverse (arc) tangent of `col1` in radians. Use [DEGREES](#degrees) to convert the output to degrees if necessary.
+
+---
+
+### **`ATAN2`**
+
+```sql title="Since: 0.27.0"
+ATAN2(y, x)
+```
+
+Returns the inverse (arc) tangent of `y / x`. This is equivalent to the angle theta when Cartesian coordinates (x, y) are converted to polar coordinates (radius, theta). The returned value is in radians. Use [DEGREES](#degrees) to convert the output to degrees if necessary.
+
+In cases where `x` is zero, and `y / x` is undefined, this function returns the approximate value of a multiple of π/2.
 
 ---
 
@@ -77,6 +123,48 @@ CEIL(col1)
 ```
 
 Returns the the smallest integer value that's greater than or equal to `col1`.
+
+---
+
+### **`COS`**
+
+```sql title="Since: 0.27.0"
+COS(col1)
+```
+
+Returns the cosine of `col1`. `col1` is in radians. Use [RADIANS](#radians) to convert the input to radians if necessary.
+
+---
+
+### **`COSH`**
+
+```sql title="Since: 0.27.0"
+COSH(col1)
+```
+
+Returns the hyperbolic cosine of `col1`. `col1` is in radians. Use [RADIANS](#radians) to convert the input to radians if necessary.
+
+---
+
+### **`COT`**
+
+```sql title="Since: 0.27.0"
+COT(col1)
+```
+
+Returns the cotangent of `col1`. `col1` is in radians. Use [RADIANS](#radians) to convert the input to radians if necessary.
+
+This implementation returns a large value approaching positive or negative infinity near the asymptotes since 2π and similar values cannot be represented exactly. At 0, it returns `Infinity` with the same sign as the input.
+
+---
+
+### **`DEGREES`**
+
+```sql title="Since: 0.27.0"
+DEGREES(col1)
+```
+
+Converts `col1` from radians to degrees.
 
 ---
 
@@ -180,6 +268,26 @@ The value of `col1` must be greater than 0.
 
 ---
 
+### **`PI`**
+
+```sql title="Since: 0.27.0"
+PI()
+```
+
+Returns an approximate value of π.
+
+---
+
+### **`RADIANS`**
+
+```sql title="Since: 0.27.0"
+RADIANS(col1)
+```
+
+Converts `col1` from degrees to radians.
+
+---
+
 ### **`RANDOM`**
 
 ```sql title="Since: 0.1.0"
@@ -223,6 +331,26 @@ Returns the sign of `col1` as an `INTEGER`:
 
 ---
 
+### **`SIN`**
+
+```sql title="Since: 0.27.0"
+SIN(col1)
+```
+
+Returns the sine of `col1`. `col1` is in radians. Use [RADIANS](#radians) to convert the input to radians if necessary.
+
+---
+
+### **`SINH`**
+
+```sql title="Since: 0.27.0"
+SINH(col1)
+```
+
+Returns the hyperbolic sine of `col1`. `col1` is in radians. Use [RADIANS](#radians) to convert the input to radians if necessary.
+
+---
+
 ### **`SQRT`**
 
 ```sql title="Since: 0.6.0"
@@ -230,6 +358,28 @@ SQRT(col1)
 ```
 
 Returns the square root of `col`.
+
+---
+
+### **`TAN`**
+
+```sql title="Since: 0.27.0"
+TAN(col1)
+```
+
+Returns the tangent of `col1`. `col1` is in radians. Use [RADIANS](#radians) to convert the input to radians if necessary.
+
+This implementation returns a large value approaching positive or negative infinity near the asymptotes since π/2 and similar values cannot be represented exactly.
+
+---
+
+### **`TANH`**
+
+```sql title="Since: 0.27.0"
+TANH(col1)
+```
+
+Returns the hyperbolic tangent of `col1`. `col1` is in radians. Use [RADIANS](#radians) to convert the input to radians if necessary.
 
 ---
 

--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -24,7 +24,7 @@ Returns the absolute value of `col1`.
 ACOS(col1)
 ```
 
-Returns the inverse (arc) cosine of `col1` in radians. Use [DEGREES](#degrees) to convert the output to degrees if necessary.
+Returns the inverse (arc) cosine of `col1`, in radians. Use the [DEGREES](#degrees) function to convert the output to degrees.
 
 Note that this function will return `NaN` for any input outside [-1, 1].
 
@@ -36,9 +36,9 @@ Note that this function will return `NaN` for any input outside [-1, 1].
 ASIN(col1)
 ```
 
-Returns the inverse (arc) sine of `col1` in radians. Use [DEGREES](#degrees) to convert the output to degrees if necessary.
+Returns the inverse (arc) sine of `col1`, in radians. Use the [DEGREES](#degrees) function to convert the output to degrees.
 
-Note that this function will return `NaN` for any input outside [-1, 1].
+This function returns `NaN` for any input outside [-1, 1].
 
 ---
 
@@ -71,7 +71,7 @@ CREATE TABLE AGG AS
 ATAN(col1)
 ```
 
-Returns the inverse (arc) tangent of `col1` in radians. Use [DEGREES](#degrees) to convert the output to degrees if necessary.
+Returns the inverse (arc) tangent of `col1`, in radians. Use the [DEGREES](#degrees) function to convert the output to degrees.
 
 ---
 
@@ -81,9 +81,9 @@ Returns the inverse (arc) tangent of `col1` in radians. Use [DEGREES](#degrees) 
 ATAN2(y, x)
 ```
 
-Returns the inverse (arc) tangent of `y / x`. This is equivalent to the angle theta when Cartesian coordinates (x, y) are converted to polar coordinates (radius, theta). The returned value is in radians. Use [DEGREES](#degrees) to convert the output to degrees if necessary.
+Returns the inverse (arc) tangent of `y / x`. This is equivalent to the angle _theta_ when Cartesian coordinates (x, y) are converted to polar coordinates (_radius_, _theta_). The returned value is in radians. Use the [DEGREES](#degrees) function to convert the output to degrees.
 
-In cases where `x` is zero, and `y / x` is undefined, this function returns the approximate value of a multiple of π/2.
+If `x` is zero, `y / x` is undefined, and this function returns the approximate value of a multiple of _π/2_.
 
 ---
 
@@ -132,7 +132,7 @@ Returns the the smallest integer value that's greater than or equal to `col1`.
 COS(col1)
 ```
 
-Returns the cosine of `col1`. `col1` is in radians. Use [RADIANS](#radians) to convert the input to radians if necessary.
+Returns the cosine of `col1`. `col1` is in radians. Use the [RADIANS](#radians) function to convert the input to radians, if necessary.
 
 ---
 
@@ -142,7 +142,7 @@ Returns the cosine of `col1`. `col1` is in radians. Use [RADIANS](#radians) to c
 COSH(col1)
 ```
 
-Returns the hyperbolic cosine of `col1`. `col1` is in radians. Use [RADIANS](#radians) to convert the input to radians if necessary.
+Returns the hyperbolic cosine of `col1`. `col1` is in radians. Use the [RADIANS](#radians) function to convert the input to radians, if necessary.
 
 ---
 
@@ -152,9 +152,9 @@ Returns the hyperbolic cosine of `col1`. `col1` is in radians. Use [RADIANS](#ra
 COT(col1)
 ```
 
-Returns the cotangent of `col1`. `col1` is in radians. Use [RADIANS](#radians) to convert the input to radians if necessary.
+Returns the cotangent of `col1`. `col1` is in radians. Use the [RADIANS](#radians) function to convert the input to radians, if necessary.
 
-This implementation returns a large value approaching positive or negative infinity near the asymptotes since 2π and similar values cannot be represented exactly. At 0, it returns `Infinity` with the same sign as the input.
+This implementation returns a large value approaching positive or negative infinity near the asymptotes, because _2π_ and similar values cannot be represented exactly. At _0_, it returns `Infinity` with the same sign as the input.
 
 ---
 
@@ -274,7 +274,7 @@ The value of `col1` must be greater than 0.
 PI()
 ```
 
-Returns an approximate value of π.
+Returns an approximate value of _π_.
 
 ---
 
@@ -337,7 +337,7 @@ Returns the sign of `col1` as an `INTEGER`:
 SIN(col1)
 ```
 
-Returns the sine of `col1`. `col1` is in radians. Use [RADIANS](#radians) to convert the input to radians if necessary.
+Returns the sine of `col1`. `col1` is in radians. Use the [RADIANS](#radians) function to convert the input to radians, if necessary.
 
 ---
 
@@ -347,7 +347,7 @@ Returns the sine of `col1`. `col1` is in radians. Use [RADIANS](#radians) to con
 SINH(col1)
 ```
 
-Returns the hyperbolic sine of `col1`. `col1` is in radians. Use [RADIANS](#radians) to convert the input to radians if necessary.
+Returns the hyperbolic sine of `col1`. `col1` is in radians. Use the [RADIANS](#radians) function to convert the input to radians, if necessary.
 
 ---
 
@@ -367,9 +367,9 @@ Returns the square root of `col`.
 TAN(col1)
 ```
 
-Returns the tangent of `col1`. `col1` is in radians. Use [RADIANS](#radians) to convert the input to radians if necessary.
+Returns the tangent of `col1`. `col1` is in radians. Use the [RADIANS](#radians) function to convert the input to radians, if necessary.
 
-This implementation returns a large value approaching positive or negative infinity near the asymptotes since π/2 and similar values cannot be represented exactly.
+This implementation returns a large value approaching positive or negative infinity near the asymptotes, because _π/2_ and similar values cannot be represented exactly.
 
 ---
 
@@ -379,7 +379,7 @@ This implementation returns a large value approaching positive or negative infin
 TANH(col1)
 ```
 
-Returns the hyperbolic tangent of `col1`. `col1` is in radians. Use [RADIANS](#radians) to convert the input to radians if necessary.
+Returns the hyperbolic tangent of `col1`. `col1` is in radians. Use the [RADIANS](#radians) function to convert the input to radians, if necessary.
 
 ---
 

--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -20,7 +20,7 @@ Returns the absolute value of `col1`.
 
 ### **`ACOS`**
 
-```sql title="Since: 0.27.0"
+```sql title="Since: 0.28.0"
 ACOS(col1)
 ```
 
@@ -32,7 +32,7 @@ This function returns `NaN` for any input outside [-1, 1].
 
 ### **`ASIN`**
 
-```sql title="Since: 0.27.0"
+```sql title="Since: 0.28.0"
 ASIN(col1)
 ```
 
@@ -67,7 +67,7 @@ CREATE TABLE AGG AS
 
 ### **`ATAN`**
 
-```sql title="Since: 0.27.0"
+```sql title="Since: 0.28.0"
 ATAN(col1)
 ```
 
@@ -77,7 +77,7 @@ Returns the inverse (arc) tangent of `col1`, in radians. Use the [DEGREES](#degr
 
 ### **`ATAN2`**
 
-```sql title="Since: 0.27.0"
+```sql title="Since: 0.28.0"
 ATAN2(y, x)
 ```
 
@@ -128,7 +128,7 @@ Returns the the smallest integer value that's greater than or equal to `col1`.
 
 ### **`COS`**
 
-```sql title="Since: 0.27.0"
+```sql title="Since: 0.28.0"
 COS(col1)
 ```
 
@@ -138,7 +138,7 @@ Returns the cosine of `col1`. `col1` is in radians. Use the [RADIANS](#radians) 
 
 ### **`COSH`**
 
-```sql title="Since: 0.27.0"
+```sql title="Since: 0.28.0"
 COSH(col1)
 ```
 
@@ -148,7 +148,7 @@ Returns the hyperbolic cosine of `col1`. `col1` is in radians. Use the [RADIANS]
 
 ### **`COT`**
 
-```sql title="Since: 0.27.0"
+```sql title="Since: 0.28.0"
 COT(col1)
 ```
 
@@ -160,7 +160,7 @@ This implementation returns a large value approaching positive or negative infin
 
 ### **`DEGREES`**
 
-```sql title="Since: 0.27.0"
+```sql title="Since: 0.28.0"
 DEGREES(col1)
 ```
 
@@ -270,7 +270,7 @@ The value of `col1` must be greater than 0.
 
 ### **`PI`**
 
-```sql title="Since: 0.27.0"
+```sql title="Since: 0.28.0"
 PI()
 ```
 
@@ -280,7 +280,7 @@ Returns an approximate value of _π_.
 
 ### **`RADIANS`**
 
-```sql title="Since: 0.27.0"
+```sql title="Since: 0.28.0"
 RADIANS(col1)
 ```
 
@@ -333,7 +333,7 @@ Returns the sign of `col1` as an `INTEGER`:
 
 ### **`SIN`**
 
-```sql title="Since: 0.27.0"
+```sql title="Since: 0.28.0"
 SIN(col1)
 ```
 
@@ -343,7 +343,7 @@ Returns the sine of `col1`. `col1` is in radians. Use the [RADIANS](#radians) fu
 
 ### **`SINH`**
 
-```sql title="Since: 0.27.0"
+```sql title="Since: 0.28.0"
 SINH(col1)
 ```
 
@@ -363,7 +363,7 @@ Returns the square root of `col`.
 
 ### **`TAN`**
 
-```sql title="Since: 0.27.0"
+```sql title="Since: 0.28.0"
 TAN(col1)
 ```
 
@@ -375,7 +375,7 @@ This implementation returns a large value approaching positive or negative infin
 
 ### **`TANH`**
 
-```sql title="Since: 0.27.0"
+```sql title="Since: 0.28.0"
 TANH(col1)
 ```
 

--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -26,7 +26,7 @@ ACOS(col1)
 
 Returns the inverse (arc) cosine of `col1`, in radians. Use the [DEGREES](#degrees) function to convert the output to degrees.
 
-Note that this function will return `NaN` for any input outside [-1, 1].
+This function returns `NaN` for any input outside [-1, 1].
 
 ---
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Acos.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Acos.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.math;
 
 import io.confluent.ksql.function.FunctionCategory;
@@ -14,35 +28,35 @@ import io.confluent.ksql.util.KsqlConstants;
 )
 public class Acos {
 
-    @Udf(description = "Returns the inverse (arc) cosine of an INT value")
-    public Double acos(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value to get the inverse cosine of."
-            ) final Integer value
-    ) {
-        return acos(value == null ? null : value.doubleValue());
-    }
+  @Udf(description = "Returns the inverse (arc) cosine of an INT value")
+  public Double acos(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value to get the inverse cosine of."
+          ) final Integer value
+  ) {
+    return acos(value == null ? null : value.doubleValue());
+  }
 
-    @Udf(description = "Returns the inverse (arc) cosine of a BIGINT value")
-    public Double acos(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value to get the inverse cosine of."
-            ) final Long value
-    ) {
-        return acos(value == null ? null : value.doubleValue());
-    }
+  @Udf(description = "Returns the inverse (arc) cosine of a BIGINT value")
+  public Double acos(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value to get the inverse cosine of."
+          ) final Long value
+  ) {
+    return acos(value == null ? null : value.doubleValue());
+  }
 
-    @Udf(description = "Returns the inverse (arc) cosine of a DOUBLE value")
-    public Double acos(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value to get the inverse cosine of."
-            ) final Double value
-    ) {
-        return value == null
-                ? null
-                : Math.acos(value);
-    }
+  @Udf(description = "Returns the inverse (arc) cosine of a DOUBLE value")
+  public Double acos(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value to get the inverse cosine of."
+          ) final Double value
+  ) {
+    return value == null
+            ? null
+            : Math.acos(value);
+  }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Acos.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Acos.java
@@ -1,0 +1,48 @@
+package io.confluent.ksql.function.udf.math;
+
+import io.confluent.ksql.function.FunctionCategory;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import io.confluent.ksql.util.KsqlConstants;
+
+@UdfDescription(
+        name = "acos",
+        category = FunctionCategory.MATHEMATICAL,
+        author = KsqlConstants.CONFLUENT_AUTHOR,
+        description = "The inverse (arc) cosine of a value. The returned value is in radians."
+)
+public class Acos {
+
+    @Udf(description = "Returns the inverse (arc) cosine of an INT value")
+    public Double acos(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value to get the inverse cosine of."
+            ) final Integer value
+    ) {
+        return acos(value == null ? null : value.doubleValue());
+    }
+
+    @Udf(description = "Returns the inverse (arc) cosine of a BIGINT value")
+    public Double acos(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value to get the inverse cosine of."
+            ) final Long value
+    ) {
+        return acos(value == null ? null : value.doubleValue());
+    }
+
+    @Udf(description = "Returns the inverse (arc) cosine of a DOUBLE value")
+    public Double acos(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value to get the inverse cosine of."
+            ) final Double value
+    ) {
+        return value == null
+                ? null
+                : Math.acos(value);
+    }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Asin.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Asin.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.math;
 
 import io.confluent.ksql.function.FunctionCategory;
@@ -14,35 +28,35 @@ import io.confluent.ksql.util.KsqlConstants;
 )
 public class Asin {
 
-    @Udf(description = "Returns the inverse (arc) sine of an INT value")
-    public Double asin(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value to get the inverse sine of."
-            ) final Integer value
-    ) {
-        return asin(value == null ? null : value.doubleValue());
-    }
+  @Udf(description = "Returns the inverse (arc) sine of an INT value")
+  public Double asin(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value to get the inverse sine of."
+          ) final Integer value
+  ) {
+    return asin(value == null ? null : value.doubleValue());
+  }
 
-    @Udf(description = "Returns the inverse (arc) sine of a BIGINT value")
-    public Double asin(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value to get the inverse sine of."
-            ) final Long value
-    ) {
-        return asin(value == null ? null : value.doubleValue());
-    }
+  @Udf(description = "Returns the inverse (arc) sine of a BIGINT value")
+  public Double asin(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value to get the inverse sine of."
+          ) final Long value
+  ) {
+    return asin(value == null ? null : value.doubleValue());
+  }
 
-    @Udf(description = "Returns the inverse (arc) sine of a DOUBLE value")
-    public Double asin(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value to get the inverse sine of."
-            ) final Double value
-    ) {
-        return value == null
-                ? null
-                : Math.asin(value);
-    }
+  @Udf(description = "Returns the inverse (arc) sine of a DOUBLE value")
+  public Double asin(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value to get the inverse sine of."
+          ) final Double value
+  ) {
+    return value == null
+            ? null
+            : Math.asin(value);
+  }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Asin.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Asin.java
@@ -1,0 +1,48 @@
+package io.confluent.ksql.function.udf.math;
+
+import io.confluent.ksql.function.FunctionCategory;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import io.confluent.ksql.util.KsqlConstants;
+
+@UdfDescription(
+        name = "asin",
+        category = FunctionCategory.MATHEMATICAL,
+        author = KsqlConstants.CONFLUENT_AUTHOR,
+        description = "The inverse (arc) sine of a value. The returned value is in radians."
+)
+public class Asin {
+
+    @Udf(description = "Returns the inverse (arc) sine of an INT value")
+    public Double asin(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value to get the inverse sine of."
+            ) final Integer value
+    ) {
+        return asin(value == null ? null : value.doubleValue());
+    }
+
+    @Udf(description = "Returns the inverse (arc) sine of a BIGINT value")
+    public Double asin(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value to get the inverse sine of."
+            ) final Long value
+    ) {
+        return asin(value == null ? null : value.doubleValue());
+    }
+
+    @Udf(description = "Returns the inverse (arc) sine of a DOUBLE value")
+    public Double asin(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value to get the inverse sine of."
+            ) final Double value
+    ) {
+        return value == null
+                ? null
+                : Math.asin(value);
+    }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Atan.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Atan.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.math;
 
 import io.confluent.ksql.function.FunctionCategory;
@@ -14,35 +28,35 @@ import io.confluent.ksql.util.KsqlConstants;
 )
 public class Atan {
 
-    @Udf(description = "Returns the inverse (arc) tangent of an INT value")
-    public Double atan(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value to get the inverse tangent of."
-            ) final Integer value
-    ) {
-        return atan(value == null ? null : value.doubleValue());
-    }
+  @Udf(description = "Returns the inverse (arc) tangent of an INT value")
+  public Double atan(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value to get the inverse tangent of."
+          ) final Integer value
+  ) {
+    return atan(value == null ? null : value.doubleValue());
+  }
 
-    @Udf(description = "Returns the inverse (arc) tangent of a BIGINT value")
-    public Double atan(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value to get the inverse tangent of."
-            ) final Long value
-    ) {
-        return atan(value == null ? null : value.doubleValue());
-    }
+  @Udf(description = "Returns the inverse (arc) tangent of a BIGINT value")
+  public Double atan(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value to get the inverse tangent of."
+          ) final Long value
+  ) {
+    return atan(value == null ? null : value.doubleValue());
+  }
 
-    @Udf(description = "Returns the inverse (arc) tangent of a DOUBLE value")
-    public Double atan(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value to get the inverse tangent of."
-            ) final Double value
-    ) {
-        return value == null
-                ? null
-                : Math.atan(value);
-    }
+  @Udf(description = "Returns the inverse (arc) tangent of a DOUBLE value")
+  public Double atan(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value to get the inverse tangent of."
+          ) final Double value
+  ) {
+    return value == null
+            ? null
+            : Math.atan(value);
+  }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Atan.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Atan.java
@@ -1,0 +1,48 @@
+package io.confluent.ksql.function.udf.math;
+
+import io.confluent.ksql.function.FunctionCategory;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import io.confluent.ksql.util.KsqlConstants;
+
+@UdfDescription(
+        name = "atan",
+        category = FunctionCategory.MATHEMATICAL,
+        author = KsqlConstants.CONFLUENT_AUTHOR,
+        description = "The inverse (arc) tangent of a value. The returned value is in radians."
+)
+public class Atan {
+
+    @Udf(description = "Returns the inverse (arc) tangent of an INT value")
+    public Double atan(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value to get the inverse tangent of."
+            ) final Integer value
+    ) {
+        return atan(value == null ? null : value.doubleValue());
+    }
+
+    @Udf(description = "Returns the inverse (arc) tangent of a BIGINT value")
+    public Double atan(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value to get the inverse tangent of."
+            ) final Long value
+    ) {
+        return atan(value == null ? null : value.doubleValue());
+    }
+
+    @Udf(description = "Returns the inverse (arc) tangent of a DOUBLE value")
+    public Double atan(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value to get the inverse tangent of."
+            ) final Double value
+    ) {
+        return value == null
+                ? null
+                : Math.atan(value);
+    }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Atan2.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Atan2.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.math;
 
 import io.confluent.ksql.function.FunctionCategory;
@@ -10,53 +24,53 @@ import io.confluent.ksql.util.KsqlConstants;
         name = "atan2",
         category = FunctionCategory.MATHEMATICAL,
         author = KsqlConstants.CONFLUENT_AUTHOR,
-        description = "The inverse (arc) tangent of y / x. This is equivalent to the angle theta when Cartesian " +
-                "coordinates (x, y) is converted to polar coordinates (radius, theta). The returned value is in " +
-                "radians."
+        description = "The inverse (arc) tangent of y / x. This is equivalent to the angle theta "
+                + "when Cartesian coordinates (x, y) is converted to polar coordinates (radius, "
+                + "theta). The returned value is in radians."
 )
 public class Atan2 {
 
-    @Udf(description = "Returns the inverse (arc) tangent of y / x")
-    public Double atan2(
-            @UdfParameter(
-                    value = "y",
-                    description = "The ordinate (y) coordinate."
-            ) final Integer y,
-            @UdfParameter(
-                    value = "x",
-                    description = "The abscissa (x) coordinate."
-            ) final Integer x
-    ) {
-        return atan2(y == null ? null : y.doubleValue(), x == null ? null : x.doubleValue());
-    }
+  @Udf(description = "Returns the inverse (arc) tangent of y / x")
+  public Double atan2(
+          @UdfParameter(
+                  value = "y",
+                  description = "The ordinate (y) coordinate."
+          ) final Integer y,
+          @UdfParameter(
+                  value = "x",
+                  description = "The abscissa (x) coordinate."
+          ) final Integer x
+  ) {
+    return atan2(y == null ? null : y.doubleValue(), x == null ? null : x.doubleValue());
+  }
 
-    @Udf(description = "Returns the inverse (arc) tangent of y / x")
-    public Double atan2(
-            @UdfParameter(
-                    value = "y",
-                    description = "The ordinate (y) coordinate."
-            ) final Long y,
-            @UdfParameter(
-                    value = "x",
-                    description = "The abscissa (x) coordinate."
-            ) final Long x
-    ) {
-        return atan2(y == null ? null : y.doubleValue(), x == null ? null : x.doubleValue());
-    }
+  @Udf(description = "Returns the inverse (arc) tangent of y / x")
+  public Double atan2(
+          @UdfParameter(
+                  value = "y",
+                  description = "The ordinate (y) coordinate."
+          ) final Long y,
+          @UdfParameter(
+                  value = "x",
+                  description = "The abscissa (x) coordinate."
+          ) final Long x
+  ) {
+    return atan2(y == null ? null : y.doubleValue(), x == null ? null : x.doubleValue());
+  }
 
-    @Udf(description = "Returns the inverse (arc) tangent of y / x")
-    public Double atan2(
-            @UdfParameter(
-                    value = "y",
-                    description = "The ordinate (y) coordinate."
-            ) final Double y,
-            @UdfParameter(
-                    value = "x",
-                    description = "The abscissa (x) coordinate."
-            ) final Double x
-    ) {
-        return x == null || y == null
-                ? null
-                : Math.atan2(y, x);
-    }
+  @Udf(description = "Returns the inverse (arc) tangent of y / x")
+  public Double atan2(
+          @UdfParameter(
+                  value = "y",
+                  description = "The ordinate (y) coordinate."
+          ) final Double y,
+          @UdfParameter(
+                  value = "x",
+                  description = "The abscissa (x) coordinate."
+          ) final Double x
+  ) {
+    return x == null || y == null
+            ? null
+            : Math.atan2(y, x);
+  }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Atan2.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Atan2.java
@@ -25,7 +25,7 @@ import io.confluent.ksql.util.KsqlConstants;
         category = FunctionCategory.MATHEMATICAL,
         author = KsqlConstants.CONFLUENT_AUTHOR,
         description = "The inverse (arc) tangent of y / x. This is equivalent to the angle theta "
-                + "when Cartesian coordinates (x, y) is converted to polar coordinates (radius, "
+                + "when Cartesian coordinates (x, y) are converted to polar coordinates (radius, "
                 + "theta). The returned value is in radians."
 )
 public class Atan2 {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Atan2.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Atan2.java
@@ -35,48 +35,6 @@ public class Atan2 {
             @UdfParameter(
                     value = "y",
                     description = "The ordinate (y) coordinate."
-            ) final Integer y,
-            @UdfParameter(
-                    value = "x",
-                    description = "The abscissa (x) coordinate."
-            ) final Long x
-    ) {
-        return atan2(y == null ? null : y.doubleValue(), x == null ? null : x.doubleValue());
-    }
-
-    @Udf(description = "Returns the inverse (arc) tangent of y / x")
-    public Double atan2(
-            @UdfParameter(
-                    value = "y",
-                    description = "The ordinate (y) coordinate."
-            ) final Integer y,
-            @UdfParameter(
-                    value = "x",
-                    description = "The abscissa (x) coordinate."
-            ) final Double x
-    ) {
-        return atan2(y == null ? null : y.doubleValue(), x);
-    }
-
-    @Udf(description = "Returns the inverse (arc) tangent of y / x")
-    public Double atan2(
-            @UdfParameter(
-                    value = "y",
-                    description = "The ordinate (y) coordinate."
-            ) final Long y,
-            @UdfParameter(
-                    value = "x",
-                    description = "The abscissa (x) coordinate."
-            ) final Integer x
-    ) {
-        return atan2(y == null ? null : y.doubleValue(), x == null ? null : x.doubleValue());
-    }
-
-    @Udf(description = "Returns the inverse (arc) tangent of y / x")
-    public Double atan2(
-            @UdfParameter(
-                    value = "y",
-                    description = "The ordinate (y) coordinate."
             ) final Long y,
             @UdfParameter(
                     value = "x",
@@ -84,48 +42,6 @@ public class Atan2 {
             ) final Long x
     ) {
         return atan2(y == null ? null : y.doubleValue(), x == null ? null : x.doubleValue());
-    }
-
-    @Udf(description = "Returns the inverse (arc) tangent of y / x")
-    public Double atan2(
-            @UdfParameter(
-                    value = "y",
-                    description = "The ordinate (y) coordinate."
-            ) final Long y,
-            @UdfParameter(
-                    value = "x",
-                    description = "The abscissa (x) coordinate."
-            ) final Double x
-    ) {
-        return atan2(y == null ? null : y.doubleValue(), x);
-    }
-
-    @Udf(description = "Returns the inverse (arc) tangent of y / x")
-    public Double atan2(
-            @UdfParameter(
-                    value = "y",
-                    description = "The ordinate (y) coordinate."
-            ) final Double y,
-            @UdfParameter(
-                    value = "x",
-                    description = "The abscissa (x) coordinate."
-            ) final Integer x
-    ) {
-        return atan2(y, x == null ? null : x.doubleValue());
-    }
-
-    @Udf(description = "Returns the inverse (arc) tangent of y / x")
-    public Double atan2(
-            @UdfParameter(
-                    value = "y",
-                    description = "The ordinate (y) coordinate."
-            ) final Double y,
-            @UdfParameter(
-                    value = "x",
-                    description = "The abscissa (x) coordinate."
-            ) final Long x
-    ) {
-        return atan2(y, x == null ? null : x.doubleValue());
     }
 
     @Udf(description = "Returns the inverse (arc) tangent of y / x")

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Atan2.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Atan2.java
@@ -1,0 +1,146 @@
+package io.confluent.ksql.function.udf.math;
+
+import io.confluent.ksql.function.FunctionCategory;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import io.confluent.ksql.util.KsqlConstants;
+
+@UdfDescription(
+        name = "atan2",
+        category = FunctionCategory.MATHEMATICAL,
+        author = KsqlConstants.CONFLUENT_AUTHOR,
+        description = "The inverse (arc) tangent of y / x. This is equivalent to the angle theta when Cartesian " +
+                "coordinates (x, y) is converted to polar coordinates (radius, theta). The returned value is in " +
+                "radians."
+)
+public class Atan2 {
+
+    @Udf(description = "Returns the inverse (arc) tangent of y / x")
+    public Double atan2(
+            @UdfParameter(
+                    value = "y",
+                    description = "The ordinate (y) coordinate."
+            ) final Integer y,
+            @UdfParameter(
+                    value = "x",
+                    description = "The abscissa (x) coordinate."
+            ) final Integer x
+    ) {
+        return atan2(y == null ? null : y.doubleValue(), x == null ? null : x.doubleValue());
+    }
+
+    @Udf(description = "Returns the inverse (arc) tangent of y / x")
+    public Double atan2(
+            @UdfParameter(
+                    value = "y",
+                    description = "The ordinate (y) coordinate."
+            ) final Integer y,
+            @UdfParameter(
+                    value = "x",
+                    description = "The abscissa (x) coordinate."
+            ) final Long x
+    ) {
+        return atan2(y == null ? null : y.doubleValue(), x == null ? null : x.doubleValue());
+    }
+
+    @Udf(description = "Returns the inverse (arc) tangent of y / x")
+    public Double atan2(
+            @UdfParameter(
+                    value = "y",
+                    description = "The ordinate (y) coordinate."
+            ) final Integer y,
+            @UdfParameter(
+                    value = "x",
+                    description = "The abscissa (x) coordinate."
+            ) final Double x
+    ) {
+        return atan2(y == null ? null : y.doubleValue(), x);
+    }
+
+    @Udf(description = "Returns the inverse (arc) tangent of y / x")
+    public Double atan2(
+            @UdfParameter(
+                    value = "y",
+                    description = "The ordinate (y) coordinate."
+            ) final Long y,
+            @UdfParameter(
+                    value = "x",
+                    description = "The abscissa (x) coordinate."
+            ) final Integer x
+    ) {
+        return atan2(y == null ? null : y.doubleValue(), x == null ? null : x.doubleValue());
+    }
+
+    @Udf(description = "Returns the inverse (arc) tangent of y / x")
+    public Double atan2(
+            @UdfParameter(
+                    value = "y",
+                    description = "The ordinate (y) coordinate."
+            ) final Long y,
+            @UdfParameter(
+                    value = "x",
+                    description = "The abscissa (x) coordinate."
+            ) final Long x
+    ) {
+        return atan2(y == null ? null : y.doubleValue(), x == null ? null : x.doubleValue());
+    }
+
+    @Udf(description = "Returns the inverse (arc) tangent of y / x")
+    public Double atan2(
+            @UdfParameter(
+                    value = "y",
+                    description = "The ordinate (y) coordinate."
+            ) final Long y,
+            @UdfParameter(
+                    value = "x",
+                    description = "The abscissa (x) coordinate."
+            ) final Double x
+    ) {
+        return atan2(y == null ? null : y.doubleValue(), x);
+    }
+
+    @Udf(description = "Returns the inverse (arc) tangent of y / x")
+    public Double atan2(
+            @UdfParameter(
+                    value = "y",
+                    description = "The ordinate (y) coordinate."
+            ) final Double y,
+            @UdfParameter(
+                    value = "x",
+                    description = "The abscissa (x) coordinate."
+            ) final Integer x
+    ) {
+        return atan2(y, x == null ? null : x.doubleValue());
+    }
+
+    @Udf(description = "Returns the inverse (arc) tangent of y / x")
+    public Double atan2(
+            @UdfParameter(
+                    value = "y",
+                    description = "The ordinate (y) coordinate."
+            ) final Double y,
+            @UdfParameter(
+                    value = "x",
+                    description = "The abscissa (x) coordinate."
+            ) final Long x
+    ) {
+        return atan2(y, x == null ? null : x.doubleValue());
+    }
+
+    @Udf(description = "Returns the inverse (arc) tangent of y / x")
+    public Double atan2(
+            @UdfParameter(
+                    value = "y",
+                    description = "The ordinate (y) coordinate."
+            ) final Double y,
+            @UdfParameter(
+                    value = "x",
+                    description = "The abscissa (x) coordinate."
+            ) final Double x
+    ) {
+        return x == null || y == null
+                ? null
+                : Math.atan2(y, x);
+    }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Cos.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Cos.java
@@ -1,0 +1,48 @@
+package io.confluent.ksql.function.udf.math;
+
+import io.confluent.ksql.function.FunctionCategory;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import io.confluent.ksql.util.KsqlConstants;
+
+@UdfDescription(
+        name = "cos",
+        category = FunctionCategory.MATHEMATICAL,
+        author = KsqlConstants.CONFLUENT_AUTHOR,
+        description = "The cosine of a value."
+)
+public class Cos {
+
+    @Udf(description = "Returns the cosine of an INT value")
+    public Double cos(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value in radians to get the cosine of."
+            ) final Integer value
+    ) {
+        return cos(value == null ? null : value.doubleValue());
+    }
+
+    @Udf(description = "Returns the cosine of a BIGINT value")
+    public Double cos(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value in radians to get the cosine of."
+            ) final Long value
+    ) {
+        return cos(value == null ? null : value.doubleValue());
+    }
+
+    @Udf(description = "Returns the cosine of a DOUBLE value")
+    public Double cos(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value in radians to get the cosine of."
+            ) final Double value
+    ) {
+        return value == null
+                ? null
+                : Math.cos(value);
+    }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Cos.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Cos.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.math;
 
 import io.confluent.ksql.function.FunctionCategory;
@@ -14,35 +28,35 @@ import io.confluent.ksql.util.KsqlConstants;
 )
 public class Cos {
 
-    @Udf(description = "Returns the cosine of an INT value")
-    public Double cos(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value in radians to get the cosine of."
-            ) final Integer value
-    ) {
-        return cos(value == null ? null : value.doubleValue());
-    }
+  @Udf(description = "Returns the cosine of an INT value")
+  public Double cos(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value in radians to get the cosine of."
+          ) final Integer value
+  ) {
+    return cos(value == null ? null : value.doubleValue());
+  }
 
-    @Udf(description = "Returns the cosine of a BIGINT value")
-    public Double cos(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value in radians to get the cosine of."
-            ) final Long value
-    ) {
-        return cos(value == null ? null : value.doubleValue());
-    }
+  @Udf(description = "Returns the cosine of a BIGINT value")
+  public Double cos(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value in radians to get the cosine of."
+          ) final Long value
+  ) {
+    return cos(value == null ? null : value.doubleValue());
+  }
 
-    @Udf(description = "Returns the cosine of a DOUBLE value")
-    public Double cos(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value in radians to get the cosine of."
-            ) final Double value
-    ) {
-        return value == null
-                ? null
-                : Math.cos(value);
-    }
+  @Udf(description = "Returns the cosine of a DOUBLE value")
+  public Double cos(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value in radians to get the cosine of."
+          ) final Double value
+  ) {
+    return value == null
+            ? null
+            : Math.cos(value);
+  }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Cosh.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Cosh.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.math;
+
+import io.confluent.ksql.function.FunctionCategory;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import io.confluent.ksql.util.KsqlConstants;
+
+@UdfDescription(
+        name = "cosh",
+        category = FunctionCategory.MATHEMATICAL,
+        author = KsqlConstants.CONFLUENT_AUTHOR,
+        description = "The hyperbolic cosine of a value."
+)
+public class Cosh {
+
+  @Udf(description = "Returns the hyperbolic cosine of an INT value")
+  public Double cosh(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value to get the hyperbolic cosine of."
+          ) final Integer value
+  ) {
+    return cosh(value == null ? null : value.doubleValue());
+  }
+
+  @Udf(description = "Returns the hyperbolic cosine of a BIGINT value")
+  public Double cosh(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value to get the hyperbolic cosine of."
+          ) final Long value
+  ) {
+    return cosh(value == null ? null : value.doubleValue());
+  }
+
+  @Udf(description = "Returns the hyperbolic cosine of a DOUBLE value")
+  public Double cosh(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value to get the hyperbolic cosine of."
+          ) final Double value
+  ) {
+    return value == null
+            ? null
+            : Math.cosh(value);
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Cosh.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Cosh.java
@@ -32,7 +32,7 @@ public class Cosh {
   public Double cosh(
           @UdfParameter(
                   value = "value",
-                  description = "The value to get the hyperbolic cosine of."
+                  description = "The value in radians to get the hyperbolic cosine of."
           ) final Integer value
   ) {
     return cosh(value == null ? null : value.doubleValue());
@@ -42,7 +42,7 @@ public class Cosh {
   public Double cosh(
           @UdfParameter(
                   value = "value",
-                  description = "The value to get the hyperbolic cosine of."
+                  description = "The value in radians to get the hyperbolic cosine of."
           ) final Long value
   ) {
     return cosh(value == null ? null : value.doubleValue());
@@ -52,7 +52,7 @@ public class Cosh {
   public Double cosh(
           @UdfParameter(
                   value = "value",
-                  description = "The value to get the hyperbolic cosine of."
+                  description = "The value in radians to get the hyperbolic cosine of."
           ) final Double value
   ) {
     return value == null

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Cot.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Cot.java
@@ -1,0 +1,48 @@
+package io.confluent.ksql.function.udf.math;
+
+import io.confluent.ksql.function.FunctionCategory;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import io.confluent.ksql.util.KsqlConstants;
+
+@UdfDescription(
+        name = "cot",
+        category = FunctionCategory.MATHEMATICAL,
+        author = KsqlConstants.CONFLUENT_AUTHOR,
+        description = "The cotangent of a value."
+)
+public class Cot {
+
+    @Udf(description = "Returns the cotangent of an INT value")
+    public Double cot(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value in radians to get the cotangent of."
+            ) final Integer value
+    ) {
+        return cot(value == null ? null : value.doubleValue());
+    }
+
+    @Udf(description = "Returns the cotangent of a BIGINT value")
+    public Double cot(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value in radians to get the cotangent of."
+            ) final Long value
+    ) {
+        return cot(value == null ? null : value.doubleValue());
+    }
+
+    @Udf(description = "Returns the cotangent of a DOUBLE value")
+    public Double cot(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value in radians to get the cotangent of."
+            ) final Double value
+    ) {
+        return value == null
+                ? null
+                : Math.cos(value) / Math.sin(value);
+    }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Cot.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Cot.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.math;
 
 import io.confluent.ksql.function.FunctionCategory;
@@ -14,35 +28,35 @@ import io.confluent.ksql.util.KsqlConstants;
 )
 public class Cot {
 
-    @Udf(description = "Returns the cotangent of an INT value")
-    public Double cot(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value in radians to get the cotangent of."
-            ) final Integer value
-    ) {
-        return cot(value == null ? null : value.doubleValue());
-    }
+  @Udf(description = "Returns the cotangent of an INT value")
+  public Double cot(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value in radians to get the cotangent of."
+          ) final Integer value
+  ) {
+    return cot(value == null ? null : value.doubleValue());
+  }
 
-    @Udf(description = "Returns the cotangent of a BIGINT value")
-    public Double cot(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value in radians to get the cotangent of."
-            ) final Long value
-    ) {
-        return cot(value == null ? null : value.doubleValue());
-    }
+  @Udf(description = "Returns the cotangent of a BIGINT value")
+  public Double cot(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value in radians to get the cotangent of."
+          ) final Long value
+  ) {
+    return cot(value == null ? null : value.doubleValue());
+  }
 
-    @Udf(description = "Returns the cotangent of a DOUBLE value")
-    public Double cot(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value in radians to get the cotangent of."
-            ) final Double value
-    ) {
-        return value == null
-                ? null
-                : 1 / Math.tan(value);
-    }
+  @Udf(description = "Returns the cotangent of a DOUBLE value")
+  public Double cot(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value in radians to get the cotangent of."
+          ) final Double value
+  ) {
+    return value == null
+            ? null
+            : 1 / Math.tan(value);
+  }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Cot.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Cot.java
@@ -43,6 +43,6 @@ public class Cot {
     ) {
         return value == null
                 ? null
-                : Math.cos(value) / Math.sin(value);
+                : 1 / Math.tan(value);
     }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Degrees.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Degrees.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.math;
 
 import io.confluent.ksql.function.FunctionCategory;
@@ -14,35 +28,35 @@ import io.confluent.ksql.util.KsqlConstants;
 )
 public class Degrees {
 
-    @Udf(description = "Converts an INT value in radians to a value in degrees")
-    public Double degrees(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value in radians to convert to degrees."
-            ) final Integer value
-    ) {
-        return degrees(value == null ? null : value.doubleValue());
-    }
+  @Udf(description = "Converts an INT value in radians to a value in degrees")
+  public Double degrees(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value in radians to convert to degrees."
+          ) final Integer value
+  ) {
+    return degrees(value == null ? null : value.doubleValue());
+  }
 
-    @Udf(description = "Converts a BIGINT value in radians to a value in degrees")
-    public Double degrees(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value in radians to convert to degrees."
-            ) final Long value
-    ) {
-        return degrees(value == null ? null : value.doubleValue());
-    }
+  @Udf(description = "Converts a BIGINT value in radians to a value in degrees")
+  public Double degrees(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value in radians to convert to degrees."
+          ) final Long value
+  ) {
+    return degrees(value == null ? null : value.doubleValue());
+  }
 
-    @Udf(description = "Converts a DOUBLE value in radians to a value in degrees")
-    public Double degrees(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value in radians to convert to degrees."
-            ) final Double value
-    ) {
-        return value == null
-                ? null
-                : Math.toDegrees(value);
-    }
+  @Udf(description = "Converts a DOUBLE value in radians to a value in degrees")
+  public Double degrees(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value in radians to convert to degrees."
+          ) final Double value
+  ) {
+    return value == null
+            ? null
+            : Math.toDegrees(value);
+  }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Degrees.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Degrees.java
@@ -1,0 +1,48 @@
+package io.confluent.ksql.function.udf.math;
+
+import io.confluent.ksql.function.FunctionCategory;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import io.confluent.ksql.util.KsqlConstants;
+
+@UdfDescription(
+        name = "degrees",
+        category = FunctionCategory.MATHEMATICAL,
+        author = KsqlConstants.CONFLUENT_AUTHOR,
+        description = "Converts a value in radians to a value in degrees."
+)
+public class Degrees {
+
+    @Udf(description = "Converts an INT value in radians to a value in degrees")
+    public Double degrees(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value in radians to convert to degrees."
+            ) final Integer value
+    ) {
+        return degrees(value == null ? null : value.doubleValue());
+    }
+
+    @Udf(description = "Converts a BIGINT value in radians to a value in degrees")
+    public Double degrees(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value in radians to convert to degrees."
+            ) final Long value
+    ) {
+        return degrees(value == null ? null : value.doubleValue());
+    }
+
+    @Udf(description = "Converts a DOUBLE value in radians to a value in degrees")
+    public Double degrees(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value in radians to convert to degrees."
+            ) final Double value
+    ) {
+        return value == null
+                ? null
+                : Math.toDegrees(value);
+    }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Pi.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Pi.java
@@ -1,0 +1,19 @@
+package io.confluent.ksql.function.udf.math;
+
+import io.confluent.ksql.function.FunctionCategory;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.util.KsqlConstants;
+
+@UdfDescription(
+        name = "pi",
+        category = FunctionCategory.MATHEMATICAL,
+        author = KsqlConstants.CONFLUENT_AUTHOR,
+        description = "Returns the approximate value of pi."
+)
+public class Pi {
+    @Udf(description = "Returns the approximate value of pi")
+    public Double pi() {
+        return Math.PI;
+    }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Pi.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Pi.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.math;
 
 import io.confluent.ksql.function.FunctionCategory;
@@ -12,8 +26,8 @@ import io.confluent.ksql.util.KsqlConstants;
         description = "Returns the approximate value of pi."
 )
 public class Pi {
-    @Udf(description = "Returns the approximate value of pi")
-    public Double pi() {
-        return Math.PI;
-    }
+  @Udf(description = "Returns the approximate value of pi")
+  public Double pi() {
+    return Math.PI;
+  }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Pi.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Pi.java
@@ -23,10 +23,10 @@ import io.confluent.ksql.util.KsqlConstants;
         name = "pi",
         category = FunctionCategory.MATHEMATICAL,
         author = KsqlConstants.CONFLUENT_AUTHOR,
-        description = "Returns the approximate value of pi."
+        description = "Returns an approximate value of pi."
 )
 public class Pi {
-  @Udf(description = "Returns the approximate value of pi")
+  @Udf(description = "Returns an approximate value of pi")
   public Double pi() {
     return Math.PI;
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Radians.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Radians.java
@@ -1,0 +1,48 @@
+package io.confluent.ksql.function.udf.math;
+
+import io.confluent.ksql.function.FunctionCategory;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import io.confluent.ksql.util.KsqlConstants;
+
+@UdfDescription(
+        name = "radians",
+        category = FunctionCategory.MATHEMATICAL,
+        author = KsqlConstants.CONFLUENT_AUTHOR,
+        description = "Converts a value in degrees to a value in radians."
+)
+public class Radians {
+
+    @Udf(description = "Converts an INT value in degrees to a value in radians")
+    public Double radians(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value in degrees to convert to radians."
+            ) final Integer value
+    ) {
+        return radians(value == null ? null : value.doubleValue());
+    }
+
+    @Udf(description = "Converts a BIGINT value in degrees to a value in radians")
+    public Double radians(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value in degrees to convert to radians."
+            ) final Long value
+    ) {
+        return radians(value == null ? null : value.doubleValue());
+    }
+
+    @Udf(description = "Converts a DOUBLE value in degrees to a value in radians")
+    public Double radians(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value in degrees to convert to radians."
+            ) final Double value
+    ) {
+        return value == null
+                ? null
+                : Math.toRadians(value);
+    }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Radians.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Radians.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.math;
 
 import io.confluent.ksql.function.FunctionCategory;
@@ -14,35 +28,35 @@ import io.confluent.ksql.util.KsqlConstants;
 )
 public class Radians {
 
-    @Udf(description = "Converts an INT value in degrees to a value in radians")
-    public Double radians(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value in degrees to convert to radians."
-            ) final Integer value
-    ) {
-        return radians(value == null ? null : value.doubleValue());
-    }
+  @Udf(description = "Converts an INT value in degrees to a value in radians")
+  public Double radians(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value in degrees to convert to radians."
+          ) final Integer value
+  ) {
+    return radians(value == null ? null : value.doubleValue());
+  }
 
-    @Udf(description = "Converts a BIGINT value in degrees to a value in radians")
-    public Double radians(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value in degrees to convert to radians."
-            ) final Long value
-    ) {
-        return radians(value == null ? null : value.doubleValue());
-    }
+  @Udf(description = "Converts a BIGINT value in degrees to a value in radians")
+  public Double radians(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value in degrees to convert to radians."
+          ) final Long value
+  ) {
+    return radians(value == null ? null : value.doubleValue());
+  }
 
-    @Udf(description = "Converts a DOUBLE value in degrees to a value in radians")
-    public Double radians(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value in degrees to convert to radians."
-            ) final Double value
-    ) {
-        return value == null
-                ? null
-                : Math.toRadians(value);
-    }
+  @Udf(description = "Converts a DOUBLE value in degrees to a value in radians")
+  public Double radians(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value in degrees to convert to radians."
+          ) final Double value
+  ) {
+    return value == null
+            ? null
+            : Math.toRadians(value);
+  }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Sin.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Sin.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.math;
 
 import io.confluent.ksql.function.FunctionCategory;
@@ -14,35 +28,35 @@ import io.confluent.ksql.util.KsqlConstants;
 )
 public class Sin {
 
-    @Udf(description = "Returns the sine of an INT value")
-    public Double sin(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value in radians to get the sine of."
-            ) final Integer value
-    ) {
-        return sin(value == null ? null : value.doubleValue());
-    }
+  @Udf(description = "Returns the sine of an INT value")
+  public Double sin(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value in radians to get the sine of."
+          ) final Integer value
+  ) {
+    return sin(value == null ? null : value.doubleValue());
+  }
 
-    @Udf(description = "Returns the sine of a BIGINT value")
-    public Double sin(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value in radians to get the sine of."
-            ) final Long value
-    ) {
-        return sin(value == null ? null : value.doubleValue());
-    }
+  @Udf(description = "Returns the sine of a BIGINT value")
+  public Double sin(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value in radians to get the sine of."
+          ) final Long value
+  ) {
+    return sin(value == null ? null : value.doubleValue());
+  }
 
-    @Udf(description = "Returns the sine of a DOUBLE value")
-    public Double sin(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value in radians to get the sine of."
-            ) final Double value
-    ) {
-        return value == null
-                ? null
-                : Math.sin(value);
-    }
+  @Udf(description = "Returns the sine of a DOUBLE value")
+  public Double sin(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value in radians to get the sine of."
+          ) final Double value
+  ) {
+    return value == null
+            ? null
+            : Math.sin(value);
+  }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Sin.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Sin.java
@@ -1,0 +1,48 @@
+package io.confluent.ksql.function.udf.math;
+
+import io.confluent.ksql.function.FunctionCategory;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import io.confluent.ksql.util.KsqlConstants;
+
+@UdfDescription(
+        name = "sin",
+        category = FunctionCategory.MATHEMATICAL,
+        author = KsqlConstants.CONFLUENT_AUTHOR,
+        description = "The sine of a value."
+)
+public class Sin {
+
+    @Udf(description = "Returns the sine of an INT value")
+    public Double sin(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value in radians to get the sine of."
+            ) final Integer value
+    ) {
+        return sin(value == null ? null : value.doubleValue());
+    }
+
+    @Udf(description = "Returns the sine of a BIGINT value")
+    public Double sin(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value in radians to get the sine of."
+            ) final Long value
+    ) {
+        return sin(value == null ? null : value.doubleValue());
+    }
+
+    @Udf(description = "Returns the sine of a DOUBLE value")
+    public Double sin(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value in radians to get the sine of."
+            ) final Double value
+    ) {
+        return value == null
+                ? null
+                : Math.sin(value);
+    }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Sinh.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Sinh.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.math;
+
+import io.confluent.ksql.function.FunctionCategory;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import io.confluent.ksql.util.KsqlConstants;
+
+@UdfDescription(
+        name = "sinh",
+        category = FunctionCategory.MATHEMATICAL,
+        author = KsqlConstants.CONFLUENT_AUTHOR,
+        description = "The hyperbolic sine of a value."
+)
+public class Sinh {
+
+  @Udf(description = "Returns the hyperbolic sine of an INT value")
+  public Double sinh(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value to get the hyperbolic sine of."
+          ) final Integer value
+  ) {
+    return sinh(value == null ? null : value.doubleValue());
+  }
+
+  @Udf(description = "Returns the hyperbolic sine of a BIGINT value")
+  public Double sinh(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value to get the hyperbolic sine of."
+          ) final Long value
+  ) {
+    return sinh(value == null ? null : value.doubleValue());
+  }
+
+  @Udf(description = "Returns the hyperbolic sine of a DOUBLE value")
+  public Double sinh(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value to get the hyperbolic sine of."
+          ) final Double value
+  ) {
+    return value == null
+            ? null
+            : Math.sinh(value);
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Sinh.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Sinh.java
@@ -32,7 +32,7 @@ public class Sinh {
   public Double sinh(
           @UdfParameter(
                   value = "value",
-                  description = "The value to get the hyperbolic sine of."
+                  description = "The value in radians to get the hyperbolic sine of."
           ) final Integer value
   ) {
     return sinh(value == null ? null : value.doubleValue());
@@ -42,7 +42,7 @@ public class Sinh {
   public Double sinh(
           @UdfParameter(
                   value = "value",
-                  description = "The value to get the hyperbolic sine of."
+                  description = "The value in radians to get the hyperbolic sine of."
           ) final Long value
   ) {
     return sinh(value == null ? null : value.doubleValue());
@@ -52,7 +52,7 @@ public class Sinh {
   public Double sinh(
           @UdfParameter(
                   value = "value",
-                  description = "The value to get the hyperbolic sine of."
+                  description = "The value in radians to get the hyperbolic sine of."
           ) final Double value
   ) {
     return value == null

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Tan.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Tan.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.math;
 
 import io.confluent.ksql.function.FunctionCategory;
@@ -14,35 +28,35 @@ import io.confluent.ksql.util.KsqlConstants;
 )
 public class Tan {
 
-    @Udf(description = "Returns the tangent of an INT value")
-    public Double tan(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value in radians to get the tangent of."
-            ) final Integer value
-    ) {
-        return tan(value == null ? null : value.doubleValue());
-    }
+  @Udf(description = "Returns the tangent of an INT value")
+  public Double tan(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value in radians to get the tangent of."
+          ) final Integer value
+  ) {
+    return tan(value == null ? null : value.doubleValue());
+  }
 
-    @Udf(description = "Returns the tangent of a BIGINT value")
-    public Double tan(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value in radians to get the tangent of."
-            ) final Long value
-    ) {
-        return tan(value == null ? null : value.doubleValue());
-    }
+  @Udf(description = "Returns the tangent of a BIGINT value")
+  public Double tan(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value in radians to get the tangent of."
+          ) final Long value
+  ) {
+    return tan(value == null ? null : value.doubleValue());
+  }
 
-    @Udf(description = "Returns the tangent of a DOUBLE value")
-    public Double tan(
-            @UdfParameter(
-                    value = "value",
-                    description = "The value in radians to get the tangent of."
-            ) final Double value
-    ) {
-        return value == null
-                ? null
-                : Math.tan(value);
-    }
+  @Udf(description = "Returns the tangent of a DOUBLE value")
+  public Double tan(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value in radians to get the tangent of."
+          ) final Double value
+  ) {
+    return value == null
+            ? null
+            : Math.tan(value);
+  }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Tan.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Tan.java
@@ -1,0 +1,48 @@
+package io.confluent.ksql.function.udf.math;
+
+import io.confluent.ksql.function.FunctionCategory;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import io.confluent.ksql.util.KsqlConstants;
+
+@UdfDescription(
+        name = "tan",
+        category = FunctionCategory.MATHEMATICAL,
+        author = KsqlConstants.CONFLUENT_AUTHOR,
+        description = "The tangent of a value."
+)
+public class Tan {
+
+    @Udf(description = "Returns the tangent of an INT value")
+    public Double tan(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value in radians to get the tangent of."
+            ) final Integer value
+    ) {
+        return tan(value == null ? null : value.doubleValue());
+    }
+
+    @Udf(description = "Returns the tangent of a BIGINT value")
+    public Double tan(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value in radians to get the tangent of."
+            ) final Long value
+    ) {
+        return tan(value == null ? null : value.doubleValue());
+    }
+
+    @Udf(description = "Returns the tangent of a DOUBLE value")
+    public Double tan(
+            @UdfParameter(
+                    value = "value",
+                    description = "The value in radians to get the tangent of."
+            ) final Double value
+    ) {
+        return value == null
+                ? null
+                : Math.tan(value);
+    }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Tanh.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Tanh.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.math;
+
+import io.confluent.ksql.function.FunctionCategory;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import io.confluent.ksql.util.KsqlConstants;
+
+@UdfDescription(
+        name = "tanh",
+        category = FunctionCategory.MATHEMATICAL,
+        author = KsqlConstants.CONFLUENT_AUTHOR,
+        description = "The hyperbolic tangent of a value."
+)
+public class Tanh {
+
+  @Udf(description = "Returns the hyperbolic tangent of an INT value")
+  public Double tanh(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value to get the hyperbolic tangent of."
+          ) final Integer value
+  ) {
+    return tanh(value == null ? null : value.doubleValue());
+  }
+
+  @Udf(description = "Returns the hyperbolic tangent of a BIGINT value")
+  public Double tanh(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value to get the hyperbolic tangent of."
+          ) final Long value
+  ) {
+    return tanh(value == null ? null : value.doubleValue());
+  }
+
+  @Udf(description = "Returns the hyperbolic tangent of a DOUBLE value")
+  public Double tanh(
+          @UdfParameter(
+                  value = "value",
+                  description = "The value to get the hyperbolic tangent of."
+          ) final Double value
+  ) {
+    return value == null
+            ? null
+            : Math.tanh(value);
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Tanh.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Tanh.java
@@ -32,7 +32,7 @@ public class Tanh {
   public Double tanh(
           @UdfParameter(
                   value = "value",
-                  description = "The value to get the hyperbolic tangent of."
+                  description = "The value in radians to get the hyperbolic tangent of."
           ) final Integer value
   ) {
     return tanh(value == null ? null : value.doubleValue());
@@ -42,7 +42,7 @@ public class Tanh {
   public Double tanh(
           @UdfParameter(
                   value = "value",
-                  description = "The value to get the hyperbolic tangent of."
+                  description = "The value in radians to get the hyperbolic tangent of."
           ) final Long value
   ) {
     return tanh(value == null ? null : value.doubleValue());
@@ -52,7 +52,7 @@ public class Tanh {
   public Double tanh(
           @UdfParameter(
                   value = "value",
-                  description = "The value to get the hyperbolic tangent of."
+                  description = "The value in radians to get the hyperbolic tangent of."
           ) final Double value
   ) {
     return value == null

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/AcosTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/AcosTest.java
@@ -1,0 +1,65 @@
+package io.confluent.ksql.function.udf.math;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class AcosTest {
+    private Acos udf;
+
+    @Before
+    public void setUp() {
+        udf = new Acos();
+    }
+
+    @Test
+    public void shouldHandleNull() {
+        assertThat(udf.acos((Integer)null), is(nullValue()));
+        assertThat(udf.acos((Long)null), is(nullValue()));
+        assertThat(udf.acos((Double)null), is(nullValue()));
+    }
+
+    @Test
+    public void shouldHandleLessThanNegativeOne() {
+        assertThat(Double.isNaN(udf.acos(-1.1)), is(true));
+        assertThat(Double.isNaN(udf.acos(-6.0)), is(true));
+        assertThat(Double.isNaN(udf.acos(-2)), is(true));
+        assertThat(Double.isNaN(udf.acos(-2L)), is(true));
+    }
+
+    @Test
+    public void shouldHandleNegative() {
+        assertThat(udf.acos(-0.43), is(2.0152891037307157));
+        assertThat(udf.acos(-0.5), is(2.0943951023931957));
+        assertThat(udf.acos(-1.0), is(3.141592653589793));
+        assertThat(udf.acos(-1), is(3.141592653589793));
+        assertThat(udf.acos(-1L), is(3.141592653589793));
+    }
+
+    @Test
+    public void shouldHandleZero() {
+        assertThat(udf.acos(0.0), is(1.5707963267948966));
+        assertThat(udf.acos(0), is(1.5707963267948966));
+        assertThat(udf.acos(0L), is(1.5707963267948966));
+    }
+
+    @Test
+    public void shouldHandlePositive() {
+        assertThat(udf.acos(0.43), is(1.1263035498590777));
+        assertThat(udf.acos(0.5), is(1.0471975511965979));
+        assertThat(udf.acos(1.0), is(0.0));
+        assertThat(udf.acos(1), is(0.0));
+        assertThat(udf.acos(1L), is(0.0));
+    }
+
+    @Test
+    public void shouldHandleMoreThanPositiveOne() {
+        assertThat(Double.isNaN(udf.acos(1.1)), is(true));
+        assertThat(Double.isNaN(udf.acos(6.0)), is(true));
+        assertThat(Double.isNaN(udf.acos(2)), is(true));
+        assertThat(Double.isNaN(udf.acos(2L)), is(true));
+    }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/AcosTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/AcosTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.math;
 
 import org.junit.Before;
@@ -8,58 +22,58 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 public class AcosTest {
-    private Acos udf;
+  private Acos udf;
 
-    @Before
-    public void setUp() {
-        udf = new Acos();
-    }
+  @Before
+  public void setUp() {
+    udf = new Acos();
+  }
 
-    @Test
-    public void shouldHandleNull() {
-        assertThat(udf.acos((Integer)null), is(nullValue()));
-        assertThat(udf.acos((Long)null), is(nullValue()));
-        assertThat(udf.acos((Double)null), is(nullValue()));
-    }
+  @Test
+  public void shouldHandleNull() {
+    assertThat(udf.acos((Integer) null), is(nullValue()));
+    assertThat(udf.acos((Long) null), is(nullValue()));
+    assertThat(udf.acos((Double) null), is(nullValue()));
+  }
 
-    @Test
-    public void shouldHandleLessThanNegativeOne() {
-        assertThat(Double.isNaN(udf.acos(-1.1)), is(true));
-        assertThat(Double.isNaN(udf.acos(-6.0)), is(true));
-        assertThat(Double.isNaN(udf.acos(-2)), is(true));
-        assertThat(Double.isNaN(udf.acos(-2L)), is(true));
-    }
+  @Test
+  public void shouldHandleLessThanNegativeOne() {
+    assertThat(Double.isNaN(udf.acos(-1.1)), is(true));
+    assertThat(Double.isNaN(udf.acos(-6.0)), is(true));
+    assertThat(Double.isNaN(udf.acos(-2)), is(true));
+    assertThat(Double.isNaN(udf.acos(-2L)), is(true));
+  }
 
-    @Test
-    public void shouldHandleNegative() {
-        assertThat(udf.acos(-0.43), is(2.0152891037307157));
-        assertThat(udf.acos(-0.5), is(2.0943951023931957));
-        assertThat(udf.acos(-1.0), is(3.141592653589793));
-        assertThat(udf.acos(-1), is(3.141592653589793));
-        assertThat(udf.acos(-1L), is(3.141592653589793));
-    }
+  @Test
+  public void shouldHandleNegative() {
+    assertThat(udf.acos(-0.43), is(2.0152891037307157));
+    assertThat(udf.acos(-0.5), is(2.0943951023931957));
+    assertThat(udf.acos(-1.0), is(3.141592653589793));
+    assertThat(udf.acos(-1), is(3.141592653589793));
+    assertThat(udf.acos(-1L), is(3.141592653589793));
+  }
 
-    @Test
-    public void shouldHandleZero() {
-        assertThat(udf.acos(0.0), is(1.5707963267948966));
-        assertThat(udf.acos(0), is(1.5707963267948966));
-        assertThat(udf.acos(0L), is(1.5707963267948966));
-    }
+  @Test
+  public void shouldHandleZero() {
+    assertThat(udf.acos(0.0), is(1.5707963267948966));
+    assertThat(udf.acos(0), is(1.5707963267948966));
+    assertThat(udf.acos(0L), is(1.5707963267948966));
+  }
 
-    @Test
-    public void shouldHandlePositive() {
-        assertThat(udf.acos(0.43), is(1.1263035498590777));
-        assertThat(udf.acos(0.5), is(1.0471975511965979));
-        assertThat(udf.acos(1.0), is(0.0));
-        assertThat(udf.acos(1), is(0.0));
-        assertThat(udf.acos(1L), is(0.0));
-    }
+  @Test
+  public void shouldHandlePositive() {
+    assertThat(udf.acos(0.43), is(1.1263035498590777));
+    assertThat(udf.acos(0.5), is(1.0471975511965979));
+    assertThat(udf.acos(1.0), is(0.0));
+    assertThat(udf.acos(1), is(0.0));
+    assertThat(udf.acos(1L), is(0.0));
+  }
 
-    @Test
-    public void shouldHandleMoreThanPositiveOne() {
-        assertThat(Double.isNaN(udf.acos(1.1)), is(true));
-        assertThat(Double.isNaN(udf.acos(6.0)), is(true));
-        assertThat(Double.isNaN(udf.acos(2)), is(true));
-        assertThat(Double.isNaN(udf.acos(2L)), is(true));
-    }
+  @Test
+  public void shouldHandleMoreThanPositiveOne() {
+    assertThat(Double.isNaN(udf.acos(1.1)), is(true));
+    assertThat(Double.isNaN(udf.acos(6.0)), is(true));
+    assertThat(Double.isNaN(udf.acos(2)), is(true));
+    assertThat(Double.isNaN(udf.acos(2L)), is(true));
+  }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/AsinTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/AsinTest.java
@@ -1,0 +1,65 @@
+package io.confluent.ksql.function.udf.math;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class AsinTest {
+    private Asin udf;
+
+    @Before
+    public void setUp() {
+        udf = new Asin();
+    }
+
+    @Test
+    public void shouldHandleNull() {
+        assertThat(udf.asin((Integer)null), is(nullValue()));
+        assertThat(udf.asin((Long)null), is(nullValue()));
+        assertThat(udf.asin((Double)null), is(nullValue()));
+    }
+
+    @Test
+    public void shouldHandleLessThanNegativeOne() {
+        assertThat(Double.isNaN(udf.asin(-1.1)), is(true));
+        assertThat(Double.isNaN(udf.asin(-6.0)), is(true));
+        assertThat(Double.isNaN(udf.asin(-2)), is(true));
+        assertThat(Double.isNaN(udf.asin(-2L)), is(true));
+    }
+
+    @Test
+    public void shouldHandleNegative() {
+        assertThat(udf.asin(-0.43), is(-0.444492776935819));
+        assertThat(udf.asin(-0.5), is(-0.5235987755982989));
+        assertThat(udf.asin(-1.0), is(-1.5707963267948966));
+        assertThat(udf.asin(-1), is(-1.5707963267948966));
+        assertThat(udf.asin(-1L), is(-1.5707963267948966));
+    }
+
+    @Test
+    public void shouldHandleZero() {
+        assertThat(udf.asin(0.0), is(0.0));
+        assertThat(udf.asin(0), is(0.0));
+        assertThat(udf.asin(0L), is(0.0));
+    }
+
+    @Test
+    public void shouldHandlePositive() {
+        assertThat(udf.asin(0.43), is(0.444492776935819));
+        assertThat(udf.asin(0.5), is(0.5235987755982989));
+        assertThat(udf.asin(1.0), is(1.5707963267948966));
+        assertThat(udf.asin(1), is(1.5707963267948966));
+        assertThat(udf.asin(1L), is(1.5707963267948966));
+    }
+
+    @Test
+    public void shouldHandleMoreThanPositiveOne() {
+        assertThat(Double.isNaN(udf.asin(1.1)), is(true));
+        assertThat(Double.isNaN(udf.asin(6.0)), is(true));
+        assertThat(Double.isNaN(udf.asin(2)), is(true));
+        assertThat(Double.isNaN(udf.asin(2L)), is(true));
+    }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/AsinTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/AsinTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.math;
 
 import org.junit.Before;
@@ -8,58 +22,58 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 public class AsinTest {
-    private Asin udf;
+  private Asin udf;
 
-    @Before
-    public void setUp() {
-        udf = new Asin();
-    }
+  @Before
+  public void setUp() {
+    udf = new Asin();
+  }
 
-    @Test
-    public void shouldHandleNull() {
-        assertThat(udf.asin((Integer)null), is(nullValue()));
-        assertThat(udf.asin((Long)null), is(nullValue()));
-        assertThat(udf.asin((Double)null), is(nullValue()));
-    }
+  @Test
+  public void shouldHandleNull() {
+    assertThat(udf.asin((Integer) null), is(nullValue()));
+    assertThat(udf.asin((Long) null), is(nullValue()));
+    assertThat(udf.asin((Double) null), is(nullValue()));
+  }
 
-    @Test
-    public void shouldHandleLessThanNegativeOne() {
-        assertThat(Double.isNaN(udf.asin(-1.1)), is(true));
-        assertThat(Double.isNaN(udf.asin(-6.0)), is(true));
-        assertThat(Double.isNaN(udf.asin(-2)), is(true));
-        assertThat(Double.isNaN(udf.asin(-2L)), is(true));
-    }
+  @Test
+  public void shouldHandleLessThanNegativeOne() {
+    assertThat(Double.isNaN(udf.asin(-1.1)), is(true));
+    assertThat(Double.isNaN(udf.asin(-6.0)), is(true));
+    assertThat(Double.isNaN(udf.asin(-2)), is(true));
+    assertThat(Double.isNaN(udf.asin(-2L)), is(true));
+  }
 
-    @Test
-    public void shouldHandleNegative() {
-        assertThat(udf.asin(-0.43), is(-0.444492776935819));
-        assertThat(udf.asin(-0.5), is(-0.5235987755982989));
-        assertThat(udf.asin(-1.0), is(-1.5707963267948966));
-        assertThat(udf.asin(-1), is(-1.5707963267948966));
-        assertThat(udf.asin(-1L), is(-1.5707963267948966));
-    }
+  @Test
+  public void shouldHandleNegative() {
+    assertThat(udf.asin(-0.43), is(-0.444492776935819));
+    assertThat(udf.asin(-0.5), is(-0.5235987755982989));
+    assertThat(udf.asin(-1.0), is(-1.5707963267948966));
+    assertThat(udf.asin(-1), is(-1.5707963267948966));
+    assertThat(udf.asin(-1L), is(-1.5707963267948966));
+  }
 
-    @Test
-    public void shouldHandleZero() {
-        assertThat(udf.asin(0.0), is(0.0));
-        assertThat(udf.asin(0), is(0.0));
-        assertThat(udf.asin(0L), is(0.0));
-    }
+  @Test
+  public void shouldHandleZero() {
+    assertThat(udf.asin(0.0), is(0.0));
+    assertThat(udf.asin(0), is(0.0));
+    assertThat(udf.asin(0L), is(0.0));
+  }
 
-    @Test
-    public void shouldHandlePositive() {
-        assertThat(udf.asin(0.43), is(0.444492776935819));
-        assertThat(udf.asin(0.5), is(0.5235987755982989));
-        assertThat(udf.asin(1.0), is(1.5707963267948966));
-        assertThat(udf.asin(1), is(1.5707963267948966));
-        assertThat(udf.asin(1L), is(1.5707963267948966));
-    }
+  @Test
+  public void shouldHandlePositive() {
+    assertThat(udf.asin(0.43), is(0.444492776935819));
+    assertThat(udf.asin(0.5), is(0.5235987755982989));
+    assertThat(udf.asin(1.0), is(1.5707963267948966));
+    assertThat(udf.asin(1), is(1.5707963267948966));
+    assertThat(udf.asin(1L), is(1.5707963267948966));
+  }
 
-    @Test
-    public void shouldHandleMoreThanPositiveOne() {
-        assertThat(Double.isNaN(udf.asin(1.1)), is(true));
-        assertThat(Double.isNaN(udf.asin(6.0)), is(true));
-        assertThat(Double.isNaN(udf.asin(2)), is(true));
-        assertThat(Double.isNaN(udf.asin(2L)), is(true));
-    }
+  @Test
+  public void shouldHandleMoreThanPositiveOne() {
+    assertThat(Double.isNaN(udf.asin(1.1)), is(true));
+    assertThat(Double.isNaN(udf.asin(6.0)), is(true));
+    assertThat(Double.isNaN(udf.asin(2)), is(true));
+    assertThat(Double.isNaN(udf.asin(2L)), is(true));
+  }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/Atan2Test.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/Atan2Test.java
@@ -1,0 +1,102 @@
+package io.confluent.ksql.function.udf.math;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class Atan2Test {
+    private Atan2 udf;
+
+    @Before
+    public void setUp() {
+        udf = new Atan2();
+    }
+
+    @Test
+    public void shouldHandleNull() {
+        assertThat(udf.atan2(null, 1), is(nullValue()));
+        assertThat(udf.atan2(null, 1L), is(nullValue()));
+        assertThat(udf.atan2(null, 0.45), is(nullValue()));
+        assertThat(udf.atan2(1, null), is(nullValue()));
+        assertThat(udf.atan2(1L, null), is(nullValue()));
+        assertThat(udf.atan2(0.45, null), is(nullValue()));
+        assertThat(udf.atan2((Integer)null, null), is(nullValue()));
+        assertThat(udf.atan2((Long)null, null), is(nullValue()));
+        assertThat(udf.atan2((Double)null, null), is(nullValue()));
+    }
+
+    @Test
+    public void shouldHandleNegativeXNegativeY() {
+        assertThat(udf.atan2(-1.1, -0.24), is(-1.7856117271965553));
+        assertThat(udf.atan2(-6.0, -7.1), is(-2.4399674339361113));
+        assertThat(udf.atan2(-2, -3), is(-2.5535900500422257));
+        assertThat(udf.atan2(-2L, -2L), is(-2.356194490192345));
+    }
+
+    @Test
+    public void shouldHandleNegativeXPositiveY() {
+        assertThat(udf.atan2(-1.1, 0.24), is(-1.355980926393238));
+        assertThat(udf.atan2(-6.0, 7.1), is(-0.7016252196536817));
+        assertThat(udf.atan2(-2, 3), is(-0.5880026035475675));
+        assertThat(udf.atan2(-2L, 2L), is(-0.7853981633974483));
+    }
+
+    @Test
+    public void shouldHandleNegativeXZeroY() {
+        assertThat(udf.atan2(-1.1, 0.0), is(-1.5707963267948966));
+        assertThat(udf.atan2(-6.0, 0.0), is(-1.5707963267948966));
+        assertThat(udf.atan2(-2, 0), is(-1.5707963267948966));
+        assertThat(udf.atan2(-2L, 0L), is(-1.5707963267948966));
+    }
+
+    @Test
+    public void shouldHandleZeroXNegativeY() {
+        assertThat(udf.atan2(0.0, -0.24), is(3.141592653589793));
+        assertThat(udf.atan2(0.0, -7.1), is(3.141592653589793));
+        assertThat(udf.atan2(0, -3), is(3.141592653589793));
+        assertThat(udf.atan2(0L, -2L), is(3.141592653589793));
+    }
+
+    @Test
+    public void shouldHandleZeroXPositiveY() {
+        assertThat(udf.atan2(0.0, 0.24), is(0.0));
+        assertThat(udf.atan2(0.0, 7.1), is(0.0));
+        assertThat(udf.atan2(0, 3), is(0.0));
+        assertThat(udf.atan2(0L, 2L), is(0.0));
+    }
+
+    @Test
+    public void shouldHandleZeroXZeroY() {
+        assertThat(udf.atan2(0.0, 0.0), is(0.0));
+        assertThat(udf.atan2(0.0, 0.0), is(0.0));
+        assertThat(udf.atan2(0, 0), is(0.0));
+        assertThat(udf.atan2(0L, 0L), is(0.0));
+    }
+
+    @Test
+    public void shouldHandlePositiveXNegativeY() {
+        assertThat(udf.atan2(1.1, -0.24), is(1.7856117271965553));
+        assertThat(udf.atan2(6.0, -7.1), is(2.4399674339361113));
+        assertThat(udf.atan2(2, -3), is(2.5535900500422257));
+        assertThat(udf.atan2(2L, -2L), is(2.356194490192345));
+    }
+
+    @Test
+    public void shouldHandlePositiveXPositiveY() {
+        assertThat(udf.atan2(1.1, 0.24), is(1.355980926393238));
+        assertThat(udf.atan2(6.0, 7.1), is(0.7016252196536817));
+        assertThat(udf.atan2(2, 3), is(0.5880026035475675));
+        assertThat(udf.atan2(2L, 2L), is(0.7853981633974483));
+    }
+
+    @Test
+    public void shouldHandlePositiveXZeroY() {
+        assertThat(udf.atan2(1.1, 0.0), is(1.5707963267948966));
+        assertThat(udf.atan2(6.0, 0.0), is(1.5707963267948966));
+        assertThat(udf.atan2(2, 0), is(1.5707963267948966));
+        assertThat(udf.atan2(2L, 0L), is(1.5707963267948966));
+    }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/Atan2Test.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/Atan2Test.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.math;
 
 import org.junit.Before;
@@ -8,95 +22,95 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 public class Atan2Test {
-    private Atan2 udf;
+  private Atan2 udf;
 
-    @Before
-    public void setUp() {
-        udf = new Atan2();
-    }
+  @Before
+  public void setUp() {
+    udf = new Atan2();
+  }
 
-    @Test
-    public void shouldHandleNull() {
-        assertThat(udf.atan2(null, 1), is(nullValue()));
-        assertThat(udf.atan2(null, 1L), is(nullValue()));
-        assertThat(udf.atan2(null, 0.45), is(nullValue()));
-        assertThat(udf.atan2(1, null), is(nullValue()));
-        assertThat(udf.atan2(1L, null), is(nullValue()));
-        assertThat(udf.atan2(0.45, null), is(nullValue()));
-        assertThat(udf.atan2((Integer)null, null), is(nullValue()));
-        assertThat(udf.atan2((Long)null, null), is(nullValue()));
-        assertThat(udf.atan2((Double)null, null), is(nullValue()));
-    }
+  @Test
+  public void shouldHandleNull() {
+    assertThat(udf.atan2(null, 1), is(nullValue()));
+    assertThat(udf.atan2(null, 1L), is(nullValue()));
+    assertThat(udf.atan2(null, 0.45), is(nullValue()));
+    assertThat(udf.atan2(1, null), is(nullValue()));
+    assertThat(udf.atan2(1L, null), is(nullValue()));
+    assertThat(udf.atan2(0.45, null), is(nullValue()));
+    assertThat(udf.atan2((Integer) null, null), is(nullValue()));
+    assertThat(udf.atan2((Long) null, null), is(nullValue()));
+    assertThat(udf.atan2((Double) null, null), is(nullValue()));
+  }
 
-    @Test
-    public void shouldHandleNegativeYNegativeX() {
-        assertThat(udf.atan2(-1.1, -0.24), is(-1.7856117271965553));
-        assertThat(udf.atan2(-6.0, -7.1), is(-2.4399674339361113));
-        assertThat(udf.atan2(-2, -3), is(-2.5535900500422257));
-        assertThat(udf.atan2(-2L, -2L), is(-2.356194490192345));
-    }
+  @Test
+  public void shouldHandleNegativeYNegativeX() {
+    assertThat(udf.atan2(-1.1, -0.24), is(-1.7856117271965553));
+    assertThat(udf.atan2(-6.0, -7.1), is(-2.4399674339361113));
+    assertThat(udf.atan2(-2, -3), is(-2.5535900500422257));
+    assertThat(udf.atan2(-2L, -2L), is(-2.356194490192345));
+  }
 
-    @Test
-    public void shouldHandleNegativeYPositiveX() {
-        assertThat(udf.atan2(-1.1, 0.24), is(-1.355980926393238));
-        assertThat(udf.atan2(-6.0, 7.1), is(-0.7016252196536817));
-        assertThat(udf.atan2(-2, 3), is(-0.5880026035475675));
-        assertThat(udf.atan2(-2L, 2L), is(-0.7853981633974483));
-    }
+  @Test
+  public void shouldHandleNegativeYPositiveX() {
+    assertThat(udf.atan2(-1.1, 0.24), is(-1.355980926393238));
+    assertThat(udf.atan2(-6.0, 7.1), is(-0.7016252196536817));
+    assertThat(udf.atan2(-2, 3), is(-0.5880026035475675));
+    assertThat(udf.atan2(-2L, 2L), is(-0.7853981633974483));
+  }
 
-    @Test
-    public void shouldHandleNegativeYZeroX() {
-        assertThat(udf.atan2(-1.1, 0.0), is(-1.5707963267948966));
-        assertThat(udf.atan2(-6.0, 0.0), is(-1.5707963267948966));
-        assertThat(udf.atan2(-2, 0), is(-1.5707963267948966));
-        assertThat(udf.atan2(-2L, 0L), is(-1.5707963267948966));
-    }
+  @Test
+  public void shouldHandleNegativeYZeroX() {
+    assertThat(udf.atan2(-1.1, 0.0), is(-1.5707963267948966));
+    assertThat(udf.atan2(-6.0, 0.0), is(-1.5707963267948966));
+    assertThat(udf.atan2(-2, 0), is(-1.5707963267948966));
+    assertThat(udf.atan2(-2L, 0L), is(-1.5707963267948966));
+  }
 
-    @Test
-    public void shouldHandleZeroYNegativeX() {
-        assertThat(udf.atan2(0.0, -0.24), is(3.141592653589793));
-        assertThat(udf.atan2(0.0, -7.1), is(3.141592653589793));
-        assertThat(udf.atan2(0, -3), is(3.141592653589793));
-        assertThat(udf.atan2(0L, -2L), is(3.141592653589793));
-    }
+  @Test
+  public void shouldHandleZeroYNegativeX() {
+    assertThat(udf.atan2(0.0, -0.24), is(3.141592653589793));
+    assertThat(udf.atan2(0.0, -7.1), is(3.141592653589793));
+    assertThat(udf.atan2(0, -3), is(3.141592653589793));
+    assertThat(udf.atan2(0L, -2L), is(3.141592653589793));
+  }
 
-    @Test
-    public void shouldHandleZeroYPositiveX() {
-        assertThat(udf.atan2(0.0, 0.24), is(0.0));
-        assertThat(udf.atan2(0.0, 7.1), is(0.0));
-        assertThat(udf.atan2(0, 3), is(0.0));
-        assertThat(udf.atan2(0L, 2L), is(0.0));
-    }
+  @Test
+  public void shouldHandleZeroYPositiveX() {
+    assertThat(udf.atan2(0.0, 0.24), is(0.0));
+    assertThat(udf.atan2(0.0, 7.1), is(0.0));
+    assertThat(udf.atan2(0, 3), is(0.0));
+    assertThat(udf.atan2(0L, 2L), is(0.0));
+  }
 
-    @Test
-    public void shouldHandleZeroYZeroX() {
-        assertThat(udf.atan2(0.0, 0.0), is(0.0));
-        assertThat(udf.atan2(0.0, 0.0), is(0.0));
-        assertThat(udf.atan2(0, 0), is(0.0));
-        assertThat(udf.atan2(0L, 0L), is(0.0));
-    }
+  @Test
+  public void shouldHandleZeroYZeroX() {
+    assertThat(udf.atan2(0.0, 0.0), is(0.0));
+    assertThat(udf.atan2(0.0, 0.0), is(0.0));
+    assertThat(udf.atan2(0, 0), is(0.0));
+    assertThat(udf.atan2(0L, 0L), is(0.0));
+  }
 
-    @Test
-    public void shouldHandlePositiveYNegativeX() {
-        assertThat(udf.atan2(1.1, -0.24), is(1.7856117271965553));
-        assertThat(udf.atan2(6.0, -7.1), is(2.4399674339361113));
-        assertThat(udf.atan2(2, -3), is(2.5535900500422257));
-        assertThat(udf.atan2(2L, -2L), is(2.356194490192345));
-    }
+  @Test
+  public void shouldHandlePositiveYNegativeX() {
+    assertThat(udf.atan2(1.1, -0.24), is(1.7856117271965553));
+    assertThat(udf.atan2(6.0, -7.1), is(2.4399674339361113));
+    assertThat(udf.atan2(2, -3), is(2.5535900500422257));
+    assertThat(udf.atan2(2L, -2L), is(2.356194490192345));
+  }
 
-    @Test
-    public void shouldHandlePositiveYPositiveX() {
-        assertThat(udf.atan2(1.1, 0.24), is(1.355980926393238));
-        assertThat(udf.atan2(6.0, 7.1), is(0.7016252196536817));
-        assertThat(udf.atan2(2, 3), is(0.5880026035475675));
-        assertThat(udf.atan2(2L, 2L), is(0.7853981633974483));
-    }
+  @Test
+  public void shouldHandlePositiveYPositiveX() {
+    assertThat(udf.atan2(1.1, 0.24), is(1.355980926393238));
+    assertThat(udf.atan2(6.0, 7.1), is(0.7016252196536817));
+    assertThat(udf.atan2(2, 3), is(0.5880026035475675));
+    assertThat(udf.atan2(2L, 2L), is(0.7853981633974483));
+  }
 
-    @Test
-    public void shouldHandlePositiveYZeroX() {
-        assertThat(udf.atan2(1.1, 0.0), is(1.5707963267948966));
-        assertThat(udf.atan2(6.0, 0.0), is(1.5707963267948966));
-        assertThat(udf.atan2(2, 0), is(1.5707963267948966));
-        assertThat(udf.atan2(2L, 0L), is(1.5707963267948966));
-    }
+  @Test
+  public void shouldHandlePositiveYZeroX() {
+    assertThat(udf.atan2(1.1, 0.0), is(1.5707963267948966));
+    assertThat(udf.atan2(6.0, 0.0), is(1.5707963267948966));
+    assertThat(udf.atan2(2, 0), is(1.5707963267948966));
+    assertThat(udf.atan2(2L, 0L), is(1.5707963267948966));
+  }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/Atan2Test.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/Atan2Test.java
@@ -29,7 +29,7 @@ public class Atan2Test {
     }
 
     @Test
-    public void shouldHandleNegativeXNegativeY() {
+    public void shouldHandleNegativeYNegativeX() {
         assertThat(udf.atan2(-1.1, -0.24), is(-1.7856117271965553));
         assertThat(udf.atan2(-6.0, -7.1), is(-2.4399674339361113));
         assertThat(udf.atan2(-2, -3), is(-2.5535900500422257));
@@ -37,7 +37,7 @@ public class Atan2Test {
     }
 
     @Test
-    public void shouldHandleNegativeXPositiveY() {
+    public void shouldHandleNegativeYPositiveX() {
         assertThat(udf.atan2(-1.1, 0.24), is(-1.355980926393238));
         assertThat(udf.atan2(-6.0, 7.1), is(-0.7016252196536817));
         assertThat(udf.atan2(-2, 3), is(-0.5880026035475675));
@@ -45,7 +45,7 @@ public class Atan2Test {
     }
 
     @Test
-    public void shouldHandleNegativeXZeroY() {
+    public void shouldHandleNegativeYZeroX() {
         assertThat(udf.atan2(-1.1, 0.0), is(-1.5707963267948966));
         assertThat(udf.atan2(-6.0, 0.0), is(-1.5707963267948966));
         assertThat(udf.atan2(-2, 0), is(-1.5707963267948966));
@@ -53,7 +53,7 @@ public class Atan2Test {
     }
 
     @Test
-    public void shouldHandleZeroXNegativeY() {
+    public void shouldHandleZeroYNegativeX() {
         assertThat(udf.atan2(0.0, -0.24), is(3.141592653589793));
         assertThat(udf.atan2(0.0, -7.1), is(3.141592653589793));
         assertThat(udf.atan2(0, -3), is(3.141592653589793));
@@ -61,7 +61,7 @@ public class Atan2Test {
     }
 
     @Test
-    public void shouldHandleZeroXPositiveY() {
+    public void shouldHandleZeroYPositiveX() {
         assertThat(udf.atan2(0.0, 0.24), is(0.0));
         assertThat(udf.atan2(0.0, 7.1), is(0.0));
         assertThat(udf.atan2(0, 3), is(0.0));
@@ -69,7 +69,7 @@ public class Atan2Test {
     }
 
     @Test
-    public void shouldHandleZeroXZeroY() {
+    public void shouldHandleZeroYZeroX() {
         assertThat(udf.atan2(0.0, 0.0), is(0.0));
         assertThat(udf.atan2(0.0, 0.0), is(0.0));
         assertThat(udf.atan2(0, 0), is(0.0));
@@ -77,7 +77,7 @@ public class Atan2Test {
     }
 
     @Test
-    public void shouldHandlePositiveXNegativeY() {
+    public void shouldHandlePositiveYNegativeX() {
         assertThat(udf.atan2(1.1, -0.24), is(1.7856117271965553));
         assertThat(udf.atan2(6.0, -7.1), is(2.4399674339361113));
         assertThat(udf.atan2(2, -3), is(2.5535900500422257));
@@ -85,7 +85,7 @@ public class Atan2Test {
     }
 
     @Test
-    public void shouldHandlePositiveXPositiveY() {
+    public void shouldHandlePositiveYPositiveX() {
         assertThat(udf.atan2(1.1, 0.24), is(1.355980926393238));
         assertThat(udf.atan2(6.0, 7.1), is(0.7016252196536817));
         assertThat(udf.atan2(2, 3), is(0.5880026035475675));
@@ -93,7 +93,7 @@ public class Atan2Test {
     }
 
     @Test
-    public void shouldHandlePositiveXZeroY() {
+    public void shouldHandlePositiveYZeroX() {
         assertThat(udf.atan2(1.1, 0.0), is(1.5707963267948966));
         assertThat(udf.atan2(6.0, 0.0), is(1.5707963267948966));
         assertThat(udf.atan2(2, 0), is(1.5707963267948966));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/AtanTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/AtanTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.math;
 
 import org.junit.Before;
@@ -8,58 +22,58 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 public class AtanTest {
-    private Atan udf;
+  private Atan udf;
 
-    @Before
-    public void setUp() {
-        udf = new Atan();
-    }
+  @Before
+  public void setUp() {
+    udf = new Atan();
+  }
 
-    @Test
-    public void shouldHandleNull() {
-        assertThat(udf.atan((Integer)null), is(nullValue()));
-        assertThat(udf.atan((Long)null), is(nullValue()));
-        assertThat(udf.atan((Double)null), is(nullValue()));
-    }
+  @Test
+  public void shouldHandleNull() {
+    assertThat(udf.atan((Integer) null), is(nullValue()));
+    assertThat(udf.atan((Long) null), is(nullValue()));
+    assertThat(udf.atan((Double) null), is(nullValue()));
+  }
 
-    @Test
-    public void shouldHandleLessThanNegativeOne() {
-        assertThat(udf.atan(-1.1), is(-0.8329812666744317));
-        assertThat(udf.atan(-6.0), is(-1.4056476493802699));
-        assertThat(udf.atan(-2), is(-1.1071487177940904));
-        assertThat(udf.atan(-2L), is(-1.1071487177940904));
-    }
+  @Test
+  public void shouldHandleLessThanNegativeOne() {
+    assertThat(udf.atan(-1.1), is(-0.8329812666744317));
+    assertThat(udf.atan(-6.0), is(-1.4056476493802699));
+    assertThat(udf.atan(-2), is(-1.1071487177940904));
+    assertThat(udf.atan(-2L), is(-1.1071487177940904));
+  }
 
-    @Test
-    public void shouldHandleNegative() {
-        assertThat(udf.atan(-0.43), is(-0.40609805831761564));
-        assertThat(udf.atan(-0.5), is(-0.4636476090008061));
-        assertThat(udf.atan(-1.0), is(-0.7853981633974483));
-        assertThat(udf.atan(-1), is(-0.7853981633974483));
-        assertThat(udf.atan(-1L), is(-0.7853981633974483));
-    }
+  @Test
+  public void shouldHandleNegative() {
+    assertThat(udf.atan(-0.43), is(-0.40609805831761564));
+    assertThat(udf.atan(-0.5), is(-0.4636476090008061));
+    assertThat(udf.atan(-1.0), is(-0.7853981633974483));
+    assertThat(udf.atan(-1), is(-0.7853981633974483));
+    assertThat(udf.atan(-1L), is(-0.7853981633974483));
+  }
 
-    @Test
-    public void shouldHandleZero() {
-        assertThat(udf.atan(0.0), is(0.0));
-        assertThat(udf.atan(0), is(0.0));
-        assertThat(udf.atan(0L), is(0.0));
-    }
+  @Test
+  public void shouldHandleZero() {
+    assertThat(udf.atan(0.0), is(0.0));
+    assertThat(udf.atan(0), is(0.0));
+    assertThat(udf.atan(0L), is(0.0));
+  }
 
-    @Test
-    public void shouldHandlePositive() {
-        assertThat(udf.atan(0.43), is(0.40609805831761564));
-        assertThat(udf.atan(0.5), is(0.4636476090008061));
-        assertThat(udf.atan(1.0), is(0.7853981633974483));
-        assertThat(udf.atan(1), is(0.7853981633974483));
-        assertThat(udf.atan(1L), is(0.7853981633974483));
-    }
+  @Test
+  public void shouldHandlePositive() {
+    assertThat(udf.atan(0.43), is(0.40609805831761564));
+    assertThat(udf.atan(0.5), is(0.4636476090008061));
+    assertThat(udf.atan(1.0), is(0.7853981633974483));
+    assertThat(udf.atan(1), is(0.7853981633974483));
+    assertThat(udf.atan(1L), is(0.7853981633974483));
+  }
 
-    @Test
-    public void shouldHandleMoreThanPositiveOne() {
-        assertThat(udf.atan(1.1), is(0.8329812666744317));
-        assertThat(udf.atan(6.0), is(1.4056476493802699));
-        assertThat(udf.atan(2), is(1.1071487177940904));
-        assertThat(udf.atan(2L), is(1.1071487177940904));
-    }
+  @Test
+  public void shouldHandleMoreThanPositiveOne() {
+    assertThat(udf.atan(1.1), is(0.8329812666744317));
+    assertThat(udf.atan(6.0), is(1.4056476493802699));
+    assertThat(udf.atan(2), is(1.1071487177940904));
+    assertThat(udf.atan(2L), is(1.1071487177940904));
+  }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/AtanTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/AtanTest.java
@@ -1,0 +1,65 @@
+package io.confluent.ksql.function.udf.math;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class AtanTest {
+    private Atan udf;
+
+    @Before
+    public void setUp() {
+        udf = new Atan();
+    }
+
+    @Test
+    public void shouldHandleNull() {
+        assertThat(udf.atan((Integer)null), is(nullValue()));
+        assertThat(udf.atan((Long)null), is(nullValue()));
+        assertThat(udf.atan((Double)null), is(nullValue()));
+    }
+
+    @Test
+    public void shouldHandleLessThanNegativeOne() {
+        assertThat(udf.atan(-1.1), is(-0.8329812666744317));
+        assertThat(udf.atan(-6.0), is(-1.4056476493802699));
+        assertThat(udf.atan(-2), is(-1.1071487177940904));
+        assertThat(udf.atan(-2L), is(-1.1071487177940904));
+    }
+
+    @Test
+    public void shouldHandleNegative() {
+        assertThat(udf.atan(-0.43), is(-0.40609805831761564));
+        assertThat(udf.atan(-0.5), is(-0.4636476090008061));
+        assertThat(udf.atan(-1.0), is(-0.7853981633974483));
+        assertThat(udf.atan(-1), is(-0.7853981633974483));
+        assertThat(udf.atan(-1L), is(-0.7853981633974483));
+    }
+
+    @Test
+    public void shouldHandleZero() {
+        assertThat(udf.atan(0.0), is(0.0));
+        assertThat(udf.atan(0), is(0.0));
+        assertThat(udf.atan(0L), is(0.0));
+    }
+
+    @Test
+    public void shouldHandlePositive() {
+        assertThat(udf.atan(0.43), is(0.40609805831761564));
+        assertThat(udf.atan(0.5), is(0.4636476090008061));
+        assertThat(udf.atan(1.0), is(0.7853981633974483));
+        assertThat(udf.atan(1), is(0.7853981633974483));
+        assertThat(udf.atan(1L), is(0.7853981633974483));
+    }
+
+    @Test
+    public void shouldHandleMoreThanPositiveOne() {
+        assertThat(udf.atan(1.1), is(0.8329812666744317));
+        assertThat(udf.atan(6.0), is(1.4056476493802699));
+        assertThat(udf.atan(2), is(1.1071487177940904));
+        assertThat(udf.atan(2L), is(1.1071487177940904));
+    }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/CosTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/CosTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.math;
 
 import org.junit.Before;
@@ -8,58 +22,58 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 public class CosTest {
-    private Cos udf;
+  private Cos udf;
 
-    @Before
-    public void setUp() {
-        udf = new Cos();
-    }
+  @Before
+  public void setUp() {
+    udf = new Cos();
+  }
 
-    @Test
-    public void shouldHandleNull() {
-        assertThat(udf.cos((Integer)null), is(nullValue()));
-        assertThat(udf.cos((Long)null), is(nullValue()));
-        assertThat(udf.cos((Double)null), is(nullValue()));
-    }
+  @Test
+  public void shouldHandleNull() {
+    assertThat(udf.cos((Integer) null), is(nullValue()));
+    assertThat(udf.cos((Long) null), is(nullValue()));
+    assertThat(udf.cos((Double) null), is(nullValue()));
+  }
 
-    @Test
-    public void shouldHandleLessThanNegative2Pi() {
-        assertThat(udf.cos(-9.1), is(-0.9477216021311119));
-        assertThat(udf.cos(-6.3), is(0.9998586363834151));
-        assertThat(udf.cos(-7), is(0.7539022543433046));
-        assertThat(udf.cos(-7L), is(0.7539022543433046));
-    }
+  @Test
+  public void shouldHandleLessThanNegative2Pi() {
+    assertThat(udf.cos(-9.1), is(-0.9477216021311119));
+    assertThat(udf.cos(-6.3), is(0.9998586363834151));
+    assertThat(udf.cos(-7), is(0.7539022543433046));
+    assertThat(udf.cos(-7L), is(0.7539022543433046));
+  }
 
-    @Test
-    public void shouldHandleNegative() {
-        assertThat(udf.cos(-0.43), is(0.9089657496748851));
-        assertThat(udf.cos(-3.14159265), is(-1.0));
-        assertThat(udf.cos(-6.28318531), is(1.0));
-        assertThat(udf.cos(-6), is(0.960170286650366));
-        assertThat(udf.cos(-6L), is(0.960170286650366));
-    }
+  @Test
+  public void shouldHandleNegative() {
+    assertThat(udf.cos(-0.43), is(0.9089657496748851));
+    assertThat(udf.cos(-3.14159265), is(-1.0));
+    assertThat(udf.cos(-6.28318531), is(1.0));
+    assertThat(udf.cos(-6), is(0.960170286650366));
+    assertThat(udf.cos(-6L), is(0.960170286650366));
+  }
 
-    @Test
-    public void shouldHandleZero() {
-        assertThat(udf.cos(0.0), is(1.0));
-        assertThat(udf.cos(0), is(1.0));
-        assertThat(udf.cos(0L), is(1.0));
-    }
+  @Test
+  public void shouldHandleZero() {
+    assertThat(udf.cos(0.0), is(1.0));
+    assertThat(udf.cos(0), is(1.0));
+    assertThat(udf.cos(0L), is(1.0));
+  }
 
-    @Test
-    public void shouldHandlePositive() {
-        assertThat(udf.cos(0.43), is(0.9089657496748851));
-        assertThat(udf.cos(3.14159265), is(-1.0));
-        assertThat(udf.cos(6.28318531), is(1.0));
-        assertThat(udf.cos(6), is(0.960170286650366));
-        assertThat(udf.cos(6L), is(0.960170286650366));
-    }
+  @Test
+  public void shouldHandlePositive() {
+    assertThat(udf.cos(0.43), is(0.9089657496748851));
+    assertThat(udf.cos(3.14159265), is(-1.0));
+    assertThat(udf.cos(6.28318531), is(1.0));
+    assertThat(udf.cos(6), is(0.960170286650366));
+    assertThat(udf.cos(6L), is(0.960170286650366));
+  }
 
-    @Test
-    public void shouldHandleMoreThanPositive2Pi() {
-        assertThat(udf.cos(9.1), is(-0.9477216021311119));
-        assertThat(udf.cos(6.3), is(0.9998586363834151));
-        assertThat(udf.cos(7), is(0.7539022543433046));
-        assertThat(udf.cos(7L), is(0.7539022543433046));
-    }
+  @Test
+  public void shouldHandleMoreThanPositive2Pi() {
+    assertThat(udf.cos(9.1), is(-0.9477216021311119));
+    assertThat(udf.cos(6.3), is(0.9998586363834151));
+    assertThat(udf.cos(7), is(0.7539022543433046));
+    assertThat(udf.cos(7L), is(0.7539022543433046));
+  }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/CosTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/CosTest.java
@@ -1,0 +1,65 @@
+package io.confluent.ksql.function.udf.math;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class CosTest {
+    private Cos udf;
+
+    @Before
+    public void setUp() {
+        udf = new Cos();
+    }
+
+    @Test
+    public void shouldHandleNull() {
+        assertThat(udf.cos((Integer)null), is(nullValue()));
+        assertThat(udf.cos((Long)null), is(nullValue()));
+        assertThat(udf.cos((Double)null), is(nullValue()));
+    }
+
+    @Test
+    public void shouldHandleLessThanNegative2Pi() {
+        assertThat(udf.cos(-9.1), is(-0.9477216021311119));
+        assertThat(udf.cos(-6.3), is(0.9998586363834151));
+        assertThat(udf.cos(-7), is(0.7539022543433046));
+        assertThat(udf.cos(-7L), is(0.7539022543433046));
+    }
+
+    @Test
+    public void shouldHandleNegative() {
+        assertThat(udf.cos(-0.43), is(0.9089657496748851));
+        assertThat(udf.cos(-3.14159265), is(-1.0));
+        assertThat(udf.cos(-6.28318531), is(1.0));
+        assertThat(udf.cos(-6), is(0.960170286650366));
+        assertThat(udf.cos(-6L), is(0.960170286650366));
+    }
+
+    @Test
+    public void shouldHandleZero() {
+        assertThat(udf.cos(0.0), is(1.0));
+        assertThat(udf.cos(0), is(1.0));
+        assertThat(udf.cos(0L), is(1.0));
+    }
+
+    @Test
+    public void shouldHandlePositive() {
+        assertThat(udf.cos(0.43), is(0.9089657496748851));
+        assertThat(udf.cos(3.14159265), is(-1.0));
+        assertThat(udf.cos(6.28318531), is(1.0));
+        assertThat(udf.cos(6), is(0.960170286650366));
+        assertThat(udf.cos(6L), is(0.960170286650366));
+    }
+
+    @Test
+    public void shouldHandleMoreThanPositive2Pi() {
+        assertThat(udf.cos(9.1), is(-0.9477216021311119));
+        assertThat(udf.cos(6.3), is(0.9998586363834151));
+        assertThat(udf.cos(7), is(0.7539022543433046));
+        assertThat(udf.cos(7L), is(0.7539022543433046));
+    }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/CosTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/CosTest.java
@@ -47,8 +47,8 @@ public class CosTest {
   @Test
   public void shouldHandleNegative() {
     assertThat(udf.cos(-0.43), is(0.9089657496748851));
-    assertThat(udf.cos(-3.14159265), is(-1.0));
-    assertThat(udf.cos(-6.28318531), is(1.0));
+    assertThat(udf.cos(-Math.PI), is(-1.0));
+    assertThat(udf.cos(-2 * Math.PI), is(1.0));
     assertThat(udf.cos(-6), is(0.960170286650366));
     assertThat(udf.cos(-6L), is(0.960170286650366));
   }
@@ -63,8 +63,8 @@ public class CosTest {
   @Test
   public void shouldHandlePositive() {
     assertThat(udf.cos(0.43), is(0.9089657496748851));
-    assertThat(udf.cos(3.14159265), is(-1.0));
-    assertThat(udf.cos(6.28318531), is(1.0));
+    assertThat(udf.cos(Math.PI), is(-1.0));
+    assertThat(udf.cos(2 * Math.PI), is(1.0));
     assertThat(udf.cos(6), is(0.960170286650366));
     assertThat(udf.cos(6L), is(0.960170286650366));
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/CoshTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/CoshTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.math;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class CoshTest {
+  private Cosh udf;
+
+  @Before
+  public void setUp() {
+    udf = new Cosh();
+  }
+
+  @Test
+  public void shouldHandleNull() {
+    assertThat(udf.cosh((Integer) null), is(nullValue()));
+    assertThat(udf.cosh((Long) null), is(nullValue()));
+    assertThat(udf.cosh((Double) null), is(nullValue()));
+  }
+
+  @Test
+  public void shouldHandleLessThanNegative2Pi() {
+    assertThat(udf.cosh(-9.1), is(4477.646407574158));
+    assertThat(udf.cosh(-6.3), is(272.286873215353));
+    assertThat(udf.cosh(-7), is(548.317035155212));
+    assertThat(udf.cosh(-7L), is(548.317035155212));
+  }
+
+  @Test
+  public void shouldHandleNegative() {
+    assertThat(udf.cosh(-0.43), is(1.0938833091357991));
+    assertThat(udf.cosh(-Math.PI), is(11.591953275521519));
+    assertThat(udf.cosh(-Math.PI * 2), is(267.7467614837482));
+    assertThat(udf.cosh(-6), is(201.7156361224559));
+    assertThat(udf.cosh(-6L), is(201.7156361224559));
+  }
+
+  @Test
+  public void shouldHandleZero() {
+    assertThat(udf.cosh(0.0), is(1.0));
+    assertThat(udf.cosh(0), is(1.0));
+    assertThat(udf.cosh(0L), is(1.0));
+  }
+
+  @Test
+  public void shouldHandlePositive() {
+    assertThat(udf.cosh(0.43), is(1.0938833091357991));
+    assertThat(udf.cosh(Math.PI), is(11.591953275521519));
+    assertThat(udf.cosh(Math.PI * 2), is(267.7467614837482));
+    assertThat(udf.cosh(6), is(201.7156361224559));
+    assertThat(udf.cosh(6L), is(201.7156361224559));
+  }
+
+  @Test
+  public void shouldHandleMoreThanPositive2Pi() {
+    assertThat(udf.cosh(9.1), is(4477.646407574158));
+    assertThat(udf.cosh(6.3), is(272.286873215353));
+    assertThat(udf.cosh(7), is(548.317035155212));
+    assertThat(udf.cosh(7L), is(548.317035155212));
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/CotTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/CotTest.java
@@ -1,0 +1,65 @@
+package io.confluent.ksql.function.udf.math;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class CotTest {
+    private Cot udf;
+
+    @Before
+    public void setUp() {
+        udf = new Cot();
+    }
+
+    @Test
+    public void shouldHandleNull() {
+        assertThat(udf.cot((Integer)null), is(nullValue()));
+        assertThat(udf.cot((Long)null), is(nullValue()));
+        assertThat(udf.cot((Double)null), is(nullValue()));
+    }
+
+    @Test
+    public void shouldHandleLessThanNegative2Pi() {
+        assertThat(udf.cot(-9.1), is(2.9699983263892054));
+        assertThat(udf.cot(-6.3), is(-59.46619211372627));
+        assertThat(udf.cot(-7), is(-1.1475154224051356));
+        assertThat(udf.cot(-7L), is(-1.1475154224051356));
+    }
+
+    @Test
+    public void shouldHandleNegative() {
+        assertThat(udf.cot(-0.43), is(-2.1804495406685085));
+        assertThat(udf.cot(-Math.PI), is(8.165619676597685E15));
+        assertThat(udf.cot(-Math.PI * 2), is(4.0828098382988425E15));
+        assertThat(udf.cot(-6), is(3.436353004180128));
+        assertThat(udf.cot(-6L), is(3.436353004180128));
+    }
+
+    @Test
+    public void shouldHandleZero() {
+        assertThat(Double.isInfinite(udf.cot(0.0)), is(true));
+        assertThat(Double.isInfinite(udf.cot(0)), is(true));
+        assertThat(Double.isInfinite(udf.cot(0L)), is(true));
+    }
+
+    @Test
+    public void shouldHandlePositive() {
+        assertThat(udf.cot(0.43), is(2.1804495406685085));
+        assertThat(udf.cot(Math.PI), is(-8.165619676597685E15));
+        assertThat(udf.cot(Math.PI * 2), is(-4.0828098382988425E15));
+        assertThat(udf.cot(6), is(-3.436353004180128));
+        assertThat(udf.cot(6L), is(-3.436353004180128));
+    }
+
+    @Test
+    public void shouldHandleMoreThanPositive2Pi() {
+        assertThat(udf.cot(9.1), is(-2.9699983263892054));
+        assertThat(udf.cot(6.3), is(59.46619211372627));
+        assertThat(udf.cot(7), is(1.1475154224051356));
+        assertThat(udf.cot(7L), is(1.1475154224051356));
+    }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/CotTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/CotTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.math;
 
 import org.junit.Before;
@@ -8,58 +22,58 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 public class CotTest {
-    private Cot udf;
+  private Cot udf;
 
-    @Before
-    public void setUp() {
-        udf = new Cot();
-    }
+  @Before
+  public void setUp() {
+    udf = new Cot();
+  }
 
-    @Test
-    public void shouldHandleNull() {
-        assertThat(udf.cot((Integer)null), is(nullValue()));
-        assertThat(udf.cot((Long)null), is(nullValue()));
-        assertThat(udf.cot((Double)null), is(nullValue()));
-    }
+  @Test
+  public void shouldHandleNull() {
+    assertThat(udf.cot((Integer) null), is(nullValue()));
+    assertThat(udf.cot((Long) null), is(nullValue()));
+    assertThat(udf.cot((Double) null), is(nullValue()));
+  }
 
-    @Test
-    public void shouldHandleLessThanNegative2Pi() {
-        assertThat(udf.cot(-9.1), is(2.9699983263892054));
-        assertThat(udf.cot(-6.3), is(-59.46619211372627));
-        assertThat(udf.cot(-7), is(-1.1475154224051356));
-        assertThat(udf.cot(-7L), is(-1.1475154224051356));
-    }
+  @Test
+  public void shouldHandleLessThanNegative2Pi() {
+    assertThat(udf.cot(-9.1), is(2.9699983263892054));
+    assertThat(udf.cot(-6.3), is(-59.46619211372627));
+    assertThat(udf.cot(-7), is(-1.1475154224051356));
+    assertThat(udf.cot(-7L), is(-1.1475154224051356));
+  }
 
-    @Test
-    public void shouldHandleNegative() {
-        assertThat(udf.cot(-0.43), is(-2.1804495406685085));
-        assertThat(udf.cot(-Math.PI), is(8.165619676597685E15));
-        assertThat(udf.cot(-Math.PI * 2), is(4.0828098382988425E15));
-        assertThat(udf.cot(-6), is(3.436353004180128));
-        assertThat(udf.cot(-6L), is(3.436353004180128));
-    }
+  @Test
+  public void shouldHandleNegative() {
+    assertThat(udf.cot(-0.43), is(-2.1804495406685085));
+    assertThat(udf.cot(-Math.PI), is(8.165619676597685E15));
+    assertThat(udf.cot(-Math.PI * 2), is(4.0828098382988425E15));
+    assertThat(udf.cot(-6), is(3.436353004180128));
+    assertThat(udf.cot(-6L), is(3.436353004180128));
+  }
 
-    @Test
-    public void shouldHandleZero() {
-        assertThat(Double.isInfinite(udf.cot(0.0)), is(true));
-        assertThat(Double.isInfinite(udf.cot(0)), is(true));
-        assertThat(Double.isInfinite(udf.cot(0L)), is(true));
-    }
+  @Test
+  public void shouldHandleZero() {
+    assertThat(Double.isInfinite(udf.cot(0.0)), is(true));
+    assertThat(Double.isInfinite(udf.cot(0)), is(true));
+    assertThat(Double.isInfinite(udf.cot(0L)), is(true));
+  }
 
-    @Test
-    public void shouldHandlePositive() {
-        assertThat(udf.cot(0.43), is(2.1804495406685085));
-        assertThat(udf.cot(Math.PI), is(-8.165619676597685E15));
-        assertThat(udf.cot(Math.PI * 2), is(-4.0828098382988425E15));
-        assertThat(udf.cot(6), is(-3.436353004180128));
-        assertThat(udf.cot(6L), is(-3.436353004180128));
-    }
+  @Test
+  public void shouldHandlePositive() {
+    assertThat(udf.cot(0.43), is(2.1804495406685085));
+    assertThat(udf.cot(Math.PI), is(-8.165619676597685E15));
+    assertThat(udf.cot(Math.PI * 2), is(-4.0828098382988425E15));
+    assertThat(udf.cot(6), is(-3.436353004180128));
+    assertThat(udf.cot(6L), is(-3.436353004180128));
+  }
 
-    @Test
-    public void shouldHandleMoreThanPositive2Pi() {
-        assertThat(udf.cot(9.1), is(-2.9699983263892054));
-        assertThat(udf.cot(6.3), is(59.46619211372627));
-        assertThat(udf.cot(7), is(1.1475154224051356));
-        assertThat(udf.cot(7L), is(1.1475154224051356));
-    }
+  @Test
+  public void shouldHandleMoreThanPositive2Pi() {
+    assertThat(udf.cot(9.1), is(-2.9699983263892054));
+    assertThat(udf.cot(6.3), is(59.46619211372627));
+    assertThat(udf.cot(7), is(1.1475154224051356));
+    assertThat(udf.cot(7L), is(1.1475154224051356));
+  }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/DegreesTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/DegreesTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.math;
 
 import org.junit.Before;
@@ -8,42 +22,42 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 public class DegreesTest {
-    private Degrees udf;
+  private Degrees udf;
 
-    @Before
-    public void setUp() {
-        udf = new Degrees();
-    }
+  @Before
+  public void setUp() {
+    udf = new Degrees();
+  }
 
-    @Test
-    public void shouldHandleNull() {
-        assertThat(udf.degrees((Integer)null), is(nullValue()));
-        assertThat(udf.degrees((Long)null), is(nullValue()));
-        assertThat(udf.degrees((Double)null), is(nullValue()));
-    }
+  @Test
+  public void shouldHandleNull() {
+    assertThat(udf.degrees((Integer) null), is(nullValue()));
+    assertThat(udf.degrees((Long) null), is(nullValue()));
+    assertThat(udf.degrees((Double) null), is(nullValue()));
+  }
 
-    @Test
-    public void shouldHandleNegative() {
-        assertThat(udf.degrees(-Math.PI), is(-180.0));
-        assertThat(udf.degrees(-2 * Math.PI), is(-360.0));
-        assertThat(udf.degrees(-1.2345), is(-70.73163980890013));
-        assertThat(udf.degrees(-2), is(-114.59155902616465));
-        assertThat(udf.degrees(-2L), is(-114.59155902616465));
-    }
+  @Test
+  public void shouldHandleNegative() {
+    assertThat(udf.degrees(-Math.PI), is(-180.0));
+    assertThat(udf.degrees(-2 * Math.PI), is(-360.0));
+    assertThat(udf.degrees(-1.2345), is(-70.73163980890013));
+    assertThat(udf.degrees(-2), is(-114.59155902616465));
+    assertThat(udf.degrees(-2L), is(-114.59155902616465));
+  }
 
-    @Test
-    public void shouldHandleZero() {
-        assertThat(udf.degrees(0), is(0.0));
-        assertThat(udf.degrees(0L), is(0.0));
-        assertThat(udf.degrees(0.0), is(0.0));
-    }
+  @Test
+  public void shouldHandleZero() {
+    assertThat(udf.degrees(0), is(0.0));
+    assertThat(udf.degrees(0L), is(0.0));
+    assertThat(udf.degrees(0.0), is(0.0));
+  }
 
-    @Test
-    public void shouldHandlePositive() {
-        assertThat(udf.degrees(Math.PI), is(180.0));
-        assertThat(udf.degrees(2 * Math.PI), is(360.0));
-        assertThat(udf.degrees(1.2345), is(70.73163980890013));
-        assertThat(udf.degrees(2), is(114.59155902616465));
-        assertThat(udf.degrees(2L), is(114.59155902616465));
-    }
+  @Test
+  public void shouldHandlePositive() {
+    assertThat(udf.degrees(Math.PI), is(180.0));
+    assertThat(udf.degrees(2 * Math.PI), is(360.0));
+    assertThat(udf.degrees(1.2345), is(70.73163980890013));
+    assertThat(udf.degrees(2), is(114.59155902616465));
+    assertThat(udf.degrees(2L), is(114.59155902616465));
+  }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/DegreesTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/DegreesTest.java
@@ -1,0 +1,49 @@
+package io.confluent.ksql.function.udf.math;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class DegreesTest {
+    private Degrees udf;
+
+    @Before
+    public void setUp() {
+        udf = new Degrees();
+    }
+
+    @Test
+    public void shouldHandleNull() {
+        assertThat(udf.degrees((Integer)null), is(nullValue()));
+        assertThat(udf.degrees((Long)null), is(nullValue()));
+        assertThat(udf.degrees((Double)null), is(nullValue()));
+    }
+
+    @Test
+    public void shouldHandleNegative() {
+        assertThat(udf.degrees(-Math.PI), is(-180.0));
+        assertThat(udf.degrees(-2 * Math.PI), is(-360.0));
+        assertThat(udf.degrees(-1.2345), is(-70.73163980890013));
+        assertThat(udf.degrees(-2), is(-114.59155902616465));
+        assertThat(udf.degrees(-2L), is(-114.59155902616465));
+    }
+
+    @Test
+    public void shouldHandleZero() {
+        assertThat(udf.degrees(0), is(0.0));
+        assertThat(udf.degrees(0L), is(0.0));
+        assertThat(udf.degrees(0.0), is(0.0));
+    }
+
+    @Test
+    public void shouldHandlePositive() {
+        assertThat(udf.degrees(Math.PI), is(180.0));
+        assertThat(udf.degrees(2 * Math.PI), is(360.0));
+        assertThat(udf.degrees(1.2345), is(70.73163980890013));
+        assertThat(udf.degrees(2), is(114.59155902616465));
+        assertThat(udf.degrees(2L), is(114.59155902616465));
+    }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/PiTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/PiTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.math;
 
 import org.junit.Before;
@@ -7,15 +21,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class PiTest {
-    private Pi udf;
+  private Pi udf;
 
-    @Before
-    public void setUp() {
-        udf = new Pi();
-    }
+  @Before
+  public void setUp() {
+    udf = new Pi();
+  }
 
-    @Test
-    public void shouldReturnPi() {
-        assertThat(udf.pi(), is(Math.PI));
-    }
+  @Test
+  public void shouldReturnPi() {
+    assertThat(udf.pi(), is(Math.PI));
+  }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/PiTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/PiTest.java
@@ -1,0 +1,21 @@
+package io.confluent.ksql.function.udf.math;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class PiTest {
+    private Pi udf;
+
+    @Before
+    public void setUp() {
+        udf = new Pi();
+    }
+
+    @Test
+    public void shouldReturnPi() {
+        assertThat(udf.pi(), is(Math.PI));
+    }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/RadiansTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/RadiansTest.java
@@ -1,0 +1,49 @@
+package io.confluent.ksql.function.udf.math;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class RadiansTest {
+    private Radians udf;
+
+    @Before
+    public void setUp() {
+        udf = new Radians();
+    }
+
+    @Test
+    public void shouldHandleNull() {
+        assertThat(udf.radians((Integer)null), is(nullValue()));
+        assertThat(udf.radians((Long)null), is(nullValue()));
+        assertThat(udf.radians((Double)null), is(nullValue()));
+    }
+
+    @Test
+    public void shouldHandleNegative() {
+        assertThat(udf.radians(-180.0), is(-Math.PI));
+        assertThat(udf.radians(-360.0), is(-2 * Math.PI));
+        assertThat(udf.radians(-70.73163980890013), is(-1.2345));
+        assertThat(udf.radians(-114), is(-1.9896753472735358));
+        assertThat(udf.radians(-114L), is(-1.9896753472735358));
+    }
+
+    @Test
+    public void shouldHandleZero() {
+        assertThat(udf.radians(0), is(0.0));
+        assertThat(udf.radians(0L), is(0.0));
+        assertThat(udf.radians(0.0), is(0.0));
+    }
+
+    @Test
+    public void shouldHandlePositive() {
+        assertThat(udf.radians(180.0), is(Math.PI));
+        assertThat(udf.radians(360.0), is(2 * Math.PI));
+        assertThat(udf.radians(70.73163980890013), is(1.2345));
+        assertThat(udf.radians(114), is(1.9896753472735358));
+        assertThat(udf.radians(114L), is(1.9896753472735358));
+    }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/RadiansTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/RadiansTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.math;
 
 import org.junit.Before;
@@ -8,42 +22,42 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 public class RadiansTest {
-    private Radians udf;
+  private Radians udf;
 
-    @Before
-    public void setUp() {
-        udf = new Radians();
-    }
+  @Before
+  public void setUp() {
+    udf = new Radians();
+  }
 
-    @Test
-    public void shouldHandleNull() {
-        assertThat(udf.radians((Integer)null), is(nullValue()));
-        assertThat(udf.radians((Long)null), is(nullValue()));
-        assertThat(udf.radians((Double)null), is(nullValue()));
-    }
+  @Test
+  public void shouldHandleNull() {
+    assertThat(udf.radians((Integer) null), is(nullValue()));
+    assertThat(udf.radians((Long) null), is(nullValue()));
+    assertThat(udf.radians((Double) null), is(nullValue()));
+  }
 
-    @Test
-    public void shouldHandleNegative() {
-        assertThat(udf.radians(-180.0), is(-Math.PI));
-        assertThat(udf.radians(-360.0), is(-2 * Math.PI));
-        assertThat(udf.radians(-70.73163980890013), is(-1.2345));
-        assertThat(udf.radians(-114), is(-1.9896753472735358));
-        assertThat(udf.radians(-114L), is(-1.9896753472735358));
-    }
+  @Test
+  public void shouldHandleNegative() {
+    assertThat(udf.radians(-180.0), is(-Math.PI));
+    assertThat(udf.radians(-360.0), is(-2 * Math.PI));
+    assertThat(udf.radians(-70.73163980890013), is(-1.2345));
+    assertThat(udf.radians(-114), is(-1.9896753472735358));
+    assertThat(udf.radians(-114L), is(-1.9896753472735358));
+  }
 
-    @Test
-    public void shouldHandleZero() {
-        assertThat(udf.radians(0), is(0.0));
-        assertThat(udf.radians(0L), is(0.0));
-        assertThat(udf.radians(0.0), is(0.0));
-    }
+  @Test
+  public void shouldHandleZero() {
+    assertThat(udf.radians(0), is(0.0));
+    assertThat(udf.radians(0L), is(0.0));
+    assertThat(udf.radians(0.0), is(0.0));
+  }
 
-    @Test
-    public void shouldHandlePositive() {
-        assertThat(udf.radians(180.0), is(Math.PI));
-        assertThat(udf.radians(360.0), is(2 * Math.PI));
-        assertThat(udf.radians(70.73163980890013), is(1.2345));
-        assertThat(udf.radians(114), is(1.9896753472735358));
-        assertThat(udf.radians(114L), is(1.9896753472735358));
-    }
+  @Test
+  public void shouldHandlePositive() {
+    assertThat(udf.radians(180.0), is(Math.PI));
+    assertThat(udf.radians(360.0), is(2 * Math.PI));
+    assertThat(udf.radians(70.73163980890013), is(1.2345));
+    assertThat(udf.radians(114), is(1.9896753472735358));
+    assertThat(udf.radians(114L), is(1.9896753472735358));
+  }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/SinTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/SinTest.java
@@ -1,0 +1,66 @@
+package io.confluent.ksql.function.udf.math;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.number.IsCloseTo.closeTo;
+
+public class SinTest {
+    private Sin udf;
+
+    @Before
+    public void setUp() {
+        udf = new Sin();
+    }
+
+    @Test
+    public void shouldHandleNull() {
+        assertThat(udf.sin((Integer)null), is(nullValue()));
+        assertThat(udf.sin((Long)null), is(nullValue()));
+        assertThat(udf.sin((Double)null), is(nullValue()));
+    }
+
+    @Test
+    public void shouldHandleLessThanNegative2Pi() {
+        assertThat(udf.sin(-9.1), is(-0.3190983623493521));
+        assertThat(udf.sin(-6.3), is(-0.016813900484349713));
+        assertThat(udf.sin(-7), is(-0.6569865987187891));
+        assertThat(udf.sin(-7L), is(-0.6569865987187891));
+    }
+
+    @Test
+    public void shouldHandleNegative() {
+        assertThat(udf.sin(-0.43), is(-0.41687080242921076));
+        assertThat(udf.sin(-Math.PI), closeTo(0, 0.000000000000001));
+        assertThat(udf.sin(-2 * Math.PI), closeTo(0, 0.000000000000001));
+        assertThat(udf.sin(-6), is(0.27941549819892586));
+        assertThat(udf.sin(-6L), is(0.27941549819892586));
+    }
+
+    @Test
+    public void shouldHandleZero() {
+        assertThat(udf.sin(0.0), is(0.0));
+        assertThat(udf.sin(0), is(0.0));
+        assertThat(udf.sin(0L), is(0.0));
+    }
+
+    @Test
+    public void shouldHandlePositive() {
+        assertThat(udf.sin(0.43), is(0.41687080242921076));
+        assertThat(udf.sin(Math.PI), closeTo(0, 0.000000000000001));
+        assertThat(udf.sin(Math.PI * 2), closeTo(0, 0.000000000000001));
+        assertThat(udf.sin(6), is(-0.27941549819892586));
+        assertThat(udf.sin(6L), is(-0.27941549819892586));
+    }
+
+    @Test
+    public void shouldHandleMoreThanPositive2Pi() {
+        assertThat(udf.sin(9.1), is(0.3190983623493521));
+        assertThat(udf.sin(6.3), is(0.016813900484349713));
+        assertThat(udf.sin(7), is(0.6569865987187891));
+        assertThat(udf.sin(7L), is(0.6569865987187891));
+    }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/SinTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/SinTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.math;
 
 import org.junit.Before;
@@ -9,58 +23,58 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.number.IsCloseTo.closeTo;
 
 public class SinTest {
-    private Sin udf;
+  private Sin udf;
 
-    @Before
-    public void setUp() {
-        udf = new Sin();
-    }
+  @Before
+  public void setUp() {
+    udf = new Sin();
+  }
 
-    @Test
-    public void shouldHandleNull() {
-        assertThat(udf.sin((Integer)null), is(nullValue()));
-        assertThat(udf.sin((Long)null), is(nullValue()));
-        assertThat(udf.sin((Double)null), is(nullValue()));
-    }
+  @Test
+  public void shouldHandleNull() {
+    assertThat(udf.sin((Integer) null), is(nullValue()));
+    assertThat(udf.sin((Long) null), is(nullValue()));
+    assertThat(udf.sin((Double) null), is(nullValue()));
+  }
 
-    @Test
-    public void shouldHandleLessThanNegative2Pi() {
-        assertThat(udf.sin(-9.1), is(-0.3190983623493521));
-        assertThat(udf.sin(-6.3), is(-0.016813900484349713));
-        assertThat(udf.sin(-7), is(-0.6569865987187891));
-        assertThat(udf.sin(-7L), is(-0.6569865987187891));
-    }
+  @Test
+  public void shouldHandleLessThanNegative2Pi() {
+    assertThat(udf.sin(-9.1), is(-0.3190983623493521));
+    assertThat(udf.sin(-6.3), is(-0.016813900484349713));
+    assertThat(udf.sin(-7), is(-0.6569865987187891));
+    assertThat(udf.sin(-7L), is(-0.6569865987187891));
+  }
 
-    @Test
-    public void shouldHandleNegative() {
-        assertThat(udf.sin(-0.43), is(-0.41687080242921076));
-        assertThat(udf.sin(-Math.PI), closeTo(0, 0.000000000000001));
-        assertThat(udf.sin(-2 * Math.PI), closeTo(0, 0.000000000000001));
-        assertThat(udf.sin(-6), is(0.27941549819892586));
-        assertThat(udf.sin(-6L), is(0.27941549819892586));
-    }
+  @Test
+  public void shouldHandleNegative() {
+    assertThat(udf.sin(-0.43), is(-0.41687080242921076));
+    assertThat(udf.sin(-Math.PI), closeTo(0, 0.000000000000001));
+    assertThat(udf.sin(-2 * Math.PI), closeTo(0, 0.000000000000001));
+    assertThat(udf.sin(-6), is(0.27941549819892586));
+    assertThat(udf.sin(-6L), is(0.27941549819892586));
+  }
 
-    @Test
-    public void shouldHandleZero() {
-        assertThat(udf.sin(0.0), is(0.0));
-        assertThat(udf.sin(0), is(0.0));
-        assertThat(udf.sin(0L), is(0.0));
-    }
+  @Test
+  public void shouldHandleZero() {
+    assertThat(udf.sin(0.0), is(0.0));
+    assertThat(udf.sin(0), is(0.0));
+    assertThat(udf.sin(0L), is(0.0));
+  }
 
-    @Test
-    public void shouldHandlePositive() {
-        assertThat(udf.sin(0.43), is(0.41687080242921076));
-        assertThat(udf.sin(Math.PI), closeTo(0, 0.000000000000001));
-        assertThat(udf.sin(Math.PI * 2), closeTo(0, 0.000000000000001));
-        assertThat(udf.sin(6), is(-0.27941549819892586));
-        assertThat(udf.sin(6L), is(-0.27941549819892586));
-    }
+  @Test
+  public void shouldHandlePositive() {
+    assertThat(udf.sin(0.43), is(0.41687080242921076));
+    assertThat(udf.sin(Math.PI), closeTo(0, 0.000000000000001));
+    assertThat(udf.sin(Math.PI * 2), closeTo(0, 0.000000000000001));
+    assertThat(udf.sin(6), is(-0.27941549819892586));
+    assertThat(udf.sin(6L), is(-0.27941549819892586));
+  }
 
-    @Test
-    public void shouldHandleMoreThanPositive2Pi() {
-        assertThat(udf.sin(9.1), is(0.3190983623493521));
-        assertThat(udf.sin(6.3), is(0.016813900484349713));
-        assertThat(udf.sin(7), is(0.6569865987187891));
-        assertThat(udf.sin(7L), is(0.6569865987187891));
-    }
+  @Test
+  public void shouldHandleMoreThanPositive2Pi() {
+    assertThat(udf.sin(9.1), is(0.3190983623493521));
+    assertThat(udf.sin(6.3), is(0.016813900484349713));
+    assertThat(udf.sin(7), is(0.6569865987187891));
+    assertThat(udf.sin(7L), is(0.6569865987187891));
+  }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/SinhTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/SinhTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.math;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class SinhTest {
+  private Sinh udf;
+
+  @Before
+  public void setUp() {
+    udf = new Sinh();
+  }
+
+  @Test
+  public void shouldHandleNull() {
+    assertThat(udf.sinh((Integer) null), is(nullValue()));
+    assertThat(udf.sinh((Long) null), is(nullValue()));
+    assertThat(udf.sinh((Double) null), is(nullValue()));
+  }
+
+  @Test
+  public void shouldHandleLessThanNegative2Pi() {
+    assertThat(udf.sinh(-9.1), is(-4477.64629590835));
+    assertThat(udf.sinh(-6.3), is(-272.28503691057597));
+    assertThat(udf.sinh(-7), is(-548.3161232732465));
+    assertThat(udf.sinh(-7L), is(-548.3161232732465));
+  }
+
+  @Test
+  public void shouldHandleNegative() {
+    assertThat(udf.sinh(-0.43), is(-0.4433742144124824));
+    assertThat(udf.sinh(-Math.PI), is(-11.548739357257748));
+    assertThat(udf.sinh(-Math.PI * 2), is(-267.74489404101644));
+    assertThat(udf.sinh(-6), is(-201.71315737027922));
+    assertThat(udf.sinh(-6L), is(-201.71315737027922));
+  }
+
+  @Test
+  public void shouldHandleZero() {
+    assertThat(udf.sinh(0.0), is(0.0));
+    assertThat(udf.sinh(0), is(0.0));
+    assertThat(udf.sinh(0L), is(0.0));
+  }
+
+  @Test
+  public void shouldHandlePositive() {
+    assertThat(udf.sinh(0.43), is(0.4433742144124824));
+    assertThat(udf.sinh(Math.PI), is(11.548739357257748));
+    assertThat(udf.sinh(Math.PI * 2), is(267.74489404101644));
+    assertThat(udf.sinh(6), is(201.71315737027922));
+    assertThat(udf.sinh(6L), is(201.71315737027922));
+  }
+
+  @Test
+  public void shouldHandleMoreThanPositive2Pi() {
+    assertThat(udf.sinh(9.1), is(4477.64629590835));
+    assertThat(udf.sinh(6.3), is(272.28503691057597));
+    assertThat(udf.sinh(7), is(548.3161232732465));
+    assertThat(udf.sinh(7L), is(548.3161232732465));
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/TanTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/TanTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.math;
 
 import org.junit.Before;
@@ -9,58 +23,58 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.number.IsCloseTo.closeTo;
 
 public class TanTest {
-    private Tan udf;
+  private Tan udf;
 
-    @Before
-    public void setUp() {
-        udf = new Tan();
-    }
+  @Before
+  public void setUp() {
+    udf = new Tan();
+  }
 
-    @Test
-    public void shouldHandleNull() {
-        assertThat(udf.tan((Integer)null), is(nullValue()));
-        assertThat(udf.tan((Long)null), is(nullValue()));
-        assertThat(udf.tan((Double)null), is(nullValue()));
-    }
+  @Test
+  public void shouldHandleNull() {
+    assertThat(udf.tan((Integer) null), is(nullValue()));
+    assertThat(udf.tan((Long) null), is(nullValue()));
+    assertThat(udf.tan((Double) null), is(nullValue()));
+  }
 
-    @Test
-    public void shouldHandleLessThanNegative2Pi() {
-        assertThat(udf.tan(-9.1), is(0.33670052643287396));
-        assertThat(udf.tan(-6.3), is(-0.016816277694182057));
-        assertThat(udf.tan(-7), is(-0.8714479827243188));
-        assertThat(udf.tan(-7L), is(-0.8714479827243188));
-    }
+  @Test
+  public void shouldHandleLessThanNegative2Pi() {
+    assertThat(udf.tan(-9.1), is(0.33670052643287396));
+    assertThat(udf.tan(-6.3), is(-0.016816277694182057));
+    assertThat(udf.tan(-7), is(-0.8714479827243188));
+    assertThat(udf.tan(-7L), is(-0.8714479827243188));
+  }
 
-    @Test
-    public void shouldHandleNegative() {
-        assertThat(udf.tan(-0.43), is(-0.45862102348555517));
-        assertThat(udf.tan(-Math.PI), closeTo(0, 0.000000000000001));
-        assertThat(udf.tan(-Math.PI * 2), closeTo(0, 0.000000000000001));
-        assertThat(udf.tan(-6), is(0.29100619138474915));
-        assertThat(udf.tan(-6L), is(0.29100619138474915));
-    }
+  @Test
+  public void shouldHandleNegative() {
+    assertThat(udf.tan(-0.43), is(-0.45862102348555517));
+    assertThat(udf.tan(-Math.PI), closeTo(0, 0.000000000000001));
+    assertThat(udf.tan(-Math.PI * 2), closeTo(0, 0.000000000000001));
+    assertThat(udf.tan(-6), is(0.29100619138474915));
+    assertThat(udf.tan(-6L), is(0.29100619138474915));
+  }
 
-    @Test
-    public void shouldHandleZero() {
-        assertThat(udf.tan(0.0), is(0.0));
-        assertThat(udf.tan(0), is(0.0));
-        assertThat(udf.tan(0L), is(0.0));
-    }
+  @Test
+  public void shouldHandleZero() {
+    assertThat(udf.tan(0.0), is(0.0));
+    assertThat(udf.tan(0), is(0.0));
+    assertThat(udf.tan(0L), is(0.0));
+  }
 
-    @Test
-    public void shouldHandlePositive() {
-        assertThat(udf.tan(0.43), is(0.45862102348555517));
-        assertThat(udf.tan(Math.PI), closeTo(0, 0.000000000000001));
-        assertThat(udf.tan(Math.PI * 2), closeTo(0, 0.000000000000001));
-        assertThat(udf.tan(6), is(-0.29100619138474915));
-        assertThat(udf.tan(6L), is(-0.29100619138474915));
-    }
+  @Test
+  public void shouldHandlePositive() {
+    assertThat(udf.tan(0.43), is(0.45862102348555517));
+    assertThat(udf.tan(Math.PI), closeTo(0, 0.000000000000001));
+    assertThat(udf.tan(Math.PI * 2), closeTo(0, 0.000000000000001));
+    assertThat(udf.tan(6), is(-0.29100619138474915));
+    assertThat(udf.tan(6L), is(-0.29100619138474915));
+  }
 
-    @Test
-    public void shouldHandleMoreThanPositive2Pi() {
-        assertThat(udf.tan(9.1), is(-0.33670052643287396));
-        assertThat(udf.tan(6.3), is(0.016816277694182057));
-        assertThat(udf.tan(7), is(0.8714479827243188));
-        assertThat(udf.tan(7L), is(0.8714479827243188));
-    }
+  @Test
+  public void shouldHandleMoreThanPositive2Pi() {
+    assertThat(udf.tan(9.1), is(-0.33670052643287396));
+    assertThat(udf.tan(6.3), is(0.016816277694182057));
+    assertThat(udf.tan(7), is(0.8714479827243188));
+    assertThat(udf.tan(7L), is(0.8714479827243188));
+  }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/TanTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/TanTest.java
@@ -1,0 +1,66 @@
+package io.confluent.ksql.function.udf.math;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.number.IsCloseTo.closeTo;
+
+public class TanTest {
+    private Tan udf;
+
+    @Before
+    public void setUp() {
+        udf = new Tan();
+    }
+
+    @Test
+    public void shouldHandleNull() {
+        assertThat(udf.tan((Integer)null), is(nullValue()));
+        assertThat(udf.tan((Long)null), is(nullValue()));
+        assertThat(udf.tan((Double)null), is(nullValue()));
+    }
+
+    @Test
+    public void shouldHandleLessThanNegative2Pi() {
+        assertThat(udf.tan(-9.1), is(0.33670052643287396));
+        assertThat(udf.tan(-6.3), is(-0.016816277694182057));
+        assertThat(udf.tan(-7), is(-0.8714479827243188));
+        assertThat(udf.tan(-7L), is(-0.8714479827243188));
+    }
+
+    @Test
+    public void shouldHandleNegative() {
+        assertThat(udf.tan(-0.43), is(-0.45862102348555517));
+        assertThat(udf.tan(-Math.PI), closeTo(0, 0.000000000000001));
+        assertThat(udf.tan(-Math.PI * 2), closeTo(0, 0.000000000000001));
+        assertThat(udf.tan(-6), is(0.29100619138474915));
+        assertThat(udf.tan(-6L), is(0.29100619138474915));
+    }
+
+    @Test
+    public void shouldHandleZero() {
+        assertThat(udf.tan(0.0), is(0.0));
+        assertThat(udf.tan(0), is(0.0));
+        assertThat(udf.tan(0L), is(0.0));
+    }
+
+    @Test
+    public void shouldHandlePositive() {
+        assertThat(udf.tan(0.43), is(0.45862102348555517));
+        assertThat(udf.tan(Math.PI), closeTo(0, 0.000000000000001));
+        assertThat(udf.tan(Math.PI * 2), closeTo(0, 0.000000000000001));
+        assertThat(udf.tan(6), is(-0.29100619138474915));
+        assertThat(udf.tan(6L), is(-0.29100619138474915));
+    }
+
+    @Test
+    public void shouldHandleMoreThanPositive2Pi() {
+        assertThat(udf.tan(9.1), is(-0.33670052643287396));
+        assertThat(udf.tan(6.3), is(0.016816277694182057));
+        assertThat(udf.tan(7), is(0.8714479827243188));
+        assertThat(udf.tan(7L), is(0.8714479827243188));
+    }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/TanTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/TanTest.java
@@ -50,6 +50,8 @@ public class TanTest {
     assertThat(udf.tan(-0.43), is(-0.45862102348555517));
     assertThat(udf.tan(-Math.PI), closeTo(0, 0.000000000000001));
     assertThat(udf.tan(-Math.PI * 2), closeTo(0, 0.000000000000001));
+    assertThat(udf.tan(-Math.PI * 2), closeTo(0, 0.000000000000001));
+    assertThat(udf.tan(-Math.PI / 2), is(-1.633123935319537E16));
     assertThat(udf.tan(-6), is(0.29100619138474915));
     assertThat(udf.tan(-6L), is(0.29100619138474915));
   }
@@ -66,6 +68,7 @@ public class TanTest {
     assertThat(udf.tan(0.43), is(0.45862102348555517));
     assertThat(udf.tan(Math.PI), closeTo(0, 0.000000000000001));
     assertThat(udf.tan(Math.PI * 2), closeTo(0, 0.000000000000001));
+    assertThat(udf.tan(Math.PI / 2), is(1.633123935319537E16));
     assertThat(udf.tan(6), is(-0.29100619138474915));
     assertThat(udf.tan(6L), is(-0.29100619138474915));
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/TanhTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/TanhTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.math;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class TanhTest {
+  private Tanh udf;
+
+  @Before
+  public void setUp() {
+    udf = new Tanh();
+  }
+
+  @Test
+  public void shouldHandleNull() {
+    assertThat(udf.tanh((Integer) null), is(nullValue()));
+    assertThat(udf.tanh((Long) null), is(nullValue()));
+    assertThat(udf.tanh((Double) null), is(nullValue()));
+  }
+
+  @Test
+  public void shouldHandleLessThanNegative2Pi() {
+    assertThat(udf.tanh(-9.1), is(-0.9999999750614947));
+    assertThat(udf.tanh(-6.3), is(-0.9999932559922726));
+    assertThat(udf.tanh(-7), is(-0.9999983369439447));
+    assertThat(udf.tanh(-7L), is(-0.9999983369439447));
+  }
+
+  @Test
+  public void shouldHandleNegative() {
+    assertThat(udf.tanh(-0.43), is(-0.4053213086894629));
+    assertThat(udf.tanh(-Math.PI), is(-0.99627207622075));
+    assertThat(udf.tanh(-Math.PI * 2), is(-0.9999930253396107));
+    assertThat(udf.tanh(-6), is(-0.9999877116507956));
+    assertThat(udf.tanh(-6L), is(-0.9999877116507956));
+  }
+
+  @Test
+  public void shouldHandleZero() {
+    assertThat(udf.tanh(0.0), is(0.0));
+    assertThat(udf.tanh(0), is(0.0));
+    assertThat(udf.tanh(0L), is(0.0));
+  }
+
+  @Test
+  public void shouldHandlePositive() {
+    assertThat(udf.tanh(0.43), is(0.4053213086894629));
+    assertThat(udf.tanh(Math.PI), is(0.99627207622075));
+    assertThat(udf.tanh(Math.PI * 2), is(0.9999930253396107));
+    assertThat(udf.tanh(6), is(0.9999877116507956));
+    assertThat(udf.tanh(6L), is(0.9999877116507956));
+  }
+
+  @Test
+  public void shouldHandleMoreThanPositive2Pi() {
+    assertThat(udf.tanh(9.1), is(0.9999999750614947));
+    assertThat(udf.tanh(6.3), is(0.9999932559922726));
+    assertThat(udf.tanh(7), is(0.9999983369439447));
+    assertThat(udf.tanh(7L), is(0.9999983369439447));
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_acos/7.3.0_1655346225437/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_acos/7.3.0_1655346225437/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (K STRING KEY, I INTEGER, L BIGINT, D DOUBLE) WITH (KAFKA_TOPIC='input', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.K K,\n  ACOS(INPUT.I) I,\n  ACOS(INPUT.L) L,\n  ACOS(INPUT.D) D\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "ACOS(I) AS I", "ACOS(L) AS L", "ACOS(D) AS D" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_acos/7.3.0_1655346225437/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_acos/7.3.0_1655346225437/spec.json
@@ -1,0 +1,182 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655346225437,
+  "path" : "query-validation-tests/math.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "acos",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : null,
+        "l" : null,
+        "d" : null
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : -2,
+        "l" : -6,
+        "d" : -1.1
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : -1,
+        "l" : -1,
+        "d" : -0.43
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 0,
+        "l" : 0,
+        "d" : 0.0
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 1,
+        "l" : 1,
+        "d" : 0.43
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 2,
+        "l" : 6,
+        "d" : 1.1
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : null,
+        "L" : null,
+        "D" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : "NaN",
+        "L" : "NaN",
+        "D" : "NaN"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 3.141592653589793,
+        "L" : 3.141592653589793,
+        "D" : 2.0152891037307157
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 1.5707963267948966,
+        "L" : 1.5707963267948966,
+        "D" : 1.5707963267948966
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 0.0,
+        "L" : 0.0,
+        "D" : 1.1263035498590777
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : "NaN",
+        "L" : "NaN",
+        "D" : "NaN"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (K STRING KEY, i INT, l BIGINT, d DOUBLE) WITH (kafka_topic='input', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT K, acos(i) i, acos(l) l, acos(d) d FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_acos/7.3.0_1655346225437/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_acos/7.3.0_1655346225437/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_asin/7.3.0_1655346225487/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_asin/7.3.0_1655346225487/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (K STRING KEY, I INTEGER, L BIGINT, D DOUBLE) WITH (KAFKA_TOPIC='input', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.K K,\n  ASIN(INPUT.I) I,\n  ASIN(INPUT.L) L,\n  ASIN(INPUT.D) D\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "ASIN(I) AS I", "ASIN(L) AS L", "ASIN(D) AS D" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_asin/7.3.0_1655346225487/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_asin/7.3.0_1655346225487/spec.json
@@ -1,0 +1,182 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655346225487,
+  "path" : "query-validation-tests/math.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "asin",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : null,
+        "l" : null,
+        "d" : null
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : -2,
+        "l" : -6,
+        "d" : -1.1
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : -1,
+        "l" : -1,
+        "d" : -0.43
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 0,
+        "l" : 0,
+        "d" : 0.0
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 1,
+        "l" : 1,
+        "d" : 0.43
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 2,
+        "l" : 6,
+        "d" : 1.1
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : null,
+        "L" : null,
+        "D" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : "NaN",
+        "L" : "NaN",
+        "D" : "NaN"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : -1.5707963267948966,
+        "L" : -1.5707963267948966,
+        "D" : -0.444492776935819
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 0.0,
+        "L" : 0.0,
+        "D" : 0.0
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 1.5707963267948966,
+        "L" : 1.5707963267948966,
+        "D" : 0.444492776935819
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : "NaN",
+        "L" : "NaN",
+        "D" : "NaN"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (K STRING KEY, i INT, l BIGINT, d DOUBLE) WITH (kafka_topic='input', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT K, asin(i) i, asin(l) l, asin(d) d FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_asin/7.3.0_1655346225487/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_asin/7.3.0_1655346225487/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_atan/7.3.0_1655346225556/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_atan/7.3.0_1655346225556/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (K STRING KEY, I INTEGER, L BIGINT, D DOUBLE) WITH (KAFKA_TOPIC='input', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.K K,\n  ATAN(INPUT.I) I,\n  ATAN(INPUT.L) L,\n  ATAN(INPUT.D) D\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "ATAN(I) AS I", "ATAN(L) AS L", "ATAN(D) AS D" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_atan/7.3.0_1655346225556/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_atan/7.3.0_1655346225556/spec.json
@@ -1,0 +1,182 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655346225556,
+  "path" : "query-validation-tests/math.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "atan",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : null,
+        "l" : null,
+        "d" : null
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : -2,
+        "l" : -6,
+        "d" : -1.1
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : -1,
+        "l" : -1,
+        "d" : -0.43
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 0,
+        "l" : 0,
+        "d" : 0.0
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 1,
+        "l" : 1,
+        "d" : 0.43
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 2,
+        "l" : 6,
+        "d" : 1.1
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : null,
+        "L" : null,
+        "D" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : -1.1071487177940904,
+        "L" : -1.4056476493802699,
+        "D" : -0.8329812666744317
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : -0.7853981633974483,
+        "L" : -0.7853981633974483,
+        "D" : -0.40609805831761564
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 0.0,
+        "L" : 0.0,
+        "D" : 0.0
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 0.7853981633974483,
+        "L" : 0.7853981633974483,
+        "D" : 0.40609805831761564
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 1.1071487177940904,
+        "L" : 1.4056476493802699,
+        "D" : 0.8329812666744317
+      }
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (K STRING KEY, i INT, l BIGINT, d DOUBLE) WITH (kafka_topic='input', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT K, atan(i) i, atan(l) l, atan(d) d FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_atan/7.3.0_1655346225556/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_atan/7.3.0_1655346225556/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_atan2/7.3.0_1655346225604/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_atan2/7.3.0_1655346225604/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (K STRING KEY, IY INTEGER, IX INTEGER, LY BIGINT, LX BIGINT, DY DOUBLE, DX DOUBLE) WITH (KAFKA_TOPIC='input', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K` STRING KEY, `IY` INTEGER, `IX` INTEGER, `LY` BIGINT, `LX` BIGINT, `DY` DOUBLE, `DX` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.K K,\n  ATAN2(INPUT.IY, INPUT.IX) I,\n  ATAN2(INPUT.LY, INPUT.LX) L,\n  ATAN2(INPUT.DY, INPUT.DX) D\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`K` STRING KEY, `IY` INTEGER, `IX` INTEGER, `LY` BIGINT, `LX` BIGINT, `DY` DOUBLE, `DX` DOUBLE",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "ATAN2(IY, IX) AS I", "ATAN2(LY, LX) AS L", "ATAN2(DY, DX) AS D" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_atan2/7.3.0_1655346225604/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_atan2/7.3.0_1655346225604/spec.json
@@ -1,0 +1,314 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655346225604,
+  "path" : "query-validation-tests/math.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `IY` INTEGER, `IX` INTEGER, `LY` BIGINT, `LX` BIGINT, `DY` DOUBLE, `DX` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "atan2",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "iy" : null,
+        "ix" : null,
+        "ly" : null,
+        "lx" : null,
+        "dy" : null,
+        "dx" : null
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "iy" : null,
+        "ix" : 1,
+        "ly" : null,
+        "lx" : 1,
+        "dy" : null,
+        "dx" : 0.45
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "iy" : 1,
+        "ix" : null,
+        "ly" : 1,
+        "lx" : null,
+        "dy" : 0.45,
+        "dx" : null
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "iy" : -2,
+        "ix" : -3,
+        "ly" : -2,
+        "lx" : -2,
+        "dy" : -1.1,
+        "dx" : -0.24
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "iy" : -2,
+        "ix" : 3,
+        "ly" : -2,
+        "lx" : 2,
+        "dy" : -1.1,
+        "dx" : 0.24
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "iy" : -2,
+        "ix" : 0,
+        "ly" : -2,
+        "lx" : 0,
+        "dy" : -1.1,
+        "dx" : 0.0
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "iy" : 2,
+        "ix" : -3,
+        "ly" : 2,
+        "lx" : -2,
+        "dy" : 1.1,
+        "dx" : -0.24
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "iy" : 2,
+        "ix" : 3,
+        "ly" : 2,
+        "lx" : 2,
+        "dy" : 1.1,
+        "dx" : 0.24
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "iy" : 2,
+        "ix" : 0,
+        "ly" : 2,
+        "lx" : 0,
+        "dy" : 1.1,
+        "dx" : 0.0
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "iy" : 0,
+        "ix" : -3,
+        "ly" : 0,
+        "lx" : -2,
+        "dy" : 0,
+        "dx" : -0.24
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "iy" : 0,
+        "ix" : 3,
+        "ly" : 0,
+        "lx" : 2,
+        "dy" : 0,
+        "dx" : 0.24
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "iy" : 0,
+        "ix" : 0,
+        "ly" : 0,
+        "lx" : 0,
+        "dy" : 0,
+        "dx" : 0
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : null,
+        "L" : null,
+        "D" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : null,
+        "L" : null,
+        "D" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : null,
+        "L" : null,
+        "D" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : -2.5535900500422257,
+        "L" : -2.356194490192345,
+        "D" : -1.7856117271965553
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : -0.5880026035475675,
+        "L" : -0.7853981633974483,
+        "D" : -1.355980926393238
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : -1.5707963267948966,
+        "L" : -1.5707963267948966,
+        "D" : -1.5707963267948966
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 2.5535900500422257,
+        "L" : 2.356194490192345,
+        "D" : 1.7856117271965553
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 0.5880026035475675,
+        "L" : 0.7853981633974483,
+        "D" : 1.355980926393238
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 1.5707963267948966,
+        "L" : 1.5707963267948966,
+        "D" : 1.5707963267948966
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 3.141592653589793,
+        "L" : 3.141592653589793,
+        "D" : 3.141592653589793
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 0.0,
+        "L" : 0.0,
+        "D" : 0.0
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 0.0,
+        "L" : 0.0,
+        "D" : 0.0
+      }
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (K STRING KEY, iy INT, ix INT, ly BIGINT, lx BIGINT, dy DOUBLE, dx DOUBLE) WITH (kafka_topic='input', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT K, atan2(iy, ix) i, atan2(ly, lx) l, atan2(dy, dx) d FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `IY` INTEGER, `IX` INTEGER, `LY` BIGINT, `LX` BIGINT, `DY` DOUBLE, `DX` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_atan2/7.3.0_1655346225604/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_atan2/7.3.0_1655346225604/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_cos/7.3.0_1655346225639/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_cos/7.3.0_1655346225639/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (K STRING KEY, I INTEGER, L BIGINT, D DOUBLE) WITH (KAFKA_TOPIC='input', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.K K,\n  COS(INPUT.I) I,\n  COS(INPUT.L) L,\n  COS(INPUT.D) D\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "COS(I) AS I", "COS(L) AS L", "COS(D) AS D" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_cos/7.3.0_1655346225639/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_cos/7.3.0_1655346225639/spec.json
@@ -1,0 +1,182 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655346225639,
+  "path" : "query-validation-tests/math.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "cos",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : null,
+        "l" : null,
+        "d" : null
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : -7,
+        "l" : -7,
+        "d" : -9.1
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : -6,
+        "l" : -6,
+        "d" : -0.43
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 0,
+        "l" : 0,
+        "d" : 0.0
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 6,
+        "l" : 6,
+        "d" : 0.43
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 7,
+        "l" : 7,
+        "d" : 9.1
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : null,
+        "L" : null,
+        "D" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 0.7539022543433046,
+        "L" : 0.7539022543433046,
+        "D" : -0.9477216021311119
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 0.960170286650366,
+        "L" : 0.960170286650366,
+        "D" : 0.9089657496748851
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 1.0,
+        "L" : 1.0,
+        "D" : 1.0
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 0.960170286650366,
+        "L" : 0.960170286650366,
+        "D" : 0.9089657496748851
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 0.7539022543433046,
+        "L" : 0.7539022543433046,
+        "D" : -0.9477216021311119
+      }
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (K STRING KEY, i INT, l BIGINT, d DOUBLE) WITH (kafka_topic='input', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT K, cos(i) i, cos(l) l, cos(d) d FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_cos/7.3.0_1655346225639/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_cos/7.3.0_1655346225639/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_cosh/7.3.0_1655415147820/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_cosh/7.3.0_1655415147820/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (K STRING KEY, I INTEGER, L BIGINT, D DOUBLE) WITH (KAFKA_TOPIC='input', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.K K,\n  COSH(INPUT.I) I,\n  COSH(INPUT.L) L,\n  COSH(INPUT.D) D\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "COSH(I) AS I", "COSH(L) AS L", "COSH(D) AS D" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_cosh/7.3.0_1655415147820/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_cosh/7.3.0_1655415147820/spec.json
@@ -1,0 +1,182 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655415147820,
+  "path" : "query-validation-tests/math.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "cosh",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : null,
+        "l" : null,
+        "d" : null
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : -7,
+        "l" : -7,
+        "d" : -9.1
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : -6,
+        "l" : -6,
+        "d" : -0.43
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 0,
+        "l" : 0,
+        "d" : 0.0
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 6,
+        "l" : 6,
+        "d" : 0.43
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 7,
+        "l" : 7,
+        "d" : 9.1
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : null,
+        "L" : null,
+        "D" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 548.317035155212,
+        "L" : 548.317035155212,
+        "D" : 4477.646407574158
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 201.7156361224559,
+        "L" : 201.7156361224559,
+        "D" : 1.0938833091357991
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 1.0,
+        "L" : 1.0,
+        "D" : 1.0
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 201.7156361224559,
+        "L" : 201.7156361224559,
+        "D" : 1.0938833091357991
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 548.317035155212,
+        "L" : 548.317035155212,
+        "D" : 4477.646407574158
+      }
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (K STRING KEY, i INT, l BIGINT, d DOUBLE) WITH (kafka_topic='input', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT K, cosh(i) i, cosh(l) l, cosh(d) d FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_cosh/7.3.0_1655415147820/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_cosh/7.3.0_1655415147820/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_cot/7.3.0_1655346225825/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_cot/7.3.0_1655346225825/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (K STRING KEY, I INTEGER, L BIGINT, D DOUBLE) WITH (KAFKA_TOPIC='input', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.K K,\n  COT(INPUT.I) I,\n  COT(INPUT.L) L,\n  COT(INPUT.D) D\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "COT(I) AS I", "COT(L) AS L", "COT(D) AS D" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_cot/7.3.0_1655346225825/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_cot/7.3.0_1655346225825/spec.json
@@ -1,0 +1,182 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655346225825,
+  "path" : "query-validation-tests/math.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "cot",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : null,
+        "l" : null,
+        "d" : null
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : -7,
+        "l" : -7,
+        "d" : -9.1
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : -6,
+        "l" : -6,
+        "d" : -0.43
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 0,
+        "l" : 0,
+        "d" : 0.0
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 6,
+        "l" : 6,
+        "d" : 0.43
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 7,
+        "l" : 7,
+        "d" : 9.1
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : null,
+        "L" : null,
+        "D" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : -1.1475154224051356,
+        "L" : -1.1475154224051356,
+        "D" : 2.9699983263892054
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 3.436353004180128,
+        "L" : 3.436353004180128,
+        "D" : -2.1804495406685085
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : "Infinity",
+        "L" : "Infinity",
+        "D" : "Infinity"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : -3.436353004180128,
+        "L" : -3.436353004180128,
+        "D" : 2.1804495406685085
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 1.1475154224051356,
+        "L" : 1.1475154224051356,
+        "D" : -2.9699983263892054
+      }
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (K STRING KEY, i INT, l BIGINT, d DOUBLE) WITH (kafka_topic='input', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT K, cot(i) i, cot(l) l, cot(d) d FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_cot/7.3.0_1655346225825/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_cot/7.3.0_1655346225825/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_degrees/7.3.0_1655346225863/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_degrees/7.3.0_1655346225863/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (K STRING KEY, I INTEGER, L BIGINT, D DOUBLE) WITH (KAFKA_TOPIC='input', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.K K,\n  DEGREES(INPUT.I) I,\n  DEGREES(INPUT.L) L,\n  DEGREES(INPUT.D) D\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "DEGREES(I) AS I", "DEGREES(L) AS L", "DEGREES(D) AS D" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_degrees/7.3.0_1655346225863/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_degrees/7.3.0_1655346225863/spec.json
@@ -1,0 +1,150 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655346225863,
+  "path" : "query-validation-tests/math.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "degrees",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : null,
+        "l" : null,
+        "d" : null
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : -2,
+        "l" : -2,
+        "d" : -1.2345
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 0,
+        "l" : 0,
+        "d" : 0.0
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 2,
+        "l" : 2,
+        "d" : 1.2345
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : null,
+        "L" : null,
+        "D" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : -114.59155902616465,
+        "L" : -114.59155902616465,
+        "D" : -70.73163980890013
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 0.0,
+        "L" : 0.0,
+        "D" : 0.0
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 114.59155902616465,
+        "L" : 114.59155902616465,
+        "D" : 70.73163980890013
+      }
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (K STRING KEY, i INT, l BIGINT, d DOUBLE) WITH (kafka_topic='input', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT K, degrees(i) i, degrees(l) l, degrees(d) d FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_degrees/7.3.0_1655346225863/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_degrees/7.3.0_1655346225863/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_pi/7.3.0_1655346225974/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_pi/7.3.0_1655346225974/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (IGNORED INTEGER) WITH (KAFKA_TOPIC='input', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`IGNORED` INTEGER",
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT PI() VAL\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`VAL` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`IGNORED` INTEGER",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "PI() AS VAL" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_pi/7.3.0_1655346225974/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_pi/7.3.0_1655346225974/spec.json
@@ -1,0 +1,96 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655346225974,
+  "path" : "query-validation-tests/math.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`IGNORED` INTEGER",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`VAL` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "pi",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : null,
+      "value" : { }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "val" : 3.141592653589793
+      }
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='input', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT pi() AS VAL FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`IGNORED` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`VAL` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_pi/7.3.0_1655346225974/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_pi/7.3.0_1655346225974/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_radians/7.3.0_1655346225902/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_radians/7.3.0_1655346225902/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (K STRING KEY, I INTEGER, L BIGINT, D DOUBLE) WITH (KAFKA_TOPIC='input', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.K K,\n  RADIANS(INPUT.I) I,\n  RADIANS(INPUT.L) L,\n  RADIANS(INPUT.D) D\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "RADIANS(I) AS I", "RADIANS(L) AS L", "RADIANS(D) AS D" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_radians/7.3.0_1655346225902/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_radians/7.3.0_1655346225902/spec.json
@@ -1,0 +1,150 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655346225902,
+  "path" : "query-validation-tests/math.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "radians",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : null,
+        "l" : null,
+        "d" : null
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : -114,
+        "l" : -114,
+        "d" : -70.73163980890013
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 0,
+        "l" : 0,
+        "d" : 0.0
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 114,
+        "l" : 114,
+        "d" : 70.73163980890013
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : null,
+        "L" : null,
+        "D" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : -1.9896753472735358,
+        "L" : -1.9896753472735358,
+        "D" : -1.2345
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 0.0,
+        "L" : 0.0,
+        "D" : 0.0
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 1.9896753472735358,
+        "L" : 1.9896753472735358,
+        "D" : 1.2345
+      }
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (K STRING KEY, i INT, l BIGINT, d DOUBLE) WITH (kafka_topic='input', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT K, radians(i) i, radians(l) l, radians(d) d FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_radians/7.3.0_1655346225902/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_radians/7.3.0_1655346225902/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_sin/7.3.0_1655346225684/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_sin/7.3.0_1655346225684/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (K STRING KEY, I INTEGER, L BIGINT, D DOUBLE) WITH (KAFKA_TOPIC='input', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.K K,\n  SIN(INPUT.I) I,\n  SIN(INPUT.L) L,\n  SIN(INPUT.D) D\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "SIN(I) AS I", "SIN(L) AS L", "SIN(D) AS D" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_sin/7.3.0_1655346225684/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_sin/7.3.0_1655346225684/spec.json
@@ -1,0 +1,182 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655346225684,
+  "path" : "query-validation-tests/math.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "sin",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : null,
+        "l" : null,
+        "d" : null
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : -7,
+        "l" : -7,
+        "d" : -9.1
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : -6,
+        "l" : -6,
+        "d" : -0.43
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 0,
+        "l" : 0,
+        "d" : 0.0
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 6,
+        "l" : 6,
+        "d" : 0.43
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 7,
+        "l" : 7,
+        "d" : 9.1
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : null,
+        "L" : null,
+        "D" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : -0.6569865987187891,
+        "L" : -0.6569865987187891,
+        "D" : -0.3190983623493521
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 0.27941549819892586,
+        "L" : 0.27941549819892586,
+        "D" : -0.41687080242921076
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 0.0,
+        "L" : 0.0,
+        "D" : 0.0
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : -0.27941549819892586,
+        "L" : -0.27941549819892586,
+        "D" : 0.41687080242921076
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 0.6569865987187891,
+        "L" : 0.6569865987187891,
+        "D" : 0.3190983623493521
+      }
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (K STRING KEY, i INT, l BIGINT, d DOUBLE) WITH (kafka_topic='input', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT K, sin(i) i, sin(l) l, sin(d) d FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_sin/7.3.0_1655346225684/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_sin/7.3.0_1655346225684/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_sinh/7.3.0_1655415147910/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_sinh/7.3.0_1655415147910/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (K STRING KEY, I INTEGER, L BIGINT, D DOUBLE) WITH (KAFKA_TOPIC='input', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.K K,\n  SINH(INPUT.I) I,\n  SINH(INPUT.L) L,\n  SINH(INPUT.D) D\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "SINH(I) AS I", "SINH(L) AS L", "SINH(D) AS D" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_sinh/7.3.0_1655415147910/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_sinh/7.3.0_1655415147910/spec.json
@@ -1,0 +1,182 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655415147910,
+  "path" : "query-validation-tests/math.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "sinh",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : null,
+        "l" : null,
+        "d" : null
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : -7,
+        "l" : -7,
+        "d" : -9.1
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : -6,
+        "l" : -6,
+        "d" : -0.43
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 0,
+        "l" : 0,
+        "d" : 0.0
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 6,
+        "l" : 6,
+        "d" : 0.43
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 7,
+        "l" : 7,
+        "d" : 9.1
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : null,
+        "L" : null,
+        "D" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : -548.3161232732465,
+        "L" : -548.3161232732465,
+        "D" : -4477.64629590835
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : -201.71315737027922,
+        "L" : -201.71315737027922,
+        "D" : -0.4433742144124824
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 0.0,
+        "L" : 0.0,
+        "D" : 0.0
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 201.71315737027922,
+        "L" : 201.71315737027922,
+        "D" : 0.4433742144124824
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 548.3161232732465,
+        "L" : 548.3161232732465,
+        "D" : 4477.64629590835
+      }
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (K STRING KEY, i INT, l BIGINT, d DOUBLE) WITH (kafka_topic='input', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT K, sinh(i) i, sinh(l) l, sinh(d) d FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_sinh/7.3.0_1655415147910/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_sinh/7.3.0_1655415147910/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_tan/7.3.0_1655346225743/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_tan/7.3.0_1655346225743/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (K STRING KEY, I INTEGER, L BIGINT, D DOUBLE) WITH (KAFKA_TOPIC='input', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.K K,\n  TAN(INPUT.I) I,\n  TAN(INPUT.L) L,\n  TAN(INPUT.D) D\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "TAN(I) AS I", "TAN(L) AS L", "TAN(D) AS D" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_tan/7.3.0_1655346225743/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_tan/7.3.0_1655346225743/spec.json
@@ -1,0 +1,182 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655346225743,
+  "path" : "query-validation-tests/math.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "tan",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : null,
+        "l" : null,
+        "d" : null
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : -7,
+        "l" : -7,
+        "d" : -9.1
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : -6,
+        "l" : -6,
+        "d" : -0.43
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 0,
+        "l" : 0,
+        "d" : 0.0
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 6,
+        "l" : 6,
+        "d" : 0.43
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 7,
+        "l" : 7,
+        "d" : 9.1
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : null,
+        "L" : null,
+        "D" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : -0.8714479827243188,
+        "L" : -0.8714479827243188,
+        "D" : 0.33670052643287396
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 0.29100619138474915,
+        "L" : 0.29100619138474915,
+        "D" : -0.45862102348555517
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 0.0,
+        "L" : 0.0,
+        "D" : 0.0
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : -0.29100619138474915,
+        "L" : -0.29100619138474915,
+        "D" : 0.45862102348555517
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 0.8714479827243188,
+        "L" : 0.8714479827243188,
+        "D" : -0.33670052643287396
+      }
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (K STRING KEY, i INT, l BIGINT, d DOUBLE) WITH (kafka_topic='input', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT K, tan(i) i, tan(l) l, tan(d) d FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_tan/7.3.0_1655346225743/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_tan/7.3.0_1655346225743/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_tanh/7.3.0_1655415147958/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_tanh/7.3.0_1655415147958/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (K STRING KEY, I INTEGER, L BIGINT, D DOUBLE) WITH (KAFKA_TOPIC='input', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.K K,\n  TANH(INPUT.I) I,\n  TANH(INPUT.L) L,\n  TANH(INPUT.D) D\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "TANH(I) AS I", "TANH(L) AS L", "TANH(D) AS D" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_tanh/7.3.0_1655415147958/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_tanh/7.3.0_1655415147958/spec.json
@@ -1,0 +1,182 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655415147958,
+  "path" : "query-validation-tests/math.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "tanh",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : null,
+        "l" : null,
+        "d" : null
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : -7,
+        "l" : -7,
+        "d" : -9.1
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : -6,
+        "l" : -6,
+        "d" : -0.43
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 0,
+        "l" : 0,
+        "d" : 0.0
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 6,
+        "l" : 6,
+        "d" : 0.43
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 7,
+        "l" : 7,
+        "d" : 9.1
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : null,
+        "L" : null,
+        "D" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : -0.9999983369439447,
+        "L" : -0.9999983369439447,
+        "D" : -0.9999999750614947
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : -0.9999877116507956,
+        "L" : -0.9999877116507956,
+        "D" : -0.4053213086894629
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 0.0,
+        "L" : 0.0,
+        "D" : 0.0
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 0.9999877116507956,
+        "L" : 0.9999877116507956,
+        "D" : 0.4053213086894629
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "I" : 0.9999983369439447,
+        "L" : 0.9999983369439447,
+        "D" : 0.9999999750614947
+      }
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (K STRING KEY, i INT, l BIGINT, d DOUBLE) WITH (kafka_topic='input', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT K, tanh(i) i, tanh(l) l, tanh(d) d FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` DOUBLE, `L` DOUBLE, `D` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_tanh/7.3.0_1655415147958/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/math_-_tanh/7.3.0_1655415147958/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/math.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/math.json
@@ -256,6 +256,251 @@
           }
         ]
       }
+    },
+    {
+      "name": "acos",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, i INT, l BIGINT, d DOUBLE) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT K, acos(i) i, acos(l) l, acos(d) d FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input", "value": {"i": null, "l": null, "d": null}},
+        {"topic": "input", "value": {"i": -2, "l": -6, "d": -1.1}},
+        {"topic": "input", "value": {"i": -1, "l": -1, "d": -0.43}},
+        {"topic": "input", "value": {"i": 0, "l": 0, "d": 0.0}},
+        {"topic": "input", "value": {"i": 1, "l": 1, "d": 0.43}},
+        {"topic": "input", "value": {"i": 2, "l": 6, "d": 1.1}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"I": null, "L": null, "D": null}},
+        {"topic": "OUTPUT", "value": {"I": "NaN", "L": "NaN", "D": "NaN"}},
+        {"topic": "OUTPUT", "value": {"I": 3.141592653589793, "L": 3.141592653589793, "D": 2.0152891037307157}},
+        {"topic": "OUTPUT", "value": {"I": 1.5707963267948966, "L": 1.5707963267948966, "D": 1.5707963267948966}},
+        {"topic": "OUTPUT", "value": {"I": 0.0, "L": 0.0, "D": 1.1263035498590777}},
+        {"topic": "OUTPUT", "value": {"I": "NaN", "L": "NaN", "D": "NaN"}}
+      ]
+    },
+    {
+      "name": "asin",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, i INT, l BIGINT, d DOUBLE) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT K, asin(i) i, asin(l) l, asin(d) d FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input", "value": {"i": null, "l": null, "d": null}},
+        {"topic": "input", "value": {"i": -2, "l": -6, "d": -1.1}},
+        {"topic": "input", "value": {"i": -1, "l": -1, "d": -0.43}},
+        {"topic": "input", "value": {"i": 0, "l": 0, "d": 0.0}},
+        {"topic": "input", "value": {"i": 1, "l": 1, "d": 0.43}},
+        {"topic": "input", "value": {"i": 2, "l": 6, "d": 1.1}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"I": null, "L": null, "D": null}},
+        {"topic": "OUTPUT", "value": {"I": "NaN", "L": "NaN", "D": "NaN"}},
+        {"topic": "OUTPUT", "value": {"I": -1.5707963267948966, "L": -1.5707963267948966, "D": -0.444492776935819}},
+        {"topic": "OUTPUT", "value": {"I": 0.0, "L": 0.0, "D": 0.0}},
+        {"topic": "OUTPUT", "value": {"I": 1.5707963267948966, "L": 1.5707963267948966, "D": 0.444492776935819}},
+        {"topic": "OUTPUT", "value": {"I": "NaN", "L": "NaN", "D": "NaN"}}
+      ]
+    },
+    {
+      "name": "atan",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, i INT, l BIGINT, d DOUBLE) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT K, atan(i) i, atan(l) l, atan(d) d FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input", "value": {"i": null, "l": null, "d": null}},
+        {"topic": "input", "value": {"i": -2, "l": -6, "d": -1.1}},
+        {"topic": "input", "value": {"i": -1, "l": -1, "d": -0.43}},
+        {"topic": "input", "value": {"i": 0, "l": 0, "d": 0.0}},
+        {"topic": "input", "value": {"i": 1, "l": 1, "d": 0.43}},
+        {"topic": "input", "value": {"i": 2, "l": 6, "d": 1.1}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"I": null, "L": null, "D": null}},
+        {"topic": "OUTPUT", "value": {"I": -1.1071487177940904, "L": -1.4056476493802699, "D": -0.8329812666744317}},
+        {"topic": "OUTPUT", "value": {"I": -0.7853981633974483, "L": -0.7853981633974483, "D": -0.40609805831761564}},
+        {"topic": "OUTPUT", "value": {"I": 0.0, "L": 0.0, "D": 0.0}},
+        {"topic": "OUTPUT", "value": {"I": 0.7853981633974483, "L": 0.7853981633974483, "D": 0.40609805831761564}},
+        {"topic": "OUTPUT", "value": {"I": 1.1071487177940904, "L": 1.4056476493802699, "D": 0.8329812666744317}}
+      ]
+    },
+    {
+      "name": "atan2",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, iy INT, ix INT, ly BIGINT, lx BIGINT, dy DOUBLE, dx DOUBLE) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT K, atan2(iy, ix) i, atan2(ly, lx) l, atan2(dy, dx) d FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input", "value": {"iy": null, "ix": null, "ly": null, "lx": null, "dy": null, "dx": null}},
+        {"topic": "input", "value": {"iy": null, "ix": 1, "ly": null, "lx": 1, "dy": null, "dx": 0.45}},
+        {"topic": "input", "value": {"iy": 1, "ix": null, "ly": 1, "lx": null, "dy": 0.45, "dx": null}},
+        {"topic": "input", "value": {"iy": -2, "ix": -3, "ly": -2, "lx": -2, "dy": -1.1, "dx": -0.24}},
+        {"topic": "input", "value": {"iy": -2, "ix": 3, "ly": -2, "lx": 2, "dy": -1.1, "dx": 0.24}},
+        {"topic": "input", "value": {"iy": -2, "ix": 0, "ly": -2, "lx": 0, "dy": -1.1, "dx": 0.0}},
+        {"topic": "input", "value": {"iy": 2, "ix": -3, "ly": 2, "lx": -2, "dy": 1.1, "dx": -0.24}},
+        {"topic": "input", "value": {"iy": 2, "ix": 3, "ly": 2, "lx": 2, "dy": 1.1, "dx": 0.24}},
+        {"topic": "input", "value": {"iy": 2, "ix": 0, "ly": 2, "lx": 0, "dy": 1.1, "dx": 0.0}},
+        {"topic": "input", "value": {"iy": 0, "ix": -3, "ly": 0, "lx": -2, "dy": 0, "dx": -0.24}},
+        {"topic": "input", "value": {"iy": 0, "ix": 3, "ly": 0, "lx": 2, "dy": 0, "dx": 0.24}},
+        {"topic": "input", "value": {"iy": 0, "ix": 0, "ly": 0, "lx": 0, "dy": 0, "dx": 0}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"I": null, "L": null, "D": null}},
+        {"topic": "OUTPUT", "value": {"I": null, "L": null, "D": null}},
+        {"topic": "OUTPUT", "value": {"I": null, "L": null, "D": null}},
+        {"topic": "OUTPUT", "value": {"I": -2.5535900500422257, "L": -2.356194490192345, "D": -1.7856117271965553}},
+        {"topic": "OUTPUT", "value": {"I": -0.5880026035475675, "L": -0.7853981633974483, "D": -1.355980926393238}},
+        {"topic": "OUTPUT", "value": {"I": -1.5707963267948966, "L": -1.5707963267948966, "D": -1.5707963267948966}},
+        {"topic": "OUTPUT", "value": {"I": 2.5535900500422257, "L": 2.356194490192345, "D": 1.7856117271965553}},
+        {"topic": "OUTPUT", "value": {"I": 0.5880026035475675, "L": 0.7853981633974483, "D": 1.355980926393238}},
+        {"topic": "OUTPUT", "value": {"I": 1.5707963267948966, "L": 1.5707963267948966, "D": 1.5707963267948966}},
+        {"topic": "OUTPUT", "value": {"I": 3.141592653589793, "L": 3.141592653589793, "D": 3.141592653589793}},
+        {"topic": "OUTPUT", "value": {"I": 0.0, "L": 0.0, "D": 0.0}},
+        {"topic": "OUTPUT", "value": {"I": 0.0, "L": 0.0, "D": 0.0}}
+      ]
+    },
+    {
+      "name": "cos",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, i INT, l BIGINT, d DOUBLE) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT K, cos(i) i, cos(l) l, cos(d) d FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input", "value": {"i": null, "l": null, "d": null}},
+        {"topic": "input", "value": {"i": -7, "l": -7, "d": -9.1}},
+        {"topic": "input", "value": {"i": -6, "l": -6, "d": -0.43}},
+        {"topic": "input", "value": {"i": 0, "l": 0, "d": 0.0}},
+        {"topic": "input", "value": {"i": 6, "l": 6, "d": 0.43}},
+        {"topic": "input", "value": {"i": 7, "l": 7, "d": 9.1}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"I": null, "L": null, "D": null}},
+        {"topic": "OUTPUT", "value": {"I": 0.7539022543433046, "L": 0.7539022543433046, "D": -0.9477216021311119}},
+        {"topic": "OUTPUT", "value": {"I": 0.960170286650366, "L": 0.960170286650366, "D": 0.9089657496748851}},
+        {"topic": "OUTPUT", "value": {"I": 1.0, "L": 1.0, "D": 1.0}},
+        {"topic": "OUTPUT", "value": {"I": 0.960170286650366, "L": 0.960170286650366, "D": 0.9089657496748851}},
+        {"topic": "OUTPUT", "value": {"I": 0.7539022543433046, "L": 0.7539022543433046, "D": -0.9477216021311119}}
+      ]
+    },
+    {
+      "name": "sin",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, i INT, l BIGINT, d DOUBLE) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT K, sin(i) i, sin(l) l, sin(d) d FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input", "value": {"i": null, "l": null, "d": null}},
+        {"topic": "input", "value": {"i": -7, "l": -7, "d": -9.1}},
+        {"topic": "input", "value": {"i": -6, "l": -6, "d": -0.43}},
+        {"topic": "input", "value": {"i": 0, "l": 0, "d": 0.0}},
+        {"topic": "input", "value": {"i": 6, "l": 6, "d": 0.43}},
+        {"topic": "input", "value": {"i": 7, "l": 7, "d": 9.1}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"I": null, "L": null, "D": null}},
+        {"topic": "OUTPUT", "value": {"I": -0.6569865987187891, "L": -0.6569865987187891, "D": -0.3190983623493521}},
+        {"topic": "OUTPUT", "value": {"I": 0.27941549819892586, "L": 0.27941549819892586, "D": -0.41687080242921076}},
+        {"topic": "OUTPUT", "value": {"I": 0.0, "L": 0.0, "D": 0.0}},
+        {"topic": "OUTPUT", "value": {"I": -0.27941549819892586, "L": -0.27941549819892586, "D": 0.41687080242921076}},
+        {"topic": "OUTPUT", "value": {"I": 0.6569865987187891, "L": 0.6569865987187891, "D": 0.3190983623493521}}
+      ]
+    },
+    {
+      "name": "tan",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, i INT, l BIGINT, d DOUBLE) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT K, tan(i) i, tan(l) l, tan(d) d FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input", "value": {"i": null, "l": null, "d": null}},
+        {"topic": "input", "value": {"i": -7, "l": -7, "d": -9.1}},
+        {"topic": "input", "value": {"i": -6, "l": -6, "d": -0.43}},
+        {"topic": "input", "value": {"i": 0, "l": 0, "d": 0.0}},
+        {"topic": "input", "value": {"i": 6, "l": 6, "d": 0.43}},
+        {"topic": "input", "value": {"i": 7, "l": 7, "d": 9.1}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"I": null, "L": null, "D": null}},
+        {"topic": "OUTPUT", "value": {"I": -0.8714479827243188, "L": -0.8714479827243188, "D": 0.33670052643287396}},
+        {"topic": "OUTPUT", "value": {"I": 0.29100619138474915, "L": 0.29100619138474915, "D": -0.45862102348555517}},
+        {"topic": "OUTPUT", "value": {"I": 0.0, "L": 0.0, "D": 0.0}},
+        {"topic": "OUTPUT", "value": {"I": -0.29100619138474915, "L": -0.29100619138474915, "D": 0.45862102348555517}},
+        {"topic": "OUTPUT", "value": {"I": 0.8714479827243188, "L": 0.8714479827243188, "D": -0.33670052643287396}}
+      ]
+    },
+    {
+      "name": "cot",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, i INT, l BIGINT, d DOUBLE) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT K, cot(i) i, cot(l) l, cot(d) d FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input", "value": {"i": null, "l": null, "d": null}},
+        {"topic": "input", "value": {"i": -7, "l": -7, "d": -9.1}},
+        {"topic": "input", "value": {"i": -6, "l": -6, "d": -0.43}},
+        {"topic": "input", "value": {"i": 0, "l": 0, "d": 0.0}},
+        {"topic": "input", "value": {"i": 6, "l": 6, "d": 0.43}},
+        {"topic": "input", "value": {"i": 7, "l": 7, "d": 9.1}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"I": null, "L": null, "D": null}},
+        {"topic": "OUTPUT", "value": {"I": -1.1475154224051356, "L": -1.1475154224051356, "D": 2.9699983263892054}},
+        {"topic": "OUTPUT", "value": {"I": 3.436353004180128, "L": 3.436353004180128, "D": -2.1804495406685085}},
+        {"topic": "OUTPUT", "value": {"I": "Infinity", "L": "Infinity", "D": "Infinity"}},
+        {"topic": "OUTPUT", "value": {"I": -3.436353004180128, "L": -3.436353004180128, "D": 2.1804495406685085}},
+        {"topic": "OUTPUT", "value": {"I": 1.1475154224051356, "L": 1.1475154224051356, "D": -2.9699983263892054}}
+      ]
+    },
+    {
+      "name": "degrees",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, i INT, l BIGINT, d DOUBLE) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT K, degrees(i) i, degrees(l) l, degrees(d) d FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input", "value": {"i": null, "l": null, "d": null}},
+        {"topic": "input", "value": {"i": -2, "l": -2, "d": -1.2345}},
+        {"topic": "input", "value": {"i": 0, "l": 0, "d": 0.0}},
+        {"topic": "input", "value": {"i": 2, "l": 2, "d": 1.2345}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"I": null, "L": null, "D": null}},
+        {"topic": "OUTPUT", "value": {"I": -114.59155902616465, "L": -114.59155902616465, "D": -70.73163980890013}},
+        {"topic": "OUTPUT", "value": {"I": 0.0, "L": 0.0, "D": 0.0}},
+        {"topic": "OUTPUT", "value": {"I": 114.59155902616465, "L": 114.59155902616465, "D": 70.73163980890013}}
+      ]
+    },
+    {
+      "name": "radians",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, i INT, l BIGINT, d DOUBLE) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT K, radians(i) i, radians(l) l, radians(d) d FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input", "value": {"i": null, "l": null, "d": null}},
+        {"topic": "input", "value": {"i": -114, "l": -114, "d": -70.73163980890013}},
+        {"topic": "input", "value": {"i": 0, "l": 0, "d": 0.0}},
+        {"topic": "input", "value": {"i": 114, "l": 114, "d": 70.73163980890013}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"I": null, "L": null, "D": null}},
+        {"topic": "OUTPUT", "value": {"I": -1.9896753472735358, "L": -1.9896753472735358, "D": -1.2345}},
+        {"topic": "OUTPUT", "value": {"I": 0.0, "L": 0.0, "D": 0.0}},
+        {"topic": "OUTPUT", "value": {"I": 1.9896753472735358, "L": 1.9896753472735358, "D": 1.2345}}
+      ]
+    },
+    {
+      "name": "pi",
+      "statements": [
+        "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT pi() AS VAL FROM INPUT;"
+      ],
+      "inputs": [{"topic": "input", "value": {}}],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"val": 3.141592653589793}}
+      ]
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/math.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/math.json
@@ -454,6 +454,75 @@
       ]
     },
     {
+      "name": "cosh",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, i INT, l BIGINT, d DOUBLE) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT K, cosh(i) i, cosh(l) l, cosh(d) d FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input", "value": {"i": null, "l": null, "d": null}},
+        {"topic": "input", "value": {"i": -7, "l": -7, "d": -9.1}},
+        {"topic": "input", "value": {"i": -6, "l": -6, "d": -0.43}},
+        {"topic": "input", "value": {"i": 0, "l": 0, "d": 0.0}},
+        {"topic": "input", "value": {"i": 6, "l": 6, "d": 0.43}},
+        {"topic": "input", "value": {"i": 7, "l": 7, "d": 9.1}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"I": null, "L": null, "D": null}},
+        {"topic": "OUTPUT", "value": {"I": 548.317035155212, "L": 548.317035155212, "D": 4477.646407574158}},
+        {"topic": "OUTPUT", "value": {"I": 201.7156361224559, "L": 201.7156361224559, "D": 1.0938833091357991}},
+        {"topic": "OUTPUT", "value": {"I": 1.0, "L": 1.0, "D": 1.0}},
+        {"topic": "OUTPUT", "value": {"I": 201.7156361224559, "L": 201.7156361224559, "D": 1.0938833091357991}},
+        {"topic": "OUTPUT", "value": {"I": 548.317035155212, "L": 548.317035155212, "D": 4477.646407574158}}
+      ]
+    },
+    {
+      "name": "sinh",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, i INT, l BIGINT, d DOUBLE) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT K, sinh(i) i, sinh(l) l, sinh(d) d FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input", "value": {"i": null, "l": null, "d": null}},
+        {"topic": "input", "value": {"i": -7, "l": -7, "d": -9.1}},
+        {"topic": "input", "value": {"i": -6, "l": -6, "d": -0.43}},
+        {"topic": "input", "value": {"i": 0, "l": 0, "d": 0.0}},
+        {"topic": "input", "value": {"i": 6, "l": 6, "d": 0.43}},
+        {"topic": "input", "value": {"i": 7, "l": 7, "d": 9.1}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"I": null, "L": null, "D": null}},
+        {"topic": "OUTPUT", "value": {"I": -548.3161232732465, "L": -548.3161232732465, "D": -4477.64629590835}},
+        {"topic": "OUTPUT", "value": {"I": -201.71315737027922, "L": -201.71315737027922, "D": -0.4433742144124824}},
+        {"topic": "OUTPUT", "value": {"I": 0.0, "L": 0.0, "D": 0.0}},
+        {"topic": "OUTPUT", "value": {"I": 201.71315737027922, "L": 201.71315737027922, "D": 0.4433742144124824}},
+        {"topic": "OUTPUT", "value": {"I": 548.3161232732465, "L": 548.3161232732465, "D": 4477.64629590835}}
+      ]
+    },
+    {
+      "name": "tanh",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, i INT, l BIGINT, d DOUBLE) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT K, tanh(i) i, tanh(l) l, tanh(d) d FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input", "value": {"i": null, "l": null, "d": null}},
+        {"topic": "input", "value": {"i": -7, "l": -7, "d": -9.1}},
+        {"topic": "input", "value": {"i": -6, "l": -6, "d": -0.43}},
+        {"topic": "input", "value": {"i": 0, "l": 0, "d": 0.0}},
+        {"topic": "input", "value": {"i": 6, "l": 6, "d": 0.43}},
+        {"topic": "input", "value": {"i": 7, "l": 7, "d": 9.1}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"I": null, "L": null, "D": null}},
+        {"topic": "OUTPUT", "value": {"I": -0.9999983369439447, "L": -0.9999983369439447, "D": -0.9999999750614947}},
+        {"topic": "OUTPUT", "value": {"I": -0.9999877116507956, "L": -0.9999877116507956, "D": -0.4053213086894629}},
+        {"topic": "OUTPUT", "value": {"I": 0.0, "L": 0.0, "D": 0.0}},
+        {"topic": "OUTPUT", "value": {"I": 0.9999877116507956, "L": 0.9999877116507956, "D": 0.4053213086894629}},
+        {"topic": "OUTPUT", "value": {"I": 0.9999983369439447, "L": 0.9999983369439447, "D": 0.9999999750614947}}
+      ]
+    },
+    {
       "name": "degrees",
       "statements": [
         "CREATE STREAM INPUT (K STRING KEY, i INT, l BIGINT, d DOUBLE) WITH (kafka_topic='input', value_format='JSON');",


### PR DESCRIPTION
### Description 
Added 14 new trig scalar functions: 
- acos() - inverse cosine
- asin() - inverse sine
- atan() - inverse tangent
- atan2() - inverse tangent w/ parameters (y, x)
- cos() - cosine
- sin() - sine
- tan() - tangent
- cot() - cotangent
- cosh() - hyperbolic cosine
- sinh() - hyperbolic sine
- tanh() - hyperbolic tangent
- degrees() - radians to degrees
- radians() - degrees to radians
- pi() - returns pi

Resolves #8758.

This implements most of the trig functions [available in Postgres](https://www.postgresql.org/docs/current/functions-math.html). I've omitted the inverse hyperbolic functions as there is no library method for these in `Math`, and they seem niche.

This also updates the scalar function documentation to include the new functions.

### Testing done 
Added unit tests and QTT tests for the new functions.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")