### PR TITLE
fix: Set auto.register.schemas to false by default #8995

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriter.java
@@ -197,7 +197,7 @@ public class JsonStreamedRowResponseWriter implements QueryStreamResponseWriter 
 
         connectSchema = ConnectSchemas.columnsToConnectSchema(schema.columns());
         serializer = new ProtobufNoSRSerdeFactory(ImmutableMap.of())
-                .createSerializer(connectSchema, Struct.class, false);
+                .createSerializer(connectSchema, Struct.class, false, false);
         return StreamedRow.headerProtobuf(
                 new QueryId(queryId), schema, logicalToProtoSchema(schema));
       }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/SerdeFactory.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/SerdeFactory.java
@@ -27,5 +27,6 @@ public interface SerdeFactory {
       KsqlConfig ksqlConfig,
       Supplier<SchemaRegistryClient> srFactory,
       Class<T> targetType,
-      boolean isKey);
+      boolean isKey,
+      boolean autoRegisterSchemas);
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/avro/AvroFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/avro/AvroFormat.java
@@ -80,7 +80,7 @@ public final class AvroFormat extends ConnectFormat {
     getConnectSchemaTranslator(formatProps).fromConnectSchema(connectSchema);
 
     return new KsqlAvroSerdeFactory(new AvroProperties(formatProps))
-        .createSerde(connectSchema, config, srFactory, targetType, isKey);
+        .createSerde(connectSchema, config, srFactory, targetType, isKey, false);
   }
 
   public static String getKeySchemaName(final String name) {

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/JsonFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/JsonFormat.java
@@ -70,6 +70,6 @@ public class JsonFormat extends ConnectFormat {
       final boolean isKey
   ) {
     return new KsqlJsonSerdeFactory()
-        .createSerde(connectSchema, config, srFactory, targetType, isKey);
+        .createSerde(connectSchema, config, srFactory, targetType, isKey, false);
   }
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/JsonSchemaFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/JsonSchemaFormat.java
@@ -78,6 +78,6 @@ public class JsonSchemaFormat extends ConnectFormat {
       final boolean isKey
   ) {
     return new KsqlJsonSerdeFactory(new JsonSchemaProperties(formatProps))
-        .createSerde(connectSchema, config, srFactory, targetType, isKey);
+        .createSerde(connectSchema, config, srFactory, targetType, isKey, false);
   }
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufFormat.java
@@ -77,6 +77,6 @@ public class ProtobufFormat extends AbstractProtobufFormat {
       final boolean isKey
   ) {
     return new ProtobufSerdeFactory(new ProtobufProperties(formatProps))
-        .createSerde(connectSchema, config, srFactory, targetType, isKey);
+        .createSerde(connectSchema, config, srFactory, targetType, isKey, false);
   }
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufNoSRFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufNoSRFormat.java
@@ -69,6 +69,6 @@ public class ProtobufNoSRFormat extends AbstractProtobufFormat {
       final boolean isKey
   ) {
     return new ProtobufNoSRSerdeFactory(new ProtobufNoSRProperties(formatProps))
-        .createSerde(connectSchema, config, srFactory, targetType, isKey);
+        .createSerde(connectSchema, config, srFactory, targetType, isKey, false);
   }
 }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroDeserializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroDeserializerTest.java
@@ -1599,6 +1599,7 @@ public class KsqlAvroDeserializerTest {
         KSQL_CONFIG,
         () -> schemaRegistryClient,
         targetType,
+        false,
         false).deserializer();
 
     deserializer.configure(Collections.emptyMap(), false);

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSchemaDeserializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSchemaDeserializerTest.java
@@ -96,7 +96,8 @@ public class KsqlJsonSchemaDeserializerTest {
         new KsqlConfig(ImmutableMap.of()),
         () -> schemaRegistryClient,
         Struct.class,
-        false
+        false,
+        false // Results in fetching the id by subject and schema
     );
 
     serializer = serde.serializer();

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSerdeFactoryTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSerdeFactoryTest.java
@@ -67,7 +67,7 @@ public class KsqlJsonSerdeFactoryTest {
 
     // When
     final Serde<String> serde =
-        jsonFactory.createSerde(connectSchema, config, srFactory, String.class, false);
+        jsonFactory.createSerde(connectSchema, config, srFactory, String.class, false, false);
 
     // Then
     assertThat(serde.deserializer(), is(instanceOf(KsqlConnectDeserializer.class)));
@@ -82,7 +82,7 @@ public class KsqlJsonSerdeFactoryTest {
 
     // When
     final Serde<String> serde =
-        jsonFactory.createSerde(connectSchema, config, srFactory, String.class, false);
+        jsonFactory.createSerde(connectSchema, config, srFactory, String.class, false, false);
 
     // Then
     assertThat(serde.deserializer(), is(instanceOf(KsqlJsonDeserializer.class)));
@@ -98,7 +98,7 @@ public class KsqlJsonSerdeFactoryTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> jsonFactory.createSerde(schemaOfInvalidMap, config, srFactory, String.class, false)
+        () -> jsonFactory.createSerde(schemaOfInvalidMap, config, srFactory, String.class, false, false)
     );
 
     // Then:
@@ -120,7 +120,7 @@ public class KsqlJsonSerdeFactoryTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> jsonFactory.createSerde(schemaWithNestedInvalidMap, config, srFactory, String.class, false)
+        () -> jsonFactory.createSerde(schemaWithNestedInvalidMap, config, srFactory, String.class, false, false)
     );
 
     // Then:

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSerializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSerializerTest.java
@@ -235,9 +235,10 @@ public class KsqlJsonSerializerTest {
   @SuppressWarnings("unchecked")
   @Test
   public void shouldThrowOnWrongValueType() {
+    boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
     final Serializer serializer =
-        givenSerializerForSchema(SchemaBuilder.OPTIONAL_INT64_SCHEMA, Long.class);
+        givenSerializerForSchema(SchemaBuilder.OPTIONAL_INT64_SCHEMA, Long.class, autoRegisterSchemas);
 
     // When:
     final Exception e = assertThrows(
@@ -252,8 +253,9 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldSerializeNullValue() {
+    boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
-    final Serializer<Struct> serializer = givenSerializerForSchema(ORDER_SCHEMA, Struct.class);
+    final Serializer<Struct> serializer = givenSerializerForSchema(ORDER_SCHEMA, Struct.class, autoRegisterSchemas);
 
     // When:
     final byte[] serializedRow = serializer.serialize(SOME_TOPIC, null);
@@ -264,8 +266,9 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldSerializeStructCorrectly() {
+    boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
-    final Serializer<Struct> serializer = givenSerializerForSchema(ORDER_SCHEMA, Struct.class);
+    final Serializer<Struct> serializer = givenSerializerForSchema(ORDER_SCHEMA, Struct.class, autoRegisterSchemas);
 
     final Struct struct = new Struct(ORDER_SCHEMA)
         .put(ORDERTIME, 1511897796092L)
@@ -306,9 +309,10 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldHandleNestedStruct() throws IOException {
+    final boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
     final Serializer<Struct> serializer = givenSerializerForSchema(SCHEMA_WITH_STRUCT,
-        Struct.class);
+        Struct.class, autoRegisterSchemas);
     final Struct struct = buildWithNestedStruct();
 
     // When:
@@ -326,9 +330,10 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldSerializeBoolean() throws Exception {
+    final boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
     final Serializer<Boolean> serializer =
-        givenSerializerForSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA, Boolean.class);
+        givenSerializerForSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA, Boolean.class, autoRegisterSchemas);
 
     // When:
     final byte[] bytes = serializer.serialize(SOME_TOPIC, true);
@@ -342,9 +347,10 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldSerializeKeyAndRegisterKeySubject() throws IOException, RestClientException {
+    final boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given;
     final Serializer<Boolean> serializer = givenJsonSerdeFactory()
-        .createSerde((ConnectSchema) Schema.OPTIONAL_BOOLEAN_SCHEMA, config, () -> srClient, Boolean.class, true)
+        .createSerde((ConnectSchema) Schema.OPTIONAL_BOOLEAN_SCHEMA, config, () -> srClient, Boolean.class, true, autoRegisterSchemas)
         .serializer();
 
     // When:
@@ -359,9 +365,10 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldSerializeInt() {
+    final boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
     final Serializer<Integer> serializer =
-        givenSerializerForSchema(Schema.OPTIONAL_INT32_SCHEMA, Integer.class);
+        givenSerializerForSchema(Schema.OPTIONAL_INT32_SCHEMA, Integer.class, autoRegisterSchemas);
 
     // When:
     final byte[] bytes = serializer.serialize(SOME_TOPIC, 62);
@@ -372,9 +379,10 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldSerializeBigInt() {
+    final boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
     final Serializer<Long> serializer =
-        givenSerializerForSchema(Schema.OPTIONAL_INT64_SCHEMA, Long.class);
+        givenSerializerForSchema(Schema.OPTIONAL_INT64_SCHEMA, Long.class, autoRegisterSchemas);
 
     // When:
     final byte[] bytes = serializer.serialize(SOME_TOPIC, 62L);
@@ -385,9 +393,10 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldSerializeDouble() {
+    final boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
     final Serializer<Double> serializer =
-        givenSerializerForSchema(Schema.OPTIONAL_FLOAT64_SCHEMA, Double.class);
+        givenSerializerForSchema(Schema.OPTIONAL_FLOAT64_SCHEMA, Double.class, autoRegisterSchemas);
 
     // When:
     final byte[] bytes = serializer.serialize(SOME_TOPIC, 62.0);
@@ -398,10 +407,12 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldSerializeDecimal() {
+    final boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
     final Serializer<BigDecimal> serializer = givenSerializerForSchema(
         DecimalUtil.builder(20, 19).build(),
-        BigDecimal.class
+        BigDecimal.class,
+        autoRegisterSchemas
     );
 
     // When:
@@ -413,10 +424,12 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldSerializeDecimalsWithoutStrippingTrailingZeros() {
+    final boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
     final Serializer<BigDecimal> serializer = givenSerializerForSchema(
         DecimalUtil.builder(3, 1).build(),
-        BigDecimal.class
+        BigDecimal.class,
+        autoRegisterSchemas
     );
 
     // When:
@@ -428,10 +441,12 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldSerializeTime() {
+    final boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
     final Serializer<java.sql.Time> serializer = givenSerializerForSchema(
         Time.SCHEMA,
-        java.sql.Time.class
+        java.sql.Time.class,
+        autoRegisterSchemas
     );
 
     // When:
@@ -443,10 +458,12 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldSerializeDate() {
+    final boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
     final Serializer<java.sql.Date> serializer = givenSerializerForSchema(
         Date.SCHEMA,
-        java.sql.Date.class
+        java.sql.Date.class,
+        autoRegisterSchemas
     );
 
     // When:
@@ -458,10 +475,12 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldSerializeTimestamp() {
+    final boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
     final Serializer<java.sql.Timestamp> serializer = givenSerializerForSchema(
         Timestamp.SCHEMA,
-        java.sql.Timestamp.class
+        java.sql.Timestamp.class,
+        autoRegisterSchemas
     );
 
     // When:
@@ -473,9 +492,10 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldSerializeString() {
+    final boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
     final Serializer<String> serializer =
-        givenSerializerForSchema(Schema.OPTIONAL_STRING_SCHEMA, String.class);
+        givenSerializerForSchema(Schema.OPTIONAL_STRING_SCHEMA, String.class, autoRegisterSchemas);
 
     // When:
     final byte[] bytes = serializer.serialize(SOME_TOPIC, "a string");
@@ -486,9 +506,10 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldSerializeBytes() {
+    final boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
     final Serializer<ByteBuffer> serializer =
-        givenSerializerForSchema(Schema.OPTIONAL_BYTES_SCHEMA, ByteBuffer.class);
+        givenSerializerForSchema(Schema.OPTIONAL_BYTES_SCHEMA, ByteBuffer.class, autoRegisterSchemas);
 
     // When:
     final byte[] bytes = serializer.serialize(SOME_TOPIC, ByteBuffer.wrap(new byte[] {123}));
@@ -499,11 +520,13 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldSerializeArray() {
+    final boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
     final Serializer<List> serializer = givenSerializerForSchema(SchemaBuilder
             .array(Schema.BOOLEAN_SCHEMA)
             .build(),
-        List.class
+        List.class,
+        autoRegisterSchemas
     );
 
     // When:
@@ -515,11 +538,13 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldThrowOnWrongElementType() {
+    boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
     final Serializer<List> serializer = givenSerializerForSchema(SchemaBuilder
             .array(Schema.BOOLEAN_SCHEMA)
             .build(),
-        List.class
+        List.class,
+        autoRegisterSchemas
     );
 
     // When:
@@ -535,11 +560,13 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldSerializeMap() {
+    boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
     final Serializer<Map> serializer = givenSerializerForSchema(SchemaBuilder
             .map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_INT32_SCHEMA)
             .build(),
-        Map.class
+        Map.class,
+        autoRegisterSchemas
     );
 
     // When:
@@ -556,11 +583,13 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldThrowIfKeyWrongType() {
+    boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
     final Serializer<Map> serializer = givenSerializerForSchema(SchemaBuilder
             .map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA)
             .build(),
-        Map.class
+        Map.class,
+        autoRegisterSchemas
     );
 
     // When:
@@ -576,11 +605,13 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldThrowIfValueWrongType() {
+    boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
     final Serializer<Map> serializer = givenSerializerForSchema(SchemaBuilder
             .map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA)
             .build(),
-        Map.class
+        Map.class,
+        autoRegisterSchemas
     );
 
     // When:
@@ -596,6 +627,7 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldThrowOnMapSchemaWithNonStringKeys() {
+    boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
     final ConnectSchema schema = (ConnectSchema) SchemaBuilder
         .struct()
@@ -610,7 +642,7 @@ public class KsqlJsonSerializerTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> factory.createSerde(schema, config, () -> null, Struct.class, false)
+        () -> factory.createSerde(schema, config, () -> null, Struct.class, false, autoRegisterSchemas)
     );
 
     // Then:
@@ -620,6 +652,7 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldThrowOnNestedMapSchemaWithNonStringKeys() {
+    boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
     final ConnectSchema schema = (ConnectSchema) SchemaBuilder
         .struct()
@@ -637,7 +670,7 @@ public class KsqlJsonSerializerTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> factory.createSerde(schema, config, () -> null, Struct.class, false)
+        () -> factory.createSerde(schema, config, () -> null, Struct.class, false, autoRegisterSchemas)
     );
 
     // Then:
@@ -647,8 +680,9 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldSerializeNullAsNull() {
+    boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
-    final Serializer<Struct> serializer = givenSerializerForSchema(ORDER_SCHEMA, Struct.class);
+    final Serializer<Struct> serializer = givenSerializerForSchema(ORDER_SCHEMA, Struct.class, autoRegisterSchemas);
 
     // Then:
     assertThat(serializer.serialize(SOME_TOPIC, null), is(nullValue()));
@@ -656,8 +690,9 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldHandleNulls() {
+    boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
-    final Serializer<Struct> serializer = givenSerializerForSchema(ORDER_SCHEMA, Struct.class);
+    final Serializer<Struct> serializer = givenSerializerForSchema(ORDER_SCHEMA, Struct.class, autoRegisterSchemas);
 
     final Struct struct = new Struct(ORDER_SCHEMA)
         .put(ORDERTIME, 1511897796092L)
@@ -695,9 +730,10 @@ public class KsqlJsonSerializerTest {
   @SuppressWarnings("unchecked")
   @Test
   public void shouldIncludeTopicNameInException() {
+    boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
     final Serializer serializer =
-        givenSerializerForSchema(Schema.OPTIONAL_INT64_SCHEMA, Long.class);
+        givenSerializerForSchema(Schema.OPTIONAL_INT64_SCHEMA, Long.class, autoRegisterSchemas);
 
     // When:
     final Exception e = assertThrows(
@@ -712,9 +748,10 @@ public class KsqlJsonSerializerTest {
   @SuppressWarnings("unchecked")
   @Test
   public void shouldNotIncludeBadValueInExceptionAsThatWouldBeASecurityIssue() {
+    boolean autoRegisterSchemas = useSchemas ? true : false;
     // Given:
     final Serializer serializer =
-        givenSerializerForSchema(Schema.OPTIONAL_INT64_SCHEMA, Long.class);
+        givenSerializerForSchema(Schema.OPTIONAL_INT64_SCHEMA, Long.class, autoRegisterSchemas);
 
     final Exception e = assertThrows(
         Exception.class,
@@ -727,10 +764,11 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldSerializePrimitiveWithSchemaId() throws Exception {
+    boolean autoRegisterSchemas = false; // Set to false when using schemaId
     // Given:
     final int intSchemaId = givenPhysicalSchema(getSRSubject(SOME_TOPIC, false), INT_JSON_SCHEMA);
     final Serializer<Long> intSerializer = givenSerializerForSchema(Schema.OPTIONAL_INT64_SCHEMA,
-        Long.class, Optional.of(intSchemaId), Optional.empty());
+        Long.class, Optional.of(intSchemaId), Optional.empty(), autoRegisterSchemas);
 
     // When:
     final byte[] intBytes = intSerializer.serialize(SOME_TOPIC, 123L);
@@ -741,10 +779,11 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldSerializeStructWithSchemaId() throws Exception {
+    boolean autoRegisterSchemas = false; // Set to false when using schemaId
     // Given:
     final int schemaId = givenPhysicalSchema(getSRSubject(SOME_TOPIC, false), ITEM_JSON_SCHEMA);
     final Serializer<Struct> serializer = givenSerializerForSchema(NON_OPTIONAL_ITEM_SCHEMA,
-        Struct.class, Optional.of(schemaId), Optional.empty());
+        Struct.class, Optional.of(schemaId), Optional.empty(), autoRegisterSchemas);
     final Struct category = new Struct(CATEGORY_SCHEMA);
     category.put("ID", 1L);
     category.put("NAME", "Food");
@@ -763,11 +802,12 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldSerializeStructWithExtraOptionalFieldWithSchemaId() throws Exception {
+    boolean autoRegisterSchemas = false; // Set to false when using schemaId
     // Given:
     final int schemaId = givenPhysicalSchema(getSRSubject(SOME_TOPIC, false),
         ITEM_JSON_SCHEMA_WITH_OPTIONAL_EXTRA_FIELD);
     final Serializer<Struct> serializer = givenSerializerForSchema(NON_OPTIONAL_ITEM_SCHEMA,
-        Struct.class, Optional.of(schemaId), Optional.empty());
+        Struct.class, Optional.of(schemaId), Optional.empty(), autoRegisterSchemas);
     final Struct category = new Struct(CATEGORY_SCHEMA);
     category.put("ID", 1L);
     category.put("NAME", "Food");
@@ -792,11 +832,12 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldSerializeWithExtraNonOptionalFieldWithSchemaId() throws Exception {
+    boolean autoRegisterSchemas = false; // Set to false when using schemaId
     // Given:
     final int schemaId = givenPhysicalSchema(getSRSubject(SOME_TOPIC, false),
         ITEM_JSON_SCHEMA_WITH_EXTRA_FIELD);
     final Serializer<Struct> serializer = givenSerializerForSchema(NON_OPTIONAL_ITEM_SCHEMA,
-        Struct.class, Optional.of(schemaId), Optional.empty());
+        Struct.class, Optional.of(schemaId), Optional.empty(), autoRegisterSchemas);
     final Struct category = new Struct(CATEGORY_SCHEMA);
     category.put("ID", 1L);
     category.put("NAME", "Food");
@@ -816,11 +857,12 @@ public class KsqlJsonSerializerTest {
 
   @Test
   public void shouldThrowIfOptionalSchemaNotCompatible() throws Exception {
+    boolean autoRegisterSchemas = false; // Set to false when using schemaId
     // Given:
     int schemaId = givenPhysicalSchema(getSRSubject(SOME_TOPIC, false),
         NON_OPTIONAL_ITEM_JSON_SCHEMA);
     final Serializer<Struct> serializer = givenSerializerForSchema(NON_OPTIONAL_ITEM_SCHEMA,
-        Struct.class, Optional.of(schemaId), Optional.of("randomName"));
+        Struct.class, Optional.of(schemaId), Optional.of("randomName"), autoRegisterSchemas);
     final Struct category = new Struct(CATEGORY_SCHEMA);
     category.put("ID", 1L);
     category.put("NAME", null);
@@ -887,15 +929,16 @@ public class KsqlJsonSerializerTest {
     return topLevel;
   }
 
-  private <T> Serializer<T> givenSerializerForSchema(final Schema schema, final Class<T> type) {
-    return givenSerializerForSchema(schema, type, Optional.empty(), Optional.empty());
+  private <T> Serializer<T> givenSerializerForSchema(final Schema schema, final Class<T> type, final boolean autoRegisterSchemas) {
+    return givenSerializerForSchema(schema, type, Optional.empty(), Optional.empty(), autoRegisterSchemas);
   }
 
   private <T> Serializer<T> givenSerializerForSchema(
       final Schema schema,
       final Class<T> targetType,
       final Optional<Integer> schemaId,
-      final Optional<String> schemaName
+      final Optional<String> schemaName,
+      final boolean autoRegisterSchemas
   ) {
     final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
     schemaName.ifPresent(s -> builder.put(ConnectProperties.FULL_SCHEMA_NAME, s));
@@ -905,7 +948,7 @@ public class KsqlJsonSerializerTest {
         new KsqlJsonSerdeFactory(new JsonSchemaProperties(builder.build())) :
         new KsqlJsonSerdeFactory();
     return factory
-        .createSerde((ConnectSchema) schema, config, () -> srClient, targetType, false)
+        .createSerde((ConnectSchema) schema, config, () -> srClient, targetType, false, autoRegisterSchemas)
         .serializer();
   }
 

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/AbstractProtobufSerdeFactoryTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/AbstractProtobufSerdeFactoryTest.java
@@ -50,7 +50,7 @@ public abstract class AbstractProtobufSerdeFactoryTest {
         .build();
 
     // When:
-    getSerdeFactory().createSerde(schema, config, srClientFactory, Struct.class, false);
+    getSerdeFactory().createSerde(schema, config, srClientFactory, Struct.class, false, false);
 
     // Then (did not throw)
   }
@@ -64,7 +64,7 @@ public abstract class AbstractProtobufSerdeFactoryTest {
 
     // When:
     getSerdeFactory().createSerde(schema, config, srClientFactory,
-        Struct.class, false);
+        Struct.class, false, false);
 
     // Then (did not throw)
   }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufDeserializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufDeserializerTest.java
@@ -87,6 +87,7 @@ public class KsqlProtobufDeserializerTest extends AbstractKsqlProtobufDeserializ
         KSQL_CONFIG,
         () -> schemaRegistryClient,
         targetType,
+        false,
         false).deserializer();
 
     deserializer.configure(Collections.emptyMap(), false);

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufNoSRDeserializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufNoSRDeserializerTest.java
@@ -56,6 +56,7 @@ public class KsqlProtobufNoSRDeserializerTest extends  AbstractKsqlProtobufDeser
             new KsqlConfig(ImmutableMap.of()),
             () -> null,
             targetType,
+            false,
             false).deserializer();
 
     deserializer.configure(Collections.emptyMap(), false);

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufNoSRSerializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufNoSRSerializerTest.java
@@ -145,7 +145,9 @@ public class KsqlProtobufNoSRSerializerTest {
             new KsqlConfig(ImmutableMap.of()),
             () -> null,
             Struct.class,
-            false).serializer();
+            false,
+            false
+        ).serializer();
 
     // When:
     final byte[] bytes = serializer.serialize(SOME_TOPIC, ksqlRecord);
@@ -191,7 +193,9 @@ public class KsqlProtobufNoSRSerializerTest {
             new KsqlConfig(ImmutableMap.of()),
             () -> null,
             Struct.class,
-            false).serializer();
+            false,
+            false
+        ).serializer();
 
     // When:
     final byte[] bytes = serializer.serialize(SOME_TOPIC, ksqlRecord);
@@ -264,7 +268,9 @@ public class KsqlProtobufNoSRSerializerTest {
             new KsqlConfig(ImmutableMap.of()),
             () -> null,
             targetType,
-            false).deserializer();
+            false,
+            false
+        ).deserializer();
 
     deserializer.configure(Collections.emptyMap(), false);
 
@@ -320,7 +326,10 @@ public class KsqlProtobufNoSRSerializerTest {
             new KsqlConfig(ImmutableMap.of()),
             () -> null,
             targetType,
-            false).serializer();
+            false,
+            false
+        )
+        .serializer();
 
     serializer.configure(Collections.emptyMap(), false);
 

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufSerializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufSerializerTest.java
@@ -163,7 +163,7 @@ public class KsqlProtobufSerializerTest {
   @Before
   public void setup() {
     final ImmutableMap<String, Object> configs = ImmutableMap.of(
-        AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS, true,
+        AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS, false,
         AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, ""
     );
 
@@ -236,7 +236,8 @@ public class KsqlProtobufSerializerTest {
             ksqlConfig,
             () -> schemaRegistryClient,
             Struct.class,
-            false).serializer();
+            false,
+            true).serializer();
 
     // When:
     final byte[] bytes = serializer.serialize(SOME_TOPIC, ksqlRecord);
@@ -299,7 +300,8 @@ public class KsqlProtobufSerializerTest {
             ksqlConfig,
             () -> schemaRegistryClient,
             Struct.class,
-            false).serializer();
+            false,
+            true).serializer();
 
     // When:
     final byte[] bytes = serializer.serialize(SOME_TOPIC, ksqlRecord);
@@ -488,7 +490,8 @@ public class KsqlProtobufSerializerTest {
             ksqlConfig,
             () -> schemaRegistryClient,
             targetType,
-            false).serializer();
+            false,
+            true).serializer();
   }
 
   private static ParsedSchema parseProtobufSchema(final String protobufSchema) {


### PR DESCRIPTION
### Description 
- INSERT statement ends up registering new schemas because ksqldb uses
  auto.register.schemas=true by default
- If user doesn't have WRITE permissions on SR, the INSERT statement fails with
  authorization denied. Users don't really need WRITE permission on SR to insert
  data into a topic.
- When schema_id is used during CREATE, we set auto.register.schemas to false
- Therefore, to keep it consistent this commit sets auto.register.schemas to
  false by default which should prevent registering schemas during INSERT
- Additionally, this is a config which is not exposed to the user

### Testing done 
Updated Unit Tests
QTT - TODO (InProgress)

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

