### PR TITLE
chore: fix the link to 0.27.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Change Log
-## [0.27.1](https://github.com/confluentinc/ksql/releases/tag/v0.27.1-ksqldb) (2022-07-21)
+## [0.27.1](https://github.com/confluentinc/ksql/releases/tag/v0.27.1) (2022-07-21)
 
 ### Features
 


### PR DESCRIPTION
### Description 

This PR fixes a broken link to 0.27.1 release in the changelog.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

