### PR TITLE
docs: cherry-pick: pin Markdown to v3.3.6 (DOCS-15035)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 jinja2==3.0.3
+Markdown==3.3.6
 mdx_gh_links==0.2
 mdx_truly_sane_lists==1.2
 mkdocs==1.2.3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -173,7 +173,7 @@ markdown_extensions:
     - attr_list
     - mdx_gh_links:
         user: confluentinc
-        repo: ksqldb
+        repo: ksql
     - mdx_truly_sane_lists
 
 plugins:


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/9299.