### PR TITLE
test: fix flaky test ClientTest.shouldFailPollStreamedQueryResultIfFailed

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/reactive/BasePublisher.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/reactive/BasePublisher.java
@@ -124,7 +124,7 @@ public abstract class BasePublisher<T> implements Publisher<T> {
     return demand;
   }
 
-  protected Subscriber<? super T> getSubscriber() {
+  public Subscriber<? super T> getSubscriber() {
     return subscriber;
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
@@ -131,6 +131,22 @@ public class BaseApiTest {
     createServer(serverConfig);
     this.client = createClient();
     setDefaultRowGenerator();
+
+    testEndpoints.getQueryPublishers().forEach(
+        publisher -> {
+          final long timeout = System.currentTimeMillis() + 30_000L;
+          while (publisher.getSubscriber() == null) {
+            try {
+              Thread.sleep(100L);
+            } catch (InterruptedException swallow) {
+            }
+
+            if (System.currentTimeMillis() > timeout) {
+              throw new RuntimeException("Test setup failed; no subscriber registered.");
+            }
+          }
+        }
+    );
   }
 
   @After


### PR DESCRIPTION
The test sometimes fails with a NPE due to a race condition.
The needed `subscriber` is registered async in a different thread.
This PR adds a check in the setup that the `subscriber` was indeed
registered and is not `null` before the test can start.