### PR TITLE
refactor: rename getAuthToken to getAuthHeader

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/ApiSecurityContext.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/ApiSecurityContext.java
@@ -24,7 +24,7 @@ public interface ApiSecurityContext {
 
   Optional<KsqlPrincipal> getPrincipal();
 
-  Optional<String> getAuthToken();
+  Optional<String> getAuthHeader();
 
   List<Entry<String, String>> getRequestHeaders();
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/AuthenticationPlugin.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/AuthenticationPlugin.java
@@ -47,15 +47,15 @@ public interface AuthenticationPlugin {
       WorkerExecutor workerExecutor);
 
   /**
-   * Retrieve the authorization token from the request. This is different from {@code handleAuth}
-   * since we need to expose the authorization token in order to provide forwarded inter-node
+   * Retrieve the authorization header from the request. This is different from {@code handleAuth}
+   * since we need to expose the authorization header in order to provide forwarded inter-node
    * requests the correct credentials.
    *
    * @param routingContext The routing context
-   * @return A String that is the authorization token that we can then use for forwarding
+   * @return A String that is the authorization header that we can then use for forwarding
    *        inter-node requests.
    */
-  default String getAuthToken(final RoutingContext routingContext) {
+  default String getAuthHeader(final RoutingContext routingContext) {
     return routingContext.request().getHeader("Authorization");
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/DefaultApiSecurityContext.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/DefaultApiSecurityContext.java
@@ -40,7 +40,7 @@ public final class DefaultApiSecurityContext implements ApiSecurityContext {
 
     String authToken = null;
     if (server.getAuthenticationPlugin().isPresent()) {
-      authToken = server.getAuthenticationPlugin().get().getAuthToken(routingContext);
+      authToken = server.getAuthenticationPlugin().get().getAuthHeader(routingContext);
     }
 
     final List<Entry<String, String>> requestHeaders = routingContext.request().headers().entries();
@@ -68,7 +68,7 @@ public final class DefaultApiSecurityContext implements ApiSecurityContext {
   }
 
   @Override
-  public Optional<String> getAuthToken() {
+  public Optional<String> getAuthHeader() {
     return authToken;
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/DefaultKsqlSecurityContextProvider.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/DefaultKsqlSecurityContextProvider.java
@@ -63,7 +63,7 @@ public class DefaultKsqlSecurityContextProvider implements KsqlSecurityContextPr
   public KsqlSecurityContext provide(final ApiSecurityContext apiSecurityContext) {
 
     final Optional<KsqlPrincipal> principal = apiSecurityContext.getPrincipal();
-    final Optional<String> authHeader = apiSecurityContext.getAuthToken();
+    final Optional<String> authHeader = apiSecurityContext.getAuthHeader();
     final List<Entry<String, String>> requestHeaders = apiSecurityContext.getRequestHeaders();
 
     // A user context is not necessary if a user context provider is not present or the user

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
@@ -312,7 +312,7 @@ public class KsqlServerEndpoints implements Endpoints {
             ksqlSecurityContext,
             context,
             new AuthenticationUtil(Clock.systemUTC())
-                .getTokenTimeout(apiSecurityContext.getAuthToken(), ksqlConfig, authTokenProvider)
+                .getTokenTimeout(apiSecurityContext.getAuthHeader(), ksqlConfig, authTokenProvider)
         );
       } finally {
         ksqlSecurityContext.getServiceContext().close();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/impl/DefaultKsqlSecurityContextProviderTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/impl/DefaultKsqlSecurityContextProviderTest.java
@@ -86,7 +86,7 @@ public class DefaultKsqlSecurityContextProviderTest {
     );
 
     when(apiSecurityContext.getPrincipal()).thenReturn(Optional.of(user1));
-    when(apiSecurityContext.getAuthToken()).thenReturn(Optional.empty());
+    when(apiSecurityContext.getAuthHeader()).thenReturn(Optional.empty());
     when(apiSecurityContext.getRequestHeaders()).thenReturn(incomingRequestHeaders);
 
     when(defaultServiceContextFactory.create(any(), any(), any(), any(), any(), any(), any()))
@@ -144,7 +144,7 @@ public class DefaultKsqlSecurityContextProviderTest {
   public void shouldPassAuthHeaderToDefaultFactory() {
     // Given:
     when(securityExtension.getUserContextProvider()).thenReturn(Optional.empty());
-    when(apiSecurityContext.getAuthToken()).thenReturn(Optional.of("some-auth"));
+    when(apiSecurityContext.getAuthHeader()).thenReturn(Optional.of("some-auth"));
 
     // When:
     ksqlSecurityContextProvider.provide(apiSecurityContext);
@@ -157,7 +157,7 @@ public class DefaultKsqlSecurityContextProviderTest {
   public void shouldPassAuthHeaderToUserFactory() {
     // Given:
     when(securityExtension.getUserContextProvider()).thenReturn(Optional.of(userContextProvider));
-    when(apiSecurityContext.getAuthToken()).thenReturn(Optional.of("some-auth"));
+    when(apiSecurityContext.getAuthHeader()).thenReturn(Optional.of("some-auth"));
 
     // When:
     ksqlSecurityContextProvider.provide(apiSecurityContext);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
@@ -343,9 +343,8 @@ public class PullQueryRoutingFunctionalTest {
     assertThat(rows_0.get(1).getRow().get().getColumns(), is(ImmutableList.of(KEY, 1)));
   }
 
-//  @Ignore
   @Test
-  public void shouldQueryWS() throws Exception {
+  public void shouldQueryWithAuthMultiNodeOverWS() {
     // Given:
     ClusterFormation clusterFormation = findClusterFormation(TEST_APP_0, TEST_APP_1, TEST_APP_2);
     waitForClusterToBeDiscovered(clusterFormation.standBy.getApp(), 3, USER_CREDS);
@@ -375,6 +374,7 @@ public class PullQueryRoutingFunctionalTest {
     assertThat(rows_0, hasSize(HEADER + 2));
   }
 
+  @Test
   public void shouldQueryActiveWhenActiveAliveStandbyDeadQueryIssuedToRouter() {
     // Given:
     ClusterFormation clusterFormation = findClusterFormation(TEST_APP_0, TEST_APP_1, TEST_APP_2);
@@ -712,7 +712,7 @@ public class PullQueryRoutingFunctionalTest {
     @Override
     public CompletableFuture<Principal> handleAuth(RoutingContext routingContext,
         WorkerExecutor workerExecutor) {
-      if (getAuthToken(routingContext) == null){
+      if (getAuthHeader(routingContext) == null){
         routingContext.fail(HttpResponseStatus.UNAUTHORIZED.code(),
             new KsqlApiException("Unauthorized", ERROR_CODE_UNAUTHORIZED));
         return CompletableFuture.completedFuture(null);
@@ -721,12 +721,12 @@ public class PullQueryRoutingFunctionalTest {
     }
 
     @Override
-    public String getAuthToken(RoutingContext routingContext) {
-      String authToken = routingContext.request().getHeader("Authorization");
-      if (authToken == null) {
-        authToken = routingContext.request().getParam("access_token");
+    public String getAuthHeader(RoutingContext routingContext) {
+      String authHeader = routingContext.request().getHeader("Authorization");
+      if (authHeader == null) {
+        authHeader = "Bearer " + routingContext.request().getParam("access_token");
       }
-      return authToken;
+      return authHeader;
     }
   }
   

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
@@ -724,7 +724,7 @@ public class PullQueryRoutingFunctionalTest {
     public String getAuthHeader(RoutingContext routingContext) {
       String authHeader = routingContext.request().getHeader("Authorization");
       if (authHeader == null) {
-        authHeader = "Bearer " + routingContext.request().getParam("access_token");
+        authHeader = routingContext.request().getParam("access_token");
       }
       return authHeader;
     }


### PR DESCRIPTION
### Description 
Refactor `getAuthToken` to be `getAuthHeader` since what we really want to pass on is a full header value, not simply just an authorization token. 

