### PR TITLE
refactor: combine yatt input and output nodes into one topic node

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/TestDriverPipeline.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/TestDriverPipeline.java
@@ -39,6 +39,26 @@ public class TestDriverPipeline {
   /*
    * The pipeline is represented as a tree of topic nodes. Each node keeps track of what nodes
    * read from them, as well as the "pipes" flowing in and out of them.
+   *
+   * For example, the pipeline for
+   *
+   * CREATE STREAM B AS SELECT * FROM A;
+   * CREATE STREAM C AS SELECT * FROM A;
+   * CREATE STREAM D AS SELECT * FROM C;
+   *
+   * looks like:
+   *                               ---------------
+   *                               | Topic B     |
+   *                           |---| Input pipes |
+   *                           |   | Output pipes|
+   *    ---------------        |   ---------------
+   *    | Topic A     |        |
+   *    | Input pipes |        |   ---------------
+   *    | Output pipes|--------|   | Topic C     |         ----------------
+   *    ----------- ---        |---| Input pipes |         | Topic D      |
+   *                               | Output pipes|---------| Input pipes  |
+   *                               ---------------         | Output pipes |
+   *                                                       ----------------
    */
 
   // ----------------------------------------------------------------------------------

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/TestDriverPipeline.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/TestDriverPipeline.java
@@ -27,8 +27,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TestOutputTopic;
@@ -37,60 +37,11 @@ import org.apache.kafka.streams.test.TestRecord;
 
 public class TestDriverPipeline {
   /*
-   * The pipeline is represented as a DAG of input/output nodes. The key aspect
-   * to notice is that each output topic may be the input topic for one or more
-   * topologies. Since each TopologyTestDriver is independent from one another,
-   * we need to pipe the output of one topology into each other topology that
-   * uses that topic as an input node manually.
-   *
-   * Take, for example, the pipeline below.
-   *
-   *                                                  +----------+     +-------+
-   *                                      +---------->+  bar.in  +---->+ topo2 |
-   *                                      |           +----------+     +-------+
-   *  +----------+     +-------+     +----+-----+
-   *  |  foo.in  +---->+ topo1 +---->+  bar.out |
-   *  +----------+     +-------+     +----+-----+
-   *                                      |           +----------+     +-------+
-   *                                      +---------->+  bar.in  +---->+ topo3 |
-   *                                                  +----------+     +-------+
-   *  +----------+     +-------+     +----------+
-   *  |  foo.in  +---->+ topo4 +---->+  baz.out |
-   *  +----------+     +-------+     +----------+
-   *
-   * There are four topologies which are all somehow related. topo1 and topo4 both
-   * read from foo.in but produce to different output topics. The output topic for
-   * topo1 (bar) is used as the input topic for two other topologies (topo2 as well
-   * as topo3).
-   *
-   * To model this pipeline, we track a mapping from topic to its corresponding input
-   * and output topics as well as a tree representation of the pipeline. In the diagram
-   * above, each ".in" is an independent input node and each ".out" is an independent
-   * output node (even if they share the same name).
+   * The pipeline is represented as a tree of topic nodes. Each node keeps track of what nodes
+   * read from them, as well as the "pipes" flowing in and out of them.
    */
 
   // ----------------------------------------------------------------------------------
-  private static final class Input {
-
-    private final TestInputTopic<GenericKey, GenericRow> topic;
-    private final List<Output> receivers;
-
-    private Input(final TestInputTopic<GenericKey, GenericRow> topic) {
-      this.topic = topic;
-      this.receivers = new ArrayList<>();
-    }
-  }
-
-  private static final class Output {
-
-    private final String name;
-    private final TestOutputTopic<GenericKey, GenericRow> topic;
-
-    private Output(final String name, final TestOutputTopic<GenericKey, GenericRow> topic) {
-      this.name = name;
-      this.topic = topic;
-    }
-  }
 
   public static final class TopicInfo {
     final String name;
@@ -108,10 +59,32 @@ public class TestDriverPipeline {
     }
   }
 
+  private static final class Topic {
+    // Topics that read from this topic
+    private final List<Topic> receivers;
+    // Drivers that take this topic as an input
+    private final List<TopologyTestDriver> drivers;
+    // Pipes flowing out of this topic
+    private final List<TestInputTopic<GenericKey, GenericRow>> topicAsInput;
+    // Pipe flowing into this topic.
+    // For now, it's left as Optional because we don't support INSERT INTO...SELECT yet.
+    private Optional<TestOutputTopic<GenericKey, GenericRow>> topicAsOutput;
+    private final String name;
+
+    private Topic(
+        final String name
+    ) {
+      this.receivers = new ArrayList<>();
+      this.drivers = new ArrayList<>();
+      this.topicAsInput = new ArrayList<>();
+      this.topicAsOutput = Optional.empty();
+      this.name = name;
+    }
+  }
+
   // ----------------------------------------------------------------------------------
 
-  private final ListMultimap<String, Input> inputs;
-  private final ListMultimap<String, Output> outputs;
+  private final Map<String, Topic> topics;
   private final ListMultimap<String, TestRecord<GenericKey, GenericRow>> topicCache;
 
   // this map indexes into the outputCache to track which records we've already
@@ -120,28 +93,30 @@ public class TestDriverPipeline {
   private final Map<String, Integer> assertPositions;
 
   public TestDriverPipeline() {
-    inputs = ArrayListMultimap.create();
-    outputs = ArrayListMultimap.create();
+    topics = new HashMap<>();
     topicCache = ArrayListMultimap.create();
-
     assertPositions = new HashMap<>();
   }
 
-  public void addDdlTopic(
-      final TopologyTestDriver driver, final TopicInfo topic
-  ) {
-    final List<Input> oldInputs = inputs.get(topic.name)
-        .stream()
-        .filter(input -> input.receivers.size() == 0)
-        .collect(Collectors.toList());
-    oldInputs.forEach(input -> inputs.remove(topic.name, input));
-    final Input input = new Input(
-        driver.createInputTopic(
-            topic.name,
-            topic.keySerde.serializer(),
-            topic.valueSerde.serializer())
+  private TestInputTopic createInputTopic(final TopologyTestDriver driver, final TopicInfo topic) {
+    return driver.createInputTopic(
+        topic.name,
+        topic.keySerde.serializer(),
+        topic.valueSerde.serializer()
     );
-    inputs.put(topic.name, input);
+  }
+
+  private void replaceAllInputs(final TopicInfo topic) {
+    topics.get(topic.name).topicAsInput.clear();
+    topics.get(topic.name).drivers.forEach(driver -> topics.get(topic.name).topicAsInput.add(createInputTopic(driver, topic)));
+  }
+
+  public void addDdlTopic(final TopicInfo topic) {
+    if (!topics.containsKey(topic.name)) {
+      topics.put(topic.name, new Topic(topic.name));
+    } else {
+      replaceAllInputs(topic);
+    }
   }
 
   public void addDriver(
@@ -149,30 +124,27 @@ public class TestDriverPipeline {
       final List<TopicInfo> inputTopics,
       final TopicInfo outputTopic
   ) {
-    // first create the output node, since whenever an event is piped to the
-    // input nodes we will need to read and propagate events to the output
-    // node
-    final Output output = new Output(
+    final TestOutputTopic output = driver.createOutputTopic(
         outputTopic.name,
-        driver.createOutputTopic(
-            outputTopic.name,
-            outputTopic.keySerde.deserializer(),
-            outputTopic.valueSerde.deserializer())
-    );
-    outputs.put(outputTopic.name, output);
+        outputTopic.keySerde.deserializer(),
+        outputTopic.valueSerde.deserializer());
+
+    if (!topics.containsKey(outputTopic.name)) {
+      topics.put(outputTopic.name, new Topic(outputTopic.name));
+    } else {
+      replaceAllInputs(outputTopic);
+    }
+    topics.get(outputTopic.name).topicAsOutput = Optional.of(output);
 
     for (TopicInfo inputTopic : inputTopics) {
-      final Input input = new Input(
-          driver.createInputTopic(
-              inputTopic.name,
-              inputTopic.keySerde.serializer(),
-              inputTopic.valueSerde.serializer())
-      );
-      inputs.put(inputTopic.name, input);
+      final TestInputTopic input = createInputTopic(driver, inputTopic);
 
-      // whenever we pipe data into input, we will need to also propagate the
-      // output for any topic that uses "outputTopic" as an input topic
-      input.receivers.add(output);
+      if (!topics.containsKey(inputTopic.name)) {
+        topics.put(inputTopic.name, new Topic(inputTopic.name));
+      }
+      topics.get(inputTopic.name).topicAsInput.add(input);
+      topics.get(inputTopic.name).receivers.add(topics.get(outputTopic.name));
+      topics.get(inputTopic.name).drivers.add(driver);
     }
   }
 
@@ -186,44 +158,44 @@ public class TestDriverPipeline {
   }
 
   private void pipeInput(
-      final String topic,
+      final String topicName,
       final GenericKey key,
       final GenericRow value,
       final long timestampMs,
       final Set<String> loopDetection,
       final String path
   ) {
-    final boolean added = loopDetection.add(topic);
+    final boolean added = loopDetection.add(topicName);
     if (!added) {
       throw new KsqlException("Detected illegal cycle in topology: " + path);
     }
 
-    final List<Input> inputs = this.inputs.get(topic);
-    if (inputs.isEmpty()) {
-      throw new KsqlException("Cannot pipe input to unknown source: " + topic);
+    if (!topics.containsKey(topicName)) {
+      throw new KsqlException("Cannot pipe input to unknown source: " + topicName);
     }
 
-    if (topic.equals(path)) {
-      topicCache.put(topic, new TestRecord(key, value, Instant.ofEpochMilli(timestampMs)));
+    final Topic topic = this.topics.get(topicName);
+
+    if (topicName.equals(path)) {
+      topicCache.put(topicName, new TestRecord(key, value, Instant.ofEpochMilli(timestampMs)));
     }
-    for (final Input input : inputs) {
-      input.topic.pipeInput(key, value, timestampMs);
 
-      // handle the fallout of piping in a record (propagation)
-      for (final Output receiver : input.receivers) {
-        for (final TestRecord<GenericKey, GenericRow> record : receiver.topic.readRecordsToList()) {
-          topicCache.put(receiver.name, record);
+    for (final TestInputTopic input : topic.topicAsInput) {
+      input.pipeInput(key, value, timestampMs);
+    }
 
-          if (this.inputs.containsKey(receiver.name)) {
-            pipeInput(
-                receiver.name,
-                record.key(),
-                record.value(),
-                record.timestamp(),
-                new HashSet<>(loopDetection),
-                path + "->" + receiver.name
-            );
-          }
+    for (final Topic receiver : topic.receivers) {
+      for (final TestRecord<GenericKey, GenericRow> record : receiver.topicAsOutput.get().readRecordsToList()) {
+        topicCache.put(receiver.name, record);
+        if (topics.get(receiver.name).topicAsInput.size() > 0) {
+          pipeInput(
+              receiver.name,
+              record.key(),
+              record.value(),
+              record.timestamp(),
+              new HashSet<>(loopDetection),
+              path + "->" + receiver.name
+          );
         }
       }
     }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/TestDriverPipeline.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/TestDriverPipeline.java
@@ -108,7 +108,8 @@ public class TestDriverPipeline {
 
   private void replaceAllInputs(final TopicInfo topic) {
     topics.get(topic.name).topicAsInput.clear();
-    topics.get(topic.name).drivers.forEach(driver -> topics.get(topic.name).topicAsInput.add(createInputTopic(driver, topic)));
+    topics.get(topic.name).drivers.forEach(driver ->
+            topics.get(topic.name).topicAsInput.add(createInputTopic(driver, topic)));
   }
 
   public void addDdlTopic(final TopicInfo topic) {
@@ -185,7 +186,8 @@ public class TestDriverPipeline {
     }
 
     for (final Topic receiver : topic.receivers) {
-      for (final TestRecord<GenericKey, GenericRow> record : receiver.topicAsOutput.get().readRecordsToList()) {
+      for (final TestRecord<GenericKey, GenericRow> record :
+          receiver.topicAsOutput.get().readRecordsToList()) {
         topicCache.put(receiver.name, record);
         if (topics.get(receiver.name).topicAsInput.size() > 0) {
           pipeInput(

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
@@ -258,21 +258,12 @@ public class KsqlTesterTest {
           ? ((CreateSource) injected.getStatement()).getName()
           : ((AlterSource) injected.getStatement()).getName();
       final DataSource input = engine.getMetaStore().getSource(name);
-      final Topology topology = new Topology();
-      topology.addSource(input.getKafkaTopicName(), input.getKafkaTopicName());
-      final Properties properties = new Properties();
-      properties.put(StreamsConfig.STATE_DIR_CONFIG, tmpFolder.getRoot().getAbsolutePath());
-      properties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
-      properties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
-
-      final TopologyTestDriver driver = new TopologyTestDriver(topology, properties);
       final TopicInfo inputTopic = new TopicInfo(
           input.getKafkaTopicName(),
           keySerde(input),
           valueSerde(input)
       );
-
-      driverPipeline.addDdlTopic(driver, inputTopic);
+      driverPipeline.addDdlTopic(inputTopic);
       return;
     }
 

--- a/ksqldb-functional-tests/src/test/resources/sql-tests/query-upgrades/chained-upgrades.sql
+++ b/ksqldb-functional-tests/src/test/resources/sql-tests/query-upgrades/chained-upgrades.sql
@@ -16,3 +16,23 @@ INSERT INTO a (id, col1, col2) VALUES (1, 0, 1);
 INSERT INTO a (id, col1, col2) VALUES (1, 1, 1);
 
 ASSERT VALUES b (id, col1, col2) VALUES (1, 1, 1);
+
+----------------------------------------------------------------------------------------------------
+--@test: ddl evolution
+----------------------------------------------------------------------------------------------------
+
+CREATE STREAM a (id INT KEY, col1 INT) WITH (kafka_topic='a', value_format='JSON');
+CREATE STREAM b AS SELECT * FROM a;
+
+INSERT INTO a (id, col1) VALUES (1, 1);
+ASSERT VALUES b (id, col1) VALUES (1, 1);
+CREATE OR REPLACE STREAM a (id INT KEY, col1 INT, col2 INT) WITH (kafka_topic='a', value_format='JSON');
+
+INSERT INTO a (id, col1, col2) VALUES (1, 55, 1);
+ASSERT VALUES b (id, col1) VALUES (1, 55);
+
+CREATE STREAM c AS SELECT * FROM b;
+CREATE OR REPLACE STREAM b AS SELECT id, col1, col1 + 1 as col1_add FROM a;
+INSERT INTO a (id, col1, col2) VALUES (1, 20, 3);
+ASSERT VALUES b (id, col1, col1_add) VALUES (1, 20, 21);
+ASSERT VALUES c (id, col1) VALUES (1, 20);


### PR DESCRIPTION
### Description 
Fixes #6059. Also enables schema upgrades on big chains of queries :)

Previously, every time a query was called, YATT would create a new input node and a new output node specifically for that query. This made evolution complicated, because the same topic would have several nodes associated with it and we would have to update every single one with the new schema. This refactor consolidates all the input and output nodes into a single topic node to make query upgrades possible. 

### Testing done 
added a yatt test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

