### PR TITLE
chore: add TERMINATED server state

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
@@ -381,6 +381,7 @@ public class CommandRunner implements Closeable {
         .getOrDefault(ClusterTerminateRequest.DELETE_TOPIC_LIST_PROP, Collections.emptyList());
 
     clusterTerminator.terminateCluster(deleteTopicList);
+    serverState.setTerminated();
     LOG.info("The KSQL server was terminated.");
     closeEarly();
     LOG.debug("The KSQL command runner was closed.");

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ServerStateTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ServerStateTest.java
@@ -48,6 +48,15 @@ public class ServerStateTest extends BaseApiTest {
     validateResponse(503, Errors.ERROR_CODE_SERVER_SHUTTING_DOWN, "The server is shutting down");
   }
 
+  @Test
+  public void shouldReturn503IfTerminated() throws Exception {
+    // Given:
+    this.serverState.setTerminated();
+
+    // When/Then:
+    validateResponse(503, Errors.ERROR_CODE_SERVER_SHUT_DOWN, "The server is shut down");
+  }
+
   private void validateResponse(
       final int expectedStatus,
       final int expectedErrorCode,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ClusterTerminationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ClusterTerminationTest.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.rest.integration;
 
 import static io.confluent.ksql.serde.FormatFactory.JSON;
 import static io.confluent.ksql.serde.FormatFactory.KAFKA;
+import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -111,17 +112,17 @@ public class ClusterTerminationTest {
     );
 
     // Then:
-    shouldReturn50303WhenTerminating();
+    shouldReturn50304WhenTerminating();
   }
 
-  private void shouldReturn50303WhenTerminating() {
+  private void shouldReturn50304WhenTerminating() {
     // Given: TERMINATE CLUSTER has been issued
 
     // When:
     final KsqlErrorMessage error = RestIntegrationTestUtil.makeKsqlRequestWithError(REST_APP, "SHOW STREAMS;");
 
     // Then:
-    assertThat(error.getErrorCode(), is(Errors.ERROR_CODE_SERVER_SHUT_DOWN));
+    assertThatEventually(() -> error.getErrorCode(), is(Errors.ERROR_CODE_SERVER_SHUT_DOWN));
   }
 
   private static void terminateCluster(final List<String> deleteTopicList) {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ClusterTerminationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ClusterTerminationTest.java
@@ -121,7 +121,7 @@ public class ClusterTerminationTest {
     final KsqlErrorMessage error = RestIntegrationTestUtil.makeKsqlRequestWithError(REST_APP, "SHOW STREAMS;");
 
     // Then:
-    assertThat(error.getErrorCode(), is(Errors.ERROR_CODE_SERVER_SHUTTING_DOWN));
+    assertThat(error.getErrorCode(), is(Errors.ERROR_CODE_SERVER_SHUT_DOWN));
   }
 
   private static void terminateCluster(final List<String> deleteTopicList) {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
@@ -225,6 +225,7 @@ public class CommandRunnerTest {
     inOrder.verify(serverState).setTerminating();
     inOrder.verify(commandStore).wakeup();
     inOrder.verify(clusterTerminator).terminateCluster(anyList());
+    inOrder.verify(serverState).setTerminated();
 
     verify(statementExecutor, never()).handleRestore(any());
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/state/ServerStateTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/state/ServerStateTest.java
@@ -60,4 +60,20 @@ public class ServerStateTest {
     assertThat(response.getStatus(), equalTo(expected.getStatus()));
     assertThat(response.getEntity(), equalTo(expected.getEntity()));
   }
+
+  @Test
+  public void shouldReturnErrorWhenTerminated() {
+    // Given:
+    serverState.setTerminated();
+
+    // When:
+    final Optional<EndpointResponse> result = serverState.checkReady();
+
+    // Then:
+    assertThat(result.isPresent(), is(true));
+    final EndpointResponse response = result.get();
+    final EndpointResponse expected = Errors.serverShutDown();
+    assertThat(response.getStatus(), equalTo(expected.getStatus()));
+    assertThat(response.getEntity(), equalTo(expected.getEntity()));
+  }
 }

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/Errors.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/Errors.java
@@ -71,6 +71,9 @@ public final class Errors {
   public static final int ERROR_CODE_SERVER_SHUTTING_DOWN =
       toErrorCode(SERVICE_UNAVAILABLE.code()) + 3;
 
+  public static final int ERROR_CODE_SERVER_SHUT_DOWN =
+      toErrorCode(SERVICE_UNAVAILABLE.code()) + 3;
+
   public static final int ERROR_CODE_SERVER_ERROR =
       toErrorCode(INTERNAL_SERVER_ERROR.code());
   
@@ -204,6 +207,15 @@ public final class Errors {
         .entity(new KsqlErrorMessage(
             ERROR_CODE_SERVER_SHUTTING_DOWN,
             "The server is shutting down"))
+        .build();
+  }
+
+  public static EndpointResponse serverShutDown() {
+    return EndpointResponse.create()
+        .status(SERVICE_UNAVAILABLE.code())
+        .entity(new KsqlErrorMessage(
+            ERROR_CODE_SERVER_SHUT_DOWN,
+            "The server is shut down"))
         .build();
   }
 

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/Errors.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/Errors.java
@@ -72,7 +72,7 @@ public final class Errors {
       toErrorCode(SERVICE_UNAVAILABLE.code()) + 3;
 
   public static final int ERROR_CODE_SERVER_SHUT_DOWN =
-      toErrorCode(SERVICE_UNAVAILABLE.code()) + 3;
+      toErrorCode(SERVICE_UNAVAILABLE.code()) + 4;
 
   public static final int ERROR_CODE_SERVER_ERROR =
       toErrorCode(INTERNAL_SERVER_ERROR.code());


### PR DESCRIPTION
### Description 
Add a new server state `TERMINATED` for when we have finished cleaning up state after calling `clusterTerminator.terminateCluster(deleteTopicList)`

### Testing done 
Unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

