### PR TITLE
chore: make precondition backoff configurable

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -403,6 +403,11 @@ public class KsqlRestConfig extends AbstractConfig {
   private static final String KSQL_COMMAND_TOPIC_RATE_LIMIT_CONFIG_DEFAULT_DOC = 
       "Sets the number of statements that can be executed against the command topic per second";
 
+  public static final String KSQL_PRECONDITION_CHECKER_BACK_OFF_TIME_MS =
+      KSQL_CONFIG_PREFIX + "server.precondition.max.backoff.ms";
+  protected static final String KSQL_PRECONDITION_CHECKER_BACK_OFF_TIME_MS_DOC =
+      "The maximum amount of time to wait before checking the KSQL server preconditions again.";
+
   private static final ConfigDef CONFIG_DEF;
 
   static {
@@ -762,6 +767,12 @@ public class KsqlRestConfig extends AbstractConfig {
         KSQL_COMMAND_TOPIC_RATE_LIMIT_CONFIG_DEFAULT,
         Importance.LOW,
         KSQL_COMMAND_TOPIC_RATE_LIMIT_CONFIG_DEFAULT_DOC
+      ).define(
+        KSQL_PRECONDITION_CHECKER_BACK_OFF_TIME_MS,
+        Type.LONG,
+        30000L,
+        Importance.MEDIUM,
+        KSQL_PRECONDITION_CHECKER_BACK_OFF_TIME_MS_DOC
       );
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -762,18 +762,18 @@ public class KsqlRestConfig extends AbstractConfig {
             Importance.LOW,
             KSQL_SERVER_SNI_CHECK_ENABLE_DOC
         ).define(
-        KSQL_COMMAND_TOPIC_RATE_LIMIT_CONFIG,
-        Type.DOUBLE,
-        KSQL_COMMAND_TOPIC_RATE_LIMIT_CONFIG_DEFAULT,
-        Importance.LOW,
-        KSQL_COMMAND_TOPIC_RATE_LIMIT_CONFIG_DEFAULT_DOC
-      ).define(
-        KSQL_PRECONDITION_CHECKER_BACK_OFF_TIME_MS,
-        Type.LONG,
-        30000L,
-        Importance.MEDIUM,
-        KSQL_PRECONDITION_CHECKER_BACK_OFF_TIME_MS_DOC
-      );
+            KSQL_COMMAND_TOPIC_RATE_LIMIT_CONFIG,
+            Type.DOUBLE,
+            KSQL_COMMAND_TOPIC_RATE_LIMIT_CONFIG_DEFAULT,
+            Importance.LOW,
+            KSQL_COMMAND_TOPIC_RATE_LIMIT_CONFIG_DEFAULT_DOC
+        ).define(
+            KSQL_PRECONDITION_CHECKER_BACK_OFF_TIME_MS,
+            Type.LONG,
+            5000L,
+            Importance.MEDIUM,
+            KSQL_PRECONDITION_CHECKER_BACK_OFF_TIME_MS_DOC
+        );
   }
 
   public KsqlRestConfig(final Map<?, ?> props) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/PreconditionChecker.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/PreconditionChecker.java
@@ -164,7 +164,8 @@ public class PreconditionChecker implements Executable {
     RetryUtil.retryWithBackoff(
         Integer.MAX_VALUE,
         1000,
-        30000,
+        Math.toIntExact(restConfig.getLong(
+            KsqlRestConfig.KSQL_PRECONDITION_CHECKER_BACK_OFF_TIME_MS)),
         this::checkPreconditions,
         terminatedFuture::isDone,
         predicates


### PR DESCRIPTION
### Description 
the precondition check backoff can reach a maximum of 30 seconds which is a bit high. Let's make it configurable

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

