### PR TITLE
feat: generalize JSON_SR union field names

### DIFF
--- a/ksqldb-functional-tests/src/test/resources/historical_plans/json_sr_-_value_-_union_schema_inference/7.3.0_1658848563187/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/json_sr_-_value_-_union_schema_inference/7.3.0_1658848563187/plan.json
@@ -1,0 +1,303 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (`connect_union_field_0` STRUCT<`keyCode` STRING>, `connect_union_field_1` STRUCT<`itemCode` STRING>) WITH (KAFKA_TOPIC='input', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON_SR', VALUE_SCHEMA_ID=1);",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`connect_union_field_0` STRUCT<`keyCode` STRING>, `connect_union_field_1` STRUCT<`itemCode` STRING>",
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON_SR",
+          "properties" : {
+            "schemaId" : "1"
+          }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM KEYCODES AS SELECT INPUT.`connect_union_field_0`->`keyCode` `keyCode`\nFROM INPUT INPUT\nWHERE (INPUT.`connect_union_field_0` IS NOT NULL)\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "KEYCODES",
+      "schema" : "`keyCode` STRING",
+      "timestampColumn" : null,
+      "topicName" : "KEYCODES",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON_SR",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "KEYCODES",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "KEYCODES"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamFilterV1",
+            "properties" : {
+              "queryContext" : "WhereFilter"
+            },
+            "source" : {
+              "@type" : "streamSourceV1",
+              "properties" : {
+                "queryContext" : "KsqlTopic/Source"
+              },
+              "topicName" : "input",
+              "formats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "JSON_SR",
+                  "properties" : {
+                    "schemaId" : "1"
+                  }
+                }
+              },
+              "timestampColumn" : null,
+              "sourceSchema" : "`connect_union_field_0` STRUCT<`keyCode` STRING>, `connect_union_field_1` STRUCT<`itemCode` STRING>",
+              "pseudoColumnVersion" : 1
+            },
+            "filterExpression" : "(`connect_union_field_0` IS NOT NULL)"
+          },
+          "keyColumnNames" : [ ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "`connect_union_field_0`->`keyCode` AS `keyCode`" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON_SR",
+            "properties" : { }
+          }
+        },
+        "topicName" : "KEYCODES",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_KEYCODES_0",
+      "runtimeId" : null
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM ITEMCODES AS SELECT INPUT.`connect_union_field_1`->`itemCode` `itemCode`\nFROM INPUT INPUT\nWHERE (INPUT.`connect_union_field_1` IS NOT NULL)\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "ITEMCODES",
+      "schema" : "`itemCode` STRING",
+      "timestampColumn" : null,
+      "topicName" : "ITEMCODES",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON_SR",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "ITEMCODES",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "ITEMCODES"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamFilterV1",
+            "properties" : {
+              "queryContext" : "WhereFilter"
+            },
+            "source" : {
+              "@type" : "streamSourceV1",
+              "properties" : {
+                "queryContext" : "KsqlTopic/Source"
+              },
+              "topicName" : "input",
+              "formats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "JSON_SR",
+                  "properties" : {
+                    "schemaId" : "1"
+                  }
+                }
+              },
+              "timestampColumn" : null,
+              "sourceSchema" : "`connect_union_field_0` STRUCT<`keyCode` STRING>, `connect_union_field_1` STRUCT<`itemCode` STRING>",
+              "pseudoColumnVersion" : 1
+            },
+            "filterExpression" : "(`connect_union_field_1` IS NOT NULL)"
+          },
+          "keyColumnNames" : [ ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "`connect_union_field_1`->`itemCode` AS `itemCode`" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON_SR",
+            "properties" : { }
+          }
+        },
+        "topicName" : "ITEMCODES",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_ITEMCODES_1",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.websocket.connection.max.timeout.ms" : "0",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "true",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.json_sr.converter.deserializer.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/json_sr_-_value_-_union_schema_inference/7.3.0_1658848563187/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/json_sr_-_value_-_union_schema_inference/7.3.0_1658848563187/spec.json
@@ -1,0 +1,239 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1658848563187,
+  "path" : "query-validation-tests/json_sr.json",
+  "schemas" : {
+    "CSAS_ITEMCODES_1.KsqlTopic.Source" : {
+      "schema" : "`connect_union_field_0` STRUCT<`keyCode` STRING>, `connect_union_field_1` STRUCT<`itemCode` STRING>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON_SR",
+        "properties" : {
+          "schemaId" : "1"
+        }
+      }
+    },
+    "CSAS_ITEMCODES_1.ITEMCODES" : {
+      "schema" : "`itemCode` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON_SR"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "value - union schema inference",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "connect_union_field_0" : {
+          "keyCode" : "key1"
+        },
+        "connect_union_field_1" : null
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "connect_union_field_1" : {
+          "itemCode" : "item1"
+        }
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "connect_union_field_0" : {
+          "keyCode" : "key2"
+        },
+        "connect_union_field_1" : null
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "connect_union_field_1" : {
+          "itemCode" : "item2"
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "KEYCODES",
+      "key" : null,
+      "value" : {
+        "keyCode" : "key1"
+      }
+    }, {
+      "topic" : "KEYCODES",
+      "key" : null,
+      "value" : {
+        "keyCode" : "key2"
+      }
+    }, {
+      "topic" : "ITEMCODES",
+      "key" : null,
+      "value" : {
+        "itemCode" : "item1"
+      }
+    }, {
+      "topic" : "ITEMCODES",
+      "key" : null,
+      "value" : {
+        "itemCode" : "item2"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "valueSchema" : {
+        "anyOf" : [ {
+          "properties" : {
+            "keyCode" : {
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        }, {
+          "properties" : {
+            "itemCode" : {
+              "type" : "string"
+            }
+          },
+          "type" : "object"
+        } ]
+      },
+      "valueFormat" : "JSON",
+      "replicas" : 1,
+      "numPartitions" : 1
+    }, {
+      "name" : "KEYCODES",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "ITEMCODES",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT WITH (kafka_topic='input', value_format='JSON_SR', value_schema_id=1);", "CREATE STREAM KEYCODES AS SELECT `connect_union_field_0`->`keyCode` FROM INPUT WHERE `connect_union_field_0` is not null;", "CREATE STREAM ITEMCODES AS SELECT `connect_union_field_1`->`itemCode` FROM INPUT WHERE `connect_union_field_1` is not null;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`connect_union_field_0` STRUCT<`keyCode` STRING>, `connect_union_field_1` STRUCT<`itemCode` STRING>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON_SR",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "ITEMCODES",
+        "type" : "STREAM",
+        "schema" : "`itemCode` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON_SR",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "KEYCODES",
+        "type" : "STREAM",
+        "schema" : "`keyCode` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON_SR",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "ITEMCODES",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON_SR"
+          },
+          "partitions" : 4,
+          "valueSchema" : {
+            "type" : "object",
+            "properties" : {
+              "itemCode" : {
+                "connect.index" : 0,
+                "oneOf" : [ {
+                  "type" : "null"
+                }, {
+                  "type" : "string"
+                } ]
+              }
+            }
+          }
+        }, {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON_SR",
+            "properties" : {
+              "schemaId" : "1"
+            }
+          },
+          "partitions" : 1,
+          "valueSchema" : {
+            "oneOf" : [ {
+              "type" : "object",
+              "connect.index" : 0,
+              "properties" : {
+                "keyCode" : {
+                  "type" : "string",
+                  "connect.index" : 0
+                }
+              }
+            }, {
+              "type" : "object",
+              "connect.index" : 1,
+              "properties" : {
+                "itemCode" : {
+                  "type" : "string",
+                  "connect.index" : 0
+                }
+              }
+            } ]
+          }
+        }, {
+          "name" : "KEYCODES",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON_SR"
+          },
+          "partitions" : 4,
+          "valueSchema" : {
+            "type" : "object",
+            "properties" : {
+              "keyCode" : {
+                "connect.index" : 0,
+                "oneOf" : [ {
+                  "type" : "null"
+                }, {
+                  "type" : "string"
+                } ]
+              }
+            }
+          }
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/json_sr_-_value_-_union_schema_inference/7.3.0_1658848563187/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/json_sr_-_value_-_union_schema_inference/7.3.0_1658848563187/topology
@@ -1,0 +1,16 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: ITEMCODES)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/json_sr.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/json_sr.json
@@ -846,6 +846,59 @@
       ]
     },
     {
+      "name": "value - union schema inference",
+      "statements": [
+        "CREATE STREAM INPUT WITH (kafka_topic='input', value_format='JSON_SR', value_schema_id=1);",
+        "CREATE STREAM KEYCODES AS SELECT `connect_union_field_0`->`keyCode` FROM INPUT WHERE `connect_union_field_0` is not null;",
+        "CREATE STREAM ITEMCODES AS SELECT `connect_union_field_1`->`itemCode` FROM INPUT WHERE `connect_union_field_1` is not null;"
+      ],
+      "topics": [
+        {
+          "name": "input",
+          "valueFormat": "JSON_SR",
+          "valueSchema": {
+            "anyOf": [
+              {
+                "properties": {
+                  "keyCode": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "itemCode": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            ]
+          }
+        }
+      ],
+      "inputs": [
+        {"topic": "input", "key": null, "value": { "connect_union_field_0": { "keyCode": "key1" }, "connect_union_field_1": null } },
+        {"topic": "input", "key": null, "value": { "connect_union_field_1": null, "connect_union_field_1": { "itemCode": "item1" } } },
+        {"topic": "input", "key": null, "value": { "connect_union_field_0": { "keyCode": "key2" }, "connect_union_field_1": null } },
+        {"topic": "input", "key": null, "value": { "connect_union_field_1": null, "connect_union_field_1": { "itemCode": "item2" } } }
+      ],
+      "outputs": [
+        {"topic": "KEYCODES", "key": null, "value": { "keyCode": "key1" } },
+        {"topic": "KEYCODES", "key": null, "value": { "keyCode": "key2" } },
+        {"topic": "ITEMCODES", "key": null, "value": { "itemCode": "item1" } },
+        {"topic": "ITEMCODES", "key": null, "value": { "itemCode": "item2" } }
+      ],
+      "post": {
+        "sources": [
+          {"name": "INPUT", "type": "stream", "schema": "`connect_union_field_0` STRUCT<`keyCode` STRING>, `connect_union_field_1` STRUCT<`itemCode` STRING>"},
+          {"name" : "KEYCODES", "type" : "STREAM", "schema" : "`keyCode` STRING", "valueFormat" : "JSON_SR"},
+          {"name" : "ITEMCODES", "type" : "STREAM", "schema" : "`itemCode` STRING", "valueFormat" : "JSON_SR"}
+        ]
+      }
+    },
+    {
       "name": "map with non-string keys fails",
       "statements": [
         "CREATE STREAM INPUT (foo MAP<INT, DOUBLE>) WITH (kafka_topic='input_topic', value_format='JSON_SR');"

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/JsonSchemaTranslator.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/JsonSchemaTranslator.java
@@ -33,7 +33,12 @@ public class JsonSchemaTranslator implements ConnectSchemaTranslator {
 
   private final JsonSchemaData jsonData = new JsonSchemaData(new JsonSchemaDataConfig(
       ImmutableMap.of(
-          JsonConverterConfig.DECIMAL_FORMAT_CONFIG, DecimalFormat.NUMERIC.name()
+          JsonConverterConfig.DECIMAL_FORMAT_CONFIG, DecimalFormat.NUMERIC.name(),
+
+          // Makes naming of unions consistent between all SR formats
+          // i.e. instead of `IO.CONFLUENT.CONNECT.JSON.ONEOF.FIELD.0` field names, we'll get
+          // `connect_union_field_0` names
+          JsonSchemaDataConfig.GENERALIZED_SUM_TYPE_SUPPORT_CONFIG, true
       )
   ));
 

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonSerdeFactory.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonSerdeFactory.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.connect.json.JsonSchemaConverter;
 import io.confluent.connect.json.JsonSchemaConverterConfig;
+import io.confluent.connect.json.JsonSchemaDataConfig;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.ksql.schema.connect.SchemaWalker;
@@ -176,6 +177,12 @@ class KsqlJsonSerdeFactory implements SerdeFactory {
         JsonSchemaConverterConfig.SCHEMA_REGISTRY_URL_CONFIG,
         ksqlConfig.getString(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY)
     );
+
+    // Makes naming of unions consistent between all SR formats
+    // i.e. instead of `IO.CONFLUENT.CONNECT.JSON.ONEOF.FIELD.0` field names, we'll get
+    // `connect_union_field_0` names
+    config.put(JsonSchemaDataConfig.GENERALIZED_SUM_TYPE_SUPPORT_CONFIG, true);
+
     if (schemaId.isPresent()) {
       // Disable auto registering schema if schema id is used
       config.put(AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS, false);


### PR DESCRIPTION
### Description 

The PR on  https://github.com/confluentinc/ksql/pull/9130 uses the new `JsonSchemaConverter` to deserialize JSON_SR records. When `anyOf` types are present in the schema, which are supported by the new converter, the union fields use names that are inconsistent with other SR formats, for instance `IO.CONFLUENT.CONNECT.JSON.ONEOF.FIELD.0`. This PR enables a `JsonSchemaConverter` flag to generialize the names and make them consistent with other SR formats.


### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

