### PR TITLE
fix: make api client recognize ddl warnings better

### DIFF
--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/DdlDmlResponseHandlers.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/DdlDmlResponseHandlers.java
@@ -73,8 +73,8 @@ final class DdlDmlResponseHandlers {
   }
 
   private static boolean isIfNotExistsWarning(final JsonObject ksqlEntity) {
-    return ksqlEntity.getString("statementText") != null
-        && ksqlEntity.getString("statementText").contains("IF NOT EXISTS")
+    return ksqlEntity.getString("message") != null
+        && ksqlEntity.getString("message").startsWith("Cannot add")
         && ksqlEntity.getString("@type") != null
         && ksqlEntity.getString("@type").equals("warning_entity");
   }

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -34,6 +34,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
@@ -827,6 +828,34 @@ public class ClientIntegrationTest {
     assertThat(e.getCause().getMessage(), containsString("Received 400 response from server"));
     assertThat(e.getCause().getMessage(), containsString("Stream NONEXISTENT does not exist"));
     assertThat(e.getCause().getMessage(), containsString("Error code: 40001"));
+  }
+
+  @Test
+  public void shouldHandleWarningResponseFromExecuteStatement()
+      throws ExecutionException, InterruptedException {
+    // Given:
+    client.executeStatement("create table if not exists tasks (taskId varchar primary key) with (kafka_topic='tasks', value_format='json', partitions=1);").get();
+
+    // When:
+    final ExecuteStatementResult result =
+        client.executeStatement("create table if not exists tasks (taskId varchar primary key) with (kafka_topic='tasks', value_format='json', partitions=1);").get();
+
+    // Then
+    assertFalse(result.queryId().isPresent());
+  }
+
+  @Test
+  public void shouldRejectWarningsFromConnectorRequestsInExecuteStatement() throws Exception {
+    // When
+    final Exception e = assertThrows(
+        ExecutionException.class, // thrown from .get() when the future completes exceptionally
+        () -> client.executeStatement("DROP CONNECTOR IF EXISTS foo;").get()
+    );
+
+    // Then
+    assertThat(e.getCause(), instanceOf(KsqlClientException.class));
+    assertThat(e.getCause().getMessage(), containsString("The ksqlDB server accepted the statement issued via executeStatement(), but the response received is of an unexpected format."));
+    assertThat(e.getCause().getMessage(), containsString("Use the dropConnector() method instead."));
   }
 
   @Test


### PR DESCRIPTION
### Description 
Fixes #9253

Previously, we were identifying DDL warnings by looking for "IF NOT EXISTS" in the command, but that fails when the command is in lower case or has extra spaces.

See discussion in #8322 for context on why we are filtering warning responses to begin with.

### Testing done 
Unit + integration

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

