### PR TITLE
fix: convert topic tag name and add consumer group member id tag to ThroughputTotalMetrics

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/MetricsTagUtils.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/MetricsTagUtils.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.internal;
 
 import java.util.regex.Pattern;
 
-final public class MetricsTagUtils {
+public final class MetricsTagUtils {
 
   private MetricsTagUtils() {
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/MetricsTagUtils.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/MetricsTagUtils.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.confluent.ksql.internal;
+
+import java.util.regex.Pattern;
+
+public class MetricsTagUtils {
+  public static final String KSQL_CONSUMER_GROUP_MEMBER_ID_TAG = "consumer_group_member_id";
+  public static final String KSQL_TASK_ID_TAG = "task-id";
+  public static final String KSQL_TOPIC_TAG = "topic";
+  public static final String KSQL_QUERY_ID_TAG = "query-id";
+
+  public static final Pattern NAMED_TOPOLOGY_PATTERN = Pattern.compile("(.*?)__\\d*_\\d*");
+  public static final Pattern QUERY_ID_PATTERN =
+    Pattern.compile("(?<=query_|transient_)(.*?)(?=-)");
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/MetricsTagUtils.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/MetricsTagUtils.java
@@ -17,6 +17,10 @@ package io.confluent.ksql.internal;
 import java.util.regex.Pattern;
 
 public class MetricsTagUtils {
+
+  private MetricsTagUtils() {
+  }
+
   public static final String KSQL_CONSUMER_GROUP_MEMBER_ID_TAG = "consumer_group_member_id";
   public static final String KSQL_TASK_ID_TAG = "task-id";
   public static final String KSQL_TOPIC_TAG = "topic";
@@ -24,5 +28,5 @@ public class MetricsTagUtils {
 
   public static final Pattern NAMED_TOPOLOGY_PATTERN = Pattern.compile("(.*?)__\\d*_\\d*");
   public static final Pattern QUERY_ID_PATTERN =
-    Pattern.compile("(?<=query_|transient_)(.*?)(?=-)");
+      Pattern.compile("(?<=query_|transient_)(.*?)(?=-)");
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/MetricsTagUtils.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/MetricsTagUtils.java
@@ -12,11 +12,12 @@
  * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package io.confluent.ksql.internal;
 
 import java.util.regex.Pattern;
 
-public class MetricsTagUtils {
+final public class MetricsTagUtils {
 
   private MetricsTagUtils() {
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
@@ -15,7 +15,13 @@
 
 package io.confluent.ksql.internal;
 
+import static io.confluent.ksql.internal.MetricsTagUtils.KSQL_QUERY_ID_TAG;
+import static io.confluent.ksql.internal.MetricsTagUtils.KSQL_TASK_ID_TAG;
+import static io.confluent.ksql.internal.MetricsTagUtils.NAMED_TOPOLOGY_PATTERN;
+import static io.confluent.ksql.internal.MetricsTagUtils.QUERY_ID_PATTERN;
 import static java.util.Objects.requireNonNull;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TASK_ID_TAG;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.THREAD_ID_TAG;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
@@ -33,7 +39,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.config.ConfigException;
@@ -44,14 +49,6 @@ import org.apache.kafka.common.metrics.MetricsContext;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TASK_ID_TAG;
-import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.THREAD_ID_TAG;
-
-import static io.confluent.ksql.internal.MetricsTagUtils.KSQL_QUERY_ID_TAG;
-import static io.confluent.ksql.internal.MetricsTagUtils.KSQL_TASK_ID_TAG;
-import static io.confluent.ksql.internal.MetricsTagUtils.NAMED_TOPOLOGY_PATTERN;
-import static io.confluent.ksql.internal.MetricsTagUtils.QUERY_ID_PATTERN;
 
 public class StorageUtilizationMetricsReporter implements MetricsReporter {
   private static final Logger LOGGER

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
@@ -45,14 +45,19 @@ import org.apache.kafka.common.metrics.MetricsReporter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TASK_ID_TAG;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.THREAD_ID_TAG;
+
+import static io.confluent.ksql.internal.MetricsTagUtils.KSQL_QUERY_ID_TAG;
+import static io.confluent.ksql.internal.MetricsTagUtils.KSQL_TASK_ID_TAG;
+import static io.confluent.ksql.internal.MetricsTagUtils.NAMED_TOPOLOGY_PATTERN;
+import static io.confluent.ksql.internal.MetricsTagUtils.QUERY_ID_PATTERN;
+
 public class StorageUtilizationMetricsReporter implements MetricsReporter {
   private static final Logger LOGGER
       = LoggerFactory.getLogger(StorageUtilizationMetricsReporter.class);
   private static final String METRIC_GROUP = "ksqldb_utilization";
   private static final String TASK_STORAGE_USED_BYTES = "task_storage_used_bytes";
-  private static final Pattern NAMED_TOPOLOGY_PATTERN = Pattern.compile("(.*?)__\\d*_\\d*");
-  private static final Pattern QUERY_ID_PATTERN =
-      Pattern.compile("(?<=query_|transient_)(.*?)(?=-)");
 
   private Map<String, Map<String, TaskStorageMetric>> metricsSeen;
   private Metrics metricRegistry;
@@ -126,7 +131,7 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
 
     handleNewSstFilesSizeMetric(
         metric,
-        metric.metricName().tags().getOrDefault("task-id", ""),
+        metric.metricName().tags().getOrDefault(TASK_ID_TAG, ""),
         getQueryId(metric)
     );
   }
@@ -139,7 +144,7 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
     }
 
     final String queryId = getQueryId(metric);
-    final String taskId = metric.metricName().tags().getOrDefault("task-id", "");
+    final String taskId = metric.metricName().tags().getOrDefault(TASK_ID_TAG, "");
     final TaskStorageMetric taskMetric = metricsSeen.get(queryId).get(taskId);
 
     handleRemovedSstFileSizeMetric(taskMetric, metric, queryId, taskId);
@@ -267,13 +272,13 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
   }
 
   private String getQueryId(final KafkaMetric metric) {
-    final String taskName = metric.metricName().tags().getOrDefault("task-id", "");
+    final String taskName = metric.metricName().tags().getOrDefault(TASK_ID_TAG, "");
     final Matcher namedTopologyMatcher = NAMED_TOPOLOGY_PATTERN.matcher(taskName);
     if (namedTopologyMatcher.find()) {
       return namedTopologyMatcher.group(1);
     }
 
-    final String queryIdTag = metric.metricName().tags().getOrDefault("thread-id", "");
+    final String queryIdTag = metric.metricName().tags().getOrDefault(THREAD_ID_TAG, "");
     final Matcher matcher = QUERY_ID_PATTERN.matcher(queryIdTag);
     if (matcher.find()) {
       return matcher.group(1);
@@ -285,7 +290,7 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
   
   private Map<String, String> getQueryMetricTags(final String queryId) {
     final Map<String, String> queryMetricTags = new HashMap<>(customTags);
-    queryMetricTags.put("query-id", queryId);
+    queryMetricTags.put(KSQL_QUERY_ID_TAG, queryId);
     return ImmutableMap.copyOf(queryMetricTags);
   }
 
@@ -294,7 +299,7 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
       final String taskId
   ) {
     final Map<String, String> taskMetricTags = new HashMap<>(queryTags);
-    taskMetricTags.put("task-id", taskId);
+    taskMetricTags.put(KSQL_TASK_ID_TAG, taskId);
     return ImmutableMap.copyOf((taskMetricTags));
   }
   

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/ThroughputMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/ThroughputMetricsReporter.java
@@ -41,7 +41,6 @@ import org.apache.kafka.common.metrics.MetricsContext;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.metrics.stats.CumulativeSum;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -207,13 +206,15 @@ public class ThroughputMetricsReporter implements MetricsReporter {
       return metric.metricName().tags().get(KSQL_QUERY_ID_TAG);
     }
 
-    final String taskName = metric.metricName().tags().getOrDefault(StreamsMetricsImpl.TASK_ID_TAG, "");
+    final String taskName =
+        metric.metricName().tags().getOrDefault(StreamsMetricsImpl.TASK_ID_TAG, "");
     final Matcher namedTopologyMatcher = NAMED_TOPOLOGY_PATTERN.matcher(taskName);
     if (namedTopologyMatcher.find()) {
       return namedTopologyMatcher.group(1);
     }
 
-    final String queryIdTag = metric.metricName().tags().getOrDefault(StreamsMetricsImpl.THREAD_ID_TAG, "");
+    final String queryIdTag =
+        metric.metricName().tags().getOrDefault(StreamsMetricsImpl.THREAD_ID_TAG, "");
     final Matcher matcher = QUERY_ID_PATTERN.matcher(queryIdTag);
     if (matcher.find()) {
       return matcher.group(1);
@@ -228,7 +229,8 @@ public class ThroughputMetricsReporter implements MetricsReporter {
       return metric.metricName().tags().get(KSQL_TOPIC_TAG);
     }
 
-    final String topic = metric.metricName().tags().getOrDefault(StreamsMetricsImpl.TOPIC_NAME_TAG, "");
+    final String topic =
+        metric.metricName().tags().getOrDefault(StreamsMetricsImpl.TOPIC_NAME_TAG, "");
     if (topic.equals("")) {
       LOGGER.error("Can't parse topic name from metric {}", metric);
       throw new KsqlException("Missing topic name when reporting total throughput metrics");

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/ThroughputMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/ThroughputMetricsReporter.java
@@ -251,8 +251,7 @@ public class ThroughputMetricsReporter implements MetricsReporter {
     queryMetricTags.remove(StreamsMetricsImpl.PROCESSOR_NODE_ID_TAG);
 
     // Convert the tag name from 'topic-name' to 'topic' to conform to client metrics
-    // TODO: we can remove this once the upstream fix is merged --
-    //  see https://github.com/apache/kafka/pull/12310
+    // We can remove this once the Streams fix is merged https://github.com/apache/kafka/pull/12310
     queryMetricTags.remove(StreamsMetricsImpl.TOPIC_NAME_TAG);
     queryMetricTags.put(KSQL_TOPIC_TAG, topic);
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/ThroughputMetricsReporterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/ThroughputMetricsReporterTest.java
@@ -69,13 +69,13 @@ public class ThroughputMetricsReporterTest {
   private static final Map<String, String> QUERY_ONE_TAGS = ImmutableMap.of(
       "logical_cluster_id", "lksqlc-12345",
       "query-id", QUERY_ID + "_1",
-      "consumer-group-member-id", THREAD_ID,
+      "consumer_group_member_id", THREAD_ID,
       "topic", TOPIC_NAME
   );
   private static final Map<String, String> QUERY_TWO_TAGS = ImmutableMap.of(
       "logical_cluster_id", "lksqlc-12345",
       "query-id", QUERY_ID + "_2",
-      "consumer-group-member-id", THREAD_ID_2,
+      "consumer_group_member_id", THREAD_ID_2,
       "topic", TOPIC_NAME_2
   );
 
@@ -275,14 +275,14 @@ public class ThroughputMetricsReporterTest {
     final Map<String, String> transientQueryTags = ImmutableMap.of(
         "logical_cluster_id", "lksqlc-12345",
         "query-id", "blahblah_4",
-        "consumer-group-member-id", TRANSIENT_THREAD_ID,
+        "consumer_group_id", TRANSIENT_THREAD_ID,
         "topic", TOPIC_NAME
     );
     listener.metricChange(mockMetric(
         BYTES_CONSUMED_TOTAL,
         2D,
         ImmutableMap.of(
-            "consumer-group-member-id", TRANSIENT_THREAD_ID,
+            "thread-id", TRANSIENT_THREAD_ID,
             "task-id", TASK_ID_1,
             "processor-node-id", PROCESSOR_NODE_ID,
             "topic", TOPIC_NAME))
@@ -298,7 +298,7 @@ public class ThroughputMetricsReporterTest {
       BYTES_CONSUMED_TOTAL,
       15D,
       ImmutableMap.of(
-        "consumer-group-member-id", TRANSIENT_THREAD_ID,
+        "thread-id", TRANSIENT_THREAD_ID,
         "task-id", TASK_ID_2,
         "processor-node-id", PROCESSOR_NODE_ID,
         "topic", TOPIC_NAME
@@ -318,14 +318,14 @@ public class ThroughputMetricsReporterTest {
     final Map<String, String> sharedRuntimeQueryTags = ImmutableMap.of(
       "logical_cluster_id", "lksqlc-12345",
       "query-id", "CTAS_TEST_5",
-      "consumer-group-member-id", "_confluent_blahblah_query-1-blahblah",
+      "consumer_group_id", "_confluent_blahblah_query-1-blahblah",
       "topic", TOPIC_NAME
     );
     listener.metricChange(mockMetric(
       BYTES_CONSUMED_TOTAL,
       2D,
       ImmutableMap.of(
-        "consumer-group-member-id", "_confluent_blahblah_query-1-blahblah",
+        "thread-id", "_confluent_blahblah_query-1-blahblah",
         "task-id", "CTAS_TEST_5__" + TASK_ID_1,
         "processor-node-id", PROCESSOR_NODE_ID,
         "topic", TOPIC_NAME))
@@ -341,7 +341,7 @@ public class ThroughputMetricsReporterTest {
       BYTES_CONSUMED_TOTAL,
       15D,
       ImmutableMap.of(
-        "consumer-group-member-id", "_confluent_blahblah_query-1-blahblah",
+        "thread-id", "_confluent_blahblah_query-1-blahblah",
         "task-id", "CTAS_TEST_5__" + TASK_ID_2,
         "processor-node-id", PROCESSOR_NODE_ID,
         "topic", TOPIC_NAME
@@ -377,7 +377,7 @@ public class ThroughputMetricsReporterTest {
         BYTES_CONSUMED_TOTAL,
         2D,
         ImmutableMap.of(
-          "consumer-group-member-id", "_confluent_blahblah_query-blahblah",
+          "thread-id", "_confluent_blahblah_query-blahblah",
           "task-id", TASK_ID_1,
           "processor-node-id", PROCESSOR_NODE_ID,
           "topic", TOPIC_NAME))
@@ -394,7 +394,7 @@ public class ThroughputMetricsReporterTest {
         BYTES_CONSUMED_TOTAL,
         2D,
         ImmutableMap.of(
-          "consumer-group-member-id", THREAD_ID,
+          "thread-id", THREAD_ID,
           "task-id", TASK_ID_1,
           "processor-node-id", PROCESSOR_NODE_ID))
       )

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/ThroughputMetricsReporterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/ThroughputMetricsReporterTest.java
@@ -69,14 +69,14 @@ public class ThroughputMetricsReporterTest {
   private static final Map<String, String> QUERY_ONE_TAGS = ImmutableMap.of(
       "logical_cluster_id", "lksqlc-12345",
       "query-id", QUERY_ID + "_1",
-      "thread-id", THREAD_ID,
-      "topic-name", TOPIC_NAME
+      "consumer-group-member-id", THREAD_ID,
+      "topic", TOPIC_NAME
   );
   private static final Map<String, String> QUERY_TWO_TAGS = ImmutableMap.of(
       "logical_cluster_id", "lksqlc-12345",
       "query-id", QUERY_ID + "_2",
-      "thread-id", THREAD_ID_2,
-      "topic-name", TOPIC_NAME_2
+      "consumer-group-member-id", THREAD_ID_2,
+      "topic", TOPIC_NAME_2
   );
 
   private ThroughputMetricsReporter listener;
@@ -275,17 +275,17 @@ public class ThroughputMetricsReporterTest {
     final Map<String, String> transientQueryTags = ImmutableMap.of(
         "logical_cluster_id", "lksqlc-12345",
         "query-id", "blahblah_4",
-        "thread-id", TRANSIENT_THREAD_ID,
-        "topic-name", TOPIC_NAME
+        "consumer-group-member-id", TRANSIENT_THREAD_ID,
+        "topic", TOPIC_NAME
     );
     listener.metricChange(mockMetric(
         BYTES_CONSUMED_TOTAL,
         2D,
         ImmutableMap.of(
-            "thread-id", TRANSIENT_THREAD_ID,
+            "consumer-group-member-id", TRANSIENT_THREAD_ID,
             "task-id", TASK_ID_1,
             "processor-node-id", PROCESSOR_NODE_ID,
-            "topic-name", TOPIC_NAME))
+            "topic", TOPIC_NAME))
     );
 
     Measurable bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_TOTAL, transientQueryTags);
@@ -298,10 +298,10 @@ public class ThroughputMetricsReporterTest {
       BYTES_CONSUMED_TOTAL,
       15D,
       ImmutableMap.of(
-        "thread-id", TRANSIENT_THREAD_ID,
+        "consumer-group-member-id", TRANSIENT_THREAD_ID,
         "task-id", TASK_ID_2,
         "processor-node-id", PROCESSOR_NODE_ID,
-        "topic-name", TOPIC_NAME
+        "topic", TOPIC_NAME
       ))
     );
 
@@ -318,17 +318,17 @@ public class ThroughputMetricsReporterTest {
     final Map<String, String> sharedRuntimeQueryTags = ImmutableMap.of(
       "logical_cluster_id", "lksqlc-12345",
       "query-id", "CTAS_TEST_5",
-      "thread-id", "_confluent_blahblah_query-1-blahblah",
-      "topic-name", TOPIC_NAME
+      "consumer-group-member-id", "_confluent_blahblah_query-1-blahblah",
+      "topic", TOPIC_NAME
     );
     listener.metricChange(mockMetric(
       BYTES_CONSUMED_TOTAL,
       2D,
       ImmutableMap.of(
-        "thread-id", "_confluent_blahblah_query-1-blahblah",
+        "consumer-group-member-id", "_confluent_blahblah_query-1-blahblah",
         "task-id", "CTAS_TEST_5__" + TASK_ID_1,
         "processor-node-id", PROCESSOR_NODE_ID,
-        "topic-name", TOPIC_NAME))
+        "topic", TOPIC_NAME))
     );
 
     Measurable bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_TOTAL, sharedRuntimeQueryTags);
@@ -341,10 +341,10 @@ public class ThroughputMetricsReporterTest {
       BYTES_CONSUMED_TOTAL,
       15D,
       ImmutableMap.of(
-        "thread-id", "_confluent_blahblah_query-1-blahblah",
+        "consumer-group-member-id", "_confluent_blahblah_query-1-blahblah",
         "task-id", "CTAS_TEST_5__" + TASK_ID_2,
         "processor-node-id", PROCESSOR_NODE_ID,
-        "topic-name", TOPIC_NAME
+        "topic", TOPIC_NAME
       ))
     );
 
@@ -377,10 +377,10 @@ public class ThroughputMetricsReporterTest {
         BYTES_CONSUMED_TOTAL,
         2D,
         ImmutableMap.of(
-          "thread-id", "_confluent_blahblah_query-blahblah",
+          "consumer-group-member-id", "_confluent_blahblah_query-blahblah",
           "task-id", TASK_ID_1,
           "processor-node-id", PROCESSOR_NODE_ID,
-          "topic-name", TOPIC_NAME))
+          "topic", TOPIC_NAME))
       )
     );
   }
@@ -394,7 +394,7 @@ public class ThroughputMetricsReporterTest {
         BYTES_CONSUMED_TOTAL,
         2D,
         ImmutableMap.of(
-          "thread-id", THREAD_ID,
+          "consumer-group-member-id", THREAD_ID,
           "task-id", TASK_ID_1,
           "processor-node-id", PROCESSOR_NODE_ID))
       )

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/ThroughputMetricsReporterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/ThroughputMetricsReporterTest.java
@@ -275,7 +275,7 @@ public class ThroughputMetricsReporterTest {
     final Map<String, String> transientQueryTags = ImmutableMap.of(
         "logical_cluster_id", "lksqlc-12345",
         "query-id", "blahblah_4",
-        "consumer_group_id", TRANSIENT_THREAD_ID,
+        "consumer_group_member_id", TRANSIENT_THREAD_ID,
         "topic", TOPIC_NAME
     );
     listener.metricChange(mockMetric(
@@ -318,7 +318,7 @@ public class ThroughputMetricsReporterTest {
     final Map<String, String> sharedRuntimeQueryTags = ImmutableMap.of(
       "logical_cluster_id", "lksqlc-12345",
       "query-id", "CTAS_TEST_5",
-      "consumer_group_id", "_confluent_blahblah_query-1-blahblah",
+      "consumer_group_member_id", "_confluent_blahblah_query-1-blahblah",
       "topic", TOPIC_NAME
     );
     listener.metricChange(mockMetric(


### PR DESCRIPTION
Adjust the throughput metric tags  used in `ThroughputMetricsReporter` to conform to the existing tag names used elsewhere (eg in the clients):

1. Convert the `"topic-name"` tag currently set by Streams to just `"topic"` -- can remove this once the upstream fix is merged & synced through to ccs-kafka (won't cause any issues if it's not removed in time, though)
2. Replace the `"thread-id"` tag with the `"consumer_group_member_id"` tag that's used in other metrics/is an existing metrics label in Druid