### PR TITLE
feat: Adding ksqlDB Query Status metric.

### DIFF
--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -151,7 +151,7 @@ The `PAUSE` / `RESUME` commands do not impact the {{ site.kstreams }} state, so 
 
 `query-status`
 
-The current Kafka Streams status of the given query.  
+The current {{ site.kstreams }} status of the given query.  
 The `ksql-query-status` metric has been added to show the ksqlDB query status.
 
 **Error status**

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -145,7 +145,7 @@ io.confluent.ksql.metrics:type=ksql-queries
 
 The current ksqlDB status of the given query.   
 The metric `query-status` shows the Kafka Streams application state.  
-The `PAUSE` / `RESUME` commands do not impact the Kafka Streams state, so this new metric shows when a query is paused.
+The `PAUSE` / `RESUME` commands do not impact the {{ site.kstreams }} state, so this new metric shows when a query is paused.
 
 **Query status**
 

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -144,7 +144,7 @@ io.confluent.ksql.metrics:type=ksql-queries
 `ksql-query-status`
 
 The current ksqlDB status of the given query.   
-The metric `query-status` shows the Kafka Streams application state.  
+The metric `query-status` shows the {{ site.kstreams }} application state.  
 The `PAUSE` / `RESUME` commands do not impact the {{ site.kstreams }} state, so this new metric shows when a query is paused.
 
 **Query status**

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -152,7 +152,7 @@ The `PAUSE` / `RESUME` commands do not impact the {{ site.kstreams }} state, so 
 `query-status`
 
 The current Kafka Streams status of the given query.  
-Note that `ksql-query-status` has been added to show the ksqlDB query status.
+The `ksql-query-status` metric has been added to show the ksqlDB query status.
 
 **Error status**
 

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -139,11 +139,20 @@ io.confluent.ksql.metrics:type=ksql-queries
 
 ### Attributes
 
+**ksqlDB query tatus**
+
+`ksql-query-status`
+
+The current ksqlDB status of the given query.   
+The metric `query-status` shows the Kafka Streams application state.  
+The `PAUSE` / `RESUME` commands do not impact the Kafka Streams state, so this new metric shows when a query is paused.
+
 **Query status**
 
 `query-status`
 
-The current status of the given query.
+The current Kafka Streams status of the given query.  
+Note that `ksql-query-status` has been added to show the ksqlDB query status.
 
 **Error status**
 

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -139,7 +139,7 @@ io.confluent.ksql.metrics:type=ksql-queries
 
 ### Attributes
 
-**ksqlDB query tatus**
+**ksqlDB query status**
 
 `ksql-query-status`
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryEventListener.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryEventListener.java
@@ -55,7 +55,7 @@ public interface QueryEventListener {
   }
 
   /**
-   * Called when the state of the ksqlDB query metadata changes
+   * Called when the ksqlDB query is paused or resumed.
    * @param query the query whose state has changed
    */
   default void onKsqlStateChange(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryEventListener.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryEventListener.java
@@ -55,6 +55,15 @@ public interface QueryEventListener {
   }
 
   /**
+   * Called when the state of the ksqlDB query metadata changes
+   * @param query the query whose state has changed
+   */
+  default void onKsqlStateChange(
+          QueryMetadata query
+  ) {
+  }
+
+  /**
    * Called when a query hits a query execution error
    * @param query the query that hit the error
    * @param error the error that the query hit

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/QueryStateMetricsReportingListener.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/QueryStateMetricsReportingListener.java
@@ -128,7 +128,6 @@ public class QueryStateMetricsReportingListener implements QueryEventListener {
     private final CumulativeSum queryRestartSum;
     private final Ticker ticker;
 
-    private volatile QueryMetadata queryMetadata;
     private volatile String state = "-";
     private volatile String ksqlQueryState = "-";
     private volatile String error = NO_ERROR;
@@ -196,10 +195,6 @@ public class QueryStateMetricsReportingListener implements QueryEventListener {
       this.metrics.addMetric(queryRestartMetricName, queryRestartSum);
       this.metrics.addMetric(ksqlQueryStatusMetricName,
               (Gauge<String>) (config, now) -> ksqlQueryState);
-    }
-
-    public void setQueryMetadata(final QueryMetadata queryMetadata) {
-      this.queryMetadata = queryMetadata;
     }
 
     public void onChange(final State newState, final State oldState) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -584,6 +584,16 @@ public class QueryRegistryImpl implements QueryRegistry {
     }
 
     @Override
+    public void onPause(final QueryMetadata queryMetadata) {
+      eventListeners.forEach(l -> l.onKsqlStateChange(queryMetadata));
+    }
+
+    @Override
+    public void onResume(final QueryMetadata queryMetadata) {
+      eventListeners.forEach(l -> l.onKsqlStateChange(queryMetadata));
+    }
+
+    @Override
     public void onClose(final QueryMetadata queryMetadata) {
       unregisterQuery(queryMetadata);
       eventListeners.forEach(l -> l.onClose(queryMetadata));

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
@@ -431,12 +431,14 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
   public void pause() {
     sharedKafkaStreamsRuntime.getKafkaStreams().pauseNamedTopology(topology.name());
     isPaused = true;
+    listener.onPause(this);
   }
 
   @Override
   public void resume() {
     sharedKafkaStreamsRuntime.getKafkaStreams().resumeNamedTopology(topology.name());
     isPaused = false;
+    listener.onPause(this);
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -90,6 +90,16 @@ public interface PersistentQueryMetadata extends QueryMetadata {
     }
 
     @Override
+    public void onPause(final QueryMetadata queryMetadata) {
+      this.listener.onPause(queryMetadata);
+    }
+
+    @Override
+    public void onResume(final QueryMetadata queryMetadata) {
+      this.listener.onResume(queryMetadata);
+    }
+
+    @Override
     public void onClose(final QueryMetadata queryMetadata) {
       this.listener.onClose(queryMetadata);
       scalablePushRegistry.ifPresent(ScalablePushRegistry::cleanup);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -107,6 +107,10 @@ public interface QueryMetadata {
         KafkaStreams.State before,
         KafkaStreams.State after);
 
+    void onPause(QueryMetadata queryMetadata);
+
+    void onResume(QueryMetadata queryMetadata);
+
     void onClose(QueryMetadata queryMetadata);
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
@@ -436,12 +436,14 @@ public class QueryMetadataImpl implements QueryMetadata {
   public void pause() {
     kafkaStreams.pause();
     isPaused.set(true);
+    listener.onPause(this);
   }
 
   @Override
   public void resume() {
     kafkaStreams.resume();
     isPaused.set(false);
+    listener.onResume(this);
   }
 
   public static class RetryEvent implements QueryMetadata.RetryEvent {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/QueryStateMetricsReportingListenerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/QueryStateMetricsReportingListenerTest.java
@@ -186,6 +186,7 @@ public class QueryStateMetricsReportingListenerTest {
   @Test
   public void shouldUpdateToNewState() {
     // When:
+    when(query.getQueryStatus()).thenReturn(KsqlConstants.KsqlQueryStatus.RUNNING);
     listener.onCreate(serviceContext, metaStore, query);
     listener.onStateChange(query, State.REBALANCING, State.RUNNING);
 
@@ -196,6 +197,7 @@ public class QueryStateMetricsReportingListenerTest {
   @Test
   public void shouldUpdateOnError() {
     // When:
+    when(query.getQueryStatus()).thenReturn(KsqlConstants.KsqlQueryStatus.RUNNING);
     listener.onCreate(serviceContext, metaStore, query);
     listener.onError(query, new QueryError(1, "foo", Type.USER));
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/QueryStateMetricsReportingListenerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/QueryStateMetricsReportingListenerTest.java
@@ -207,17 +207,22 @@ public class QueryStateMetricsReportingListenerTest {
   public void shouldReportKsqlQueryStatus() {
     // When:
     listener.onCreate(serviceContext, metaStore, query);
-    listener.onStateChange(query, State.REBALANCING, State.RUNNING);
 
     when(query.getQueryStatus())
             .thenReturn(KsqlConstants.KsqlQueryStatus.RUNNING)
             .thenReturn(KsqlConstants.KsqlQueryStatus.PAUSED)
-            .thenReturn(KsqlConstants.KsqlQueryStatus.RUNNING);
+            .thenReturn(KsqlConstants.KsqlQueryStatus.UNRESPONSIVE)
+            .thenReturn(KsqlConstants.KsqlQueryStatus.ERROR);
 
     // Then:
+    listener.onKsqlStateChange(query);
     assertThat(currentGaugeValue(METRIC_NAME_4), is("RUNNING"));
+    listener.onKsqlStateChange(query);
     assertThat(currentGaugeValue(METRIC_NAME_4), is("PAUSED"));
-    assertThat(currentGaugeValue(METRIC_NAME_4), is("RUNNING"));
+    listener.onKsqlStateChange(query);
+    assertThat(currentGaugeValue(METRIC_NAME_4), is("UNRESPONSIVE"));
+    listener.onKsqlStateChange(query);
+    assertThat(currentGaugeValue(METRIC_NAME_4), is("ERROR"));
   }
 
   @Test


### PR DESCRIPTION
### Description 

The existing metric `query-status` reports the state of the Kafka Streams application.

This new metric `ksql-query-status` reports the state of the ksqlDB.

This is being added to show that the query can be paused.  (While a ksqlDB query is paused,
the underlying Kafka Stream application is still in the `RUNNING` state.)


### Testing done 
Added unit tests and verified the new metric with JConsole locally.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

