### PR TITLE
minor: Allow passing test name as a parameter to run specific tests

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/loader/TestLoader.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/loader/TestLoader.java
@@ -33,7 +33,14 @@ public interface TestLoader<T extends Test> {
   // Example:
   //   mvn test -pl ksql-engine -Dtest=QueryTranslationTest -Dksql.test.files=test1.json
   //   mvn test -pl ksql-engine -Dtest=QueryTranslationTest -Dksql.test.files=test1.json,test2,json
+  // Pass a single test name or multiple test names separated by commas to the test framework.
+  // Example:
+  //   mvn test -pl ksql-engine -Dtest=QueryTranslationTest -Dksql.test.names="foo bar"
+  //   mvn test -pl ksql-engine -Dtest=QueryTranslationTest -Dksql.test.names="foo bar","foo baz"
+  //   mvn test -pl ksql-engine -Dtest=QueryTranslationTest
+  //        -Dksql.test.files=foo.sql -Dksql.test.names="foo bar"
   String KSQL_TEST_FILES = "ksql.test.files";
+  String KSQL_TEST_NAMES = "ksql.test.names";
 
   Stream<T> load() throws IOException;
 
@@ -44,5 +51,14 @@ public interface TestLoader<T extends Test> {
     }
 
     return ImmutableList.copyOf(ksqlTestFiles.split(","));
+  }
+
+  static List<String> getWhiteListTestNames() {
+    final String ksqlTestNames = System.getProperty(KSQL_TEST_NAMES, "").trim();
+    if (ksqlTestNames.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    return ImmutableList.copyOf(ksqlTestNames.split(","));
   }
 }


### PR DESCRIPTION
- Currently, we can pass the test file as an input and it runs all the tests
  within the file.
- However, we might be interested in running/debugging a specific test within
  a file or across all the tests
- This commit adds support to a parameter ksql.test.names which accepts one or
  more test names and only runs those whitelisted tests
- It doesn't alter the old behavior i.e. if you don't pass the test names it
  runs all the tests


### Testing done 
Tested by running all the tests without any parameter
Tested by passing the -Dksql.test.names="foo bar" and ensuring only "foo bar" test ran
Tested by passing the -Dksql.test.files=foo.sql and ensuring all tests run from the file
Tested by passing the -Dksql.test.files=foo.sql and -Dksql.test.names="foo bar" and ensuring only "foo bar" test ran
Tested by passing the -Dksql.test.files=foo.sql and -Dksql.test.names="foo bar","foo baz" and ensuring both "foo bar" and "foo baz" ran

