### PR TITLE
KSE-1045: Classify serialization exception

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/KsqlSerializationClassifier.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/KsqlSerializationClassifier.java
@@ -25,8 +25,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * {@code SerializationClassifier} classifies serialization exceptions as user error
- * while writing to a user topic due to schema mismatch
+ * {@code KsqlSerializationClassifier} classifies serialization exceptions caused due to schema
+ * mismatch as user error when topic name doesn't contain a prefix of "_confluent-ksql-" otherwise
+ * classifies it as non-user error
  */
 public class KsqlSerializationClassifier implements QueryErrorClassifier {
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/KsqlSerializationClassifier.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/KsqlSerializationClassifier.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.query;
+
+import io.confluent.ksql.query.QueryError.Type;
+import io.confluent.ksql.serde.KsqlSerializationException;
+import io.confluent.ksql.util.ReservedInternalTopics;
+import java.util.Objects;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@code SerializationClassifier} classifies serialization exceptions as user error
+ * while writing to a user topic due to schema mismatch
+ */
+public class KsqlSerializationClassifier implements QueryErrorClassifier {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KsqlSerializationClassifier.class);
+
+  private final String queryId;
+
+  public KsqlSerializationClassifier(final String queryId) {
+    this.queryId = Objects.requireNonNull(queryId, "queryId");
+  }
+
+  private boolean hasInternalTopicPrefix(final Throwable e) {
+    final int index = ExceptionUtils.indexOfThrowable(e, KsqlSerializationException.class);
+    final KsqlSerializationException kse =
+        (KsqlSerializationException) ExceptionUtils.getThrowableList(e).get(index);
+
+    return kse.getTopic().startsWith(ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX);
+  }
+
+  @Override
+  public Type classify(final Throwable e) {
+    Type type = Type.UNKNOWN;
+
+    if (e instanceof KsqlSerializationException
+        || (e instanceof StreamsException
+            && (ExceptionUtils.indexOfThrowable(e, KsqlSerializationException.class) != -1))) {
+      if (!hasInternalTopicPrefix(e)) {
+        type = Type.USER;
+        LOG.info(
+            "Classified error as USER error based on schema mismatch. Query ID: {} Exception: {}",
+            queryId,
+            e);
+      }
+    }
+
+    return type;
+  }
+
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -653,7 +653,8 @@ final class QueryBuilder {
         .and(new AuthorizationClassifier(applicationId))
         .and(new KsqlFunctionClassifier(applicationId))
         .and(new MissingSubjectClassifier(applicationId))
-        .and(new SchemaAuthorizationClassifier(applicationId));
+        .and(new SchemaAuthorizationClassifier(applicationId))
+        .and(new KsqlSerializationClassifier(applicationId));
     return buildConfiguredClassifiers(ksqlConfig, applicationId)
         .map(userErrorClassifiers::and)
         .orElse(userErrorClassifiers);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/KsqlSerializationClassifierTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/KsqlSerializationClassifierTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.query;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import io.confluent.ksql.query.QueryError.Type;
+import io.confluent.ksql.serde.KsqlSerializationException;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KsqlSerializationClassifierTest {
+
+  @Test
+  public void shouldClassifyWrappedKsqlSerializationExceptionWithUserTopicAsUserError() {
+    // Given:
+    final String topic = "foo.bar";
+    final Exception e = new StreamsException(
+        new KsqlSerializationException(
+            topic,
+            "Error serializing message to topic: " + topic,
+            new DataException("Struct schemas do not match.")));
+
+    // When:
+    final Type type = new KsqlSerializationClassifier("").classify(e);
+
+    // Then:
+    assertThat(type, is(Type.USER));
+  }
+
+  @Test
+  public void shouldClassifyWrappedKsqlSerializationExceptionWithRepartitionTopicAsUnknownError() {
+    // Given:
+    final String topic = "_confluent-ksql-default_query_CTAS_USERS_0-Aggregate-GroupBy-repartition";
+    final Exception e = new StreamsException(
+        new KsqlSerializationException(
+            topic,
+            "Error serializing message to topic: " + topic,
+            new DataException("Struct schemas do not match.")));
+
+    // When:
+    final Type type = new KsqlSerializationClassifier("").classify(e);
+
+    // Then:
+    assertThat(type, is(Type.UNKNOWN));
+  }
+
+  @Test
+  public void shouldClassifyWrappedKsqlSerializationExceptionWithChangelogTopicAsUnknownError() {
+    // Given:
+    final String topic = "_confluent-ksql-default_query_CTAS_USERS_0-Aggregate-Aggregate-Materialize-changelog";
+    final Exception e = new StreamsException(
+        new KsqlSerializationException(
+            topic,
+            "Error serializing message to topic: " + topic,
+            new DataException("Struct schemas do not match.")));
+
+    // When:
+    final Type type = new KsqlSerializationClassifier("").classify(e);
+
+    // Then:
+    assertThat(type, is(Type.UNKNOWN));
+  }
+
+  @Test
+  public void shouldClassifyKsqlSerializationExceptionWithUserTopicAsUserError() {
+    // Given:
+    final String topic = "foo.bar";
+    final Exception e = new KsqlSerializationException(
+        topic,
+        "Error serializing message to topic: " + topic);
+
+    // When:
+    final Type type = new KsqlSerializationClassifier("").classify(e);
+
+    // Then:
+    assertThat(type, is(Type.USER));
+  }
+
+  @Test
+  public void shouldClassifyKsqlSerializationExceptionWithRepartitionTopicAsUnknownError() {
+    // Given:
+    final String topic = "_confluent-ksql-default_query_CTAS_USERS_0-Aggregate-GroupBy-repartition";
+    final Exception e = new KsqlSerializationException(
+        topic,
+        "Error serializing message to topic: " + topic);
+
+    // When:
+    final Type type = new KsqlSerializationClassifier("").classify(e);
+
+    // Then:
+    assertThat(type, is(Type.UNKNOWN));
+  }
+
+  @Test
+  public void shouldClassifyNonKsqlSerializationExceptionAsUnknownError() {
+    // Given:
+    final Exception e = new StreamsException(new DataException("Something went wrong"));
+
+    // When:
+    final Type type = new KsqlSerializationClassifier("").classify(e);
+
+    // Then:
+    assertThat(type, is(Type.UNKNOWN));
+  }
+
+}

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/KsqlSerializationException.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/KsqlSerializationException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.serde;
+
+import org.apache.kafka.common.errors.SerializationException;
+
+public class KsqlSerializationException extends SerializationException {
+
+  private static final long serialVersionUID = 1L;
+  private final String topic;
+
+  public KsqlSerializationException(
+      final String topic, final String message, final Throwable throwable) {
+    super(message, throwable);
+    this.topic = topic;
+  }
+
+  public KsqlSerializationException(final String topic, final String message) {
+    super(message);
+    this.topic = topic;
+  }
+
+  public String getTopic() {
+    return topic;
+  }
+
+}

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/KsqlConnectSerializer.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/KsqlConnectSerializer.java
@@ -15,10 +15,10 @@
 
 package io.confluent.ksql.serde.connect;
 
+import io.confluent.ksql.serde.KsqlSerializationException;
 import io.confluent.ksql.serde.SerdeUtils;
 import java.util.Map;
 import java.util.Objects;
-import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.storage.Converter;
@@ -52,8 +52,8 @@ public class KsqlConnectSerializer<T> implements Serializer<T> {
       final Object connectRow = translator.toConnectRow(data);
       return converter.fromConnectData(topic, schema, connectRow);
     } catch (final Exception e) {
-      throw new SerializationException(
-          "Error serializing message to topic: " + topic + ". " + e.getMessage(), e);
+      throw new KsqlSerializationException(
+          topic, "Error serializing message to topic: " + topic + ". " + e.getMessage(), e);
     }
   }
 


### PR DESCRIPTION
### Description 
Add a classifier to classify SerializationException as USER error
It looks for the exception message and verifies the topic name doesn't contain the prefix `_confluent_ksql`

### Testing done 
Added unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

