### PR TITLE
fix: remove regex from migration tool

### DIFF
--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -63,9 +63,9 @@ statement
     | (LIST | SHOW) QUERIES EXTENDED?                                       #listQueries
     | TERMINATE identifier                                                  #terminateQuery
     | TERMINATE ALL                                                         #terminateQuery
-    | SET (VARIABLE | STRING) EQ (VARIABLE | STRING)                        #setProperty
+    | SET STRING EQ STRING                                                  #setProperty
     | ALTER SYSTEM STRING EQ STRING                                         #alterSystemProperty
-    | UNSET (VARIABLE | STRING)                                             #unsetProperty
+    | UNSET STRING                                                          #unsetProperty
     | DEFINE variableName EQ variableValue                                  #defineVariable
     | UNDEFINE variableName                                                 #undefineVariable
     | CREATE (OR REPLACE)? (SOURCE)? STREAM (IF NOT EXISTS)? sourceName

--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -63,9 +63,9 @@ statement
     | (LIST | SHOW) QUERIES EXTENDED?                                       #listQueries
     | TERMINATE identifier                                                  #terminateQuery
     | TERMINATE ALL                                                         #terminateQuery
-    | SET STRING EQ STRING                                                  #setProperty
+    | SET (VARIABLE | STRING) EQ (VARIABLE | STRING)                        #setProperty
     | ALTER SYSTEM STRING EQ STRING                                         #alterSystemProperty
-    | UNSET STRING                                                          #unsetProperty
+    | UNSET (VARIABLE | STRING)                                             #unsetProperty
     | DEFINE variableName EQ variableValue                                  #defineVariable
     | UNDEFINE variableName                                                 #undefineVariable
     | CREATE (OR REPLACE)? (SOURCE)? STREAM (IF NOT EXISTS)? sourceName

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/VariableSubstitutor.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/VariableSubstitutor.java
@@ -158,6 +158,19 @@ public final class VariableSubstitutor {
       return null;
     }
 
+    @Override
+    public Void visitSetProperty(final SqlBaseParser.SetPropertyContext context) {
+      lookupVariables(context.STRING(0).getText());
+      lookupVariables(context.STRING(1).getText());
+      return null;
+    }
+
+    @Override
+    public Void visitUnsetProperty(final SqlBaseParser.UnsetPropertyContext context) {
+      lookupVariables(context.STRING().getText());
+      return null;
+    }
+
     private String getIdentifierText(final String value) {
       final char firstChar = value.charAt(0);
       final char lastChar = value.charAt(value.length() - 1);

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/CommandParser.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/CommandParser.java
@@ -33,12 +33,13 @@ import io.confluent.ksql.metastore.TypeRegistry;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.AstBuilder;
 import io.confluent.ksql.parser.DefaultKsqlParser;
+import io.confluent.ksql.parser.KsqlParser;
+import io.confluent.ksql.parser.VariableSubstitutor;
 import io.confluent.ksql.parser.exception.ParseFailedException;
-
-import io.confluent.ksql.parser.tree.CreateConnector.Type;
 import io.confluent.ksql.parser.tree.AssertSchema;
 import io.confluent.ksql.parser.tree.AssertTopic;
 import io.confluent.ksql.parser.tree.CreateConnector;
+import io.confluent.ksql.parser.tree.CreateConnector.Type;
 import io.confluent.ksql.parser.tree.DefineVariable;
 import io.confluent.ksql.parser.tree.DropConnector;
 import io.confluent.ksql.parser.tree.InsertValues;
@@ -47,11 +48,6 @@ import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.UndefineVariable;
 import io.confluent.ksql.parser.tree.UnsetProperty;
 import io.confluent.ksql.tools.migrations.MigrationException;
-import io.confluent.ksql.parser.KsqlParser;
-import io.confluent.ksql.parser.VariableSubstitutor;
-
-
-
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/CommandParserTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/CommandParserTest.java
@@ -196,7 +196,7 @@ public class CommandParserTest {
         ImmutableMap.of("name", "foo.property", "value", "bar"));
     assertThat(commands.size(), is(1));
     assertThat(commands.get(0), instanceOf(SqlPropertyCommand.class));
-    assertThat(commands.get(0).getCommand(), is("SET '${name}'='${value}';"));
+    assertThat(commands.get(0).getCommand(), is("SET 'foo.property'='bar';"));
     assertThat(((SqlPropertyCommand) commands.get(0)).isSetCommand(), is(true));
     assertThat(((SqlPropertyCommand) commands.get(0)).getProperty(), is("foo.property"));
     assertThat(((SqlPropertyCommand) commands.get(0)).getValue().get(), is("bar"));


### PR DESCRIPTION
### Description 
Instead of using regex for parsing commands in migration tool, reuse the ksql parser.

### Testing done 
unit test

[issue #9146](https://github.com/confluentinc/ksql/issues/9146)

