### PR TITLE
fix: complete rollback of pinned nanoversions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ common {
     downStreamRepos = ["confluent-security-plugins", "confluent-cloud-plugins", "cc-docker-ksql"]
     downStreamValidate = false
     nanoVersion = true
-    pinnedNanoVersions = true
+    pinnedNanoVersions = false
     maxBuildsToKeep = 99
     maxDaysToKeep = 90
     extraBuildArgs = "-Dmaven.gitcommitid.nativegit=true"

--- a/pom.xml
+++ b/pom.xml
@@ -291,25 +291,25 @@
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-avro-converter</artifactId>
-                <version>7.3.0-674</version>
+                <version>7.3.0-cc-docker-ksql.119-678-rc2</version>
             </dependency>
 
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-json-serializer</artifactId>
-                <version>7.3.0-674</version>
+                <version>7.3.0-cc-docker-ksql.119-678-rc2</version>
             </dependency>
 
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-avro-serializer</artifactId>
-                <version>7.3.0-674</version>
+                <version>7.3.0-cc-docker-ksql.119-678-rc2</version>
             </dependency>
 
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-schema-registry-client</artifactId>
-                <version>7.3.0-674</version>
+                <version>7.3.0-cc-docker-ksql.119-678-rc2</version>
             </dependency>
 
             <dependency>
@@ -333,25 +333,25 @@
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-json-schema-provider</artifactId>
-                <version>7.3.0-674</version>
+                <version>7.3.0-cc-docker-ksql.119-678-rc2</version>
             </dependency>
 
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-protobuf-provider</artifactId>
-                <version>7.3.0-674</version>
+                <version>7.3.0-cc-docker-ksql.119-678-rc2</version>
             </dependency>
 
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-json-schema-converter</artifactId>
-                <version>7.3.0-674</version>
+                <version>7.3.0-cc-docker-ksql.119-678-rc2</version>
             </dependency>
 
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-protobuf-converter</artifactId>
-                <version>7.3.0-674</version>
+                <version>7.3.0-cc-docker-ksql.119-678-rc2</version>
             </dependency>
 
             <!-- End Confluent dependencies -->


### PR DESCRIPTION
Pinned nanoversions aren't completely implemented for the release stabilization tool, so re-cutting this release resulted in a mixed dependency set. This PR manually fixes up the dependencies and disables pinned nanoversions.

For future reference, there are two commits we need to undo for releases to function:
1. https://github.com/confluentinc/ksql/commit/577029425c4ae4288fa527488acf1ef4820aade2
2. https://github.com/confluentinc/ksql/commit/d3545b9d8873465f967b6e951a45260fb775c948