### PR TITLE
feat: refresh service context and topic client in precondition checker

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/PreconditionCheckerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/PreconditionCheckerTest.java
@@ -54,6 +54,8 @@ public class PreconditionCheckerTest {
   @Mock
   private ServiceContext serviceContext;
   @Mock
+  private Supplier<ServiceContext> serviceContextSupplier;
+  @Mock
   private KafkaTopicClient topicClient;
   @Mock
   private ServerState serverState;
@@ -68,7 +70,7 @@ public class PreconditionCheckerTest {
   public void setup() {
     checker = new PreconditionChecker(
         propertiesLoader,
-        serviceContext,
+        serviceContextSupplier,
         restConfig,
         topicClient,
         vertx,
@@ -80,6 +82,7 @@ public class PreconditionCheckerTest {
     when(precondition2.checkPrecondition(any(), any(), any())).thenReturn(Optional.empty());
     when(server.started()).thenReturn(true);
     when(propertiesLoader.get()).thenReturn(PROPERTIES);
+    when(serviceContextSupplier.get()).thenReturn(serviceContext);
   }
 
   @Test
@@ -87,7 +90,7 @@ public class PreconditionCheckerTest {
     // Given:
     PreconditionChecker checker = new PreconditionChecker(
         propertiesLoader,
-        serviceContext,
+        serviceContextSupplier,
         restConfig,
         topicClient,
         vertx,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/PreconditionCheckerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/PreconditionCheckerTest.java
@@ -58,6 +58,8 @@ public class PreconditionCheckerTest {
   @Mock
   private KafkaTopicClient topicClient;
   @Mock
+  private Supplier<KafkaTopicClient> topicClientSupplier;
+  @Mock
   private ServerState serverState;
   @Mock
   private Supplier<Map<String, String>> propertiesLoader;
@@ -72,7 +74,7 @@ public class PreconditionCheckerTest {
         propertiesLoader,
         serviceContextSupplier,
         restConfig,
-        topicClient,
+        topicClientSupplier,
         vertx,
         ImmutableList.of(precondition1, precondition2),
         server,
@@ -83,6 +85,7 @@ public class PreconditionCheckerTest {
     when(server.started()).thenReturn(true);
     when(propertiesLoader.get()).thenReturn(PROPERTIES);
     when(serviceContextSupplier.get()).thenReturn(serviceContext);
+    when(topicClientSupplier.get()).thenReturn(topicClient);
   }
 
   @Test
@@ -92,7 +95,7 @@ public class PreconditionCheckerTest {
         propertiesLoader,
         serviceContextSupplier,
         restConfig,
-        topicClient,
+        topicClientSupplier,
         vertx,
         ImmutableList.of(),
         server,


### PR DESCRIPTION
### Description 
We only create the service context when the pre condition checker is initialized, we should actually get a new service context each time we do a check as the service context should have the most up to date properties from the properties loader (incase new configs have come in since last time)

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

