### PR TITLE
fix: remove topic tag conversion hack and update tests

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/ThroughputMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/ThroughputMetricsReporter.java
@@ -250,11 +250,6 @@ public class ThroughputMetricsReporter implements MetricsReporter {
     queryMetricTags.remove(StreamsMetricsImpl.TASK_ID_TAG);
     queryMetricTags.remove(StreamsMetricsImpl.PROCESSOR_NODE_ID_TAG);
 
-    // Convert the tag name from 'topic-name' to 'topic' to conform to client metrics
-    // We can remove this once the Streams fix is merged https://github.com/apache/kafka/pull/12310
-    queryMetricTags.remove(StreamsMetricsImpl.TOPIC_NAME_TAG);
-    queryMetricTags.put(KSQL_TOPIC_TAG, topic);
-
     // Replace thread id with consumer group member id to match existing client tag/Druid label
     final String threadId = queryMetricTags.remove(StreamsMetricsImpl.THREAD_ID_TAG);
     queryMetricTags.put(KSQL_CONSUMER_GROUP_MEMBER_ID_TAG, threadId);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/ThroughputMetricsReporterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/ThroughputMetricsReporterTest.java
@@ -46,25 +46,25 @@ public class ThroughputMetricsReporterTest {
       "thread-id", THREAD_ID,
       "task-id", TASK_ID_1,
       "processor-node-id", PROCESSOR_NODE_ID,
-      "topic-name", TOPIC_NAME
+      "topic", TOPIC_NAME
   );
   private static final Map<String, String> STREAMS_TAGS_TASK_2 = ImmutableMap.of(
       "thread-id", THREAD_ID,
       "task-id", TASK_ID_2,
       "processor-node-id", PROCESSOR_NODE_ID,
-      "topic-name", TOPIC_NAME
+      "topic", TOPIC_NAME
   );
   private static final Map<String, String> STREAMS_TAGS_PROCESSOR_2 = ImmutableMap.of(
       "thread-id", THREAD_ID,
       "task-id", TASK_ID_2,
       "processor-node-id", PROCESSOR_NODE_ID_2,
-      "topic-name", TOPIC_NAME
+      "topic", TOPIC_NAME
   );
   private static final Map<String, String> STREAMS_TAGS_TOPIC_2 = ImmutableMap.of(
       "thread-id", THREAD_ID_2,
       "task-id", TASK_ID_1,
       "processor-node-id", PROCESSOR_NODE_ID,
-      "topic-name", TOPIC_NAME_2
+      "topic", TOPIC_NAME_2
   );
   private static final Map<String, String> QUERY_ONE_TAGS = ImmutableMap.of(
       "logical_cluster_id", "lksqlc-12345",


### PR DESCRIPTION
Followup to https://github.com/apache/kafka/pull/12310 to fix the tests and remove the temporary hack for converting the `topic-name` tag to just `topic`