### PR TITLE
test: fix version pattern in ClientImplTest

### DIFF
--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/ClientImplTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/ClientImplTest.java
@@ -87,7 +87,7 @@ public class ClientImplTest {
     client.streamQuery("SELECT * from STREAM1 EMIT CHANGES;");
     assertThat(headers.size(), is(2));
     assertThat(headers.containsKey(USER_AGENT.toString()), is(true));
-    assertThat(headers.get(USER_AGENT.toString()).matches("ksqlDB Java Client v\\d\\.\\d\\.\\d.*"),
+    assertThat(headers.get(USER_AGENT.toString()).matches("ksqlDB Java Client v\\d*\\.\\d*\\.\\d*.*"),
         is(true));
 
     assertThat(headers.containsKey(ACCEPT.toString()), is(true));


### PR DESCRIPTION
We currently test single digit version numbers only, ie, `1.2.3`, which fails for double digits, eg, `0.27.0`.

Not sure why this was not an issue earlier.

