### PR TITLE
feat: add pseudocolumn ROWID

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
@@ -21,13 +21,13 @@ import static io.confluent.ksql.schema.ksql.Column.Namespace.VALUE;
 import static io.confluent.ksql.schema.ksql.SystemColumns.CURRENT_PSEUDOCOLUMN_VERSION_NUMBER;
 import static io.confluent.ksql.schema.ksql.SystemColumns.HEADERS_TYPE;
 import static io.confluent.ksql.schema.ksql.SystemColumns.ROWID_NAME;
+import static io.confluent.ksql.schema.ksql.SystemColumns.ROWID_PSEUDOCOLUMN_VERSION;
 import static io.confluent.ksql.schema.ksql.SystemColumns.ROWID_TYPE;
 import static io.confluent.ksql.schema.ksql.SystemColumns.ROWOFFSET_NAME;
 import static io.confluent.ksql.schema.ksql.SystemColumns.ROWOFFSET_TYPE;
 import static io.confluent.ksql.schema.ksql.SystemColumns.ROWPARTITION_NAME;
 import static io.confluent.ksql.schema.ksql.SystemColumns.ROWPARTITION_ROWOFFSET_PSEUDOCOLUMN_VERSION;
 import static io.confluent.ksql.schema.ksql.SystemColumns.ROWPARTITION_TYPE;
-import static io.confluent.ksql.schema.ksql.SystemColumns.ROWID_PSEUDOCOLUMN_VERSION;
 import static io.confluent.ksql.schema.ksql.SystemColumns.ROWTIME_NAME;
 import static io.confluent.ksql.schema.ksql.SystemColumns.ROWTIME_PSEUDOCOLUMN_VERSION;
 import static io.confluent.ksql.schema.ksql.SystemColumns.ROWTIME_TYPE;
@@ -62,6 +62,7 @@ import java.util.stream.Collectors;
 /**
  * Immutable KSQL logical schema.
  */
+@SuppressWarnings({"NPathComplexity", "CyclomaticComplexity"})
 @Immutable
 public final class LogicalSchema {
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -538,6 +538,13 @@ public class KsqlConfig extends AbstractConfig {
       "Feature flag for ROWPARTITION and ROWOFFSET pseudocolumns. If enabled, new queries will be"
           + "built with ROWPARTITION and ROWOFFSET pseudocolumns. If off, they will not be.";
 
+  public static final String KSQL_ROWID_ENABLED =
+      "ksql.rowid..enabled";
+  public static final Boolean KSQL_ROWID_ENABLED_DEFAULT = false;
+  public static final String KSQL_ROWID_ENABLED_DOC =
+      "Feature flag for ROWID pseudocolumns. If enabled, new queries will be"
+          + "built with ROWID pseudocolumns. If off, they will not be.";
+
   public static final String KSQL_HEADERS_COLUMNS_ENABLED =
       "ksql.headers.columns.enabled";
   public static final Boolean KSQL_HEADERS_COLUMNS_ENABLED_DEFAULT = true;

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -540,7 +540,7 @@ public class KsqlConfig extends AbstractConfig {
 
   public static final String KSQL_ROWID_ENABLED =
       "ksql.rowid..enabled";
-  public static final Boolean KSQL_ROWID_ENABLED_DEFAULT = true;
+  public static final Boolean KSQL_ROWID_ENABLED_DEFAULT = false;
   public static final String KSQL_ROWID_ENABLED_DOC =
       "Feature flag for ROWID pseudocolumns. If enabled, new queries will be"
           + "built with ROWID pseudocolumns. If off, they will not be.";

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -540,7 +540,7 @@ public class KsqlConfig extends AbstractConfig {
 
   public static final String KSQL_ROWID_ENABLED =
       "ksql.rowid..enabled";
-  public static final Boolean KSQL_ROWID_ENABLED_DEFAULT = false;
+  public static final Boolean KSQL_ROWID_ENABLED_DEFAULT = true;
   public static final String KSQL_ROWID_ENABLED_DOC =
       "Feature flag for ROWID pseudocolumns. If enabled, new queries will be"
           + "built with ROWID pseudocolumns. If off, they will not be.";
@@ -1385,8 +1385,13 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_ROWPARTITION_ROWOFFSET_DEFAULT,
             Importance.LOW,
             KSQL_ROWPARTITION_ROWOFFSET_DOC
-        )
-        .define(
+        ).define(
+        KSQL_ROWID_ENABLED,
+        Type.BOOLEAN,
+        KSQL_ROWID_ENABLED_DEFAULT,
+        Importance.LOW,
+        KSQL_ROWID_ENABLED_DOC
+        ).define(
             KSQL_SHARED_RUNTIME_ENABLED,
             Type.BOOLEAN,
             KSQL_SHARED_RUNTIME_ENABLED_DEFAULT,

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -540,7 +540,7 @@ public class KsqlConfig extends AbstractConfig {
 
   public static final String KSQL_ROWID_ENABLED =
       "ksql.rowid..enabled";
-  public static final Boolean KSQL_ROWID_ENABLED_DEFAULT = false;
+  public static final Boolean KSQL_ROWID_ENABLED_DEFAULT = true;
   public static final String KSQL_ROWID_ENABLED_DOC =
       "Feature flag for ROWID pseudocolumns. If enabled, new queries will be"
           + "built with ROWID pseudocolumns. If off, they will not be.";

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -539,7 +539,7 @@ public class KsqlConfig extends AbstractConfig {
           + "built with ROWPARTITION and ROWOFFSET pseudocolumns. If off, they will not be.";
 
   public static final String KSQL_ROWID_ENABLED =
-      "ksql.rowid..enabled";
+      "ksql.rowid.enabled";
   public static final Boolean KSQL_ROWID_ENABLED_DEFAULT = false;
   public static final String KSQL_ROWID_ENABLED_DOC =
       "Feature flag for ROWID pseudocolumns. If enabled, new queries will be"

--- a/ksqldb-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
@@ -75,7 +75,8 @@ public class LogicalSchemaTest {
   private static final ColumnName H0 = ColumnName.of("h0");
   private static final ColumnName H1 = ColumnName.of("h1");
   private static final ColumnName VALUE = ColumnName.of("value");
-  private static final KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of());
+  private static final KsqlConfig ksqlConfig =
+      new KsqlConfig(ImmutableMap.of(KsqlConfig.KSQL_ROWID_ENABLED, true));
 
   private static final LogicalSchema SOME_SCHEMA = LogicalSchema.builder()
       .valueColumn(F0, STRING)

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -104,6 +104,7 @@ class Analyzer {
   private final MetaStore metaStore;
   private final String topicPrefix;
   private final boolean rowpartitionRowoffsetEnabled;
+  private final boolean rowIdEnabled;
   private final boolean pullLimitClauseEnabled;
 
   /**
@@ -116,12 +117,14 @@ class Analyzer {
       final MetaStore metaStore,
       final String topicPrefix,
       final boolean rowpartitionRowoffsetEnabled,
+      final boolean rowIdEnabled,
       final boolean pullLimitClauseEnabled
 
   ) {
     this.metaStore = requireNonNull(metaStore, "metaStore");
     this.topicPrefix = requireNonNull(topicPrefix, "topicPrefix");
     this.rowpartitionRowoffsetEnabled = rowpartitionRowoffsetEnabled;
+    this.rowIdEnabled = rowIdEnabled;
     this.pullLimitClauseEnabled = pullLimitClauseEnabled;
   }
 
@@ -160,6 +163,7 @@ class Analyzer {
       this.analysis = new Analysis(
               query.getRefinement(),
               rowpartitionRowoffsetEnabled,
+              rowIdEnabled,
               pullLimitClauseEnabled
           );
 
@@ -630,7 +634,7 @@ class Analyzer {
     private void validateSelect(final SingleColumn column) {
 
       final int pseudoColumnVersion = SystemColumns
-          .getPseudoColumnVersionFromConfig(rowpartitionRowoffsetEnabled);
+          .getPseudoColumnVersionFromConfig(rowpartitionRowoffsetEnabled , rowIdEnabled);
 
       SystemColumns.systemColumnNames(pseudoColumnVersion)
           .forEach(col -> checkForReservedToken(column, col));

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/PullQueryValidator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/PullQueryValidator.java
@@ -119,7 +119,8 @@ public class PullQueryValidator implements QueryValidator {
         .map(ColumnExtractor::extractColumns)
         .flatMap(Collection::stream)
         .map(ColumnReferenceExp::getColumnName)
-        .filter(name -> disallowedInPullQueries(name, analysis.getRowpartitionRowoffsetEnabled()))
+        .filter(name -> disallowedInPullQueries(name, analysis.getRowpartitionRowoffsetEnabled(),
+            analysis.getRowIdEnabled()))
         .map(Name::toString)
         .collect(Collectors.joining(", "));
 
@@ -142,7 +143,8 @@ public class PullQueryValidator implements QueryValidator {
     final String disallowedColumns = ColumnExtractor.extractColumns(expression.get())
         .stream()
         .map(ColumnReferenceExp::getColumnName)
-        .filter(name -> disallowedInPullQueries(name, analysis.getRowpartitionRowoffsetEnabled()))
+        .filter(name -> disallowedInPullQueries(name, analysis.getRowpartitionRowoffsetEnabled(),
+            analysis.getRowIdEnabled()))
         .map(Name::toString)
         .collect(Collectors.joining(", "));
 
@@ -157,10 +159,11 @@ public class PullQueryValidator implements QueryValidator {
 
   private static boolean disallowedInPullQueries(
       final ColumnName columnName,
-      final boolean rowpartitionRowoffsetEnabled
+      final boolean rowpartitionRowoffsetEnabled,
+      final boolean rowIdEnabled
   ) {
     final int pseudoColumnVersion = SystemColumns
-        .getPseudoColumnVersionFromConfig(rowpartitionRowoffsetEnabled);
+        .getPseudoColumnVersionFromConfig(rowpartitionRowoffsetEnabled, rowIdEnabled);
     return SystemColumns.isDisallowedInPullOrScalablePushQueries(columnName, pseudoColumnVersion);
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/QueryAnalyzer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/QueryAnalyzer.java
@@ -36,6 +36,7 @@ public class QueryAnalyzer {
       final MetaStore metaStore,
       final String outputTopicPrefix,
       final boolean rowpartitionRowoffsetEnabled,
+      final boolean rowIdEnabled,
       final boolean pullLimitClauseEnabled
   ) {
     this(
@@ -43,6 +44,7 @@ public class QueryAnalyzer {
                 metaStore,
                 outputTopicPrefix,
                 rowpartitionRowoffsetEnabled,
+                rowIdEnabled,
                 pullLimitClauseEnabled),
 
         new PullQueryValidator(),

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/QueryValidatorUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/QueryValidatorUtil.java
@@ -41,6 +41,7 @@ public final class QueryValidatorUtil {
   static void validateNoUserColumnsWithSameNameAsPseudoColumns(final Analysis analysis) {
 
     final boolean rowpartitionRowoffsetEnabled = analysis.getRowpartitionRowoffsetEnabled();
+    final boolean rowIdEnabled = analysis.getRowIdEnabled();
 
     final String disallowedNames = analysis.getAllDataSources()
         .stream()
@@ -49,7 +50,8 @@ public final class QueryValidatorUtil {
         .map(LogicalSchema::value)
         .flatMap(Collection::stream)
         .map(Column::name)
-        .filter(name -> SystemColumns.isPseudoColumn(name, rowpartitionRowoffsetEnabled))
+        .filter(
+            name -> SystemColumns.isPseudoColumn(name, rowpartitionRowoffsetEnabled, rowIdEnabled))
         .map(ColumnName::toString)
         .collect(Collectors.joining(", "));
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/SourceSchemas.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/SourceSchemas.java
@@ -36,17 +36,28 @@ public final class SourceSchemas {
 
   private final ImmutableMap<SourceName, LogicalSchema> sourceSchemas;
   private final boolean rowpartitionRowoffsetEnabled;
+  private final boolean rowIdEnabled;
 
   SourceSchemas(
       final Map<SourceName, LogicalSchema> sourceSchemas,
-      final boolean rowpartitionRowoffsetEnabled) {
+      final boolean rowpartitionRowoffsetEnabled,
+      final boolean rowIdEnabled) {
     this.sourceSchemas = ImmutableMap.copyOf(requireNonNull(sourceSchemas, "sourceSchemas"));
     this.rowpartitionRowoffsetEnabled = rowpartitionRowoffsetEnabled;
+    this.rowIdEnabled = rowIdEnabled;
 
     // This will fail
     if (sourceSchemas.isEmpty()) {
       throw new IllegalArgumentException("Must supply at least one schema");
     }
+  }
+
+  public interface SourceSchemasFactory {
+    SourceSchemas create(
+        Map<SourceName, LogicalSchema> sourceSchemas,
+        boolean rowpartitionRowoffsetEnabled,
+        boolean rowIdEnabled
+    );
   }
 
   /**
@@ -100,7 +111,7 @@ public final class SourceSchemas {
     if (!source.isPresent()) {
       return sourceSchemas.values().stream()
           .anyMatch(schema ->
-              SystemColumns.isPseudoColumn(column, rowpartitionRowoffsetEnabled)
+              SystemColumns.isPseudoColumn(column, rowpartitionRowoffsetEnabled, rowIdEnabled)
                   || schema.isKeyColumn(column));
     }
 
@@ -111,6 +122,6 @@ public final class SourceSchemas {
     }
 
     return sourceSchema.isKeyColumn(column)
-        || SystemColumns.isPseudoColumn(column, rowpartitionRowoffsetEnabled);
+        || SystemColumns.isPseudoColumn(column, rowpartitionRowoffsetEnabled, rowIdEnabled);
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -805,6 +805,7 @@ final class EngineExecutor {
           metaStore,
           ksqlConfig,
           getRowpartitionRowoffsetEnabled(ksqlConfig, statement.getSessionConfig().getOverrides()),
+          getRowIdEnabled(ksqlConfig, statement.getSessionConfig().getOverrides()),
           statement.getStatementText()
       );
 
@@ -1172,5 +1173,18 @@ final class EngineExecutor {
     }
 
     return ksqlConfig.getBoolean(KsqlConfig.KSQL_ROWPARTITION_ROWOFFSET_ENABLED);
+  }
+
+  private static boolean getRowIdEnabled(
+      final KsqlConfig ksqlConfig,
+      final Map<String, Object> configOverrides
+  ) {
+    final Object rowIdEnabled =
+        configOverrides.get(KsqlConfig.KSQL_ROWID_ENABLED);
+    if (rowIdEnabled != null) {
+      return "true".equalsIgnoreCase(rowIdEnabled.toString());
+    }
+
+    return ksqlConfig.getBoolean(KsqlConfig.KSQL_ROWID_ENABLED);
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -678,6 +678,7 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable, KsqlConfigur
         getMetaStore(),
         "",
         getRowpartitionRowoffsetEnabled(ksqlConfig, configOverrides),
+        getRowIdEnabled(ksqlConfig, configOverrides),
         ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_LIMIT_CLAUSE_ENABLED)
     );
 
@@ -774,6 +775,19 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable, KsqlConfigur
     }
 
     return ksqlConfig.getBoolean(KsqlConfig.KSQL_ROWPARTITION_ROWOFFSET_ENABLED);
+  }
+
+  private static boolean getRowIdEnabled(
+      final KsqlConfig ksqlConfig,
+      final Map<String, Object> configOverrides
+  ) {
+    final Object rowIdEnabled =
+        configOverrides.get(KsqlConfig.KSQL_ROWID_ENABLED);
+    if (rowIdEnabled != null) {
+      return "true".equalsIgnoreCase(rowIdEnabled.toString());
+    }
+
+    return ksqlConfig.getBoolean(KsqlConfig.KSQL_ROWID_ENABLED);
   }
 
   private boolean getTransientQueryCleanupServiceEnabled(final KsqlConfig ksqlConfig) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryEngine.java
@@ -61,6 +61,7 @@ class QueryEngine {
       final MetaStore metaStore,
       final KsqlConfig config,
       final boolean rowpartitionRowoffsetEnabled,
+      final boolean rowIdEnabled,
       final String statementTextMasked
   ) {
     final String outputPrefix = config.getString(KsqlConfig.KSQL_OUTPUT_TOPIC_NAME_PREFIX_CONFIG);
@@ -71,6 +72,7 @@ class QueryEngine {
         new QueryAnalyzer(metaStore,
             outputPrefix,
             rowpartitionRowoffsetEnabled,
+            rowIdEnabled,
             pullLimitClauseEnabled
         );
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/AstSanitizer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/AstSanitizer.java
@@ -69,18 +69,21 @@ public final class AstSanitizer {
   public static Statement sanitize(
       final Statement node,
       final MetaStore metaStore,
-      final boolean rowpartitionRowoffsetEnabled) {
-    return sanitize(node, metaStore, true, rowpartitionRowoffsetEnabled);
+      final boolean rowpartitionRowoffsetEnabled,
+      final boolean rowIdEnabled
+  ) {
+    return sanitize(node, metaStore, true, rowpartitionRowoffsetEnabled, rowIdEnabled);
   }
 
   public static Statement sanitize(
       final Statement node,
       final MetaStore metaStore,
       final Boolean lambdaEnabled,
-      final boolean rowpartitionRowoffsetEnabled
+      final boolean rowpartitionRowoffsetEnabled,
+      final boolean rowIdEnabled
   ) {
     final DataSourceExtractor dataSourceExtractor =
-        new DataSourceExtractor(metaStore, rowpartitionRowoffsetEnabled);
+        new DataSourceExtractor(metaStore, rowpartitionRowoffsetEnabled, rowIdEnabled);
     dataSourceExtractor.extractDataSources(node);
 
     final RewriterPlugin rewriterPlugin =

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/DataSourceExtractor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/DataSourceExtractor.java
@@ -46,13 +46,17 @@ public class DataSourceExtractor {
   private final Set<ColumnName> allColumns = new HashSet<>();
   private final Set<ColumnName> clashingColumns = new HashSet<>();
   private final boolean rowpartitionRowoffsetEnabled;
+  private final boolean rowIdEnabled;
 
   private boolean isJoin = false;
 
-  public DataSourceExtractor(final MetaStore metaStore,
-                             final boolean rowpartitionRowoffsetEnabled) {
+  public DataSourceExtractor(
+      final MetaStore metaStore,
+      final boolean rowpartitionRowoffsetEnabled,
+      final boolean rowIdEnabled) {
     this.metaStore = Objects.requireNonNull(metaStore, "metaStore");
     this.rowpartitionRowoffsetEnabled = rowpartitionRowoffsetEnabled;
+    this.rowIdEnabled = rowIdEnabled;
   }
 
   public Set<Analysis.AliasedDataSource> extractDataSources(final AstNode node) {
@@ -73,7 +77,7 @@ public class DataSourceExtractor {
       return false;
     }
 
-    if (SystemColumns.isPseudoColumn(name, rowpartitionRowoffsetEnabled)) {
+    if (SystemColumns.isPseudoColumn(name, rowpartitionRowoffsetEnabled, rowIdEnabled)) {
       return true;
     }
 
@@ -82,7 +86,8 @@ public class DataSourceExtractor {
 
   public List<SourceName> getSourcesFor(final ColumnName columnName) {
     return allSources.stream()
-        .filter(aliased -> hasColumn(columnName, aliased, rowpartitionRowoffsetEnabled))
+        .filter(
+            aliased -> hasColumn(columnName, aliased, rowpartitionRowoffsetEnabled, rowIdEnabled))
         .map(AliasedDataSource::getAlias)
         .collect(Collectors.toList());
   }
@@ -90,9 +95,10 @@ public class DataSourceExtractor {
   private static boolean hasColumn(
       final ColumnName columnName,
       final AliasedDataSource aliased,
-      final boolean rowpartitionRowoffsetEnabled
+      final boolean rowpartitionRowoffsetEnabled,
+      final boolean rowIdEnabled
   ) {
-    if (SystemColumns.isPseudoColumn(columnName, rowpartitionRowoffsetEnabled)) {
+    if (SystemColumns.isPseudoColumn(columnName, rowpartitionRowoffsetEnabled, rowIdEnabled)) {
       return true;
     }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/QueryFilterNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/QueryFilterNode.java
@@ -135,7 +135,8 @@ public class QueryFilterNode extends SingleSourcePlanNode {
     this.intermediateSchema = QueryLogicalPlanUtil.buildIntermediateSchema(
         source.getSchema().withoutPseudoAndKeyColsInValue(ksqlConfig),
         addAdditionalColumnsToIntermediateSchema, isWindowed,
-        ksqlConfig.getBoolean(KsqlConfig.KSQL_ROWPARTITION_ROWOFFSET_ENABLED));
+        ksqlConfig.getBoolean(KsqlConfig.KSQL_ROWPARTITION_ROWOFFSET_ENABLED),
+        ksqlConfig.getBoolean(KsqlConfig.KSQL_ROWID_ENABLED));
     compiledWhereClause = getExpressionEvaluator(
         rewrittenPredicate, intermediateSchema, metaStore, ksqlConfig, queryPlannerOptions);
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/QueryLogicalPlanUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/QueryLogicalPlanUtil.java
@@ -31,12 +31,14 @@ final class QueryLogicalPlanUtil {
       final LogicalSchema schema,
       final boolean addAdditionalColumnsToIntermediateSchema,
       final boolean isWindowed,
-      final boolean rowpartitionRowoffsetEnabled
+      final boolean rowpartitionRowoffsetEnabled,
+      final boolean rowidEnabled
   ) {
     if (!addAdditionalColumnsToIntermediateSchema) {
       return schema;
     } else {
-      return schema.withPseudoAndKeyColsInValue(isWindowed, rowpartitionRowoffsetEnabled, true);
+      return schema.withPseudoAndKeyColsInValue(
+          isWindowed, rowpartitionRowoffsetEnabled, rowidEnabled, true);
     }
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/QueryProjectNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/QueryProjectNode.java
@@ -103,8 +103,9 @@ public class QueryProjectNode extends ProjectNode {
           source.getSchema().withoutPseudoAndKeyColsInValue(),
           addAdditionalColumnsToIntermediateSchema,
           isWindowed,
-          ksqlConfig.getBoolean(KsqlConfig.KSQL_ROWPARTITION_ROWOFFSET_ENABLED)
-      );
+          ksqlConfig.getBoolean(KsqlConfig.KSQL_ROWPARTITION_ROWOFFSET_ENABLED),
+        ksqlConfig.getBoolean(KsqlConfig.KSQL_ROWID_ENABLED)
+        );
     this.compiledSelectExpressions = isSelectStar
         ? ImmutableList.of()
         : selectExpressions

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/AnalysisTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/AnalysisTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.confluent.ksql.analyzer.SourceSchemas.SourceSchemasFactory;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.model.WindowType;
@@ -35,9 +36,7 @@ import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.RefinementInfo;
 import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.serde.WindowInfo;
-import java.util.Map;
 import java.util.Optional;
-import java.util.function.BiFunction;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -48,6 +47,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class AnalysisTest {
   
   private static final boolean ROWPARTITION_ROWOFFSET_ENABLED = true;
+  private static final boolean ROW_ID_ENABLED = true;
 
   private static final SourceName ALIAS = SourceName.of("ds1");
   private static final FormatInfo A_FORMAT = FormatInfo.of("JSON");
@@ -63,7 +63,7 @@ public class AnalysisTest {
   @Mock
   private KsqlStream<?> dataSource;
   @Mock
-  private BiFunction<Map<SourceName, LogicalSchema>, Boolean, SourceSchemas> sourceSchemasFactory;
+  private SourceSchemasFactory sourceSchemasFactory;
   @Mock
   private WindowExpression windowExpression;
 
@@ -71,7 +71,7 @@ public class AnalysisTest {
 
   @Before
   public void setUp() {
-    analysis = new Analysis(Optional.of(refinementInfo), sourceSchemasFactory, ROWPARTITION_ROWOFFSET_ENABLED, true);
+    analysis = new Analysis(Optional.of(refinementInfo), sourceSchemasFactory, ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED, true);
 
     when(dataSource.getSchema()).thenReturn(SOURCE_SCHEMA);
   }
@@ -88,12 +88,13 @@ public class AnalysisTest {
     analysis.getFromSourceSchemas(false);
 
     // Then:
-    verify(sourceSchemasFactory).apply(
+    verify(sourceSchemasFactory).create(
         ImmutableMap.of(
             ALIAS,
-            SOURCE_SCHEMA.withPseudoAndKeyColsInValue(false, ROWPARTITION_ROWOFFSET_ENABLED)
+            SOURCE_SCHEMA.withPseudoAndKeyColsInValue(false, ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED)
         ),
-        ROWPARTITION_ROWOFFSET_ENABLED
+        ROWPARTITION_ROWOFFSET_ENABLED,
+        ROW_ID_ENABLED
     );
   }
 
@@ -109,12 +110,13 @@ public class AnalysisTest {
     analysis.getFromSourceSchemas(false);
 
     // Then:
-    verify(sourceSchemasFactory).apply(
+    verify(sourceSchemasFactory).create(
         ImmutableMap.of(
             ALIAS,
-            SOURCE_SCHEMA.withPseudoAndKeyColsInValue(true, ROWPARTITION_ROWOFFSET_ENABLED)
+            SOURCE_SCHEMA.withPseudoAndKeyColsInValue(true, ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED)
         ),
-        ROWPARTITION_ROWOFFSET_ENABLED
+        ROWPARTITION_ROWOFFSET_ENABLED,
+        ROW_ID_ENABLED
     );
   }
 
@@ -131,12 +133,13 @@ public class AnalysisTest {
     analysis.getFromSourceSchemas(false);
 
     // Then:
-    verify(sourceSchemasFactory).apply(
+    verify(sourceSchemasFactory).create(
         ImmutableMap.of(
             ALIAS,
-            SOURCE_SCHEMA.withPseudoAndKeyColsInValue(false, ROWPARTITION_ROWOFFSET_ENABLED)
+            SOURCE_SCHEMA.withPseudoAndKeyColsInValue(false, ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED)
         ),
-        ROWPARTITION_ROWOFFSET_ENABLED
+        ROWPARTITION_ROWOFFSET_ENABLED,
+        ROW_ID_ENABLED
     );
   }
 
@@ -152,12 +155,13 @@ public class AnalysisTest {
     analysis.getFromSourceSchemas(true);
 
     // Then:
-    verify(sourceSchemasFactory).apply(
+    verify(sourceSchemasFactory).create(
         ImmutableMap.of(
             ALIAS,
-            SOURCE_SCHEMA.withPseudoAndKeyColsInValue(false, ROWPARTITION_ROWOFFSET_ENABLED)
+            SOURCE_SCHEMA.withPseudoAndKeyColsInValue(false, ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED)
         ),
-        ROWPARTITION_ROWOFFSET_ENABLED
+        ROWPARTITION_ROWOFFSET_ENABLED,
+        ROW_ID_ENABLED
     );
   }
 
@@ -173,12 +177,13 @@ public class AnalysisTest {
     analysis.getFromSourceSchemas(true);
 
     // Then:
-    verify(sourceSchemasFactory).apply(
+    verify(sourceSchemasFactory).create(
         ImmutableMap.of(
             ALIAS,
-            SOURCE_SCHEMA.withPseudoAndKeyColsInValue(true, ROWPARTITION_ROWOFFSET_ENABLED)
+            SOURCE_SCHEMA.withPseudoAndKeyColsInValue(true, ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED)
         ),
-        ROWPARTITION_ROWOFFSET_ENABLED
+        ROWPARTITION_ROWOFFSET_ENABLED,
+        ROW_ID_ENABLED
     );
   }
 
@@ -195,12 +200,13 @@ public class AnalysisTest {
     analysis.getFromSourceSchemas(true);
 
     // Then:
-    verify(sourceSchemasFactory).apply(
+    verify(sourceSchemasFactory).create(
         ImmutableMap.of(
             ALIAS,
-            SOURCE_SCHEMA.withPseudoAndKeyColsInValue(true, ROWPARTITION_ROWOFFSET_ENABLED)
+            SOURCE_SCHEMA.withPseudoAndKeyColsInValue(true, ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED)
         ),
-        ROWPARTITION_ROWOFFSET_ENABLED
+        ROWPARTITION_ROWOFFSET_ENABLED,
+        ROW_ID_ENABLED
     );
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerFunctionalTest.java
@@ -73,6 +73,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class AnalyzerFunctionalTest {
 
   private static final boolean ROWPARTITION_ROWOFFSET_ENABLED = true;
+  private static final boolean ROW_ID_ENABLED = true;
   private static final boolean PULL_LIMIT_CLAUSE_ENABLED = true;
 
   private static final ColumnName COL0 = ColumnName.of("COL0");
@@ -96,7 +97,7 @@ public class AnalyzerFunctionalTest {
         ValueFormat.of(FormatInfo.of(FormatFactory.AVRO.name()), SerdeFeatures.of())
     );
 
-    analyzer = new Analyzer(jsonMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
+    analyzer = new Analyzer(jsonMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
 
     query = parseSingle("Select COL0, COL1 from TEST1;");
 
@@ -115,7 +116,7 @@ public class AnalyzerFunctionalTest {
     final CreateStreamAsSelect createStreamAsSelect = (CreateStreamAsSelect) statements.get(0);
     final Query query = createStreamAsSelect.getQuery();
 
-    final Analyzer analyzer = new Analyzer(jsonMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
+    final Analyzer analyzer = new Analyzer(jsonMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
     final Analysis analysis = analyzer.analyze(query, Optional.of(createStreamAsSelect.getSink()));
 
     assertThat(analysis.getInto(), is(not(Optional.empty())));
@@ -132,7 +133,7 @@ public class AnalyzerFunctionalTest {
     final CreateStreamAsSelect createStreamAsSelect = (CreateStreamAsSelect) statements.get(0);
     final Query query = createStreamAsSelect.getQuery();
 
-    final Analyzer analyzer = new Analyzer(jsonMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
+    final Analyzer analyzer = new Analyzer(jsonMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
     final Analysis analysis = analyzer.analyze(query, Optional.of(createStreamAsSelect.getSink()));
 
     assertThat(analysis.getInto(), is(not(Optional.empty())));
@@ -148,7 +149,7 @@ public class AnalyzerFunctionalTest {
     final CreateStreamAsSelect createStreamAsSelect = (CreateStreamAsSelect) statements.get(0);
     final Query query = createStreamAsSelect.getQuery();
 
-    final Analyzer analyzer = new Analyzer(avroMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
+    final Analyzer analyzer = new Analyzer(avroMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
     final Analysis analysis = analyzer.analyze(query, Optional.of(createStreamAsSelect.getSink()));
 
     assertThat(analysis.getInto(), is(not(Optional.empty())));
@@ -192,7 +193,7 @@ public class AnalyzerFunctionalTest {
     final CreateStreamAsSelect createStreamAsSelect = (CreateStreamAsSelect) statements.get(0);
     final Query query = createStreamAsSelect.getQuery();
 
-    final Analyzer analyzer = new Analyzer(newAvroMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
+    final Analyzer analyzer = new Analyzer(newAvroMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
     final Analysis analysis = analyzer.analyze(query, Optional.of(createStreamAsSelect.getSink()));
 
     assertThat(analysis.getInto(), is(not(Optional.empty())));
@@ -208,7 +209,7 @@ public class AnalyzerFunctionalTest {
     final CreateStreamAsSelect createStreamAsSelect = (CreateStreamAsSelect) statements.get(0);
     final Query query = createStreamAsSelect.getQuery();
 
-    final Analyzer analyzer = new Analyzer(avroMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
+    final Analyzer analyzer = new Analyzer(avroMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
     final Analysis analysis = analyzer.analyze(query, Optional.of(createStreamAsSelect.getSink()));
 
     assertThat(analysis.getInto(), is(not(Optional.empty())));
@@ -242,7 +243,7 @@ public class AnalyzerFunctionalTest {
 
     final Query query = createStreamAsSelect.getQuery();
 
-    final Analyzer analyzer = new Analyzer(jsonMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
+    final Analyzer analyzer = new Analyzer(jsonMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
 
     // When:
     final Exception e = assertThrows(
@@ -265,7 +266,7 @@ public class AnalyzerFunctionalTest {
 
     final Query query = createStreamAsSelect.getQuery();
 
-    final Analyzer analyzer = new Analyzer(jsonMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
+    final Analyzer analyzer = new Analyzer(jsonMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
 
     // When:
     final Exception e = assertThrows(
@@ -290,7 +291,7 @@ public class AnalyzerFunctionalTest {
 
     final Query query = createStreamAsSelect.getQuery();
 
-    final Analyzer analyzer = new Analyzer(jsonMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
+    final Analyzer analyzer = new Analyzer(jsonMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
 
     // When:
     final Exception e = assertThrows(
@@ -307,7 +308,7 @@ public class AnalyzerFunctionalTest {
   public void shouldFailOnTableFunctionInsideCaseFunction() {
     // Given:
     final Query query = parseSingle("SELECT CASE WHEN false then EXPLODE(ARRAY[1.2]) END FROM test1;");
-    final Analyzer analyzer = new Analyzer(jsonMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
+    final Analyzer analyzer = new Analyzer(jsonMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
     when(functionRegistry.isTableFunction(FunctionName.of("EXPLODE"))).thenReturn(true);
 
     // When:
@@ -332,7 +333,7 @@ public class AnalyzerFunctionalTest {
 
     final Query query = createStreamAsSelect.getQuery();
 
-    final Analyzer analyzer = new Analyzer(jsonMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
+    final Analyzer analyzer = new Analyzer(jsonMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
 
     // When:
     final Exception e = assertThrows(
@@ -357,7 +358,7 @@ public class AnalyzerFunctionalTest {
 
     final Query query = createStreamAsSelect.getQuery();
 
-    final Analyzer analyzer = new Analyzer(jsonMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
+    final Analyzer analyzer = new Analyzer(jsonMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
 
     // When:
     final Exception e = assertThrows(
@@ -382,7 +383,7 @@ public class AnalyzerFunctionalTest {
 
     final Query query = createStreamAsSelect.getQuery();
 
-    final Analyzer analyzer = new Analyzer(jsonMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
+    final Analyzer analyzer = new Analyzer(jsonMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
 
     // When:
     final Exception e = assertThrows(
@@ -430,7 +431,7 @@ public class AnalyzerFunctionalTest {
       final String simpleQuery,
       final MetaStore metaStore
   ) {
-    return KsqlParserTestUtil.buildAst(simpleQuery, metaStore, ROWPARTITION_ROWOFFSET_ENABLED)
+    return KsqlParserTestUtil.buildAst(simpleQuery, metaStore, ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED)
         .stream()
         .map(PreparedStatement::getStatement)
         .collect(Collectors.toList());

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/QueryAnalyzerFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/QueryAnalyzerFunctionalTest.java
@@ -44,12 +44,13 @@ import org.junit.Test;
 public class QueryAnalyzerFunctionalTest {
 
   private static final boolean ROWPARTITION_ROWOFFSET_ENABLED = true;
+  private static final boolean ROW_ID_ENABLED = true;
   private static final boolean PULL_LIMIT_CLAUSE_ENABLED = true;
 
   private final InternalFunctionRegistry functionRegistry = new InternalFunctionRegistry();
   private final MetaStore metaStore = MetaStoreFixture.getNewMetaStore(functionRegistry);
   private final QueryAnalyzer queryAnalyzer =
-      new QueryAnalyzer(metaStore, "prefix-~", ROWPARTITION_ROWOFFSET_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
+      new QueryAnalyzer(metaStore, "prefix-~", ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED, PULL_LIMIT_CLAUSE_ENABLED);
 
   @Test
   public void shouldAnalyseTableFunctions() {
@@ -85,7 +86,7 @@ public class QueryAnalyzerFunctionalTest {
   public void shouldHandleValueFormat() {
     // Given:
     final PreparedStatement<CreateStreamAsSelect> statement = KsqlParserTestUtil.buildSingleAst(
-        "create stream s with(value_format='delimited') as select * from test1;", metaStore, ROWPARTITION_ROWOFFSET_ENABLED);
+        "create stream s with(value_format='delimited') as select * from test1;", metaStore, ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED);
     final Query query = statement.getStatement().getQuery();
     final Optional<Sink> sink = Optional.of(statement.getStatement().getSink());
 
@@ -98,6 +99,6 @@ public class QueryAnalyzerFunctionalTest {
   }
 
   private Query givenQuery(final String sql) {
-    return KsqlParserTestUtil.<Query>buildSingleAst(sql, metaStore, ROWPARTITION_ROWOFFSET_ENABLED).getStatement();
+    return KsqlParserTestUtil.<Query>buildSingleAst(sql, metaStore, ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED).getStatement();
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/SourceSchemasTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/SourceSchemasTest.java
@@ -37,6 +37,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class SourceSchemasTest {
 
   private static final boolean ROWPARTITION_ROWOFFSET_ENABLED = true;
+  private static final boolean ROW_ID_ENABLED = true;
 
   private static final SourceName ALIAS_1 = SourceName.of("S1");
   private static final SourceName ALIAS_2 = SourceName.of("S2");
@@ -66,18 +67,18 @@ public class SourceSchemasTest {
 
   @Before
   public void setUp() {
-    sourceSchemas = new SourceSchemas(ImmutableMap.of(ALIAS_1, SCHEMA_1, ALIAS_2, SCHEMA_2), ROWPARTITION_ROWOFFSET_ENABLED);
+    sourceSchemas = new SourceSchemas(ImmutableMap.of(ALIAS_1, SCHEMA_1, ALIAS_2, SCHEMA_2), ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void shouldThrowOnNoSchemas() {
-    new SourceSchemas(ImmutableMap.of(), ROWPARTITION_ROWOFFSET_ENABLED);
+    new SourceSchemas(ImmutableMap.of(), ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED);
   }
 
   @Test
   public void shouldNotBeJoinIfSingleSchema() {
     // When:
-    sourceSchemas = new SourceSchemas(ImmutableMap.of(ALIAS_1, SCHEMA_1), ROWPARTITION_ROWOFFSET_ENABLED);
+    sourceSchemas = new SourceSchemas(ImmutableMap.of(ALIAS_1, SCHEMA_1), ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED);
 
     // Then:
     assertThat(sourceSchemas.isJoin(), is(false));
@@ -86,7 +87,7 @@ public class SourceSchemasTest {
   @Test
   public void shouldBeJoinIfMultipleSchemas() {
     // When:
-    sourceSchemas = new SourceSchemas(ImmutableMap.of(ALIAS_1, SCHEMA_1, ALIAS_2, SCHEMA_2), ROWPARTITION_ROWOFFSET_ENABLED);
+    sourceSchemas = new SourceSchemas(ImmutableMap.of(ALIAS_1, SCHEMA_1, ALIAS_2, SCHEMA_2), ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED);
 
     // Then:
     assertThat(sourceSchemas.isJoin(), is(true));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/AstSanitizerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/AstSanitizerTest.java
@@ -22,7 +22,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.execution.expression.tree.ArithmeticBinaryExpression;
@@ -48,7 +47,6 @@ import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.MetaStoreFixture;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -69,7 +67,7 @@ public class AstSanitizerTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> AstSanitizer.sanitize(stmt, META_STORE, true)
+        () -> AstSanitizer.sanitize(stmt, META_STORE, true, true)
     );
 
     // Then:
@@ -85,7 +83,7 @@ public class AstSanitizerTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> AstSanitizer.sanitize(stmt, META_STORE, true)
+        () -> AstSanitizer.sanitize(stmt, META_STORE, true, true)
     );
 
     // Then:
@@ -102,7 +100,7 @@ public class AstSanitizerTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> AstSanitizer.sanitize(stmt, META_STORE, true)
+        () -> AstSanitizer.sanitize(stmt, META_STORE, true, true)
     );
 
     // Then:
@@ -119,7 +117,7 @@ public class AstSanitizerTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> AstSanitizer.sanitize(stmt, META_STORE, true)
+        () -> AstSanitizer.sanitize(stmt, META_STORE, true, true)
     );
 
     // Then:
@@ -135,7 +133,7 @@ public class AstSanitizerTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> AstSanitizer.sanitize(stmt, META_STORE, true)
+        () -> AstSanitizer.sanitize(stmt, META_STORE, true, true)
     );
 
     // Then:
@@ -152,7 +150,7 @@ public class AstSanitizerTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> AstSanitizer.sanitize(stmt, META_STORE, true)
+        () -> AstSanitizer.sanitize(stmt, META_STORE, true, true)
     );
 
     // Then:
@@ -169,7 +167,7 @@ public class AstSanitizerTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> AstSanitizer.sanitize(stmt, META_STORE, true)
+        () -> AstSanitizer.sanitize(stmt, META_STORE, true, true)
     );
 
     // Then:
@@ -200,7 +198,7 @@ public class AstSanitizerTest {
     final Statement stmt = givenQuery("SELECT COL0 FROM TEST1;");
 
     // When:
-    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE, true);
+    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE, true, true);
 
     // Then:
     assertThat(result.getSelect(), is(new Select(ImmutableList.of(
@@ -216,7 +214,7 @@ public class AstSanitizerTest {
         "SELECT COL5 FROM TEST1 JOIN TEST2 ON TEST1.COL0=TEST2.COL0;");
 
     // When:
-    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE, true);
+    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE, true, true);
 
     // Then:
     assertThat(result.getSelect(), is(new Select(ImmutableList.of(
@@ -232,7 +230,7 @@ public class AstSanitizerTest {
         "SELECT COL5 FROM TEST2 JOIN TEST1 ON TEST2.COL0=TEST1.COL0;");
 
     // When:
-    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE, true);
+    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE, true, true);
 
     // Then:
     assertThat(result.getSelect(), is(new Select(ImmutableList.of(
@@ -248,7 +246,7 @@ public class AstSanitizerTest {
         "SELECT TRANSFORM_ARRAY(Col4, X => X + 5, (X,Y) => Y + 5) FROM TEST1;");
 
     // When:
-    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE, true);
+    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE, true, true);
 
     // Then:
     assertThat(result.getSelect(), is(new Select(ImmutableList.of(
@@ -284,7 +282,7 @@ public class AstSanitizerTest {
         "SELECT TRANSFORM_ARRAY(Col4, (X,Y,Z) => TRANSFORM_MAP(Col4, Q => 4, H => 5), (X,Y,Z) => 0) FROM TEST1;");
 
     // When:
-    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE, true);
+    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE, true, true);
 
     // Then:
     assertThat(result.getSelect(), is(new Select(ImmutableList.of(
@@ -328,7 +326,7 @@ public class AstSanitizerTest {
 
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> AstSanitizer.sanitize(stmt, META_STORE, true)
+        () -> AstSanitizer.sanitize(stmt, META_STORE, true, true)
     );
 
     // Then:
@@ -347,11 +345,11 @@ public class AstSanitizerTest {
 
     final Exception e1 = assertThrows(
         KsqlException.class,
-        () -> AstSanitizer.sanitize(stmt1, META_STORE, true)
+        () -> AstSanitizer.sanitize(stmt1, META_STORE, true, true)
     );
     final Exception e2 = assertThrows(
         KsqlException.class,
-        () -> AstSanitizer.sanitize(stmt2, META_STORE, true)
+        () -> AstSanitizer.sanitize(stmt2, META_STORE, true, true)
     );
 
     // Then:
@@ -370,7 +368,7 @@ public class AstSanitizerTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> AstSanitizer.sanitize(stmt, META_STORE, true)
+        () -> AstSanitizer.sanitize(stmt, META_STORE, true, true)
     );
 
     // Then:
@@ -384,7 +382,7 @@ public class AstSanitizerTest {
     final Statement stmt = givenQuery("SELECT TEST1.COL0 FROM TEST1;");
 
     // When:
-    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE, true);
+    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE, true, true);
 
     // Then:
     assertThat(result.getSelect(), is(new Select(ImmutableList.of(
@@ -399,7 +397,7 @@ public class AstSanitizerTest {
     final Statement stmt = givenQuery("SELECT T.COL0 FROM TEST2 T;");
 
     // When:
-    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE, true);
+    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE, true, true);
 
     // Then:
     assertThat(result.getSelect(), is(new Select(ImmutableList.of(
@@ -414,7 +412,7 @@ public class AstSanitizerTest {
     final Statement stmt = givenQuery("SELECT COL0 FROM TEST1;");
 
     // When:
-    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE, true);
+    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE, true, true);
 
     // Then:
     final SingleColumn col = (SingleColumn) result.getSelect().getSelectItems().get(0);
@@ -428,7 +426,7 @@ public class AstSanitizerTest {
         "SELECT TEST1.COL0 FROM TEST1 JOIN TEST2 ON TEST1.COL0=TEST2.COL0;");
 
     // When:
-    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE, true);
+    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE, true, true);
 
     // Then:
     final SingleColumn col = (SingleColumn) result.getSelect().getSelectItems().get(0);
@@ -441,7 +439,7 @@ public class AstSanitizerTest {
     final Statement stmt = givenQuery("SELECT ADDRESS->NUMBER FROM ORDERS;");
 
     // When:
-    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE, true);
+    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE, true, true);
 
     // Then:
     final SingleColumn col = (SingleColumn) result.getSelect().getSelectItems().get(0);
@@ -454,7 +452,7 @@ public class AstSanitizerTest {
     final Statement stmt = givenQuery("SELECT 1 + 2 FROM ORDERS;");
 
     // When:
-    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE, true);
+    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE, true, true);
 
     // Then:
     final SingleColumn col = (SingleColumn) result.getSelect().getSelectItems().get(0);
@@ -467,7 +465,7 @@ public class AstSanitizerTest {
     final Statement stmt = givenQuery("SELECT COL1 AS BOB FROM TEST1;");
 
     // When:
-    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE, true);
+    final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE, true, true);
 
     // Then:
     assertThat(result.getSelect(), is(new Select(ImmutableList.of(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/AstSanitizerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/AstSanitizerTest.java
@@ -184,7 +184,7 @@ public class AstSanitizerTest {
     // When:
     final Exception e = assertThrows(
         UnsupportedOperationException.class,
-        () -> AstSanitizer.sanitize(stmt, META_STORE, false, true)
+        () -> AstSanitizer.sanitize(stmt, META_STORE, false, true, true)
     );
 
     // Then:

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/DataSourceExtractorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/DataSourceExtractorTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.analyzer.Analysis.AliasedDataSource;
 import io.confluent.ksql.function.FunctionRegistry;
@@ -46,6 +45,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class DataSourceExtractorTest {
 
   private static final boolean ROWPARTITION_ROWOFFSET_ENABLED = true;
+  private static final boolean ROW_ID_ENABLED = true;
 
   private static final SourceName TEST1 = SourceName.of("TEST1");
   private static final SourceName TEST2 = SourceName.of("TEST2");
@@ -61,7 +61,7 @@ public class DataSourceExtractorTest {
 
   @Before
   public void setUp() {
-    extractor = new DataSourceExtractor(META_STORE, ROWPARTITION_ROWOFFSET_ENABLED);
+    extractor = new DataSourceExtractor(META_STORE, ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED);
   }
 
   @Test
@@ -216,7 +216,7 @@ public class DataSourceExtractorTest {
     extractor.extractDataSources(stmt);
 
     // Then:
-    SystemColumns.pseudoColumnNames(ROWPARTITION_ROWOFFSET_ENABLED).forEach(pseudoCol ->
+    SystemColumns.pseudoColumnNames(ROWPARTITION_ROWOFFSET_ENABLED, ROW_ID_ENABLED).forEach(pseudoCol ->
         assertThat(pseudoCol + " should clash", extractor.isClashingColumnName(pseudoCol))
     );
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriterTest.java
@@ -765,7 +765,7 @@ public class ExpressionTreeRewriterTest {
   private <T extends Expression> T parseExpression(final String asText) {
     final String ksql = String.format("SELECT %s FROM test1;", asText);
 
-    final PreparedStatement<Query> stmt = KsqlParserTestUtil.buildSingleAst(ksql, metaStore, true);
+    final PreparedStatement<Query> stmt = KsqlParserTestUtil.buildSingleAst(ksql, metaStore, true, true);
     final SelectItem selectItem = stmt.getStatement().getSelect().getSelectItems().get(0);
     return (T) ((SingleColumn) selectItem).getExpression();
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/StatementRewriteForMagicPseudoTimestampTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/StatementRewriteForMagicPseudoTimestampTest.java
@@ -319,7 +319,7 @@ public class StatementRewriteForMagicPseudoTimestampTest {
 
   private Expression getPredicate(final String querySql) {
     final Query statement = (Query) KsqlParserTestUtil
-        .buildSingleAst(querySql, metaStore, true)
+        .buildSingleAst(querySql, metaStore, true, true)
         .getStatement();
 
     return statement.getWhere().get();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/execution/ExpressionEvaluatorParityTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/execution/ExpressionEvaluatorParityTest.java
@@ -1,9 +1,7 @@
 package io.confluent.ksql.execution;
 
-import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -50,7 +48,6 @@ import java.util.concurrent.Callable;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
-import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -443,7 +440,7 @@ public class ExpressionEvaluatorParityTest {
 
   private Expression getWhereExpression(final String table, String expression) {
     final Query statement = (Query) KsqlParserTestUtil
-        .buildSingleAst("SELECT * FROM " + table + " WHERE " + expression + ";", metaStore, true)
+        .buildSingleAst("SELECT * FROM " + table + " WHERE " + expression + ";", metaStore, true, true)
         .getStatement();
 
     assertThat(statement.getWhere().isPresent(), is(true));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/LogicRewriterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/LogicRewriterTest.java
@@ -3,7 +3,6 @@ package io.confluent.ksql.planner.plan;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.function.FunctionRegistry;
@@ -151,7 +150,7 @@ public class LogicRewriterTest {
 
   private Expression getWhereExpression(final String table, String expression) {
     final Query statement = (Query) KsqlParserTestUtil
-        .buildSingleAst("SELECT * FROM " + table + " WHERE " + expression + ";", metaStore, true)
+        .buildSingleAst("SELECT * FROM " + table + " WHERE " + expression + ";", metaStore, true, true)
         .getStatement();
 
     assertThat(statement.getWhere().isPresent(), is(true));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PullQueryRewriterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PullQueryRewriterTest.java
@@ -3,7 +3,6 @@ package io.confluent.ksql.planner.plan;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.function.FunctionRegistry;
@@ -57,7 +56,7 @@ public class PullQueryRewriterTest {
 
   private Expression getWhereExpression(final String table, String expression) {
     final Query statement = (Query) KsqlParserTestUtil
-        .buildSingleAst("SELECT * FROM " + table + " WHERE " + expression + ";", metaStore, true)
+        .buildSingleAst("SELECT * FROM " + table + " WHERE " + expression + ";", metaStore, true, true)
         .getStatement();
 
     assertThat(statement.getWhere().isPresent(), is(true));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/QueryProjectNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/QueryProjectNodeTest.java
@@ -130,7 +130,7 @@ public class QueryProjectNodeTest {
 
     // Then:
     final LogicalSchema expectedSchema = QueryLogicalPlanUtil.buildIntermediateSchema(
-        INPUT_SCHEMA, true, false, true);
+        INPUT_SCHEMA, true, false, true, false);
     assertThat(expectedSchema, is(projectNode.getIntermediateSchema()));
   }
 
@@ -156,7 +156,7 @@ public class QueryProjectNodeTest {
 
     // Then:
     final LogicalSchema expectedSchema = QueryLogicalPlanUtil.buildIntermediateSchema(
-        INPUT_SCHEMA, true, true, true);;
+        INPUT_SCHEMA, true, true, true, false);;
     assertThat(expectedSchema, is(projectNode.getIntermediateSchema()));
   }
 
@@ -316,7 +316,7 @@ public class QueryProjectNodeTest {
     // Then:
     final LogicalSchema expectedSchema = INPUT_SCHEMA;
     final LogicalSchema expectedIntermediateSchema = QueryLogicalPlanUtil.buildIntermediateSchema(
-        INPUT_SCHEMA, true, false, true);
+        INPUT_SCHEMA, true, false, true, false);
     assertThat(expectedIntermediateSchema, is(projectNode.getIntermediateSchema()));
     assertThat(expectedSchema.withoutPseudoAndKeyColsInValue(), is(projectNode.getSchema()));
     assertThrows(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorFunctionalTest.java
@@ -632,7 +632,7 @@ public class DefaultSchemaInjectorFunctionalTest {
     }
 
     final PreparedStatement<Statement> prepared = KsqlParserTestUtil
-        .buildSingleAst(this.statement, metaStore, true);
+        .buildSingleAst(this.statement, metaStore, true, true);
 
     // When:
     final KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of());
@@ -644,7 +644,7 @@ public class DefaultSchemaInjectorFunctionalTest {
       validateCsasInference((ConfiguredStatement<CreateStreamAsSelect>) inferred, this.avroSchema);
     } else {
       final Statement withSchema = KsqlParserTestUtil
-          .buildSingleAst(inferred.getStatementText(), metaStore, true)
+          .buildSingleAst(inferred.getStatementText(), metaStore, true, true)
           .getStatement();
 
       final Schema actual = getSchemaForDdlStatement((CreateSource) withSchema);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKSourceFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKSourceFactoryTest.java
@@ -258,7 +258,7 @@ public class SchemaKSourceFactoryTest {
     // Given:
     givenNonWindowedStream();
     givenExistingQueryWithOldPseudoColumnVersion(streamSource);
-    givenOnNewPseudoColumnVersion();
+    givenOnCurrentPseudoColumnVersion();
 
     // When:
     final SchemaKStream<?> result = SchemaKSourceFactory.buildSource(
@@ -276,7 +276,7 @@ public class SchemaKSourceFactoryTest {
   public void shouldCreateNonWindowedStreamSourceWithNewPseudoColumnVersionIfNoOldQuery() {
     // Given:
     givenNonWindowedStream();
-    givenOnNewPseudoColumnVersion();
+    givenOnCurrentPseudoColumnVersion();
 
     // When:
     final SchemaKStream<?> result = SchemaKSourceFactory.buildSource(
@@ -295,7 +295,7 @@ public class SchemaKSourceFactoryTest {
     // Given:
     givenWindowedStream();
     givenExistingQueryWithOldPseudoColumnVersion(windowedStreamSource);
-    givenOnNewPseudoColumnVersion();
+    givenOnCurrentPseudoColumnVersion();
 
     // When:
     final SchemaKStream<?> result = SchemaKSourceFactory.buildSource(
@@ -313,7 +313,7 @@ public class SchemaKSourceFactoryTest {
   public void shouldCreateWindowedStreamSourceWithNewPseudoColumnVersionIfNoOldQuery() {
     // Given:
     givenWindowedStream();
-    givenOnNewPseudoColumnVersion();
+    givenOnCurrentPseudoColumnVersion();
 
     // When:
     final SchemaKStream<?> result = SchemaKSourceFactory.buildSource(
@@ -331,7 +331,7 @@ public class SchemaKSourceFactoryTest {
   public void shouldCreateNonWindowedTableSourceV2WithNewPseudoColumnVersionIfNoOldQuery() {
     // Given:
     givenNonWindowedTable();
-    givenOnNewPseudoColumnVersion();
+    givenOnCurrentPseudoColumnVersion();
 
     // When:
     final SchemaKStream<?> result = SchemaKSourceFactory.buildSource(
@@ -354,7 +354,7 @@ public class SchemaKSourceFactoryTest {
     // Given:
     givenNonWindowedTable();
     givenExistingQueryWithOldPseudoColumnVersion(tableSource);
-    givenOnNewPseudoColumnVersion();
+    givenOnCurrentPseudoColumnVersion();
 
     // When:
     final SchemaKStream<?> result = SchemaKSourceFactory.buildSource(
@@ -372,7 +372,7 @@ public class SchemaKSourceFactoryTest {
   public void shouldCreateNonWindowedTableSourceV1WithOldPseudoColumnVersionIfNoOldQuery() {
     // Given:
     givenNonWindowedTable();
-    givenOnOldPseudoColumnVersion();
+    givenOnLegacyPseudoColumnVersion();
 
     // When:
     final SchemaKStream<?> result = SchemaKSourceFactory.buildSource(
@@ -391,7 +391,7 @@ public class SchemaKSourceFactoryTest {
     // Given:
     givenNonWindowedTable();
     givenExistingQueryWithOldPseudoColumnVersion(tableSourceV1);
-    givenOnNewPseudoColumnVersion();
+    givenOnCurrentPseudoColumnVersion();
 
     // When:
     final SchemaKStream<?> result = SchemaKSourceFactory.buildSource(
@@ -410,7 +410,7 @@ public class SchemaKSourceFactoryTest {
     // Given:
     givenWindowedTable();
     givenExistingQueryWithOldPseudoColumnVersion(windowedTableSource);
-    givenOnNewPseudoColumnVersion();
+    givenOnCurrentPseudoColumnVersion();
 
     // When:
     final SchemaKStream<?> result = SchemaKSourceFactory.buildSource(
@@ -428,7 +428,7 @@ public class SchemaKSourceFactoryTest {
   public void shouldCreateWindowedTableSourceWithNewPseudoColumnVersionIfNoOldQuery() {
     // Given:
     givenWindowedTable();
-    givenOnNewPseudoColumnVersion();
+    givenOnCurrentPseudoColumnVersion();
 
     // When:
     final SchemaKStream<?> result = SchemaKSourceFactory.buildSource(
@@ -496,11 +496,13 @@ public class SchemaKSourceFactoryTest {
     when(step.getPseudoColumnVersion()).thenReturn(LEGACY_PSEUDOCOLUMN_VERSION_NUMBER);
   }
 
-  private void givenOnNewPseudoColumnVersion() {
+  private void givenOnCurrentPseudoColumnVersion() {
+    when(ksqlConfig.getBoolean(KsqlConfig.KSQL_ROWID_ENABLED)).thenReturn(true);
     when(ksqlConfig.getBoolean(KsqlConfig.KSQL_ROWPARTITION_ROWOFFSET_ENABLED)).thenReturn(true);
   }
 
-  private void givenOnOldPseudoColumnVersion() {
+  private void givenOnLegacyPseudoColumnVersion() {
+    when(ksqlConfig.getBoolean(KsqlConfig.KSQL_ROWID_ENABLED)).thenReturn(false);
     when(ksqlConfig.getBoolean(KsqlConfig.KSQL_ROWPARTITION_ROWOFFSET_ENABLED)).thenReturn(false);
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/testutils/AnalysisTestUtil.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/testutils/AnalysisTestUtil.java
@@ -45,10 +45,13 @@ public final class AnalysisTestUtil {
   ) {
     final boolean rowpartitionRowoffsetEnabled =
         ksqlConfig.getBoolean(KsqlConfig.KSQL_ROWPARTITION_ROWOFFSET_ENABLED);
+    final boolean rowIdEnabled =
+        ksqlConfig.getBoolean(KsqlConfig.KSQL_ROWID_ENABLED);
     final boolean pullLimitClauseEnabled =
             ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_LIMIT_CLAUSE_ENABLED);
 
-    final Analyzer analyzer = new Analyzer(queryStr, metaStore, rowpartitionRowoffsetEnabled, pullLimitClauseEnabled);
+    final Analyzer analyzer = new Analyzer(
+        queryStr, metaStore, rowpartitionRowoffsetEnabled, rowIdEnabled, pullLimitClauseEnabled);
 
     final LogicalPlanner logicalPlanner =
         new LogicalPlanner(ksqlConfig, analyzer.analysis, metaStore);
@@ -64,12 +67,14 @@ public final class AnalysisTestUtil {
         final String queryStr,
         final MetaStore metaStore,
         final boolean rowpartitionRowoffsetEnabled,
+        final boolean rowIdEnabled,
         final boolean pullLimitClauseEnabled
     ) {
       final QueryAnalyzer queryAnalyzer = new QueryAnalyzer(
-          metaStore, "", rowpartitionRowoffsetEnabled, pullLimitClauseEnabled);
+          metaStore, "", rowpartitionRowoffsetEnabled, rowIdEnabled,
+          pullLimitClauseEnabled);
       final Statement statement =
-          parseStatement(queryStr, metaStore, rowpartitionRowoffsetEnabled);
+          parseStatement(queryStr, metaStore, rowpartitionRowoffsetEnabled, rowIdEnabled);
       final Query query = statement instanceof QueryContainer
           ? ((QueryContainer) statement).getQuery()
           : (Query) statement;
@@ -84,10 +89,12 @@ public final class AnalysisTestUtil {
     private static Statement parseStatement(
         final String queryStr,
         final MetaStore metaStore,
-        final boolean rowpartitionRowoffsetEnabled
+        final boolean rowpartitionRowoffsetEnabled,
+        final boolean rowIdEnabled
     ) {
       final List<PreparedStatement<?>> statements =
-          KsqlParserTestUtil.buildAst(queryStr, metaStore, rowpartitionRowoffsetEnabled);
+          KsqlParserTestUtil.buildAst(
+              queryStr, metaStore, rowpartitionRowoffsetEnabled, rowIdEnabled);
       assertThat(statements, hasSize(1));
       return statements.get(0).getStatement();
     }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/KsqlParserTestUtil.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/KsqlParserTestUtil.java
@@ -38,10 +38,11 @@ public final class KsqlParserTestUtil {
   public static <T extends Statement> PreparedStatement<T> buildSingleAst(
       final String sql,
       final MetaStore metaStore,
-      final boolean rowpartitionRowoffsetEnabled
+      final boolean rowpartitionRowoffsetEnabled,
+      final boolean rowIdEnabled
   ) {
     final List<PreparedStatement<?>> statements =
-        buildAst(sql, metaStore, rowpartitionRowoffsetEnabled);
+        buildAst(sql, metaStore, rowpartitionRowoffsetEnabled, rowIdEnabled);
     assertThat(statements, hasSize(1));
     return (PreparedStatement<T>)statements.get(0);
   }
@@ -49,13 +50,14 @@ public final class KsqlParserTestUtil {
   public static List<PreparedStatement<?>> buildAst(
       final String sql,
       final MetaStore metaStore,
-      final boolean rowpartitionRowoffsetEnabled) {
+      final boolean rowpartitionRowoffsetEnabled,
+      final boolean rowIdEnabled) {
     return KSQL_PARSER.parse(sql).stream()
         .map(parsed -> KSQL_PARSER.prepare(parsed, metaStore))
         .map(prepared -> PreparedStatement.of(
             prepared.getUnMaskedStatementText(),
             AstSanitizer.sanitize(
-                prepared.getStatement(), metaStore, rowpartitionRowoffsetEnabled)))
+                prepared.getStatement(), metaStore, rowpartitionRowoffsetEnabled, rowIdEnabled)))
         .collect(Collectors.toList());
   }
 }

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestUtils.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestUtils.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.test.model.KsqlVersion;
 import io.confluent.ksql.test.tools.TestCase;
 import io.confluent.ksql.test.tools.TestCaseBuilder;
 import io.confluent.ksql.test.tools.TopologyAndConfigs;
+import io.confluent.ksql.util.KsqlConfig;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,6 +32,7 @@ import java.io.InputStreamReader;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public final class PlannedTestUtils {
@@ -47,7 +49,8 @@ public final class PlannedTestUtils {
 
   public static boolean isNotExcluded(final TestCase testCase) {
     // Place temporary logic here to exclude test cases based on feature flags, etc.
-    return true;
+    final Map<String, Object> props = testCase.properties();
+    return !(boolean) props.getOrDefault(KsqlConfig.KSQL_ROWID_ENABLED, false);
   }
 
   public static boolean isSamePlan(

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
@@ -105,7 +105,6 @@ public class RestQueryTranslationTest {
       .withProperty(KsqlConfig.KSQL_QUERY_PUSH_V2_ENABLED, true)
       .withProperty(KsqlConfig.KSQL_QUERY_PUSH_V2_NEW_LATEST_DELAY_MS, 0L)
       .withProperty(KsqlConfig.KSQL_ROWPARTITION_ROWOFFSET_ENABLED, true)
-      .withProperty(KsqlConfig.KSQL_ROWID_ENABLED, true)
       .withProperty(KsqlConfig.KSQL_HEADERS_COLUMNS_ENABLED, true)
       .withStaticServiceContext(TEST_HARNESS::getServiceContext)
       .build();

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
@@ -105,6 +105,7 @@ public class RestQueryTranslationTest {
       .withProperty(KsqlConfig.KSQL_QUERY_PUSH_V2_ENABLED, true)
       .withProperty(KsqlConfig.KSQL_QUERY_PUSH_V2_NEW_LATEST_DELAY_MS, 0L)
       .withProperty(KsqlConfig.KSQL_ROWPARTITION_ROWOFFSET_ENABLED, true)
+      .withProperty(KsqlConfig.KSQL_ROWID_ENABLED, true)
       .withProperty(KsqlConfig.KSQL_HEADERS_COLUMNS_ENABLED, true)
       .withStaticServiceContext(TEST_HARNESS::getServiceContext)
       .build();

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/row-id.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/row-id.json
@@ -18,65 +18,68 @@
       }
     },
     {
-      "name": "test ROWOFFSET and ROWPARTITION sink user columns with pseudocolumn data types",
+      "name": "test ROWID sink user columns with pseudocolumn data types",
+      "properties": {
+        "ksql.rowid.enabled": true
+      },
       "statements": [
         "CREATE STREAM input (id INT KEY, val INTEGER, other_val BIGINT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT id, val AS ROWPARTITION, other_val AS ROWOFFSET FROM input;"
+        "CREATE STREAM OUTPUT AS SELECT id, val AS ROWID FROM input;"
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "`ROWPARTITION` is a reserved column name. You cannot use it as an alias for a column."
+        "message": "`ROWID` is a reserved column name. You cannot use it as an alias for a column."
       }
     },
     {
-      "name": "create ROWOFFSET and ROWPARTITION source user columns as STRINGs",
+      "name": "create ROWID source user columns as STRINGs",
+      "properties": {
+        "ksql.rowid.enabled": true
+      },
       "statements": [
-        "CREATE STREAM input (id INT KEY, ROWPARTITION string, ROWOFFSET string) WITH (kafka_topic='test_topic', value_format='JSON');"
+        "CREATE STREAM input (id INT KEY, ROWID string) WITH (kafka_topic='test_topic', value_format='JSON');"
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "'ROWPARTITION' is a reserved column name. You cannot use it as a name for a column."
+        "message": "'ROWID' is a reserved column name. You cannot use it as a name for a column."
       }
     },
     {
-      "name": "test ROWOFFSET and ROWPARTITION source user columns with pseudocolumn data types",
+      "name": "test ROWID source user columns with pseudocolumn data types",
+      "properties": {
+        "ksql.rowid.enabled": true
+      },
       "statements": [
-        "CREATE STREAM input (id INT KEY, ROWPARTITION INTEGER, ROWOFFSET BIGINT) WITH (kafka_topic='test_topic', value_format='JSON');"
+        "CREATE STREAM input (id INT KEY, ROWID INTEGER) WITH (kafka_topic='test_topic', value_format='JSON');"
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "'ROWPARTITION' is a reserved column name. You cannot use it as a name for a column."
+        "message": "'ROWID' is a reserved column name. You cannot use it as a name for a column."
       }
     },
     {
-      "name": "INSERT INTO ROWPARTITION should fail",
+      "name": "INSERT INTO ROWID should fail",
+      "properties": {
+        "ksql.rowid.enabled": true
+      },
       "statements": [
         "CREATE STREAM a (id INT KEY, val INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE STREAM b (id INT KEY) WITH (kafka_topic='test_topic_2', value_format='JSON');",
-        "INSERT INTO a SELECT id, ROWPARTITION from b EMIT CHANGES;"
+        "INSERT INTO a SELECT id, ROWID from b EMIT CHANGES;"
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Reserved column name in select: `ROWPARTITION`. Please remove or alias the column."
+        "message": "Reserved column name in select: `ROWID`. Please remove or alias the column."
       }
     },
     {
-      "name": "INSERT INTO ROWOFFSET should fail",
-      "statements": [
-        "CREATE STREAM a (id INT KEY, val BIGINT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM b (id INT KEY) WITH (kafka_topic='test_topic_2', value_format='JSON');",
-        "INSERT INTO a SELECT id, ROWOFFSET from b EMIT CHANGES;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Reserved column name in select: `ROWOFFSET`. Please remove or alias the column."
-      }
-    },
-    {
-      "name": "Select ROWPARTITION/ROWOFFSET columns with aliases - stream",
+      "name": "Select ROWID columns with aliases - stream",
+      "properties": {
+        "ksql.rowid.enabled": true
+      },
       "statements": [
         "CREATE STREAM input (id INT KEY, foo STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM output AS SELECT id, ROWPARTITION AS rp, ROWOFFSET AS ro, ROWTIME AS rt FROM input;"
+        "CREATE STREAM output AS SELECT id, ROWID AS ri, ROWTIME AS rt FROM input;"
       ],
       "inputs": [
         {"topic":  "test_topic", "key": 1, "value": {"foo": "a"}, "timestamp": 5},
@@ -84,21 +87,24 @@
         {"topic":  "test_topic", "key": 3, "value": {"foo": "c"}, "timestamp":  7}
       ],
       "outputs": [
-        {"topic":  "OUTPUT", "key": 1, "value": {"RP": 0, "RO": 0, "RT": 5}, "timestamp": 5},
-        {"topic":  "OUTPUT", "key": 2, "value": {"RP": 0, "RO": 1, "RT": 6}, "timestamp": 6},
-        {"topic":  "OUTPUT", "key": 3, "value": {"RP": 0, "RO": 2, "RT": 7}, "timestamp": 7}
+        {"topic":  "OUTPUT", "key": 1, "value": {"RI": "AAAAAQ==", "RT": 5}, "timestamp": 5},
+        {"topic":  "OUTPUT", "key": 2, "value": {"RI": "AAAAAg==", "RT": 6}, "timestamp": 6},
+        {"topic":  "OUTPUT", "key": 3, "value": {"RI": "AAAAAw==", "RT": 7}, "timestamp": 7}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, RP INT, RO BIGINT, RT BIGINT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, RI BYTES, RT BIGINT"}
         ]
       }
     },
     {
-      "name": "Select ROWPARTITION/ROWOFFSET with aliases - table",
+      "name": "Select ROWID with aliases - table",
+      "properties": {
+        "ksql.rowid.enabled": true
+      },
       "statements": [
         "CREATE TABLE input (id INT PRIMARY KEY, foo STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE TABLE output AS SELECT id, ROWPARTITION AS rp, ROWOFFSET AS ro FROM input;"
+        "CREATE TABLE output AS SELECT id, ROWID AS ri FROM input;"
       ],
       "inputs": [
         {"topic":  "test_topic", "key": 1, "value": {"foo": "a"}, "timestamp": 5},
@@ -106,268 +112,114 @@
         {"topic":  "test_topic", "key": 3, "value": {"foo": "c"}, "timestamp":  7}
       ],
       "outputs": [
-        {"topic":  "OUTPUT", "key": 1, "value": {"RP": 0, "RO": 0}, "timestamp": 5},
-        {"topic":  "OUTPUT", "key": 2, "value": {"RP": 0, "RO": 1}, "timestamp": 6},
-        {"topic":  "OUTPUT", "key": 3, "value": {"RP": 0, "RO": 2}, "timestamp": 7}
+        {"topic":  "OUTPUT", "key": 1, "value": {"RI": "AAAAAQ=="}, "timestamp": 5},
+        {"topic":  "OUTPUT", "key": 2, "value": {"RI": "AAAAAg=="}, "timestamp": 6},
+        {"topic":  "OUTPUT", "key": 3, "value": {"RI": "AAAAAw=="}, "timestamp": 7}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "schema": "ID INT KEY, RP INT, RO BIGINT"}
+          {"name": "OUTPUT", "type": "table", "schema": "ID INT KEY, RI BYTES"}
         ]
       }
     },
     {
-      "name": "join on ROWPARTITION",
+      "name": "join on ROWID",
+      "properties": {
+        "ksql.rowid.enabled": true
+      },
       "statements": [
-        "CREATE STREAM a (id INT KEY, foo STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM b (id INT KEY, bar STRING) WITH (kafka_topic='test_topic_2', value_format='JSON');",
-        "CREATE STREAM output AS SELECT foo, bar, a.ROWPARTITION AS rpa, b.ROWPARTITION as rpb FROM a JOIN b WITHIN 5 SECONDS ON a.ROWPARTITION = b.ROWPARTITION;"
+        "CREATE STREAM a (id STRING KEY, foo STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM b (id STRING KEY, bar STRING) WITH (kafka_topic='test_topic_2', value_format='JSON');",
+        "CREATE STREAM output AS SELECT foo, bar, a.ROWID AS ria, b.ROWID as rib FROM a JOIN b WITHIN 5 SECONDS ON a.ROWID = b.ROWID;"
       ],
       "inputs": [
-        {"topic":  "test_topic", "key": 0, "value": {"foo": "a"}, "timestamp": 5},
-        {"topic":  "test_topic", "key": 0, "value": {"foo": "b"}, "timestamp": 6},
-        {"topic":  "test_topic_2", "key": 0, "value": {"bar": "c"}, "timestamp":  7}
+        {"topic":  "test_topic", "key": "z", "value": {"foo": "a"}, "timestamp": 5},
+        {"topic":  "test_topic", "key": "z", "value": {"foo": "b"}, "timestamp": 6},
+        {"topic":  "test_topic_2", "key": "z", "value": {"bar": "c"}, "timestamp":  7}
       ],
       "outputs": [
-        {"topic":  "OUTPUT", "key": 0, "value": {"foo": "a", "bar": "c", "rpb": 0}, "timestamp": 7},
-        {"topic":  "OUTPUT", "key": 0, "value": {"foo":  "b", "bar": "c", "rpb": 0}, "timestamp": 7}
+        {"topic":  "OUTPUT", "key": "z", "value": {"foo": "a", "bar": "c", "rib": "eg=="}, "timestamp": 7},
+        {"topic":  "OUTPUT", "key": "z", "value": {"foo":  "b", "bar": "c", "rib": "eg=="}, "timestamp": 7}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "RPA INTEGER KEY, FOO STRING, BAR STRING, RPB INTEGER"}
+          {"name": "OUTPUT", "type": "stream", "schema": "RIA BYTES KEY, FOO STRING, BAR STRING, RIB BYTES"}
         ]
       }
     },
     {
-      "name": "join on ROWOFFSET",
+      "name": "CAST ROWID",
+      "properties": {
+        "ksql.rowid.enabled": true
+      },
       "statements": [
-        "CREATE STREAM a (id INT KEY, foo STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM b (id INT KEY, bar STRING) WITH (kafka_topic='test_topic_2', value_format='JSON');",
-        "CREATE STREAM output AS SELECT foo, bar, a.ROWOFFSET AS roa, b.ROWOFFSET as rob FROM a JOIN b WITHIN 5 SECONDS ON a.ROWOFFSET = b.ROWOFFSET;"
-      ],
-      "inputs": [
-        {"topic":  "test_topic", "key": 1, "value": {"foo": "a"}, "timestamp": 5},
-        {"topic":  "test_topic", "key": 2, "value": {"foo": "b"}, "timestamp": 6},
-        {"topic":  "test_topic", "key": 3, "value": {"foo": "c"}, "timestamp":  7},
-        {"topic":  "test_topic_2", "key": 4, "value": {"bar": "d"}, "timestamp":  8},
-        {"topic":  "test_topic_2", "key": 5, "value": {"bar": "e"}, "timestamp":  9},
-        {"topic":  "test_topic_2", "key": 6, "value": {"bar": "f"}, "timestamp":  10}
-      ],
-      "outputs": [
-        {"topic":  "OUTPUT", "key": 0, "value": {"foo": "a", "bar": "d", "rob": 0}, "timestamp": 8},
-        {"topic":  "OUTPUT", "key": 1, "value": {"foo":  "b", "bar": "e", "rob": 1}, "timestamp": 9},
-        {"topic":  "OUTPUT", "key": 2, "value": {"foo":  "c", "bar": "f", "rob": 2}, "timestamp": 10}
-      ],
-      "post": {
-        "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ROA BIGINT KEY, FOO STRING, BAR STRING, ROB BIGINT"}
-        ]
-      }
-    },
-    {
-      "name": "CAST ROWPARTITION and ROWOFFSET",
-      "statements": [
-        "CREATE STREAM input (id INT KEY, foo STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM output AS SELECT id, CAST(ROWPARTITION AS BIGINT) AS rp, CAST(ROWOFFSET AS DOUBLE) AS ro FROM input;"
-      ],
-      "inputs": [
-        {"topic":  "test_topic", "key": 1, "value": {"foo": "a"}, "timestamp": 5},
-        {"topic":  "test_topic", "key": 2, "value": {"foo": "b"}, "timestamp": 6},
-        {"topic":  "test_topic", "key": 3, "value": {"foo": "c"}, "timestamp":  7}
-      ],
-      "outputs": [
-        {"topic":  "OUTPUT", "key": 1, "value": {"RP": 0, "RO": 0.0}, "timestamp": 5},
-        {"topic":  "OUTPUT", "key": 2, "value": {"RP": 0, "RO": 1.0}, "timestamp": 6},
-        {"topic":  "OUTPUT", "key": 3, "value": {"RP": 0, "RO": 2.0}, "timestamp": 7}
-      ],
-      "post": {
-        "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, RP BIGINT, RO DOUBLE"}
-        ]
-      }
-    },
-    {
-      "name": "ROWPARTITION and ROWOFFSET in mathematical expression",
-      "statements": [
-        "CREATE STREAM input (id INT KEY, foo STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM output AS SELECT id, ROWPARTITION + 3 AS rp, ROWOFFSET * 3 AS ro FROM input;"
-      ],
-      "inputs": [
-        {"topic":  "test_topic", "key": 1, "value": {"foo": "a"}, "timestamp": 5},
-        {"topic":  "test_topic", "key": 2, "value": {"foo": "b"}, "timestamp": 6},
-        {"topic":  "test_topic", "key": 3, "value": {"foo": "c"}, "timestamp":  7}
-      ],
-      "outputs": [
-        {"topic":  "OUTPUT", "key": 1, "value": {"RP": 3, "RO": 0}, "timestamp": 5},
-        {"topic":  "OUTPUT", "key": 2, "value": {"RP": 3, "RO": 3}, "timestamp": 6},
-        {"topic":  "OUTPUT", "key": 3, "value": {"RP": 3, "RO": 6}, "timestamp": 7}
-      ],
-      "post": {
-        "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, RP INT, RO BIGINT"}
-        ]
-      }
-    },
-    {
-      "name": "PARTITION BY ROWOFFSET",
-      "statements": [
-        "CREATE STREAM input (id INT KEY, val INT) WITH (kafka_topic='input', value_format='JSON');",
-        "CREATE STREAM output AS select * FROM input PARTITION BY ROWOFFSET;"
-      ],
-      "inputs": [
-        {"topic": "input", "key": 10, "value": {"val":  5}},
-        {"topic": "input", "key": 9, "value": {"val":  6}},
-        {"topic": "input", "key": 8, "value": {"val":  7}}
-      ],
-      "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"ID": 10, "VAL":  5}},
-        {"topic": "OUTPUT", "key": 1, "value": {"ID": 9, "VAL":  6}},
-        {"topic": "OUTPUT", "key": 2, "value": {"ID": 8, "VAL":  7}}
-      ],
-      "post": {
-        "topics": {
-          "blacklist": ".*-repartition"
-        },
-        "comments": "The schema shouldn't contain a key column named ROWOFFSET, this is a bug with PARTITION BY. See https://github.com/confluentinc/ksql/issues/8193",
-        "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ROWOFFSET BIGINT KEY, val INT, id INT"}
-        ]
-      }
-    },
-    {
-      "name": "PARTITION BY ROWPARTITION",
-      "comments": "Not the most useful PARTITION BY!",
-      "statements": [
-        "CREATE STREAM input (id INT KEY, val INT) WITH (kafka_topic='input', value_format='JSON');",
-        "CREATE STREAM output AS select * FROM input PARTITION BY ROWPARTITION;"
-      ],
-      "inputs": [
-        {"topic": "input", "key": 10, "value": {"val":  5}},
-        {"topic": "input", "key": 9, "value": {"val":  6}},
-        {"topic": "input", "key": 8, "value": {"val":  7}}
-      ],
-      "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"ID": 10, "VAL":  5}},
-        {"topic": "OUTPUT", "key": 0, "value": {"ID": 9, "VAL":  6}},
-        {"topic": "OUTPUT", "key": 0, "value": {"ID": 8, "VAL":  7}}
-      ],
-      "post": {
-        "topics": {
-          "blacklist": ".*-repartition"
-        },
-        "comments": "The schema shouldn't contain a key column named ROWPARTITION, this is a bug with PARTITION BY. See https://github.com/confluentinc/ksql/issues/8193",
-        "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ROWPARTITION INT KEY, val INT, id INT"}
-        ]
-      }
-    },
-    {
-      "name": "Should fail if select ROWPARTITION without aliases",
-      "statements": [
-        "CREATE STREAM input (id INT KEY, foo STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM output AS SELECT id, ROWPARTITION FROM input;"
+        "CREATE STREAM input (id STRING KEY, foo STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM output AS SELECT id, CAST(ROWID AS STRING) AS ri FROM input;"
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Reserved column name in select: `ROWPARTITION`. Please remove or alias the column."
+        "message": "Invalid Select: Cast of BYTES to STRING is not supported."
       }
     },
     {
-      "name": "Should fail if select ROWOFFSET without aliases",
+      "name": "Should fail if select ROWID without aliases",
+      "properties": {
+        "ksql.rowid.enabled": true
+      },
       "statements": [
         "CREATE STREAM input (id INT KEY, foo STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM output AS SELECT id, ROWOFFSET FROM input;"
+        "CREATE STREAM output AS SELECT id, ROWID FROM input;"
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Reserved column name in select: `ROWOFFSET`. Please remove or alias the column."
+        "message": "Reserved column name in select: `ROWID`. Please remove or alias the column."
       }
     },
     {
-      "name": "Filter using ROWPARTITION",
+      "name": "Filter using ROWID",
+      "properties": {
+        "ksql.rowid.enabled": true
+      },
       "statements": [
-        "CREATE STREAM input (id INT KEY, foo STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM output AS SELECT *, ROWTIME AS rt FROM input WHERE ROWPARTITION = 0;"
+        "CREATE STREAM TEST (ID INT KEY, a BYTES, b BYTES) WITH (kafka_topic='test', value_format='JSON');",
+        "CREATE STREAM TEST2 AS SELECT ID, ROWID AS RESULT FROM TEST WHERE ROWID BETWEEN a AND b;"
       ],
       "inputs": [
-        {"topic":  "test_topic", "key": 1, "value": {"foo": "a"}, "timestamp": 5},
-        {"topic":  "test_topic", "key": 2, "value": {"foo": "b"}, "timestamp": 6},
-        {"topic":  "test_topic", "key": 3, "value": {"foo": "c"}, "timestamp": 7}
+        {"topic": "test","key": 0, "value": {"A": "AAAAAQ==", "B": "AAAAAQ=="}},
+        {"topic": "test","key": 1, "value": {"A": "AAAAAQ==", "B": "AAAAAQ=="}},
+        {"topic": "test","key": 2, "value": {"A": "AAAAAQ==", "B": "AAAAAg=="}},
+        {"topic": "test","key": 3, "value": {"A": "AAAAAQ==", "B": "AAAAAg=="}},
+        {"topic": "test","key": 3, "value": {"A": "AAAAAQ==", "B": "AAAAAw=="}},
+        {"topic": "test","key": 4, "value": {"A": "AAAAAQ==", "B": "AAAAAw=="}}
       ],
       "outputs": [
-        {"topic":  "OUTPUT", "key": 1, "value": {"FOO":  "a", "RT": 5}, "timestamp": 5},
-        {"topic":  "OUTPUT", "key": 2, "value": {"FOO":  "b", "RT": 6}, "timestamp": 6},
-        {"topic":  "OUTPUT", "key": 3, "value": {"FOO":  "c", "RT": 7}, "timestamp": 7}
-      ],
-      "post": {
-        "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, FOO STRING, RT BIGINT"}
-        ]
-      }
+        {"topic": "TEST2", "key": 1,"value": {"RESULT": "AAAAAQ=="}},
+        {"topic": "TEST2", "key": 2,"value": {"RESULT": "AAAAAg=="}},
+        {"topic": "TEST2", "key": 3,"value": {"RESULT": "AAAAAw=="}}
+      ]
     },
     {
-      "name": "Filter using ROWOFFSET",
+      "name": "GROUP BY ROWID",
+      "properties": {
+        "ksql.rowid.enabled": true
+      },
       "statements": [
-        "CREATE STREAM input (id INT KEY, foo STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM output AS SELECT *, ROWTIME AS rt FROM input WHERE ROWOFFSET % 3 = 0;"
+        "CREATE STREAM L (A STRING KEY, B INT) WITH (kafka_topic='LEFT', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT COUNT(B) AS bc, ROWID AS ri FROM L GROUP BY ROWID;"
       ],
       "inputs": [
-        {"topic":  "test_topic", "key": 1, "value": {"foo": "a"}, "timestamp": 5},
-        {"topic":  "test_topic", "key": 2, "value": {"foo": "b"}, "timestamp": 6},
-        {"topic":  "test_topic", "key": 3, "value": {"foo": "c"}, "timestamp": 7},
-        {"topic":  "test_topic", "key": 4, "value": {"foo": "d"}, "timestamp": 8}
+        {"topic": "LEFT", "key": "a", "value": {"B": 100}, "timestamp": 11},
+        {"topic": "LEFT", "key": "b", "value": {"B": 100}, "timestamp": 11},
+        {"topic": "LEFT", "key": "c", "value": {"B": 100}, "timestamp": 11}
       ],
       "outputs": [
-        {"topic":  "OUTPUT", "key": 1, "value": {"FOO":  "a", "RT": 5}, "timestamp": 5},
-        {"topic":  "OUTPUT", "key": 4, "value": {"FOO":  "d", "RT": 8}, "timestamp": 8}
+        {"topic": "OUTPUT", "key": "a", "value": {"BC": 1}, "timestamp": 11},
+        {"topic": "OUTPUT", "key": "b", "value": {"BC": 1}, "timestamp": 11},
+        {"topic": "OUTPUT", "key": "c", "value": {"BC": 1}, "timestamp": 11}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, FOO STRING, RT BIGINT"}
-        ]
-      }
-    },
-    {
-      "name": "GROUP BY ROWPARTITION",
-      "statements": [
-        "CREATE STREAM L (A INT KEY, B INT) WITH (kafka_topic='LEFT', value_format='JSON');",
-        "CREATE TABLE OUTPUT AS SELECT COUNT(B) AS bc, ROWPARTITION AS rp FROM L GROUP BY ROWPARTITION;"
-      ],
-      "inputs": [
-        {"topic": "LEFT", "key": 1, "value": {"B": 100}, "timestamp": 11},
-        {"topic": "LEFT", "key": 2, "value": {"B": 100}, "timestamp": 11},
-        {"topic": "LEFT", "key": 3, "value": {"B": 100}, "timestamp": 11}
-      ],
-      "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"BC": 1}, "timestamp": 11},
-        {"topic": "OUTPUT", "key": 0, "value": {"BC": 2}, "timestamp": 11},
-        {"topic": "OUTPUT", "key": 0, "value": {"BC": 3}, "timestamp": 11}
-      ],
-      "post": {
-        "sources": [
-          {"name": "OUTPUT", "type": "table", "schema": "rp INT KEY, bc BIGINT"}
-        ]
-      }
-    },
-    {
-      "name": "GROUP BY ROWOFFSET",
-      "statements": [
-        "CREATE STREAM L (A INT KEY, B INT) WITH (kafka_topic='LEFT', value_format='JSON');",
-        "CREATE TABLE OUTPUT AS SELECT COUNT(B) as bc, ROWOFFSET AS ro FROM L GROUP BY ROWOFFSET;"
-      ],
-      "inputs": [
-        {"topic": "LEFT", "key": 1, "value": {"B": 1}, "timestamp": 11},
-        {"topic": "LEFT", "key": 1, "value": {"B": 5}, "timestamp": 11},
-        {"topic": "LEFT", "key": 1, "value": {"B": 10}, "timestamp": 11}
-      ],
-      "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"BC": 1}, "timestamp": 11},
-        {"topic": "OUTPUT", "key": 1, "value": {"BC": 1}, "timestamp": 11},
-        {"topic": "OUTPUT", "key": 2, "value": {"BC": 1}, "timestamp": 11}
-      ],
-      "post": {
-        "sources": [
-          {"name": "OUTPUT", "type": "table", "schema": "ro BIGINT KEY, bc BIGINT"}
+          {"name": "OUTPUT", "type": "table", "schema": "ri BYTES KEY, bc BIGINT"}
         ]
       }
     }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/row-id.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/row-id.json
@@ -1,0 +1,375 @@
+{
+  "comments": [
+    "Tests covering ROWID pseudocolumn"
+  ],
+  "tests": [
+    {
+      "name": "create ROWID sink user columns as STRINGs",
+      "properties": {
+        "ksql.rowid.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM input (id INT KEY, val STRING, other_val STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT id, val AS ROWID FROM input;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "`ROWID` is a reserved column name. You cannot use it as an alias for a column."
+      }
+    },
+    {
+      "name": "test ROWOFFSET and ROWPARTITION sink user columns with pseudocolumn data types",
+      "statements": [
+        "CREATE STREAM input (id INT KEY, val INTEGER, other_val BIGINT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT id, val AS ROWPARTITION, other_val AS ROWOFFSET FROM input;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "`ROWPARTITION` is a reserved column name. You cannot use it as an alias for a column."
+      }
+    },
+    {
+      "name": "create ROWOFFSET and ROWPARTITION source user columns as STRINGs",
+      "statements": [
+        "CREATE STREAM input (id INT KEY, ROWPARTITION string, ROWOFFSET string) WITH (kafka_topic='test_topic', value_format='JSON');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "'ROWPARTITION' is a reserved column name. You cannot use it as a name for a column."
+      }
+    },
+    {
+      "name": "test ROWOFFSET and ROWPARTITION source user columns with pseudocolumn data types",
+      "statements": [
+        "CREATE STREAM input (id INT KEY, ROWPARTITION INTEGER, ROWOFFSET BIGINT) WITH (kafka_topic='test_topic', value_format='JSON');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "'ROWPARTITION' is a reserved column name. You cannot use it as a name for a column."
+      }
+    },
+    {
+      "name": "INSERT INTO ROWPARTITION should fail",
+      "statements": [
+        "CREATE STREAM a (id INT KEY, val INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM b (id INT KEY) WITH (kafka_topic='test_topic_2', value_format='JSON');",
+        "INSERT INTO a SELECT id, ROWPARTITION from b EMIT CHANGES;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Reserved column name in select: `ROWPARTITION`. Please remove or alias the column."
+      }
+    },
+    {
+      "name": "INSERT INTO ROWOFFSET should fail",
+      "statements": [
+        "CREATE STREAM a (id INT KEY, val BIGINT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM b (id INT KEY) WITH (kafka_topic='test_topic_2', value_format='JSON');",
+        "INSERT INTO a SELECT id, ROWOFFSET from b EMIT CHANGES;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Reserved column name in select: `ROWOFFSET`. Please remove or alias the column."
+      }
+    },
+    {
+      "name": "Select ROWPARTITION/ROWOFFSET columns with aliases - stream",
+      "statements": [
+        "CREATE STREAM input (id INT KEY, foo STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM output AS SELECT id, ROWPARTITION AS rp, ROWOFFSET AS ro, ROWTIME AS rt FROM input;"
+      ],
+      "inputs": [
+        {"topic":  "test_topic", "key": 1, "value": {"foo": "a"}, "timestamp": 5},
+        {"topic":  "test_topic", "key": 2, "value": {"foo": "b"}, "timestamp": 6},
+        {"topic":  "test_topic", "key": 3, "value": {"foo": "c"}, "timestamp":  7}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "key": 1, "value": {"RP": 0, "RO": 0, "RT": 5}, "timestamp": 5},
+        {"topic":  "OUTPUT", "key": 2, "value": {"RP": 0, "RO": 1, "RT": 6}, "timestamp": 6},
+        {"topic":  "OUTPUT", "key": 3, "value": {"RP": 0, "RO": 2, "RT": 7}, "timestamp": 7}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, RP INT, RO BIGINT, RT BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "Select ROWPARTITION/ROWOFFSET with aliases - table",
+      "statements": [
+        "CREATE TABLE input (id INT PRIMARY KEY, foo STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE output AS SELECT id, ROWPARTITION AS rp, ROWOFFSET AS ro FROM input;"
+      ],
+      "inputs": [
+        {"topic":  "test_topic", "key": 1, "value": {"foo": "a"}, "timestamp": 5},
+        {"topic":  "test_topic", "key": 2, "value": {"foo": "b"}, "timestamp": 6},
+        {"topic":  "test_topic", "key": 3, "value": {"foo": "c"}, "timestamp":  7}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "key": 1, "value": {"RP": 0, "RO": 0}, "timestamp": 5},
+        {"topic":  "OUTPUT", "key": 2, "value": {"RP": 0, "RO": 1}, "timestamp": 6},
+        {"topic":  "OUTPUT", "key": 3, "value": {"RP": 0, "RO": 2}, "timestamp": 7}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "schema": "ID INT KEY, RP INT, RO BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "join on ROWPARTITION",
+      "statements": [
+        "CREATE STREAM a (id INT KEY, foo STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM b (id INT KEY, bar STRING) WITH (kafka_topic='test_topic_2', value_format='JSON');",
+        "CREATE STREAM output AS SELECT foo, bar, a.ROWPARTITION AS rpa, b.ROWPARTITION as rpb FROM a JOIN b WITHIN 5 SECONDS ON a.ROWPARTITION = b.ROWPARTITION;"
+      ],
+      "inputs": [
+        {"topic":  "test_topic", "key": 0, "value": {"foo": "a"}, "timestamp": 5},
+        {"topic":  "test_topic", "key": 0, "value": {"foo": "b"}, "timestamp": 6},
+        {"topic":  "test_topic_2", "key": 0, "value": {"bar": "c"}, "timestamp":  7}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "key": 0, "value": {"foo": "a", "bar": "c", "rpb": 0}, "timestamp": 7},
+        {"topic":  "OUTPUT", "key": 0, "value": {"foo":  "b", "bar": "c", "rpb": 0}, "timestamp": 7}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "RPA INTEGER KEY, FOO STRING, BAR STRING, RPB INTEGER"}
+        ]
+      }
+    },
+    {
+      "name": "join on ROWOFFSET",
+      "statements": [
+        "CREATE STREAM a (id INT KEY, foo STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM b (id INT KEY, bar STRING) WITH (kafka_topic='test_topic_2', value_format='JSON');",
+        "CREATE STREAM output AS SELECT foo, bar, a.ROWOFFSET AS roa, b.ROWOFFSET as rob FROM a JOIN b WITHIN 5 SECONDS ON a.ROWOFFSET = b.ROWOFFSET;"
+      ],
+      "inputs": [
+        {"topic":  "test_topic", "key": 1, "value": {"foo": "a"}, "timestamp": 5},
+        {"topic":  "test_topic", "key": 2, "value": {"foo": "b"}, "timestamp": 6},
+        {"topic":  "test_topic", "key": 3, "value": {"foo": "c"}, "timestamp":  7},
+        {"topic":  "test_topic_2", "key": 4, "value": {"bar": "d"}, "timestamp":  8},
+        {"topic":  "test_topic_2", "key": 5, "value": {"bar": "e"}, "timestamp":  9},
+        {"topic":  "test_topic_2", "key": 6, "value": {"bar": "f"}, "timestamp":  10}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "key": 0, "value": {"foo": "a", "bar": "d", "rob": 0}, "timestamp": 8},
+        {"topic":  "OUTPUT", "key": 1, "value": {"foo":  "b", "bar": "e", "rob": 1}, "timestamp": 9},
+        {"topic":  "OUTPUT", "key": 2, "value": {"foo":  "c", "bar": "f", "rob": 2}, "timestamp": 10}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ROA BIGINT KEY, FOO STRING, BAR STRING, ROB BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "CAST ROWPARTITION and ROWOFFSET",
+      "statements": [
+        "CREATE STREAM input (id INT KEY, foo STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM output AS SELECT id, CAST(ROWPARTITION AS BIGINT) AS rp, CAST(ROWOFFSET AS DOUBLE) AS ro FROM input;"
+      ],
+      "inputs": [
+        {"topic":  "test_topic", "key": 1, "value": {"foo": "a"}, "timestamp": 5},
+        {"topic":  "test_topic", "key": 2, "value": {"foo": "b"}, "timestamp": 6},
+        {"topic":  "test_topic", "key": 3, "value": {"foo": "c"}, "timestamp":  7}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "key": 1, "value": {"RP": 0, "RO": 0.0}, "timestamp": 5},
+        {"topic":  "OUTPUT", "key": 2, "value": {"RP": 0, "RO": 1.0}, "timestamp": 6},
+        {"topic":  "OUTPUT", "key": 3, "value": {"RP": 0, "RO": 2.0}, "timestamp": 7}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, RP BIGINT, RO DOUBLE"}
+        ]
+      }
+    },
+    {
+      "name": "ROWPARTITION and ROWOFFSET in mathematical expression",
+      "statements": [
+        "CREATE STREAM input (id INT KEY, foo STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM output AS SELECT id, ROWPARTITION + 3 AS rp, ROWOFFSET * 3 AS ro FROM input;"
+      ],
+      "inputs": [
+        {"topic":  "test_topic", "key": 1, "value": {"foo": "a"}, "timestamp": 5},
+        {"topic":  "test_topic", "key": 2, "value": {"foo": "b"}, "timestamp": 6},
+        {"topic":  "test_topic", "key": 3, "value": {"foo": "c"}, "timestamp":  7}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "key": 1, "value": {"RP": 3, "RO": 0}, "timestamp": 5},
+        {"topic":  "OUTPUT", "key": 2, "value": {"RP": 3, "RO": 3}, "timestamp": 6},
+        {"topic":  "OUTPUT", "key": 3, "value": {"RP": 3, "RO": 6}, "timestamp": 7}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, RP INT, RO BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "PARTITION BY ROWOFFSET",
+      "statements": [
+        "CREATE STREAM input (id INT KEY, val INT) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM output AS select * FROM input PARTITION BY ROWOFFSET;"
+      ],
+      "inputs": [
+        {"topic": "input", "key": 10, "value": {"val":  5}},
+        {"topic": "input", "key": 9, "value": {"val":  6}},
+        {"topic": "input", "key": 8, "value": {"val":  7}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"ID": 10, "VAL":  5}},
+        {"topic": "OUTPUT", "key": 1, "value": {"ID": 9, "VAL":  6}},
+        {"topic": "OUTPUT", "key": 2, "value": {"ID": 8, "VAL":  7}}
+      ],
+      "post": {
+        "topics": {
+          "blacklist": ".*-repartition"
+        },
+        "comments": "The schema shouldn't contain a key column named ROWOFFSET, this is a bug with PARTITION BY. See https://github.com/confluentinc/ksql/issues/8193",
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ROWOFFSET BIGINT KEY, val INT, id INT"}
+        ]
+      }
+    },
+    {
+      "name": "PARTITION BY ROWPARTITION",
+      "comments": "Not the most useful PARTITION BY!",
+      "statements": [
+        "CREATE STREAM input (id INT KEY, val INT) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM output AS select * FROM input PARTITION BY ROWPARTITION;"
+      ],
+      "inputs": [
+        {"topic": "input", "key": 10, "value": {"val":  5}},
+        {"topic": "input", "key": 9, "value": {"val":  6}},
+        {"topic": "input", "key": 8, "value": {"val":  7}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"ID": 10, "VAL":  5}},
+        {"topic": "OUTPUT", "key": 0, "value": {"ID": 9, "VAL":  6}},
+        {"topic": "OUTPUT", "key": 0, "value": {"ID": 8, "VAL":  7}}
+      ],
+      "post": {
+        "topics": {
+          "blacklist": ".*-repartition"
+        },
+        "comments": "The schema shouldn't contain a key column named ROWPARTITION, this is a bug with PARTITION BY. See https://github.com/confluentinc/ksql/issues/8193",
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ROWPARTITION INT KEY, val INT, id INT"}
+        ]
+      }
+    },
+    {
+      "name": "Should fail if select ROWPARTITION without aliases",
+      "statements": [
+        "CREATE STREAM input (id INT KEY, foo STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM output AS SELECT id, ROWPARTITION FROM input;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Reserved column name in select: `ROWPARTITION`. Please remove or alias the column."
+      }
+    },
+    {
+      "name": "Should fail if select ROWOFFSET without aliases",
+      "statements": [
+        "CREATE STREAM input (id INT KEY, foo STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM output AS SELECT id, ROWOFFSET FROM input;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Reserved column name in select: `ROWOFFSET`. Please remove or alias the column."
+      }
+    },
+    {
+      "name": "Filter using ROWPARTITION",
+      "statements": [
+        "CREATE STREAM input (id INT KEY, foo STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM output AS SELECT *, ROWTIME AS rt FROM input WHERE ROWPARTITION = 0;"
+      ],
+      "inputs": [
+        {"topic":  "test_topic", "key": 1, "value": {"foo": "a"}, "timestamp": 5},
+        {"topic":  "test_topic", "key": 2, "value": {"foo": "b"}, "timestamp": 6},
+        {"topic":  "test_topic", "key": 3, "value": {"foo": "c"}, "timestamp": 7}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "key": 1, "value": {"FOO":  "a", "RT": 5}, "timestamp": 5},
+        {"topic":  "OUTPUT", "key": 2, "value": {"FOO":  "b", "RT": 6}, "timestamp": 6},
+        {"topic":  "OUTPUT", "key": 3, "value": {"FOO":  "c", "RT": 7}, "timestamp": 7}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, FOO STRING, RT BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "Filter using ROWOFFSET",
+      "statements": [
+        "CREATE STREAM input (id INT KEY, foo STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM output AS SELECT *, ROWTIME AS rt FROM input WHERE ROWOFFSET % 3 = 0;"
+      ],
+      "inputs": [
+        {"topic":  "test_topic", "key": 1, "value": {"foo": "a"}, "timestamp": 5},
+        {"topic":  "test_topic", "key": 2, "value": {"foo": "b"}, "timestamp": 6},
+        {"topic":  "test_topic", "key": 3, "value": {"foo": "c"}, "timestamp": 7},
+        {"topic":  "test_topic", "key": 4, "value": {"foo": "d"}, "timestamp": 8}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "key": 1, "value": {"FOO":  "a", "RT": 5}, "timestamp": 5},
+        {"topic":  "OUTPUT", "key": 4, "value": {"FOO":  "d", "RT": 8}, "timestamp": 8}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, FOO STRING, RT BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "GROUP BY ROWPARTITION",
+      "statements": [
+        "CREATE STREAM L (A INT KEY, B INT) WITH (kafka_topic='LEFT', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT COUNT(B) AS bc, ROWPARTITION AS rp FROM L GROUP BY ROWPARTITION;"
+      ],
+      "inputs": [
+        {"topic": "LEFT", "key": 1, "value": {"B": 100}, "timestamp": 11},
+        {"topic": "LEFT", "key": 2, "value": {"B": 100}, "timestamp": 11},
+        {"topic": "LEFT", "key": 3, "value": {"B": 100}, "timestamp": 11}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"BC": 1}, "timestamp": 11},
+        {"topic": "OUTPUT", "key": 0, "value": {"BC": 2}, "timestamp": 11},
+        {"topic": "OUTPUT", "key": 0, "value": {"BC": 3}, "timestamp": 11}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "schema": "rp INT KEY, bc BIGINT"}
+        ]
+      }
+    },
+    {
+      "name": "GROUP BY ROWOFFSET",
+      "statements": [
+        "CREATE STREAM L (A INT KEY, B INT) WITH (kafka_topic='LEFT', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT COUNT(B) as bc, ROWOFFSET AS ro FROM L GROUP BY ROWOFFSET;"
+      ],
+      "inputs": [
+        {"topic": "LEFT", "key": 1, "value": {"B": 1}, "timestamp": 11},
+        {"topic": "LEFT", "key": 1, "value": {"B": 5}, "timestamp": 11},
+        {"topic": "LEFT", "key": 1, "value": {"B": 10}, "timestamp": 11}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"BC": 1}, "timestamp": 11},
+        {"topic": "OUTPUT", "key": 1, "value": {"BC": 1}, "timestamp": 11},
+        {"topic": "OUTPUT", "key": 2, "value": {"BC": 1}, "timestamp": 11}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "schema": "ro BIGINT KEY, bc BIGINT"}
+        ]
+      }
+    }
+  ]
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DeprecatedStatementsChecker.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DeprecatedStatementsChecker.java
@@ -107,7 +107,7 @@ public class DeprecatedStatementsChecker {
   private boolean isStream(final Relation relation) {
     // DataSourceExtractor must be initialized everytime we need to extract data from a node
     // because it changes its internal state to keep all sources found
-    final DataSourceExtractor dataSourceExtractor = new DataSourceExtractor(metaStore, false);
+    final DataSourceExtractor dataSourceExtractor = new DataSourceExtractor(metaStore, false, false);
 
     // The relation object should have only one joined source, but the extract sources method
     // returns a list. This loop checks all returned values are a Stream just to prevent throwing

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DeprecatedStatementsChecker.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DeprecatedStatementsChecker.java
@@ -107,7 +107,8 @@ public class DeprecatedStatementsChecker {
   private boolean isStream(final Relation relation) {
     // DataSourceExtractor must be initialized everytime we need to extract data from a node
     // because it changes its internal state to keep all sources found
-    final DataSourceExtractor dataSourceExtractor = new DataSourceExtractor(metaStore, false, false);
+    final DataSourceExtractor dataSourceExtractor =
+        new DataSourceExtractor(metaStore, false, false);
 
     // The relation object should have only one joined source, but the extract sources method
     // returns a list. This loop checks all returned values are a Stream just to prevent throwing

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
@@ -46,7 +46,6 @@ import io.confluent.ksql.test.util.KsqlIdentifierTestUtil;
 import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.test.util.TestBasicJaasConfig;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlRequestConfig;
 import io.confluent.ksql.util.UserDataProvider;
 import io.vertx.core.net.SocketAddress;
 import java.io.IOException;
@@ -137,7 +136,9 @@ public class PullQueryFunctionalTest {
       .withProperty(KsqlConfig.KSQL_QUERY_PULL_ENABLE_STANDBY_READS, true)
       .withProperty(KsqlConfig.KSQL_STREAMS_PREFIX + "num.standby.replicas", 1)
       .withProperty(KsqlConfig.KSQL_STREAMS_PREFIX + "cache.max.bytes.buffering", 10000)
-      .withProperty(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED, true)
+      .withProperty(KsqlConfig.KSQL_ROWPARTITION_ROWOFFSET_ENABLED, true)
+//      .withProperty(KsqlConfig.KSQL_ROWID_ENABLED, true)
+//      .withProperty(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED, true)
       .build();
 
   private static final TestKsqlRestApp REST_APP_1 = TestKsqlRestApp
@@ -150,6 +151,8 @@ public class PullQueryFunctionalTest {
       .withProperty(KsqlConfig.KSQL_QUERY_PULL_ENABLE_STANDBY_READS, true)
       .withProperty(KsqlConfig.KSQL_STREAMS_PREFIX + "num.standby.replicas", 1)
       .withProperty(KsqlConfig.KSQL_STREAMS_PREFIX + "cache.max.bytes.buffering", 10000)
+//      .withProperty(KsqlConfig.KSQL_ROWPARTITION_ROWOFFSET_ENABLED, true)
+//      .withProperty(KsqlConfig.KSQL_ROWID_ENABLED, true)
       .withProperty(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED, true)
       .build();
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
@@ -236,6 +236,11 @@ final class SourceBuilder extends SourceBuilderBase {
             row.append(offset);
           }
 
+          // how do i get the key/ do i even need the real key??
+          if (pseudoColumnVersion >= SystemColumns.ROWID_PSEUDOCOLUMN_VERSION) {
+            final byte[] id = (byte[]) key;
+            row.append(id);
+          }
           return row;
         }
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
@@ -36,7 +36,6 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.SystemColumns;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -194,7 +193,7 @@ final class SourceBuilder extends SourceBuilderBase {
     private final int pseudoColumnVersion;
     private final int numPseudoColumnsToMaterialize;
     private final List<Column> headerColumns;
-    private final Serde<GenericKey> keySerde;
+    private final Serde<K> keySerde;
 
     AddPseudoColumnsToMaterialize(
         final int pseudoColumnVersion,
@@ -208,7 +207,7 @@ final class SourceBuilder extends SourceBuilderBase {
           .filter(SystemColumns::mustBeMaterializedForTableJoins)
           .count() + headerColumns.size();
       this.headerColumns = headerColumns;
-      this.keySerde = (Serde<GenericKey>) keySerde;
+      this.keySerde = keySerde;
     }
 
     @Override

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilderBase.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilderBase.java
@@ -87,6 +87,7 @@ abstract class SourceBuilderBase {
         consumed,
         GenericKey::values,
         materialized,
+        keySerde,
         valueSerde,
         stateStoreName,
         planInfo
@@ -119,6 +120,7 @@ abstract class SourceBuilderBase {
       Consumed<K, GenericRow> consumed,
       Function<K, Collection<?>> keyGenerator,
       Materialized<K, GenericRow, KeyValueStore<Bytes, byte[]>> materialized,
+      Serde<K> keySerde,
       Serde<GenericRow> valueSerde,
       String stateStoreName,
       PlanInfo planInfo

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilderUtils.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilderUtils.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.serde.StaticTopicSerde;
 import io.confluent.ksql.serde.WindowInfo;
 import io.confluent.ksql.util.KsqlConfig;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -391,6 +392,12 @@ final class SourceBuilderUtils {
             final long offset = processorContext.offset();
             row.append(partition);
             row.append(offset);
+          }
+
+          // how do i get the key/ do i even need the real key??
+          if (pseudoColumnVersion >= SystemColumns.ROWID_PSEUDOCOLUMN_VERSION) {
+            final byte[] id = processorContext.applicationId().getBytes(StandardCharsets.UTF_8);
+            row.append(id);
           }
 
           row.appendAll(keyColumns);

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilderV1.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilderV1.java
@@ -200,6 +200,7 @@ final class SourceBuilderV1 extends SourceBuilderBase {
         consumed,
         windowedKeyGenerator(source.getSourceSchema()),
         materialized,
+        keySerde,
         valueSerde,
         stateStoreName,
         planInfo
@@ -236,6 +237,7 @@ final class SourceBuilderV1 extends SourceBuilderBase {
       final Consumed<K, GenericRow> consumed,
       final Function<K, Collection<?>> keyGenerator,
       final Materialized<K, GenericRow, KeyValueStore<Bytes, byte[]>> materialized,
+      final Serde<K> keySerde,
       final Serde<GenericRow> valueSerde,
       final String stateStoreName,
       final PlanInfo planInfo

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/SourceBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/SourceBuilderTest.java
@@ -22,7 +22,6 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -458,7 +457,7 @@ public class SourceBuilderTest {
     tableSource.build(planBuilder, planInfo);
 
     // Then:
-    verify(buildContext, atLeastOnce()).buildKeySerde(
+    verify(buildContext).buildKeySerde(
         keyFormatInfo,
         PhysicalSchema.from(SOURCE_SCHEMA, KEY_FEATURES, VALUE_FEATURES),
         ctx

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/SourceBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/SourceBuilderTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -457,7 +458,7 @@ public class SourceBuilderTest {
     tableSource.build(planBuilder, planInfo);
 
     // Then:
-    verify(buildContext).buildKeySerde(
+    verify(buildContext, atLeastOnce()).buildKeySerde(
         keyFormatInfo,
         PhysicalSchema.from(SOURCE_SCHEMA, KEY_FEATURES, VALUE_FEATURES),
         ctx

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderV1Test.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderV1Test.java
@@ -62,12 +62,14 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class StreamSelectKeyBuilderV1Test {
 
+  private static final KsqlConfig KSQL_CONFIG =
+      new KsqlConfig(ImmutableMap.of(KsqlConfig.KSQL_ROWID_ENABLED, true));
   private static final LogicalSchema SOURCE_SCHEMA = LogicalSchema.builder()
       .keyColumn(ColumnName.of("k0"), SqlTypes.DOUBLE)
       .valueColumn(ColumnName.of("BIG"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("BOI"), SqlTypes.BIGINT)
       .build()
-      .withPseudoAndKeyColsInValue(false, new KsqlConfig(ImmutableMap.of()));
+      .withPseudoAndKeyColsInValue(false, KSQL_CONFIG);
 
   private static final UnqualifiedColumnReferenceExp KEY =
       new UnqualifiedColumnReferenceExp(ColumnName.of("BOI"));
@@ -117,7 +119,7 @@ public class StreamSelectKeyBuilderV1Test {
   @SuppressWarnings({"unchecked", "rawtypes"})
   public void init() {
     when(buildContext.getFunctionRegistry()).thenReturn(functionRegistry);
-    when(buildContext.getKsqlConfig()).thenReturn(new KsqlConfig(ImmutableMap.of(KsqlConfig.KSQL_ROWID_ENABLED, true)));
+    when(buildContext.getKsqlConfig()).thenReturn(KSQL_CONFIG);
     when(kstream.filter(any())).thenReturn(filteredKStream);
     when(filteredKStream.selectKey(any(KeyValueMapper.class))).thenReturn(rekeyedKstream);
     when(sourceStep.build(any(), eq(planInfo))).thenReturn(

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderV1Test.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderV1Test.java
@@ -79,6 +79,7 @@ public class StreamSelectKeyBuilderV1Test {
       .valueColumn(ColumnName.of(SystemColumns.ROWTIME_NAME.text()), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of(SystemColumns.ROWPARTITION_NAME.text()), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of(SystemColumns.ROWOFFSET_NAME.text()), SqlTypes.BIGINT)
+      .valueColumn(ColumnName.of(SystemColumns.ROWID_NAME.text()), SqlTypes.BYTES)
       .valueColumn(ColumnName.of("k0"), SqlTypes.DOUBLE)
       .build();
 
@@ -116,7 +117,7 @@ public class StreamSelectKeyBuilderV1Test {
   @SuppressWarnings({"unchecked", "rawtypes"})
   public void init() {
     when(buildContext.getFunctionRegistry()).thenReturn(functionRegistry);
-    when(buildContext.getKsqlConfig()).thenReturn(new KsqlConfig(ImmutableMap.of()));
+    when(buildContext.getKsqlConfig()).thenReturn(new KsqlConfig(ImmutableMap.of(KsqlConfig.KSQL_ROWID_ENABLED, true)));
     when(kstream.filter(any())).thenReturn(filteredKStream);
     when(filteredKStream.selectKey(any(KeyValueMapper.class))).thenReturn(rekeyedKstream);
     when(sourceStep.build(any(), eq(planInfo))).thenReturn(


### PR DESCRIPTION
### Description 
Fixes #6373 by adding a new pseudocolumn `ROWID` which is the serialized bytes of the key in the kafka record. This was implemented as part of a larger effort to introduce keyless tables, in order to achieve new functionality such as having CTAS statements with aggregates without requiring a groupby clause.
 
### Testing done 
Unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

