### PR TITLE
fix: Trig tests failing on master/Java 8

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/AcosTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/AcosTest.java
@@ -18,6 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -46,27 +47,27 @@ public class AcosTest {
 
   @Test
   public void shouldHandleNegative() {
-    assertThat(udf.acos(-0.43), is(2.0152891037307157));
-    assertThat(udf.acos(-0.5), is(2.0943951023931957));
-    assertThat(udf.acos(-1.0), is(3.141592653589793));
-    assertThat(udf.acos(-1), is(3.141592653589793));
-    assertThat(udf.acos(-1L), is(3.141592653589793));
+    assertThat(udf.acos(-0.43), closeTo(2.0152891037307157, 0.000000000000001));
+    assertThat(udf.acos(-0.5), closeTo(2.0943951023931957, 0.000000000000001));
+    assertThat(udf.acos(-1.0), closeTo(3.141592653589793, 0.000000000000001));
+    assertThat(udf.acos(-1), closeTo(3.141592653589793, 0.000000000000001));
+    assertThat(udf.acos(-1L), closeTo(3.141592653589793, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleZero() {
-    assertThat(udf.acos(0.0), is(1.5707963267948966));
-    assertThat(udf.acos(0), is(1.5707963267948966));
-    assertThat(udf.acos(0L), is(1.5707963267948966));
+    assertThat(udf.acos(0.0), closeTo(1.5707963267948966, 0.000000000000001));
+    assertThat(udf.acos(0), closeTo(1.5707963267948966, 0.000000000000001));
+    assertThat(udf.acos(0L), closeTo(1.5707963267948966, 0.000000000000001));
   }
 
   @Test
   public void shouldHandlePositive() {
-    assertThat(udf.acos(0.43), is(1.1263035498590777));
-    assertThat(udf.acos(0.5), is(1.0471975511965979));
-    assertThat(udf.acos(1.0), is(0.0));
-    assertThat(udf.acos(1), is(0.0));
-    assertThat(udf.acos(1L), is(0.0));
+    assertThat(udf.acos(0.43), closeTo(1.1263035498590777, 0.000000000000001));
+    assertThat(udf.acos(0.5), closeTo(1.0471975511965979, 0.000000000000001));
+    assertThat(udf.acos(1.0), closeTo(0.0, 0.000000000000001));
+    assertThat(udf.acos(1), closeTo(0.0, 0.000000000000001));
+    assertThat(udf.acos(1L), closeTo(0.0, 0.000000000000001));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/AsinTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/AsinTest.java
@@ -18,6 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -46,27 +47,27 @@ public class AsinTest {
 
   @Test
   public void shouldHandleNegative() {
-    assertThat(udf.asin(-0.43), is(-0.444492776935819));
-    assertThat(udf.asin(-0.5), is(-0.5235987755982989));
-    assertThat(udf.asin(-1.0), is(-1.5707963267948966));
-    assertThat(udf.asin(-1), is(-1.5707963267948966));
-    assertThat(udf.asin(-1L), is(-1.5707963267948966));
+    assertThat(udf.asin(-0.43), closeTo(-0.444492776935819, 0.000000000000001));
+    assertThat(udf.asin(-0.5), closeTo(-0.5235987755982989, 0.000000000000001));
+    assertThat(udf.asin(-1.0), closeTo(-1.5707963267948966, 0.000000000000001));
+    assertThat(udf.asin(-1), closeTo(-1.5707963267948966, 0.000000000000001));
+    assertThat(udf.asin(-1L), closeTo(-1.5707963267948966, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleZero() {
-    assertThat(udf.asin(0.0), is(0.0));
-    assertThat(udf.asin(0), is(0.0));
-    assertThat(udf.asin(0L), is(0.0));
+    assertThat(udf.asin(0.0), closeTo(0.0, 0.000000000000001));
+    assertThat(udf.asin(0), closeTo(0.0, 0.000000000000001));
+    assertThat(udf.asin(0L), closeTo(0.0, 0.000000000000001));
   }
 
   @Test
   public void shouldHandlePositive() {
-    assertThat(udf.asin(0.43), is(0.444492776935819));
-    assertThat(udf.asin(0.5), is(0.5235987755982989));
-    assertThat(udf.asin(1.0), is(1.5707963267948966));
-    assertThat(udf.asin(1), is(1.5707963267948966));
-    assertThat(udf.asin(1L), is(1.5707963267948966));
+    assertThat(udf.asin(0.43), closeTo(0.444492776935819, 0.000000000000001));
+    assertThat(udf.asin(0.5), closeTo(0.5235987755982989, 0.000000000000001));
+    assertThat(udf.asin(1.0), closeTo(1.5707963267948966, 0.000000000000001));
+    assertThat(udf.asin(1), closeTo(1.5707963267948966, 0.000000000000001));
+    assertThat(udf.asin(1L), closeTo(1.5707963267948966, 0.000000000000001));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/Atan2Test.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/Atan2Test.java
@@ -18,6 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -44,73 +45,73 @@ public class Atan2Test {
 
   @Test
   public void shouldHandleNegativeYNegativeX() {
-    assertThat(udf.atan2(-1.1, -0.24), is(-1.7856117271965553));
-    assertThat(udf.atan2(-6.0, -7.1), is(-2.4399674339361113));
-    assertThat(udf.atan2(-2, -3), is(-2.5535900500422257));
-    assertThat(udf.atan2(-2L, -2L), is(-2.356194490192345));
+    assertThat(udf.atan2(-1.1, -0.24), closeTo(-1.7856117271965553, 0.000000000000001));
+    assertThat(udf.atan2(-6.0, -7.1), closeTo(-2.4399674339361113, 0.000000000000001));
+    assertThat(udf.atan2(-2, -3), closeTo(-2.5535900500422257, 0.000000000000001));
+    assertThat(udf.atan2(-2L, -2L), closeTo(-2.356194490192345, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleNegativeYPositiveX() {
-    assertThat(udf.atan2(-1.1, 0.24), is(-1.355980926393238));
-    assertThat(udf.atan2(-6.0, 7.1), is(-0.7016252196536817));
-    assertThat(udf.atan2(-2, 3), is(-0.5880026035475675));
-    assertThat(udf.atan2(-2L, 2L), is(-0.7853981633974483));
+    assertThat(udf.atan2(-1.1, 0.24), closeTo(-1.355980926393238, 0.000000000000001));
+    assertThat(udf.atan2(-6.0, 7.1), closeTo(-0.7016252196536817, 0.000000000000001));
+    assertThat(udf.atan2(-2, 3), closeTo(-0.5880026035475675, 0.000000000000001));
+    assertThat(udf.atan2(-2L, 2L), closeTo(-0.7853981633974483, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleNegativeYZeroX() {
-    assertThat(udf.atan2(-1.1, 0.0), is(-1.5707963267948966));
-    assertThat(udf.atan2(-6.0, 0.0), is(-1.5707963267948966));
-    assertThat(udf.atan2(-2, 0), is(-1.5707963267948966));
-    assertThat(udf.atan2(-2L, 0L), is(-1.5707963267948966));
+    assertThat(udf.atan2(-1.1, 0.0), closeTo(-1.5707963267948966, 0.000000000000001));
+    assertThat(udf.atan2(-6.0, 0.0), closeTo(-1.5707963267948966, 0.000000000000001));
+    assertThat(udf.atan2(-2, 0), closeTo(-1.5707963267948966, 0.000000000000001));
+    assertThat(udf.atan2(-2L, 0L), closeTo(-1.5707963267948966, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleZeroYNegativeX() {
-    assertThat(udf.atan2(0.0, -0.24), is(3.141592653589793));
-    assertThat(udf.atan2(0.0, -7.1), is(3.141592653589793));
-    assertThat(udf.atan2(0, -3), is(3.141592653589793));
-    assertThat(udf.atan2(0L, -2L), is(3.141592653589793));
+    assertThat(udf.atan2(0.0, -0.24), closeTo(3.141592653589793, 0.000000000000001));
+    assertThat(udf.atan2(0.0, -7.1), closeTo(3.141592653589793, 0.000000000000001));
+    assertThat(udf.atan2(0, -3), closeTo(3.141592653589793, 0.000000000000001));
+    assertThat(udf.atan2(0L, -2L), closeTo(3.141592653589793, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleZeroYPositiveX() {
-    assertThat(udf.atan2(0.0, 0.24), is(0.0));
-    assertThat(udf.atan2(0.0, 7.1), is(0.0));
-    assertThat(udf.atan2(0, 3), is(0.0));
-    assertThat(udf.atan2(0L, 2L), is(0.0));
+    assertThat(udf.atan2(0.0, 0.24), closeTo(0.0, 0.000000000000001));
+    assertThat(udf.atan2(0.0, 7.1), closeTo(0.0, 0.000000000000001));
+    assertThat(udf.atan2(0, 3), closeTo(0.0, 0.000000000000001));
+    assertThat(udf.atan2(0L, 2L), closeTo(0.0, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleZeroYZeroX() {
-    assertThat(udf.atan2(0.0, 0.0), is(0.0));
-    assertThat(udf.atan2(0.0, 0.0), is(0.0));
-    assertThat(udf.atan2(0, 0), is(0.0));
-    assertThat(udf.atan2(0L, 0L), is(0.0));
+    assertThat(udf.atan2(0.0, 0.0), closeTo(0.0, 0.000000000000001));
+    assertThat(udf.atan2(0.0, 0.0), closeTo(0.0, 0.000000000000001));
+    assertThat(udf.atan2(0, 0), closeTo(0.0, 0.000000000000001));
+    assertThat(udf.atan2(0L, 0L), closeTo(0.0, 0.000000000000001));
   }
 
   @Test
   public void shouldHandlePositiveYNegativeX() {
-    assertThat(udf.atan2(1.1, -0.24), is(1.7856117271965553));
-    assertThat(udf.atan2(6.0, -7.1), is(2.4399674339361113));
-    assertThat(udf.atan2(2, -3), is(2.5535900500422257));
-    assertThat(udf.atan2(2L, -2L), is(2.356194490192345));
+    assertThat(udf.atan2(1.1, -0.24), closeTo(1.7856117271965553, 0.000000000000001));
+    assertThat(udf.atan2(6.0, -7.1), closeTo(2.4399674339361113, 0.000000000000001));
+    assertThat(udf.atan2(2, -3), closeTo(2.5535900500422257, 0.000000000000001));
+    assertThat(udf.atan2(2L, -2L), closeTo(2.356194490192345, 0.000000000000001));
   }
 
   @Test
   public void shouldHandlePositiveYPositiveX() {
-    assertThat(udf.atan2(1.1, 0.24), is(1.355980926393238));
-    assertThat(udf.atan2(6.0, 7.1), is(0.7016252196536817));
-    assertThat(udf.atan2(2, 3), is(0.5880026035475675));
-    assertThat(udf.atan2(2L, 2L), is(0.7853981633974483));
+    assertThat(udf.atan2(1.1, 0.24), closeTo(1.355980926393238, 0.000000000000001));
+    assertThat(udf.atan2(6.0, 7.1), closeTo(0.7016252196536817, 0.000000000000001));
+    assertThat(udf.atan2(2, 3), closeTo(0.5880026035475675, 0.000000000000001));
+    assertThat(udf.atan2(2L, 2L), closeTo(0.7853981633974483, 0.000000000000001));
   }
 
   @Test
   public void shouldHandlePositiveYZeroX() {
-    assertThat(udf.atan2(1.1, 0.0), is(1.5707963267948966));
-    assertThat(udf.atan2(6.0, 0.0), is(1.5707963267948966));
-    assertThat(udf.atan2(2, 0), is(1.5707963267948966));
-    assertThat(udf.atan2(2L, 0L), is(1.5707963267948966));
+    assertThat(udf.atan2(1.1, 0.0), closeTo(1.5707963267948966, 0.000000000000001));
+    assertThat(udf.atan2(6.0, 0.0), closeTo(1.5707963267948966, 0.000000000000001));
+    assertThat(udf.atan2(2, 0), closeTo(1.5707963267948966, 0.000000000000001));
+    assertThat(udf.atan2(2L, 0L), closeTo(1.5707963267948966, 0.000000000000001));
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/AtanTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/AtanTest.java
@@ -18,6 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -38,42 +39,42 @@ public class AtanTest {
 
   @Test
   public void shouldHandleLessThanNegativeOne() {
-    assertThat(udf.atan(-1.1), is(-0.8329812666744317));
-    assertThat(udf.atan(-6.0), is(-1.4056476493802699));
-    assertThat(udf.atan(-2), is(-1.1071487177940904));
-    assertThat(udf.atan(-2L), is(-1.1071487177940904));
+    assertThat(udf.atan(-1.1), closeTo(-0.8329812666744317, 0.000000000000001));
+    assertThat(udf.atan(-6.0), closeTo(-1.4056476493802699, 0.000000000000001));
+    assertThat(udf.atan(-2), closeTo(-1.1071487177940904, 0.000000000000001));
+    assertThat(udf.atan(-2L), closeTo(-1.1071487177940904, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleNegative() {
-    assertThat(udf.atan(-0.43), is(-0.40609805831761564));
-    assertThat(udf.atan(-0.5), is(-0.4636476090008061));
-    assertThat(udf.atan(-1.0), is(-0.7853981633974483));
-    assertThat(udf.atan(-1), is(-0.7853981633974483));
-    assertThat(udf.atan(-1L), is(-0.7853981633974483));
+    assertThat(udf.atan(-0.43), closeTo(-0.40609805831761564, 0.000000000000001));
+    assertThat(udf.atan(-0.5), closeTo(-0.4636476090008061, 0.000000000000001));
+    assertThat(udf.atan(-1.0), closeTo(-0.7853981633974483, 0.000000000000001));
+    assertThat(udf.atan(-1), closeTo(-0.7853981633974483, 0.000000000000001));
+    assertThat(udf.atan(-1L), closeTo(-0.7853981633974483, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleZero() {
-    assertThat(udf.atan(0.0), is(0.0));
-    assertThat(udf.atan(0), is(0.0));
-    assertThat(udf.atan(0L), is(0.0));
+    assertThat(udf.atan(0.0), closeTo(0.0, 0.000000000000001));
+    assertThat(udf.atan(0), closeTo(0.0, 0.000000000000001));
+    assertThat(udf.atan(0L), closeTo(0.0, 0.000000000000001));
   }
 
   @Test
   public void shouldHandlePositive() {
-    assertThat(udf.atan(0.43), is(0.40609805831761564));
-    assertThat(udf.atan(0.5), is(0.4636476090008061));
-    assertThat(udf.atan(1.0), is(0.7853981633974483));
-    assertThat(udf.atan(1), is(0.7853981633974483));
-    assertThat(udf.atan(1L), is(0.7853981633974483));
+    assertThat(udf.atan(0.43), closeTo(0.40609805831761564, 0.000000000000001));
+    assertThat(udf.atan(0.5), closeTo(0.4636476090008061, 0.000000000000001));
+    assertThat(udf.atan(1.0), closeTo(0.7853981633974483, 0.000000000000001));
+    assertThat(udf.atan(1), closeTo(0.7853981633974483, 0.000000000000001));
+    assertThat(udf.atan(1L), closeTo(0.7853981633974483, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleMoreThanPositiveOne() {
-    assertThat(udf.atan(1.1), is(0.8329812666744317));
-    assertThat(udf.atan(6.0), is(1.4056476493802699));
-    assertThat(udf.atan(2), is(1.1071487177940904));
-    assertThat(udf.atan(2L), is(1.1071487177940904));
+    assertThat(udf.atan(1.1), closeTo(0.8329812666744317, 0.000000000000001));
+    assertThat(udf.atan(6.0), closeTo(1.4056476493802699, 0.000000000000001));
+    assertThat(udf.atan(2), closeTo(1.1071487177940904, 0.000000000000001));
+    assertThat(udf.atan(2L), closeTo(1.1071487177940904, 0.000000000000001));
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/CosTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/CosTest.java
@@ -18,6 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -38,42 +39,42 @@ public class CosTest {
 
   @Test
   public void shouldHandleLessThanNegative2Pi() {
-    assertThat(udf.cos(-9.1), is(-0.9477216021311119));
-    assertThat(udf.cos(-6.3), is(0.9998586363834151));
-    assertThat(udf.cos(-7), is(0.7539022543433046));
-    assertThat(udf.cos(-7L), is(0.7539022543433046));
+    assertThat(udf.cos(-9.1), closeTo(-0.9477216021311119, 0.000000000000001));
+    assertThat(udf.cos(-6.3), closeTo(0.9998586363834151, 0.000000000000001));
+    assertThat(udf.cos(-7), closeTo(0.7539022543433046, 0.000000000000001));
+    assertThat(udf.cos(-7L), closeTo(0.7539022543433046, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleNegative() {
-    assertThat(udf.cos(-0.43), is(0.9089657496748851));
-    assertThat(udf.cos(-Math.PI), is(-1.0));
-    assertThat(udf.cos(-2 * Math.PI), is(1.0));
-    assertThat(udf.cos(-6), is(0.960170286650366));
-    assertThat(udf.cos(-6L), is(0.960170286650366));
+    assertThat(udf.cos(-0.43), closeTo(0.9089657496748851, 0.000000000000001));
+    assertThat(udf.cos(-Math.PI), closeTo(-1.0, 0.000000000000001));
+    assertThat(udf.cos(-2 * Math.PI), closeTo(1.0, 0.000000000000001));
+    assertThat(udf.cos(-6), closeTo(0.960170286650366, 0.000000000000001));
+    assertThat(udf.cos(-6L), closeTo(0.960170286650366, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleZero() {
-    assertThat(udf.cos(0.0), is(1.0));
-    assertThat(udf.cos(0), is(1.0));
-    assertThat(udf.cos(0L), is(1.0));
+    assertThat(udf.cos(0.0), closeTo(1.0, 0.000000000000001));
+    assertThat(udf.cos(0), closeTo(1.0, 0.000000000000001));
+    assertThat(udf.cos(0L), closeTo(1.0, 0.000000000000001));
   }
 
   @Test
   public void shouldHandlePositive() {
-    assertThat(udf.cos(0.43), is(0.9089657496748851));
-    assertThat(udf.cos(Math.PI), is(-1.0));
-    assertThat(udf.cos(2 * Math.PI), is(1.0));
-    assertThat(udf.cos(6), is(0.960170286650366));
-    assertThat(udf.cos(6L), is(0.960170286650366));
+    assertThat(udf.cos(0.43), closeTo(0.9089657496748851, 0.000000000000001));
+    assertThat(udf.cos(Math.PI), closeTo(-1.0, 0.000000000000001));
+    assertThat(udf.cos(2 * Math.PI), closeTo(1.0, 0.000000000000001));
+    assertThat(udf.cos(6), closeTo(0.960170286650366, 0.000000000000001));
+    assertThat(udf.cos(6L), closeTo(0.960170286650366, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleMoreThanPositive2Pi() {
-    assertThat(udf.cos(9.1), is(-0.9477216021311119));
-    assertThat(udf.cos(6.3), is(0.9998586363834151));
-    assertThat(udf.cos(7), is(0.7539022543433046));
-    assertThat(udf.cos(7L), is(0.7539022543433046));
+    assertThat(udf.cos(9.1), closeTo(-0.9477216021311119, 0.000000000000001));
+    assertThat(udf.cos(6.3), closeTo(0.9998586363834151, 0.000000000000001));
+    assertThat(udf.cos(7), closeTo(0.7539022543433046, 0.000000000000001));
+    assertThat(udf.cos(7L), closeTo(0.7539022543433046, 0.000000000000001));
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/CoshTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/CoshTest.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.function.udf.math;
 import org.junit.Before;
 import org.junit.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -37,42 +38,42 @@ public class CoshTest {
 
   @Test
   public void shouldHandleLessThanNegative2Pi() {
-    assertThat(udf.cosh(-9.1), is(4477.646407574158));
-    assertThat(udf.cosh(-6.3), is(272.286873215353));
-    assertThat(udf.cosh(-7), is(548.317035155212));
-    assertThat(udf.cosh(-7L), is(548.317035155212));
+    assertThat(udf.cosh(-9.1), closeTo(4477.646407574158, 0.000000000000001));
+    assertThat(udf.cosh(-6.3), closeTo(272.286873215353, 0.000000000000001));
+    assertThat(udf.cosh(-7), closeTo(548.317035155212, 0.000000000000001));
+    assertThat(udf.cosh(-7L), closeTo(548.317035155212, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleNegative() {
-    assertThat(udf.cosh(-0.43), is(1.0938833091357991));
-    assertThat(udf.cosh(-Math.PI), is(11.591953275521519));
-    assertThat(udf.cosh(-Math.PI * 2), is(267.7467614837482));
-    assertThat(udf.cosh(-6), is(201.7156361224559));
-    assertThat(udf.cosh(-6L), is(201.7156361224559));
+    assertThat(udf.cosh(-0.43), closeTo(1.0938833091357991, 0.000000000000001));
+    assertThat(udf.cosh(-Math.PI), closeTo(11.591953275521519, 0.000000000000001));
+    assertThat(udf.cosh(-Math.PI * 2), closeTo(267.7467614837482, 0.000000000000001));
+    assertThat(udf.cosh(-6), closeTo(201.7156361224559, 0.000000000000001));
+    assertThat(udf.cosh(-6L), closeTo(201.7156361224559, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleZero() {
-    assertThat(udf.cosh(0.0), is(1.0));
-    assertThat(udf.cosh(0), is(1.0));
-    assertThat(udf.cosh(0L), is(1.0));
+    assertThat(udf.cosh(0.0), closeTo(1.0, 0.000000000000001));
+    assertThat(udf.cosh(0), closeTo(1.0, 0.000000000000001));
+    assertThat(udf.cosh(0L), closeTo(1.0, 0.000000000000001));
   }
 
   @Test
   public void shouldHandlePositive() {
-    assertThat(udf.cosh(0.43), is(1.0938833091357991));
-    assertThat(udf.cosh(Math.PI), is(11.591953275521519));
-    assertThat(udf.cosh(Math.PI * 2), is(267.7467614837482));
-    assertThat(udf.cosh(6), is(201.7156361224559));
-    assertThat(udf.cosh(6L), is(201.7156361224559));
+    assertThat(udf.cosh(0.43), closeTo(1.0938833091357991, 0.000000000000001));
+    assertThat(udf.cosh(Math.PI), closeTo(11.591953275521519, 0.000000000000001));
+    assertThat(udf.cosh(Math.PI * 2), closeTo(267.7467614837482, 0.000000000000001));
+    assertThat(udf.cosh(6), closeTo(201.7156361224559, 0.000000000000001));
+    assertThat(udf.cosh(6L), closeTo(201.7156361224559, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleMoreThanPositive2Pi() {
-    assertThat(udf.cosh(9.1), is(4477.646407574158));
-    assertThat(udf.cosh(6.3), is(272.286873215353));
-    assertThat(udf.cosh(7), is(548.317035155212));
-    assertThat(udf.cosh(7L), is(548.317035155212));
+    assertThat(udf.cosh(9.1), closeTo(4477.646407574158, 0.000000000000001));
+    assertThat(udf.cosh(6.3), closeTo(272.286873215353, 0.000000000000001));
+    assertThat(udf.cosh(7), closeTo(548.317035155212, 0.000000000000001));
+    assertThat(udf.cosh(7L), closeTo(548.317035155212, 0.000000000000001));
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/CotTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/CotTest.java
@@ -18,6 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -38,19 +39,19 @@ public class CotTest {
 
   @Test
   public void shouldHandleLessThanNegative2Pi() {
-    assertThat(udf.cot(-9.1), is(2.9699983263892054));
-    assertThat(udf.cot(-6.3), is(-59.46619211372627));
-    assertThat(udf.cot(-7), is(-1.1475154224051356));
-    assertThat(udf.cot(-7L), is(-1.1475154224051356));
+    assertThat(udf.cot(-9.1), closeTo(2.9699983263892054, 0.000000000000001));
+    assertThat(udf.cot(-6.3), closeTo(-59.46619211372627, 0.000000000000001));
+    assertThat(udf.cot(-7), closeTo(-1.1475154224051356, 0.000000000000001));
+    assertThat(udf.cot(-7L), closeTo(-1.1475154224051356, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleNegative() {
-    assertThat(udf.cot(-0.43), is(-2.1804495406685085));
-    assertThat(udf.cot(-Math.PI), is(8.165619676597685E15));
-    assertThat(udf.cot(-Math.PI * 2), is(4.0828098382988425E15));
-    assertThat(udf.cot(-6), is(3.436353004180128));
-    assertThat(udf.cot(-6L), is(3.436353004180128));
+    assertThat(udf.cot(-0.43), closeTo(-2.1804495406685085, 0.000000000000001));
+    assertThat(udf.cot(-Math.PI), closeTo(8.165619676597685E15, 0.000000000000001));
+    assertThat(udf.cot(-Math.PI * 2), closeTo(4.0828098382988425E15, 0.000000000000001));
+    assertThat(udf.cot(-6), closeTo(3.436353004180128, 0.000000000000001));
+    assertThat(udf.cot(-6L), closeTo(3.436353004180128, 0.000000000000001));
   }
 
   @Test
@@ -62,18 +63,18 @@ public class CotTest {
 
   @Test
   public void shouldHandlePositive() {
-    assertThat(udf.cot(0.43), is(2.1804495406685085));
-    assertThat(udf.cot(Math.PI), is(-8.165619676597685E15));
-    assertThat(udf.cot(Math.PI * 2), is(-4.0828098382988425E15));
-    assertThat(udf.cot(6), is(-3.436353004180128));
-    assertThat(udf.cot(6L), is(-3.436353004180128));
+    assertThat(udf.cot(0.43), closeTo(2.1804495406685085, 0.000000000000001));
+    assertThat(udf.cot(Math.PI), closeTo(-8.165619676597685E15, 0.000000000000001));
+    assertThat(udf.cot(Math.PI * 2), closeTo(-4.0828098382988425E15, 0.000000000000001));
+    assertThat(udf.cot(6), closeTo(-3.436353004180128, 0.000000000000001));
+    assertThat(udf.cot(6L), closeTo(-3.436353004180128, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleMoreThanPositive2Pi() {
-    assertThat(udf.cot(9.1), is(-2.9699983263892054));
-    assertThat(udf.cot(6.3), is(59.46619211372627));
-    assertThat(udf.cot(7), is(1.1475154224051356));
-    assertThat(udf.cot(7L), is(1.1475154224051356));
+    assertThat(udf.cot(9.1), closeTo(-2.9699983263892054, 0.000000000000001));
+    assertThat(udf.cot(6.3), closeTo(59.46619211372627, 0.000000000000001));
+    assertThat(udf.cot(7), closeTo(1.1475154224051356, 0.000000000000001));
+    assertThat(udf.cot(7L), closeTo(1.1475154224051356, 0.000000000000001));
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/DegreesTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/DegreesTest.java
@@ -18,6 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -38,26 +39,26 @@ public class DegreesTest {
 
   @Test
   public void shouldHandleNegative() {
-    assertThat(udf.degrees(-Math.PI), is(-180.0));
-    assertThat(udf.degrees(-2 * Math.PI), is(-360.0));
-    assertThat(udf.degrees(-1.2345), is(-70.73163980890013));
-    assertThat(udf.degrees(-2), is(-114.59155902616465));
-    assertThat(udf.degrees(-2L), is(-114.59155902616465));
+    assertThat(udf.degrees(-Math.PI), closeTo(-180.0, 0.000000000000001));
+    assertThat(udf.degrees(-2 * Math.PI), closeTo(-360.0, 0.000000000000001));
+    assertThat(udf.degrees(-1.2345), closeTo(-70.73163980890013, 0.000000000000001));
+    assertThat(udf.degrees(-2), closeTo(-114.59155902616465, 0.000000000000001));
+    assertThat(udf.degrees(-2L), closeTo(-114.59155902616465, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleZero() {
-    assertThat(udf.degrees(0), is(0.0));
-    assertThat(udf.degrees(0L), is(0.0));
-    assertThat(udf.degrees(0.0), is(0.0));
+    assertThat(udf.degrees(0), closeTo(0.0, 0.000000000000001));
+    assertThat(udf.degrees(0L), closeTo(0.0, 0.000000000000001));
+    assertThat(udf.degrees(0.0), closeTo(0.0, 0.000000000000001));
   }
 
   @Test
   public void shouldHandlePositive() {
-    assertThat(udf.degrees(Math.PI), is(180.0));
-    assertThat(udf.degrees(2 * Math.PI), is(360.0));
-    assertThat(udf.degrees(1.2345), is(70.73163980890013));
-    assertThat(udf.degrees(2), is(114.59155902616465));
-    assertThat(udf.degrees(2L), is(114.59155902616465));
+    assertThat(udf.degrees(Math.PI), closeTo(180.0, 0.000000000000001));
+    assertThat(udf.degrees(2 * Math.PI), closeTo(360.0, 0.000000000000001));
+    assertThat(udf.degrees(1.2345), closeTo(70.73163980890013, 0.000000000000001));
+    assertThat(udf.degrees(2), closeTo(114.59155902616465, 0.000000000000001));
+    assertThat(udf.degrees(2L), closeTo(114.59155902616465, 0.000000000000001));
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/PiTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/PiTest.java
@@ -18,7 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.closeTo;
 
 public class PiTest {
   private Pi udf;
@@ -30,6 +30,6 @@ public class PiTest {
 
   @Test
   public void shouldReturnPi() {
-    assertThat(udf.pi(), is(Math.PI));
+    assertThat(udf.pi(), closeTo(Math.PI, 0.000000000000001));
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/RadiansTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/RadiansTest.java
@@ -18,6 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -38,26 +39,26 @@ public class RadiansTest {
 
   @Test
   public void shouldHandleNegative() {
-    assertThat(udf.radians(-180.0), is(-Math.PI));
-    assertThat(udf.radians(-360.0), is(-2 * Math.PI));
-    assertThat(udf.radians(-70.73163980890013), is(-1.2345));
-    assertThat(udf.radians(-114), is(-1.9896753472735358));
-    assertThat(udf.radians(-114L), is(-1.9896753472735358));
+    assertThat(udf.radians(-180.0), closeTo(-Math.PI, 0.000000000000001));
+    assertThat(udf.radians(-360.0), closeTo(-2 * Math.PI, 0.000000000000001));
+    assertThat(udf.radians(-70.73163980890013), closeTo(-1.2345, 0.000000000000001));
+    assertThat(udf.radians(-114), closeTo(-1.9896753472735358, 0.000000000000001));
+    assertThat(udf.radians(-114L), closeTo(-1.9896753472735358, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleZero() {
-    assertThat(udf.radians(0), is(0.0));
-    assertThat(udf.radians(0L), is(0.0));
-    assertThat(udf.radians(0.0), is(0.0));
+    assertThat(udf.radians(0), closeTo(0.0, 0.000000000000001));
+    assertThat(udf.radians(0L), closeTo(0.0, 0.000000000000001));
+    assertThat(udf.radians(0.0), closeTo(0.0, 0.000000000000001));
   }
 
   @Test
   public void shouldHandlePositive() {
-    assertThat(udf.radians(180.0), is(Math.PI));
-    assertThat(udf.radians(360.0), is(2 * Math.PI));
-    assertThat(udf.radians(70.73163980890013), is(1.2345));
-    assertThat(udf.radians(114), is(1.9896753472735358));
-    assertThat(udf.radians(114L), is(1.9896753472735358));
+    assertThat(udf.radians(180.0), closeTo(Math.PI, 0.000000000000001));
+    assertThat(udf.radians(360.0), closeTo(2 * Math.PI, 0.000000000000001));
+    assertThat(udf.radians(70.73163980890013), closeTo(1.2345, 0.000000000000001));
+    assertThat(udf.radians(114), closeTo(1.9896753472735358, 0.000000000000001));
+    assertThat(udf.radians(114L), closeTo(1.9896753472735358, 0.000000000000001));
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/SinTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/SinTest.java
@@ -39,42 +39,42 @@ public class SinTest {
 
   @Test
   public void shouldHandleLessThanNegative2Pi() {
-    assertThat(udf.sin(-9.1), is(-0.3190983623493521));
-    assertThat(udf.sin(-6.3), is(-0.016813900484349713));
-    assertThat(udf.sin(-7), is(-0.6569865987187891));
-    assertThat(udf.sin(-7L), is(-0.6569865987187891));
+    assertThat(udf.sin(-9.1), closeTo(-0.3190983623493521, 0.000000000000001));
+    assertThat(udf.sin(-6.3), closeTo(-0.016813900484349713, 0.000000000000001));
+    assertThat(udf.sin(-7), closeTo(-0.6569865987187891, 0.000000000000001));
+    assertThat(udf.sin(-7L), closeTo(-0.6569865987187891, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleNegative() {
-    assertThat(udf.sin(-0.43), is(-0.41687080242921076));
+    assertThat(udf.sin(-0.43), closeTo(-0.41687080242921076, 0.000000000000001));
     assertThat(udf.sin(-Math.PI), closeTo(0, 0.000000000000001));
     assertThat(udf.sin(-2 * Math.PI), closeTo(0, 0.000000000000001));
-    assertThat(udf.sin(-6), is(0.27941549819892586));
-    assertThat(udf.sin(-6L), is(0.27941549819892586));
+    assertThat(udf.sin(-6), closeTo(0.27941549819892586, 0.000000000000001));
+    assertThat(udf.sin(-6L), closeTo(0.27941549819892586, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleZero() {
-    assertThat(udf.sin(0.0), is(0.0));
-    assertThat(udf.sin(0), is(0.0));
-    assertThat(udf.sin(0L), is(0.0));
+    assertThat(udf.sin(0.0), closeTo(0.0, 0.000000000000001));
+    assertThat(udf.sin(0), closeTo(0.0, 0.000000000000001));
+    assertThat(udf.sin(0L), closeTo(0.0, 0.000000000000001));
   }
 
   @Test
   public void shouldHandlePositive() {
-    assertThat(udf.sin(0.43), is(0.41687080242921076));
+    assertThat(udf.sin(0.43), closeTo(0.41687080242921076, 0.000000000000001));
     assertThat(udf.sin(Math.PI), closeTo(0, 0.000000000000001));
     assertThat(udf.sin(Math.PI * 2), closeTo(0, 0.000000000000001));
-    assertThat(udf.sin(6), is(-0.27941549819892586));
-    assertThat(udf.sin(6L), is(-0.27941549819892586));
+    assertThat(udf.sin(6), closeTo(-0.27941549819892586, 0.000000000000001));
+    assertThat(udf.sin(6L), closeTo(-0.27941549819892586, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleMoreThanPositive2Pi() {
-    assertThat(udf.sin(9.1), is(0.3190983623493521));
-    assertThat(udf.sin(6.3), is(0.016813900484349713));
-    assertThat(udf.sin(7), is(0.6569865987187891));
-    assertThat(udf.sin(7L), is(0.6569865987187891));
+    assertThat(udf.sin(9.1), closeTo(0.3190983623493521, 0.000000000000001));
+    assertThat(udf.sin(6.3), closeTo(0.016813900484349713, 0.000000000000001));
+    assertThat(udf.sin(7), closeTo(0.6569865987187891, 0.000000000000001));
+    assertThat(udf.sin(7L), closeTo(0.6569865987187891, 0.000000000000001));
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/SinhTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/SinhTest.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.function.udf.math;
 import org.junit.Before;
 import org.junit.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -37,42 +38,42 @@ public class SinhTest {
 
   @Test
   public void shouldHandleLessThanNegative2Pi() {
-    assertThat(udf.sinh(-9.1), is(-4477.64629590835));
-    assertThat(udf.sinh(-6.3), is(-272.28503691057597));
-    assertThat(udf.sinh(-7), is(-548.3161232732465));
-    assertThat(udf.sinh(-7L), is(-548.3161232732465));
+    assertThat(udf.sinh(-9.1), closeTo(-4477.64629590835, 0.000000000000001));
+    assertThat(udf.sinh(-6.3), closeTo(-272.28503691057597, 0.000000000000001));
+    assertThat(udf.sinh(-7), closeTo(-548.3161232732465, 0.000000000000001));
+    assertThat(udf.sinh(-7L), closeTo(-548.3161232732465, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleNegative() {
-    assertThat(udf.sinh(-0.43), is(-0.4433742144124824));
-    assertThat(udf.sinh(-Math.PI), is(-11.548739357257748));
-    assertThat(udf.sinh(-Math.PI * 2), is(-267.74489404101644));
-    assertThat(udf.sinh(-6), is(-201.71315737027922));
-    assertThat(udf.sinh(-6L), is(-201.71315737027922));
+    assertThat(udf.sinh(-0.43), closeTo(-0.4433742144124824, 0.000000000000001));
+    assertThat(udf.sinh(-Math.PI), closeTo(-11.548739357257748, 0.000000000000001));
+    assertThat(udf.sinh(-Math.PI * 2), closeTo(-267.74489404101644, 0.000000000000001));
+    assertThat(udf.sinh(-6), closeTo(-201.71315737027922, 0.000000000000001));
+    assertThat(udf.sinh(-6L), closeTo(-201.71315737027922, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleZero() {
-    assertThat(udf.sinh(0.0), is(0.0));
-    assertThat(udf.sinh(0), is(0.0));
-    assertThat(udf.sinh(0L), is(0.0));
+    assertThat(udf.sinh(0.0), closeTo(0.0, 0.000000000000001));
+    assertThat(udf.sinh(0), closeTo(0.0, 0.000000000000001));
+    assertThat(udf.sinh(0L), closeTo(0.0, 0.000000000000001));
   }
 
   @Test
   public void shouldHandlePositive() {
-    assertThat(udf.sinh(0.43), is(0.4433742144124824));
-    assertThat(udf.sinh(Math.PI), is(11.548739357257748));
-    assertThat(udf.sinh(Math.PI * 2), is(267.74489404101644));
-    assertThat(udf.sinh(6), is(201.71315737027922));
-    assertThat(udf.sinh(6L), is(201.71315737027922));
+    assertThat(udf.sinh(0.43), closeTo(0.4433742144124824, 0.000000000000001));
+    assertThat(udf.sinh(Math.PI), closeTo(11.548739357257748, 0.000000000000001));
+    assertThat(udf.sinh(Math.PI * 2), closeTo(267.74489404101644, 0.000000000000001));
+    assertThat(udf.sinh(6), closeTo(201.71315737027922, 0.000000000000001));
+    assertThat(udf.sinh(6L), closeTo(201.71315737027922, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleMoreThanPositive2Pi() {
-    assertThat(udf.sinh(9.1), is(4477.64629590835));
-    assertThat(udf.sinh(6.3), is(272.28503691057597));
-    assertThat(udf.sinh(7), is(548.3161232732465));
-    assertThat(udf.sinh(7L), is(548.3161232732465));
+    assertThat(udf.sinh(9.1), closeTo(4477.64629590835, 0.000000000000001));
+    assertThat(udf.sinh(6.3), closeTo(272.28503691057597, 0.000000000000001));
+    assertThat(udf.sinh(7), closeTo(548.3161232732465, 0.000000000000001));
+    assertThat(udf.sinh(7L), closeTo(548.3161232732465, 0.000000000000001));
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/TanTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/TanTest.java
@@ -39,45 +39,45 @@ public class TanTest {
 
   @Test
   public void shouldHandleLessThanNegative2Pi() {
-    assertThat(udf.tan(-9.1), is(0.33670052643287396));
-    assertThat(udf.tan(-6.3), is(-0.016816277694182057));
-    assertThat(udf.tan(-7), is(-0.8714479827243188));
-    assertThat(udf.tan(-7L), is(-0.8714479827243188));
+    assertThat(udf.tan(-9.1), closeTo(0.33670052643287396, 0.000000000000001));
+    assertThat(udf.tan(-6.3), closeTo(-0.016816277694182057, 0.000000000000001));
+    assertThat(udf.tan(-7), closeTo(-0.8714479827243188, 0.000000000000001));
+    assertThat(udf.tan(-7L), closeTo(-0.8714479827243188, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleNegative() {
-    assertThat(udf.tan(-0.43), is(-0.45862102348555517));
+    assertThat(udf.tan(-0.43), closeTo(-0.45862102348555517, 0.000000000000001));
     assertThat(udf.tan(-Math.PI), closeTo(0, 0.000000000000001));
     assertThat(udf.tan(-Math.PI * 2), closeTo(0, 0.000000000000001));
     assertThat(udf.tan(-Math.PI * 2), closeTo(0, 0.000000000000001));
-    assertThat(udf.tan(-Math.PI / 2), is(-1.633123935319537E16));
-    assertThat(udf.tan(-6), is(0.29100619138474915));
-    assertThat(udf.tan(-6L), is(0.29100619138474915));
+    assertThat(udf.tan(-Math.PI / 2), closeTo(-1.633123935319537E16, 0.000000000000001));
+    assertThat(udf.tan(-6), closeTo(0.29100619138474915, 0.000000000000001));
+    assertThat(udf.tan(-6L), closeTo(0.29100619138474915, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleZero() {
-    assertThat(udf.tan(0.0), is(0.0));
-    assertThat(udf.tan(0), is(0.0));
-    assertThat(udf.tan(0L), is(0.0));
+    assertThat(udf.tan(0.0), closeTo(0.0, 0.000000000000001));
+    assertThat(udf.tan(0), closeTo(0.0, 0.000000000000001));
+    assertThat(udf.tan(0L), closeTo(0.0, 0.000000000000001));
   }
 
   @Test
   public void shouldHandlePositive() {
-    assertThat(udf.tan(0.43), is(0.45862102348555517));
+    assertThat(udf.tan(0.43), closeTo(0.45862102348555517, 0.000000000000001));
     assertThat(udf.tan(Math.PI), closeTo(0, 0.000000000000001));
     assertThat(udf.tan(Math.PI * 2), closeTo(0, 0.000000000000001));
-    assertThat(udf.tan(Math.PI / 2), is(1.633123935319537E16));
-    assertThat(udf.tan(6), is(-0.29100619138474915));
-    assertThat(udf.tan(6L), is(-0.29100619138474915));
+    assertThat(udf.tan(Math.PI / 2), closeTo(1.633123935319537E16, 0.000000000000001));
+    assertThat(udf.tan(6), closeTo(-0.29100619138474915, 0.000000000000001));
+    assertThat(udf.tan(6L), closeTo(-0.29100619138474915, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleMoreThanPositive2Pi() {
-    assertThat(udf.tan(9.1), is(-0.33670052643287396));
-    assertThat(udf.tan(6.3), is(0.016816277694182057));
-    assertThat(udf.tan(7), is(0.8714479827243188));
-    assertThat(udf.tan(7L), is(0.8714479827243188));
+    assertThat(udf.tan(9.1), closeTo(-0.33670052643287396, 0.000000000000001));
+    assertThat(udf.tan(6.3), closeTo(0.016816277694182057, 0.000000000000001));
+    assertThat(udf.tan(7), closeTo(0.8714479827243188, 0.000000000000001));
+    assertThat(udf.tan(7L), closeTo(0.8714479827243188, 0.000000000000001));
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/TanhTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/TanhTest.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.function.udf.math;
 import org.junit.Before;
 import org.junit.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -37,42 +38,42 @@ public class TanhTest {
 
   @Test
   public void shouldHandleLessThanNegative2Pi() {
-    assertThat(udf.tanh(-9.1), is(-0.9999999750614947));
-    assertThat(udf.tanh(-6.3), is(-0.9999932559922726));
-    assertThat(udf.tanh(-7), is(-0.9999983369439447));
-    assertThat(udf.tanh(-7L), is(-0.9999983369439447));
+    assertThat(udf.tanh(-9.1), closeTo(-0.9999999750614947, 0.000000000000001));
+    assertThat(udf.tanh(-6.3), closeTo(-0.9999932559922726, 0.000000000000001));
+    assertThat(udf.tanh(-7), closeTo(-0.9999983369439447, 0.000000000000001));
+    assertThat(udf.tanh(-7L), closeTo(-0.9999983369439447, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleNegative() {
-    assertThat(udf.tanh(-0.43), is(-0.4053213086894629));
-    assertThat(udf.tanh(-Math.PI), is(-0.99627207622075));
-    assertThat(udf.tanh(-Math.PI * 2), is(-0.9999930253396107));
-    assertThat(udf.tanh(-6), is(-0.9999877116507956));
-    assertThat(udf.tanh(-6L), is(-0.9999877116507956));
+    assertThat(udf.tanh(-0.43), closeTo(-0.4053213086894629, 0.000000000000001));
+    assertThat(udf.tanh(-Math.PI), closeTo(-0.99627207622075, 0.000000000000001));
+    assertThat(udf.tanh(-Math.PI * 2), closeTo(-0.9999930253396107, 0.000000000000001));
+    assertThat(udf.tanh(-6), closeTo(-0.9999877116507956, 0.000000000000001));
+    assertThat(udf.tanh(-6L), closeTo(-0.9999877116507956, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleZero() {
-    assertThat(udf.tanh(0.0), is(0.0));
-    assertThat(udf.tanh(0), is(0.0));
-    assertThat(udf.tanh(0L), is(0.0));
+    assertThat(udf.tanh(0.0), closeTo(0.0, 0.000000000000001));
+    assertThat(udf.tanh(0), closeTo(0.0, 0.000000000000001));
+    assertThat(udf.tanh(0L), closeTo(0.0, 0.000000000000001));
   }
 
   @Test
   public void shouldHandlePositive() {
-    assertThat(udf.tanh(0.43), is(0.4053213086894629));
-    assertThat(udf.tanh(Math.PI), is(0.99627207622075));
-    assertThat(udf.tanh(Math.PI * 2), is(0.9999930253396107));
-    assertThat(udf.tanh(6), is(0.9999877116507956));
-    assertThat(udf.tanh(6L), is(0.9999877116507956));
+    assertThat(udf.tanh(0.43), closeTo(0.4053213086894629, 0.000000000000001));
+    assertThat(udf.tanh(Math.PI), closeTo(0.99627207622075, 0.000000000000001));
+    assertThat(udf.tanh(Math.PI * 2), closeTo(0.9999930253396107, 0.000000000000001));
+    assertThat(udf.tanh(6), closeTo(0.9999877116507956, 0.000000000000001));
+    assertThat(udf.tanh(6L), closeTo(0.9999877116507956, 0.000000000000001));
   }
 
   @Test
   public void shouldHandleMoreThanPositive2Pi() {
-    assertThat(udf.tanh(9.1), is(0.9999999750614947));
-    assertThat(udf.tanh(6.3), is(0.9999932559922726));
-    assertThat(udf.tanh(7), is(0.9999983369439447));
-    assertThat(udf.tanh(7L), is(0.9999983369439447));
+    assertThat(udf.tanh(9.1), closeTo(0.9999999750614947, 0.000000000000001));
+    assertThat(udf.tanh(6.3), closeTo(0.9999932559922726, 0.000000000000001));
+    assertThat(udf.tanh(7), closeTo(0.9999983369439447, 0.000000000000001));
+    assertThat(udf.tanh(7L), closeTo(0.9999983369439447, 0.000000000000001));
   }
 }


### PR DESCRIPTION
### Description 
The checks for PR #9213 passed because they used Java 11. However, master uses Java 8, and some of the unit tests are now failing because the floating point values are not matching. (The Java library trig methods allow a 1 ulp difference from the exact result, so some implementation or optimization must have changed between versions.)

I have updated the trig unit tests to use close matches for floating point values instead of exact matches.

### Testing done 
Confirmed the tests were failing locally on Java 8 and then passing after these fixes. Also checked Java 11.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

