### PR TITLE
fix: allow YATT to insert into and check contents of DDL sources

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/TestDriverPipeline.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/TestDriverPipeline.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TestOutputTopic;
@@ -129,6 +130,11 @@ public class TestDriverPipeline {
   public void addDdlTopic(
       final TopologyTestDriver driver, final TopicInfo topic
   ) {
+    List<Input> oldInputs = inputs.get(topic.name)
+        .stream()
+        .filter(input -> input.receivers.size() == 0)
+        .collect(Collectors.toList());
+    oldInputs.forEach(input -> inputs.remove(topic.name, input));
     final Input input = new Input(
         driver.createInputTopic(
             topic.name,

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/TestDriverPipeline.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/TestDriverPipeline.java
@@ -203,7 +203,9 @@ public class TestDriverPipeline {
       throw new KsqlException("Cannot pipe input to unknown source: " + topic);
     }
 
-    topicCache.put(topic, new TestRecord(key, value, Instant.ofEpochMilli(timestampMs)));
+    if (topic.equals(path)) {
+      topicCache.put(topic, new TestRecord(key, value, Instant.ofEpochMilli(timestampMs)));
+    }
     for (final Input input : inputs) {
       input.topic.pipeInput(key, value, timestampMs);
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/TestDriverPipeline.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/TestDriverPipeline.java
@@ -130,7 +130,7 @@ public class TestDriverPipeline {
   public void addDdlTopic(
       final TopologyTestDriver driver, final TopicInfo topic
   ) {
-    List<Input> oldInputs = inputs.get(topic.name)
+    final List<Input> oldInputs = inputs.get(topic.name)
         .stream()
         .filter(input -> input.receivers.size() == 0)
         .collect(Collectors.toList());

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
@@ -33,9 +33,11 @@ import io.confluent.ksql.logging.processing.NoopProcessingLogContext;
 import io.confluent.ksql.metastore.MetaStoreImpl;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metrics.MetricCollectors;
+import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.AssertTable;
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
+import io.confluent.ksql.parser.tree.AlterSource;
 import io.confluent.ksql.parser.tree.AssertStatement;
 import io.confluent.ksql.parser.tree.AssertStream;
 import io.confluent.ksql.parser.tree.AssertTombstone;
@@ -252,7 +254,10 @@ public class KsqlTesterTest {
 
     // is DDL statement
     if (!result.getQuery().isPresent()) {
-      final DataSource input = engine.getMetaStore().getSource(((CreateSource) injected.getStatement()).getName());
+      final SourceName name = injected.getStatement() instanceof CreateSource
+          ? ((CreateSource) injected.getStatement()).getName()
+          : ((AlterSource) injected.getStatement()).getName();
+      final DataSource input = engine.getMetaStore().getSource(name);
       final Topology topology = new Topology();
       topology.addSource(input.getKafkaTopicName(), input.getKafkaTopicName());
       final Properties properties = new Properties();

--- a/ksqldb-functional-tests/src/test/resources/sql-tests/test.sql
+++ b/ksqldb-functional-tests/src/test/resources/sql-tests/test.sql
@@ -245,3 +245,15 @@ CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='
 CREATE STREAM bar AS SELECT * FROM foo;
 
 ASSERT STREAM bar (id INT KEY, col1 INT) WITH (kafka_topic='BAR', value_format='JSON', wrap_single_value=false);
+
+----------------------------------------------------------------------------------------------------
+--@test: assert contents of a DDL source
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 2, 1);
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 1);
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 3, 1);
+ASSERT VALUES foo (rowtime, id, col1) VALUES (1, 2, 1);
+ASSERT VALUES foo (rowtime, id, col1) VALUES (1, 1, 1);
+ASSERT VALUES foo (rowtime, id, col1) VALUES (1, 3, 1);


### PR DESCRIPTION
### Description 
Fixes #6113 and #6058

The issue is that the testing tool works by creating a `TopologyTestDriver` for every query, so when doing insertions and checking values, it looks for drivers. DDL sources are not queries though, so YATT ends up not finding a driver.  The fix here is to register a driver with an empty topology for every DDL source.

### Testing done 
Added a test to the testing tool test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

