### PR TITLE
fix: respect authentication.skip.paths properly

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/AuthenticationPluginHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/AuthenticationPluginHandler.java
@@ -41,7 +41,7 @@ import java.util.regex.Pattern;
  * Handler that calls any authentication plugin
  */
 public class AuthenticationPluginHandler implements Handler<RoutingContext> {
-  public static final Set<String> KSQL_AUTHENTICATION_SKIP_PATHS = ImmutableSet
+  private static final Set<String> KSQL_AUTHENTICATION_SKIP_PATHS = ImmutableSet
       .of("/v1/metadata", "/v1/metadata/id", "/healthcheck");
 
   private final Server server;
@@ -53,17 +53,9 @@ public class AuthenticationPluginHandler implements Handler<RoutingContext> {
       final AuthenticationPlugin securityHandlerPlugin) {
     this.server = Objects.requireNonNull(server);
     this.securityHandlerPlugin = Objects.requireNonNull(securityHandlerPlugin);
-    // We add in all the paths that don't require authentication/authorization from
-    // KsqlAuthorizationProviderHandler
-    final Set<String> unauthenticatedPaths = new HashSet<>(KSQL_AUTHENTICATION_SKIP_PATHS);
-    // And then we add anything from the property authentication.skip.paths
-    // This preserves the behaviour from the previous Jetty based implementation
     final List<String> unauthed = server.getConfig()
         .getList(KsqlRestConfig.AUTHENTICATION_SKIP_PATHS_CONFIG);
-    unauthenticatedPaths.addAll(unauthed);
-    final String paths = String.join(",", unauthenticatedPaths);
-    final String converted = convertCommaSeparatedWilcardsToRegex(paths);
-    unauthedPathsPattern = Pattern.compile(converted);
+    unauthedPathsPattern = getAuthorizationSkipPaths(unauthed);
   }
 
   @Override
@@ -89,6 +81,18 @@ public class AuthenticationPluginHandler implements Handler<RoutingContext> {
       routingContext.fail(t);
       return null;
     });
+  }
+
+  public static Pattern getAuthorizationSkipPaths(final List<String> unauthed) {
+    // We add in all the paths that don't require authentication/authorization from
+    // KsqlAuthorizationProviderHandler
+    final Set<String> unauthenticatedPaths = new HashSet<>(KSQL_AUTHENTICATION_SKIP_PATHS);
+    // And then we add anything from the property authentication.skip.paths
+    // This preserves the behaviour from the previous Jetty based implementation
+    unauthenticatedPaths.addAll(unauthed);
+    final String paths = String.join(",", unauthenticatedPaths);
+    final String converted = convertCommaSeparatedWilcardsToRegex(paths);
+    return Pattern.compile(converted);
   }
 
   private static class AuthPluginUser implements ApiUser {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/AuthHandlers.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/AuthHandlers.java
@@ -52,8 +52,7 @@ public final class AuthHandlers {
       // For authorization use auth provider configured via security extension (if any)
       securityExtension.getAuthorizationProvider()
           .ifPresent(ksqlAuthorizationProvider -> router.route()
-              .handler(new KsqlAuthorizationProviderHandler(server.getWorkerExecutor(),
-                  ksqlAuthorizationProvider)));
+              .handler(new KsqlAuthorizationProviderHandler(server, ksqlAuthorizationProvider)));
 
       router.route().handler(AuthHandlers::resumeHandler);
     }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/auth/AuthenticationPluginHandlerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/auth/AuthenticationPluginHandlerTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.auth;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.junit.Test;
+
+public class AuthenticationPluginHandlerTest {
+
+  @Test
+  public void shouldBuildRegexThatRespectsSkipPaths() {
+    // Given:
+    final List<String> configs = ImmutableList.of("/heartbeat", "/lag");
+
+    // When:
+    final Pattern skips = AuthenticationPluginHandler.getAuthorizationSkipPaths(configs);
+
+    // Then:
+    assertThat(skips.matcher("/heartbeat").matches(), is(true));
+  }
+
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/auth/AuthenticationPluginHandlerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/auth/AuthenticationPluginHandlerTest.java
@@ -35,6 +35,7 @@ public class AuthenticationPluginHandlerTest {
 
     // Then:
     assertThat(skips.matcher("/heartbeat").matches(), is(true));
+    assertThat(skips.matcher("/foo").matches(), is(false));
   }
 
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/auth/KsqlAuthorizationProviderHandlerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/auth/KsqlAuthorizationProviderHandlerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.auth;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.api.server.Server;
+import io.confluent.ksql.rest.server.KsqlRestConfig;
+import io.confluent.ksql.security.KsqlAuthorizationProvider;
+import io.vertx.core.WorkerExecutor;
+import io.vertx.ext.web.RoutingContext;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KsqlAuthorizationProviderHandlerTest {
+
+  @Mock
+  private Server server;
+  @Mock
+  private KsqlAuthorizationProvider authProvider;
+  @Mock
+  private WorkerExecutor workerExecutor;
+  @Mock
+  private RoutingContext routingContext;
+
+  @Test
+  public void shouldRespectServerAuthSkipPathsConfig() {
+    // Given:
+    Mockito.when(server.getWorkerExecutor()).thenReturn(workerExecutor);
+    Mockito.when(server.getConfig()).thenReturn(new KsqlRestConfig(
+        ImmutableMap.of(
+            KsqlRestConfig.AUTHENTICATION_SKIP_PATHS_CONFIG,
+            ImmutableList.of("/heartbeat")
+        )
+    ));
+    Mockito.when(routingContext.normalisedPath()).thenReturn("/heartbeat");
+    KsqlAuthorizationProviderHandler handler = new KsqlAuthorizationProviderHandler(server, authProvider);
+
+    // When:
+    handler.handle(routingContext);
+
+    // Then (make sure the authorization "work" is skipped):
+    Mockito.verify(routingContext).next();
+    Mockito.verifyZeroInteractions(workerExecutor);
+  }
+
+}


### PR DESCRIPTION
### Description 
fixes #9206 by respecting the `authentication.skip.paths` in `KsqlAuthorizationProviderHandler.java`

### Testing done 
spun up CFK with MTLS and RBAC enabled on the normal endpoints. see relevant portion of configuration:
```
    authentication.skip.paths=/chc*,/heartbeat,/lag
    bootstrap.servers=kafka.operator-feyrhf.svc.cluster.local:9073
    config.providers=file
    config.providers.file.class=org.apache.kafka.common.config.provider.FileConfigProvider
    confluent.metadata.basic.auth.user.info=${file:/mnt/secrets/ksqldb-mds-client/bearer.txt:username}:${file:/mnt/secrets/ksqldb-mds-client/bearer.txt:password}
    confluent.metadata.bootstrap.server.urls=https://kafka.operator-feyrhf.svc.cluster.local:8090
    confluent.metadata.http.auth.credentials.provider=BASIC
    confluent.metadata.ssl.truststore.location=/mnt/sslcerts/truststore.jks
    confluent.metadata.ssl.truststore.password=${file:/mnt/sslcerts/jksPassword.txt:jksPassword}
    ksql.authentication.plugin.class=io.confluent.ksql.security.VertxBearerOrBasicAuthenticationPlugin
    ksql.heartbeat.enable=true
    ksql.lag.reporting.enable=true
    ksql.query.pull.enable.standby.reads=true
    ksql.security.extension.class=io.confluent.ksql.security.KsqlConfluentSecurityExtension
    ksql.streams.num.standby.replicas=1
    sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required metadataServerUrls="https://kafka.operator-feyrhf.svc.cluster.local:8090" username="${file:/mnt/secrets/ksqldb-mds-client/bearer.txt:username}" password="${file:/mnt/secrets/ksqldb-mds-client/bearer.txt:password}";
    sasl.login.callback.handler.class=io.confluent.kafka.clients.plugins.auth.token.TokenUserLoginCallbackHandler
    sasl.mechanism=OAUTHBEARER
    security.protocol=SASL_SSL
    ssl.enabled.protocols=TLSv1.2
    ssl.key.password=${file:/mnt/sslcerts/jksPassword.txt:jksPassword}
    ssl.keystore.location=/mnt/sslcerts/keystore.jks
    ssl.keystore.password=${file:/mnt/sslcerts/jksPassword.txt:jksPassword}
    ssl.truststore.location=/mnt/sslcerts/truststore.jks
    ssl.truststore.password=${file:/mnt/sslcerts/jksPassword.txt:jksPassword}
```

setting up unit testing for this is nigh impossible and the fix is blocking production users

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

