### PR TITLE
fix: Return proper status code for QPS ratelimit.

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlRateLimitException.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlRateLimitException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+public class KsqlRateLimitException extends KsqlException {
+
+  public KsqlRateLimitException(final String message) {
+    super(message);
+  }
+
+  public KsqlRateLimitException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerUtils.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerUtils.java
@@ -19,14 +19,17 @@ import static io.confluent.ksql.rest.Errors.ERROR_CODE_BAD_REQUEST;
 import static io.confluent.ksql.rest.Errors.ERROR_CODE_BAD_STATEMENT;
 import static io.confluent.ksql.rest.Errors.ERROR_CODE_HTTP2_ONLY;
 import static io.confluent.ksql.rest.Errors.ERROR_CODE_SERVER_ERROR;
+import static io.confluent.ksql.rest.Errors.ERROR_CODE_TOO_MANY_REQUESTS;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.netty.handler.codec.http.HttpResponseStatus.TOO_MANY_REQUESTS;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import io.confluent.ksql.rest.ApiJsonMapper;
+import io.confluent.ksql.util.KsqlRateLimitException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpVersion;
@@ -117,6 +120,10 @@ public final class ServerUtils {
         routingContext.fail(BAD_REQUEST.code(),
             new KsqlApiException(actual.getMessage(), ERROR_CODE_BAD_STATEMENT,
                 ((KsqlStatementException) actual).getSqlStatement()));
+        return null;
+      } else if (actual instanceof KsqlRateLimitException) {
+        routingContext.fail(TOO_MANY_REQUESTS.code(),
+            new KsqlApiException(actual.getMessage(), ERROR_CODE_TOO_MANY_REQUESTS));
         return null;
       } else if (actual instanceof KsqlApiException) {
         routingContext.fail(BAD_REQUEST.code(), actual);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/RateLimiter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/RateLimiter.java
@@ -15,7 +15,7 @@
 
 package io.confluent.ksql.rest.util;
 
-import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.KsqlRateLimitException;
 import io.confluent.ksql.util.ReservedInternalTopics;
 import java.util.Map;
 import org.apache.kafka.common.MetricName;
@@ -51,7 +51,7 @@ public class RateLimiter {
   public void checkLimit() {
     if (!rateLimiter.tryAcquire()) {
       rejectSensor.record();
-      throw new KsqlException("Host is at rate limit for pull queries. Currently set to "
+      throw new KsqlRateLimitException("Host is at rate limit for pull queries. Currently set to "
           + rateLimiter.getRate() + " qps.");
     }
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/ServerUtilsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/ServerUtilsTest.java
@@ -1,0 +1,35 @@
+package io.confluent.ksql.api.server;
+
+import static io.confluent.ksql.rest.Errors.ERROR_CODE_TOO_MANY_REQUESTS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static io.netty.handler.codec.http.HttpResponseStatus.TOO_MANY_REQUESTS;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+import io.confluent.ksql.util.KsqlRateLimitException;
+import io.vertx.ext.web.RoutingContext;
+import java.util.concurrent.CompletionException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ServerUtilsTest {
+  @Mock RoutingContext routingContext;
+
+  @Test
+  public void testHandleServerRateLimitException() {
+    String ratelimitErrorMsg = "Host is at rate limit for pull queries. Currently set to 1 QPS";
+    CompletionException ratelimitException = new CompletionException(
+        new KsqlRateLimitException(ratelimitErrorMsg));
+    ServerUtils.handleEndpointException(ratelimitException, routingContext, "test msg");
+    verify(routingContext).fail(eq(TOO_MANY_REQUESTS.code()), argThat(x -> {
+      assertThat(x.getMessage(), equalTo(ratelimitErrorMsg));
+      assertThat(((KsqlApiException) x).getErrorCode(), equalTo(ERROR_CODE_TOO_MANY_REQUESTS));
+      return true;
+    }));
+  }
+}


### PR DESCRIPTION
### Description 
When configuring and testing `ksql.query.pull.max.qps`, the error message on client side is 
```
{"@type":"generic_error","error_code":50000,"message":"The server encountered an internal error when processing the query. Please consult the server logs for more information."}
```

This change intends to surface a proper code and message back to clients. 

### Testing done 
I will add unit test if this change looks sane. 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

