### PR TITLE
fix: change auth token provider to accept token strings instead of principals

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlAuthTokenProvider.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlAuthTokenProvider.java
@@ -15,9 +15,6 @@
 
 package io.confluent.ksql.security;
 
-import java.security.Principal;
-import java.util.Optional;
-
 /**
  * Interface to extract auth token information to ksqlDB
  */
@@ -26,8 +23,8 @@ public interface KsqlAuthTokenProvider {
   /**
    * Extract the lifetime of a token from the Principal.
    *
-   * @param principal The {@link Principal} that's carrying the auth token.
+   * @param token The auth token.
    * @return An {@Optional} containing the expiration time of the token in ms if there is one
    */
-  Optional<Long> getLifetimeMs(Principal principal);
+  long getLifetimeMs(String token);
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
@@ -312,7 +312,7 @@ public class KsqlServerEndpoints implements Endpoints {
             ksqlSecurityContext,
             context,
             new AuthenticationUtil(Clock.systemUTC())
-                .getTokenTimeout(apiSecurityContext.getPrincipal(), ksqlConfig, authTokenProvider)
+                .getTokenTimeout(apiSecurityContext.getAuthToken(), ksqlConfig, authTokenProvider)
         );
       } finally {
         ksqlSecurityContext.getServiceContext().close();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/AuthenticationUtilTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/AuthenticationUtilTest.java
@@ -20,7 +20,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.security.KsqlAuthTokenProvider;
-import io.confluent.ksql.security.KsqlPrincipal;
 import io.confluent.ksql.util.KsqlConfig;
 import java.time.Clock;
 import java.time.Instant;
@@ -39,14 +38,13 @@ public class AuthenticationUtilTest {
   private KsqlConfig ksqlConfig;
   @Mock
   private KsqlAuthTokenProvider authTokenProvider;
-  @Mock
-  private String token;
+  private final String TOKEN = "TOKEN";
   private final AuthenticationUtil authenticationUtil
       = new AuthenticationUtil(Clock.fixed(Instant.ofEpochMilli(0), ZoneId.of("UTC")));
 
   @Before
   public void init() {
-    when(authTokenProvider.getLifetimeMs(token)).thenReturn(50000L);
+    when(authTokenProvider.getLifetimeMs(TOKEN)).thenReturn(50000L);
     when(ksqlConfig.getLong(KsqlConfig.KSQL_WEBSOCKET_CONNECTION_MAX_TIMEOUT_MS)).thenReturn(60000L);
   }
 
@@ -56,7 +54,7 @@ public class AuthenticationUtilTest {
     when(ksqlConfig.getLong(KsqlConfig.KSQL_WEBSOCKET_CONNECTION_MAX_TIMEOUT_MS)).thenReturn(0L);
 
     // Then:
-    assertThat(authenticationUtil.getTokenTimeout(Optional.of(token), ksqlConfig, Optional.of(authTokenProvider)), equalTo(Optional.empty()));
+    assertThat(authenticationUtil.getTokenTimeout(Optional.of(TOKEN), ksqlConfig, Optional.of(authTokenProvider)), equalTo(Optional.empty()));
   }
 
   @Test
@@ -66,29 +64,29 @@ public class AuthenticationUtilTest {
 
   @Test
   public void shouldReturnDefaultWhenNoAuthTokenProviderPresent() {
-    assertThat(authenticationUtil.getTokenTimeout(Optional.of(token), ksqlConfig, Optional.empty()), equalTo(Optional.of(60000L)));
+    assertThat(authenticationUtil.getTokenTimeout(Optional.of(TOKEN), ksqlConfig, Optional.empty()), equalTo(Optional.of(60000L)));
   }
 
   @Test
   public void shouldReturnZeroWhenPrincipalHasTooLowExpiryTime() {
     // Given:
-    when(authTokenProvider.getLifetimeMs(token)).thenReturn(-10L);
+    when(authTokenProvider.getLifetimeMs(TOKEN)).thenReturn(-10L);
 
     // Then:
-    assertThat(authenticationUtil.getTokenTimeout(Optional.of(token), ksqlConfig, Optional.of(authTokenProvider)), equalTo(Optional.of(0)));
+    assertThat(authenticationUtil.getTokenTimeout(Optional.of(TOKEN), ksqlConfig, Optional.of(authTokenProvider)), equalTo(Optional.of(0L)));
   }
 
   @Test
   public void shouldReturnTokenExpiryTime() {
-    assertThat(authenticationUtil.getTokenTimeout(Optional.of(token), ksqlConfig, Optional.of(authTokenProvider)), equalTo(Optional.of(50000L)));
+    assertThat(authenticationUtil.getTokenTimeout(Optional.of(TOKEN), ksqlConfig, Optional.of(authTokenProvider)), equalTo(Optional.of(50000L)));
   }
 
   @Test
   public void shouldReturnMaxTimeout() {
     // Given:
-    when(authTokenProvider.getLifetimeMs(token)).thenReturn(50000000L);
+    when(authTokenProvider.getLifetimeMs(TOKEN)).thenReturn(50000000L);
 
     // Then:
-    assertThat(authenticationUtil.getTokenTimeout(Optional.of(token), ksqlConfig, Optional.of(authTokenProvider)), equalTo(Optional.of(60000L)));
+    assertThat(authenticationUtil.getTokenTimeout(Optional.of(TOKEN), ksqlConfig, Optional.of(authTokenProvider)), equalTo(Optional.of(60000L)));
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/AuthenticationUtilTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/AuthenticationUtilTest.java
@@ -38,7 +38,7 @@ public class AuthenticationUtilTest {
   private KsqlConfig ksqlConfig;
   @Mock
   private KsqlAuthTokenProvider authTokenProvider;
-  private final String TOKEN = "TOKEN";
+  private static final String TOKEN = "TOKEN";
   private final AuthenticationUtil authenticationUtil
       = new AuthenticationUtil(Clock.fixed(Instant.ofEpochMilli(0), ZoneId.of("UTC")));
 


### PR DESCRIPTION
### Description 
After #9239 was merged, the *correct* auth token is accessible from ApiSecurityContext, so we can use that instead of generic Principals to extract timeouts.

### Testing done 
Updated unit test. Will manually test as well.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

