### PR TITLE
MINOR: improve error message for missing key

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNode.java
@@ -181,7 +181,7 @@ public abstract class PlanNode {
         + "This expression must be included in the projection and may be aliased. "
         : "";
 
-    throw new KsqlException("Key" + keyPostfix + " missing from projection. "
+    throw new KsqlException("Key" + keyPostfix + " missing from projection (ie, SELECT). "
         + additional1
         + System.lineSeparator()
         + "The query used to build " + sinkName


### PR DESCRIPTION
I have encountered multiple times, that uses cannot read this error message, because they don't know what "projection" means...