### PR TITLE
feat: add `CORRELATION` UDAF

### DIFF
--- a/docs/developer-guide/ksqldb-reference/aggregate-functions.md
+++ b/docs/developer-guide/ksqldb-reference/aggregate-functions.md
@@ -71,6 +71,20 @@ originally processed.
 
 ---
 
+## **`CORRELATION`**
+
+```sql title="Applies to: stream, table<br>Since: 0.29.0"
+CORRELATION(x, y)
+```
+
+Returns the Pearson correlation coefficient between `DOUBLE` columns `x` and `y`. If either value in `x` or `y` is `NULL` for a particular row, that row is ignored.
+
+If all rows contain `NULL` for `x` or `y`, or if there is only one non-null row, `NaN` is returned. When there are only two non-null rows, either `1.0` or `-1.0` is returned, depending on the sign of the slope of the line that would be drawn between the two points.
+
+If all the values in one column are equal, `NaN` is returned.
+
+---
+
 ## **`COUNT`**
 
 ```sql title="Applies to: stream, table<br>"

--- a/docs/developer-guide/ksqldb-reference/aggregate-functions.md
+++ b/docs/developer-guide/ksqldb-reference/aggregate-functions.md
@@ -77,7 +77,7 @@ originally processed.
 CORRELATION(x, y)
 ```
 
-Returns the Pearson correlation coefficient between `DOUBLE` columns `x` and `y`. If either value in `x` or `y` is `NULL` for a particular row, that row is ignored.
+Returns the Pearson correlation coefficient between columns `x` and `y`. If either value in `x` or `y` is `NULL` for a particular row, that row is ignored.
 
 If all rows contain `NULL` for `x` or `y`, or if there is only one non-null row, `NaN` is returned. When there are only two non-null rows, either `1.0` or `-1.0` is returned, depending on the sign of the slope of the line that would be drawn between the two points.
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/correlation/CorrelationUdaf.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/correlation/CorrelationUdaf.java
@@ -35,12 +35,13 @@ public class CorrelationUdaf implements TableUdaf<Pair<Double, Double>, Struct, 
   private static final String XY_SUM = "XY_SUM";
   private static final String COUNT = "COUNT";
   private static final Schema structSchema = SchemaBuilder.struct()
-          .field(X_SUM, Schema.FLOAT64_SCHEMA)
-          .field(Y_SUM, Schema.FLOAT64_SCHEMA)
-          .field(X_SQUARED_SUM, Schema.FLOAT64_SCHEMA)
-          .field(Y_SQUARED_SUM, Schema.FLOAT64_SCHEMA)
-          .field(XY_SUM, Schema.FLOAT64_SCHEMA)
-          .field(COUNT, Schema.INT64_SCHEMA)
+          .optional()
+          .field(X_SUM, Schema.OPTIONAL_FLOAT64_SCHEMA)
+          .field(Y_SUM, Schema.OPTIONAL_FLOAT64_SCHEMA)
+          .field(X_SQUARED_SUM, Schema.OPTIONAL_FLOAT64_SCHEMA)
+          .field(Y_SQUARED_SUM, Schema.OPTIONAL_FLOAT64_SCHEMA)
+          .field(XY_SUM, Schema.OPTIONAL_FLOAT64_SCHEMA)
+          .field(COUNT, Schema.OPTIONAL_INT64_SCHEMA)
           .build();
 
   @UdafFactory(description = "Computes the Pearson correlation coefficient between "

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/correlation/CorrelationUdaf.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/correlation/CorrelationUdaf.java
@@ -44,7 +44,8 @@ public class CorrelationUdaf implements TableUdaf<Pair<Double, Double>, Struct, 
           .build();
 
   @UdafFactory(description = "Computes the Pearson correlation coefficient between "
-          + "two DOUBLE columns.")
+          + "two DOUBLE columns.", aggregateSchema = "STRUCT<X_SUM double, Y_SUM double, "
+          + "X_SQUARED_SUM double, Y_SQUARED_SUM double, XY_SUM double, COUNT bigint>")
   public static TableUdaf<Pair<Double, Double>, Struct, Double> createCorrelation() {
     return new CorrelationUdaf();
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/correlation/CorrelationUdaf.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/correlation/CorrelationUdaf.java
@@ -66,10 +66,10 @@ public class CorrelationUdaf<T> implements TableUdaf<Pair<T, T>, Struct, Double>
     return new CorrelationUdaf<>(Long::doubleValue);
   }
 
-  private final Function<T, Double> toNumber;
+  private final Function<T, Double> toDouble;
 
-  public CorrelationUdaf(final Function<T, Double> toNumber) {
-    this.toNumber = toNumber;
+  public CorrelationUdaf(final Function<T, Double> toDouble) {
+    this.toDouble = toDouble;
   }
 
   @Override
@@ -89,8 +89,8 @@ public class CorrelationUdaf<T> implements TableUdaf<Pair<T, T>, Struct, Double>
       return aggregate;
     }
 
-    final double x = toNumber.apply(current.getLeft());
-    final double y = toNumber.apply(current.getRight());
+    final double x = toDouble.apply(current.getLeft());
+    final double y = toDouble.apply(current.getRight());
 
     return new Struct(structSchema)
             .put(X_SUM, aggregate.getFloat64(X_SUM) + x)
@@ -139,8 +139,8 @@ public class CorrelationUdaf<T> implements TableUdaf<Pair<T, T>, Struct, Double>
       return aggregateValue;
     }
 
-    final double x = toNumber.apply(valueToUndo.getLeft());
-    final double y = toNumber.apply(valueToUndo.getRight());
+    final double x = toDouble.apply(valueToUndo.getLeft());
+    final double y = toDouble.apply(valueToUndo.getRight());
 
     return new Struct(structSchema)
             .put(X_SUM, aggregateValue.getFloat64(X_SUM) - x)

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/correlation/CorrelationUdaf.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/correlation/CorrelationUdaf.java
@@ -91,6 +91,9 @@ public class CorrelationUdaf implements TableUdaf<Pair<Double, Double>, Struct, 
 
   @Override
   public Double map(final Struct agg) {
+
+    /* These calculations are based on the single-pass correlation formula shown at
+    https://www.mathsisfun.com/data/correlation.html. (See "Note for Programmers.") */
     final double sumX = agg.getFloat64(X_SUM);
     final double sumY = agg.getFloat64(Y_SUM);
     final double squaredXSum = agg.getFloat64(X_SQUARED_SUM);
@@ -100,9 +103,9 @@ public class CorrelationUdaf implements TableUdaf<Pair<Double, Double>, Struct, 
 
     final double numerator = count * sumXY - sumX * sumY;
 
-    final double denominatorX = Math.sqrt(count * squaredXSum - sumX * sumX);
-    final double denominatorY = Math.sqrt(count * squaredYSum - sumY * sumY);
-    final double denominator = denominatorX * denominatorY;
+    final double denominatorX = count * squaredXSum - sumX * sumX;
+    final double denominatorY = count * squaredYSum - sumY * sumY;
+    final double denominator = Math.sqrt(denominatorX * denominatorY);
 
     return numerator / denominator;
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/correlation/CorrelationUdaf.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/correlation/CorrelationUdaf.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udaf.correlation;
+
+import io.confluent.ksql.function.udaf.TableUdaf;
+import io.confluent.ksql.function.udaf.UdafDescription;
+import io.confluent.ksql.function.udaf.UdafFactory;
+import io.confluent.ksql.util.KsqlConstants;
+import io.confluent.ksql.util.Pair;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+
+@UdafDescription(name = "correlation",
+        description = "Computes the Pearson correlation coefficient between two columns of data.",
+        author = KsqlConstants.CONFLUENT_AUTHOR
+)
+public class CorrelationUdaf implements TableUdaf<Pair<Double, Double>, Struct, Double> {
+  private static final String X_SUM = "X_SUM";
+  private static final String Y_SUM = "Y_SUM";
+  private static final String X_SQUARED_SUM = "X_SQUARED_SUM";
+  private static final String Y_SQUARED_SUM = "Y_SQUARED_SUM";
+  private static final String XY_SUM = "XY_SUM";
+  private static final String COUNT = "COUNT";
+  private static final Schema structSchema = SchemaBuilder.struct()
+          .field(X_SUM, Schema.FLOAT64_SCHEMA)
+          .field(Y_SUM, Schema.FLOAT64_SCHEMA)
+          .field(X_SQUARED_SUM, Schema.FLOAT64_SCHEMA)
+          .field(Y_SQUARED_SUM, Schema.FLOAT64_SCHEMA)
+          .field(XY_SUM, Schema.FLOAT64_SCHEMA)
+          .field(COUNT, Schema.INT64_SCHEMA)
+          .build();
+
+  @UdafFactory(description = "Computes the Pearson correlation coefficient between "
+          + "two DOUBLE columns.")
+  public static TableUdaf<Pair<Double, Double>, Struct, Double> createCorrelation() {
+    return new CorrelationUdaf();
+  }
+
+  @Override
+  public Struct initialize() {
+    return new Struct(structSchema)
+            .put(X_SUM, 0.0)
+            .put(Y_SUM, 0.0)
+            .put(X_SQUARED_SUM, 0.0)
+            .put(Y_SQUARED_SUM, 0.0)
+            .put(XY_SUM, 0.0)
+            .put(COUNT, 0L);
+  }
+
+  @Override
+  public Struct aggregate(final Pair<Double, Double> current, final Struct aggregate) {
+    final Double x = current.getLeft();
+    final Double y = current.getRight();
+
+    if (x == null || y == null) {
+      return aggregate;
+    }
+
+    return new Struct(structSchema)
+            .put(X_SUM, aggregate.getFloat64(X_SUM) + x)
+            .put(Y_SUM, aggregate.getFloat64(Y_SUM) + y)
+            .put(X_SQUARED_SUM, aggregate.getFloat64(X_SQUARED_SUM) + x * x)
+            .put(Y_SQUARED_SUM, aggregate.getFloat64(Y_SQUARED_SUM) + y * y)
+            .put(XY_SUM, aggregate.getFloat64(XY_SUM) + x * y)
+            .put(COUNT, aggregate.getInt64(COUNT) + 1L);
+  }
+
+  @Override
+  public Struct merge(final Struct aggOne, final Struct aggTwo) {
+    return new Struct(structSchema)
+            .put(X_SUM, aggOne.getFloat64(X_SUM) + aggTwo.getFloat64(X_SUM))
+            .put(Y_SUM, aggOne.getFloat64(Y_SUM) + aggTwo.getFloat64(Y_SUM))
+            .put(X_SQUARED_SUM, aggOne.getFloat64(X_SQUARED_SUM) + aggTwo.getFloat64(X_SQUARED_SUM))
+            .put(Y_SQUARED_SUM, aggOne.getFloat64(Y_SQUARED_SUM) + aggTwo.getFloat64(Y_SQUARED_SUM))
+            .put(XY_SUM, aggOne.getFloat64(XY_SUM) + aggTwo.getFloat64(XY_SUM))
+            .put(COUNT, aggOne.getInt64(COUNT) + aggTwo.getInt64(COUNT));
+  }
+
+  @Override
+  public Double map(final Struct agg) {
+    final double sumX = agg.getFloat64(X_SUM);
+    final double sumY = agg.getFloat64(Y_SUM);
+    final double squaredXSum = agg.getFloat64(X_SQUARED_SUM);
+    final double squaredYSum = agg.getFloat64(Y_SQUARED_SUM);
+    final double sumXY = agg.getFloat64(XY_SUM);
+    final long count = agg.getInt64(COUNT);
+
+    final double numerator = count * sumXY - sumX * sumY;
+
+    final double denominatorX = Math.sqrt(count * squaredXSum - sumX * sumX);
+    final double denominatorY = Math.sqrt(count * squaredYSum - sumY * sumY);
+    final double denominator = denominatorX * denominatorY;
+
+    return numerator / denominator;
+  }
+
+  @Override
+  public Struct undo(final Pair<Double, Double> valueToUndo, final Struct aggregateValue) {
+    final Double x = valueToUndo.getLeft();
+    final Double y = valueToUndo.getRight();
+
+    if (x == null || y == null) {
+      return aggregateValue;
+    }
+
+    return new Struct(structSchema)
+            .put(X_SUM, aggregateValue.getFloat64(X_SUM) - x)
+            .put(Y_SUM, aggregateValue.getFloat64(Y_SUM) - y)
+            .put(X_SQUARED_SUM, aggregateValue.getFloat64(X_SQUARED_SUM) - x * x)
+            .put(Y_SQUARED_SUM, aggregateValue.getFloat64(Y_SQUARED_SUM) - y * y)
+            .put(XY_SUM, aggregateValue.getFloat64(XY_SUM) - x * y)
+            .put(COUNT, aggregateValue.getInt64(COUNT) - 1L);
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/correlation/CorrelationUdaf.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/correlation/CorrelationUdaf.java
@@ -68,7 +68,7 @@ public class CorrelationUdaf<T> implements TableUdaf<Pair<T, T>, Struct, Double>
 
   private final Function<T, Double> toNumber;
 
-  public CorrelationUdaf(Function<T, Double> toNumber) {
+  public CorrelationUdaf(final Function<T, Double> toNumber) {
     this.toNumber = toNumber;
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/correlation/CorrelationUdafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/correlation/CorrelationUdafTest.java
@@ -393,6 +393,50 @@ public class CorrelationUdafTest {
   }
 
   @Test
+  public void shouldCorrelateDoublesSameXValues() {
+    final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
+            CorrelationUdaf.createCorrelation();
+
+    Struct agg = udaf.initialize();
+    final List<Pair<Double, Double>> values = ImmutableList.of(
+            Pair.of(20.0, 15.0),
+            Pair.of(20.0, 10.0),
+            Pair.of(20.0, 5.0),
+            Pair.of(20.0, 0.0),
+            Pair.of(20.0, -5.0),
+            Pair.of(20.0, -10.0)
+    );
+    for (final Pair<Double, Double> thisValue : values) {
+      agg = udaf.aggregate(thisValue, agg);
+    }
+    final double correlation = udaf.map(agg);
+
+    assertThat(Double.isNaN(correlation), is(true));
+  }
+
+  @Test
+  public void shouldCorrelateDoublesSameYValues() {
+    final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
+            CorrelationUdaf.createCorrelation();
+
+    Struct agg = udaf.initialize();
+    final List<Pair<Double, Double>> values = ImmutableList.of(
+            Pair.of(15.0, 20.0),
+            Pair.of(10.0, 20.0),
+            Pair.of(5.0, 20.0),
+            Pair.of(0.0, 20.0),
+            Pair.of(-5.0, 20.0),
+            Pair.of(-10.0, 20.0)
+    );
+    for (final Pair<Double, Double> thisValue : values) {
+      agg = udaf.aggregate(thisValue, agg);
+    }
+    final double correlation = udaf.map(agg);
+
+    assertThat(Double.isNaN(correlation), is(true));
+  }
+
+  @Test
   public void shouldMergeCorrelations() {
     final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
             CorrelationUdaf.createCorrelation();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/correlation/CorrelationUdafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/correlation/CorrelationUdafTest.java
@@ -1,0 +1,414 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udaf.correlation;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.is;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.function.udaf.TableUdaf;
+import io.confluent.ksql.util.Pair;
+import java.util.List;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.Test;
+
+public class CorrelationUdafTest {
+
+  @Test
+  public void shouldCorrelateDoublesPerfectPositiveNoNulls() {
+    final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
+            CorrelationUdaf.createCorrelation();
+
+    Struct agg = udaf.initialize();
+    final List<Pair<Double, Double>> values = ImmutableList.of(
+            Pair.of(1.5, 8.0),
+            Pair.of(2.0, 9.0),
+            Pair.of(0.5, 6.0),
+            Pair.of(1.0, 7.0),
+            Pair.of(-3.5, -2.0),
+            Pair.of(-1.0, 3.0),
+            Pair.of(1.5, 8.0),
+            Pair.of(2.5, 10.0),
+            Pair.of(-4.5, -4.0),
+            Pair.of(-3.0, -1.0),
+            Pair.of(3.0, 11.0),
+            Pair.of(4.0, 13.0)
+    );
+    for (final Pair<Double, Double> thisValue : values) {
+      agg = udaf.aggregate(thisValue, agg);
+    }
+    final double correlation = udaf.map(agg);
+
+    assertThat(1.0, closeTo(correlation, 0.00005));
+  }
+
+  @Test
+  public void shouldCorrelateDoublesStrongPositiveNoNulls() {
+    final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
+            CorrelationUdaf.createCorrelation();
+
+    Struct agg = udaf.initialize();
+    final List<Pair<Double, Double>> values = ImmutableList.of(
+            Pair.of(1.5, 14.0),
+            Pair.of(2.0, 11.0),
+            Pair.of(5.5, 3.0),
+            Pair.of(-5.0, 7.0),
+            Pair.of(-3.5, -8.0),
+            Pair.of(-1.0, 6.0),
+            Pair.of(1.5, 5.0),
+            Pair.of(8.5, 19.0),
+            Pair.of(-8.0, -6.5),
+            Pair.of(-3.0, -2.0),
+            Pair.of(-3.0, 12.5),
+            Pair.of(4.0, 16.5)
+    );
+    for (final Pair<Double, Double> thisValue : values) {
+      agg = udaf.aggregate(thisValue, agg);
+    }
+    final double correlation = udaf.map(agg);
+
+    assertThat(0.6717, closeTo(correlation, 0.00005));
+  }
+
+  @Test
+  public void shouldCorrelateDoublesWeakPositiveNoNulls() {
+    final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
+            CorrelationUdaf.createCorrelation();
+
+    Struct agg = udaf.initialize();
+    final List<Pair<Double, Double>> values = ImmutableList.of(
+            Pair.of(5.5, 14.0),
+            Pair.of(9.0, 11.0),
+            Pair.of(15.5, 3.0),
+            Pair.of(-6.0, 7.0),
+            Pair.of(-3.5, -8.0),
+            Pair.of(-17.0, 6.0),
+            Pair.of(9.5, 5.0),
+            Pair.of(5.5, 19.0),
+            Pair.of(-15.0, -6.5),
+            Pair.of(-11.0, -2.0),
+            Pair.of(-3.0, 12.5),
+            Pair.of(9.0, 16.5)
+    );
+    for (final Pair<Double, Double> thisValue : values) {
+      agg = udaf.aggregate(thisValue, agg);
+    }
+    final double correlation = udaf.map(agg);
+
+    assertThat(0.4890, closeTo(correlation, 0.00005));
+  }
+
+  @Test
+  public void shouldCorrelateDoublesNoCorrelationNoNulls() {
+    final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
+            CorrelationUdaf.createCorrelation();
+
+    Struct agg = udaf.initialize();
+    final List<Pair<Double, Double>> values = ImmutableList.of(
+            Pair.of(-5.5, 14.0),
+            Pair.of(5.5, 14.0),
+            Pair.of(-9.0, -11.0),
+            Pair.of(9.0, -11.0),
+            Pair.of(-2.0, -8.0),
+            Pair.of(2.0, -8.0),
+            Pair.of(-3.5, 5.0),
+            Pair.of(3.5, 5.0),
+            Pair.of(-11.0, 6.5),
+            Pair.of(11.0, 6.5),
+            Pair.of(-3.0, 0.0),
+            Pair.of(3.0, 0.0)
+    );
+    for (final Pair<Double, Double> thisValue : values) {
+      agg = udaf.aggregate(thisValue, agg);
+    }
+    final double correlation = udaf.map(agg);
+
+    assertThat(0.0, closeTo(correlation, 0.00005));
+  }
+
+  @Test
+  public void shouldCorrelateDoublesWeakNegativeNoNulls() {
+    final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
+            CorrelationUdaf.createCorrelation();
+
+    Struct agg = udaf.initialize();
+    final List<Pair<Double, Double>> values = ImmutableList.of(
+            Pair.of(5.5, -14.0),
+            Pair.of(9.0, -11.0),
+            Pair.of(15.5, -3.0),
+            Pair.of(-6.0, -7.0),
+            Pair.of(-3.5, 8.0),
+            Pair.of(-17.0, -6.0),
+            Pair.of(9.5, -5.0),
+            Pair.of(5.5, -19.0),
+            Pair.of(-15.0, 6.5),
+            Pair.of(-11.0, 2.0),
+            Pair.of(-3.0, -12.5),
+            Pair.of(9.0, -16.5)
+    );
+    for (final Pair<Double, Double> thisValue : values) {
+      agg = udaf.aggregate(thisValue, agg);
+    }
+    final double correlation = udaf.map(agg);
+
+    assertThat(-0.4890, closeTo(correlation, 0.00005));
+  }
+
+  @Test
+  public void shouldCorrelateDoublesStrongNegativeNoNulls() {
+    final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
+            CorrelationUdaf.createCorrelation();
+
+    Struct agg = udaf.initialize();
+    final List<Pair<Double, Double>> values = ImmutableList.of(
+            Pair.of(1.5, -14.0),
+            Pair.of(2.0, -11.0),
+            Pair.of(5.5, -3.0),
+            Pair.of(-5.0, -7.0),
+            Pair.of(-3.5, 8.0),
+            Pair.of(-1.0, -6.0),
+            Pair.of(1.5, -5.0),
+            Pair.of(8.5, -19.0),
+            Pair.of(-8.0, 6.5),
+            Pair.of(-3.0, 2.0),
+            Pair.of(-3.0, -12.5),
+            Pair.of(4.0, -16.5)
+    );
+    for (final Pair<Double, Double> thisValue : values) {
+      agg = udaf.aggregate(thisValue, agg);
+    }
+    final double correlation = udaf.map(agg);
+
+    assertThat(-0.6717, closeTo(correlation, 0.00005));
+  }
+
+  @Test
+  public void shouldCorrelateDoublesPerfectNegativeNoNulls() {
+    final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
+            CorrelationUdaf.createCorrelation();
+
+    Struct agg = udaf.initialize();
+    final List<Pair<Double, Double>> values = ImmutableList.of(
+            Pair.of(1.5, -8.0),
+            Pair.of(2.0, -9.0),
+            Pair.of(0.5, -6.0),
+            Pair.of(1.0, -7.0),
+            Pair.of(-3.5, 2.0),
+            Pair.of(-1.0, -3.0),
+            Pair.of(1.5, -8.0),
+            Pair.of(2.5, -10.0),
+            Pair.of(-4.5, 4.0),
+            Pair.of(-3.0, 1.0),
+            Pair.of(3.0, -11.0),
+            Pair.of(4.0, -13.0)
+    );
+    for (final Pair<Double, Double> thisValue : values) {
+      agg = udaf.aggregate(thisValue, agg);
+    }
+    final double correlation = udaf.map(agg);
+
+    assertThat(-1.0, closeTo(correlation, 0.00005));
+  }
+
+  @Test
+  public void shouldCorrelateDoublesOnlyPositiveValuesNoNulls() {
+    final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
+            CorrelationUdaf.createCorrelation();
+
+    Struct agg = udaf.initialize();
+    final List<Pair<Double, Double>> values = ImmutableList.of(
+            Pair.of(14.2, 215.0),
+            Pair.of(16.4, 325.0),
+            Pair.of(11.9, 185.0),
+            Pair.of(15.2, 332.0),
+            Pair.of(18.5, 406.0),
+            Pair.of(22.1, 522.0),
+            Pair.of(19.4, 412.0),
+            Pair.of(25.1, 614.0),
+            Pair.of(23.4, 544.0),
+            Pair.of(18.1, 421.0),
+            Pair.of(22.6, 445.0),
+            Pair.of(17.2, 408.0)
+    );
+    for (final Pair<Double, Double> thisValue : values) {
+      agg = udaf.aggregate(thisValue, agg);
+    }
+    final double correlation = udaf.map(agg);
+
+    assertThat(0.9575, closeTo(correlation, 0.00005));
+  }
+
+  @Test
+  public void shouldCorrelateDoublesOnlyNegativeValuesNoNulls() {
+    final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
+            CorrelationUdaf.createCorrelation();
+
+    Struct agg = udaf.initialize();
+    final List<Pair<Double, Double>> values = ImmutableList.of(
+            Pair.of(-14.2, -215.0),
+            Pair.of(-16.4, -325.0),
+            Pair.of(-11.9, -185.0),
+            Pair.of(-15.2, -332.0),
+            Pair.of(-18.5, -406.0),
+            Pair.of(-22.1, -522.0),
+            Pair.of(-19.4, -412.0),
+            Pair.of(-25.1, -614.0),
+            Pair.of(-23.4, -544.0),
+            Pair.of(-18.1, -421.0),
+            Pair.of(-22.6, -445.0),
+            Pair.of(-17.2, -408.0)
+    );
+    for (final Pair<Double, Double> thisValue : values) {
+      agg = udaf.aggregate(thisValue, agg);
+    }
+    final double correlation = udaf.map(agg);
+
+    assertThat(0.9575, closeTo(correlation, 0.00005));
+  }
+
+  @Test
+  public void shouldCorrelateDoublesIgnoresNulls() {
+    final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
+            CorrelationUdaf.createCorrelation();
+
+    Struct agg = udaf.initialize();
+    final List<Pair<Double, Double>> values = ImmutableList.of(
+            Pair.of(14.2, 215.0),
+            Pair.of(16.4, 325.0),
+            Pair.of(11.9, 185.0),
+            Pair.of(15.2, 332.0),
+            Pair.of(18.5, 406.0),
+            Pair.of(13.1, null),
+            Pair.of(22.1, 522.0),
+            Pair.of(19.4, 412.0),
+            Pair.of(25.1, 614.0),
+            Pair.of(23.4, 544.0),
+            Pair.of(18.1, 421.0),
+            Pair.of(22.6, 445.0),
+            Pair.of(null, 620.0),
+            Pair.of(17.2, 408.0)
+    );
+    for (final Pair<Double, Double> thisValue : values) {
+      agg = udaf.aggregate(thisValue, agg);
+    }
+    final double correlation = udaf.map(agg);
+
+    assertThat(0.9575, closeTo(correlation, 0.00005));
+  }
+
+  @Test
+  public void shouldCorrelateDoublesOnlyNulls() {
+    final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
+            CorrelationUdaf.createCorrelation();
+
+    Struct agg = udaf.initialize();
+    final List<Pair<Double, Double>> values = ImmutableList.of(
+            Pair.of(null, null),
+            Pair.of(null, null),
+            Pair.of(null, null),
+            Pair.of(null, null),
+            Pair.of(null, null),
+            Pair.of(null, null),
+            Pair.of(null, null),
+            Pair.of(null, null),
+            Pair.of(null, null),
+            Pair.of(null, null),
+            Pair.of(null, null),
+            Pair.of(null, null),
+            Pair.of(null, null),
+            Pair.of(null, null)
+    );
+    for (final Pair<Double, Double> thisValue : values) {
+      agg = udaf.aggregate(thisValue, agg);
+    }
+    final double correlation = udaf.map(agg);
+
+    assertThat(Double.isNaN(correlation), is(true));
+  }
+
+  @Test
+  public void shouldMergeCorrelations() {
+    final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
+            CorrelationUdaf.createCorrelation();
+
+    Struct leftAgg = udaf.initialize();
+    final List<Pair<Double, Double>> leftValues = ImmutableList.of(
+            Pair.of(14.2, 215.0),
+            Pair.of(16.4, 325.0),
+            Pair.of(11.9, 185.0),
+            Pair.of(15.2, 332.0),
+            Pair.of(18.5, 406.0),
+            Pair.of(22.1, 522.0),
+            Pair.of(19.4, 412.0),
+            Pair.of(25.1, 614.0),
+            Pair.of(23.4, 544.0)
+    );
+    for (final Pair<Double, Double> thisValue : leftValues) {
+      leftAgg = udaf.aggregate(thisValue, leftAgg);
+    }
+
+    Struct rightAgg = udaf.initialize();
+    final List<Pair<Double, Double>> rightValues = ImmutableList.of(
+            Pair.of(18.1, 421.0),
+            Pair.of(22.6, 445.0),
+            Pair.of(17.2, 408.0)
+    );
+    for (final Pair<Double, Double> thisValue : rightValues) {
+      rightAgg = udaf.aggregate(thisValue, rightAgg);
+    }
+
+    final double correlation = udaf.map(udaf.merge(leftAgg, rightAgg));
+
+    assertThat(0.9575, closeTo(correlation, 0.00005));
+  }
+
+  @Test
+  public void shouldUndoCorrelations() {
+    final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
+            CorrelationUdaf.createCorrelation();
+
+    Struct agg = udaf.initialize();
+    final List<Pair<Double, Double>> values = ImmutableList.of(
+            Pair.of(14.2, 215.0),
+            Pair.of(16.4, 325.0),
+            Pair.of(11.9, 185.0),
+            Pair.of(15.2, 332.0),
+            Pair.of(18.5, 406.0),
+            Pair.of(23.4, 203.0),
+            Pair.of(13.1, null),
+            Pair.of(22.1, 522.0),
+            Pair.of(19.4, 412.0),
+            Pair.of(25.1, 614.0),
+            Pair.of(23.4, 544.0),
+            Pair.of(18.1, 421.0),
+            Pair.of(22.6, 445.0),
+            Pair.of(null, 620.0),
+            Pair.of(17.2, 408.0)
+    );
+    for (final Pair<Double, Double> thisValue : values) {
+      agg = udaf.aggregate(thisValue, agg);
+    }
+
+    agg = udaf.undo(Pair.of(23.4, 203.0), agg);
+    agg = udaf.undo(Pair.of(13.1, null), agg);
+    agg = udaf.undo(Pair.of(null, 620.0), agg);
+
+    final double correlation = udaf.map(agg);
+
+    assertThat(0.9575, closeTo(correlation, 0.00005));
+  }
+
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/correlation/CorrelationUdafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/correlation/CorrelationUdafTest.java
@@ -340,6 +340,59 @@ public class CorrelationUdafTest {
   }
 
   @Test
+  public void shouldCorrelateDoublesOnePoint() {
+    final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
+            CorrelationUdaf.createCorrelation();
+
+    Struct agg = udaf.initialize();
+    final List<Pair<Double, Double>> values = ImmutableList.of(
+            Pair.of(15.0, 20.0)
+    );
+    for (final Pair<Double, Double> thisValue : values) {
+      agg = udaf.aggregate(thisValue, agg);
+    }
+    final double correlation = udaf.map(agg);
+
+    assertThat(Double.isNaN(correlation), is(true));
+  }
+
+  @Test
+  public void shouldCorrelateDoublesTwoPointsPositive() {
+    final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
+            CorrelationUdaf.createCorrelation();
+
+    Struct agg = udaf.initialize();
+    final List<Pair<Double, Double>> values = ImmutableList.of(
+            Pair.of(15.0, 20.0),
+            Pair.of(20.0, 30.0)
+    );
+    for (final Pair<Double, Double> thisValue : values) {
+      agg = udaf.aggregate(thisValue, agg);
+    }
+    final double correlation = udaf.map(agg);
+
+    assertThat(correlation, closeTo(1.0, 0.00005));
+  }
+
+  @Test
+  public void shouldCorrelateDoublesTwoPointsNegative() {
+    final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
+            CorrelationUdaf.createCorrelation();
+
+    Struct agg = udaf.initialize();
+    final List<Pair<Double, Double>> values = ImmutableList.of(
+            Pair.of(15.0, 20.0),
+            Pair.of(20.0, -30.0)
+    );
+    for (final Pair<Double, Double> thisValue : values) {
+      agg = udaf.aggregate(thisValue, agg);
+    }
+    final double correlation = udaf.map(agg);
+
+    assertThat(correlation, closeTo(-1.0, 0.00005));
+  }
+
+  @Test
   public void shouldMergeCorrelations() {
     final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
             CorrelationUdaf.createCorrelation();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/correlation/CorrelationUdafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/correlation/CorrelationUdafTest.java
@@ -30,7 +30,7 @@ public class CorrelationUdafTest {
   @Test
   public void shouldCorrelateDoublesPerfectPositiveNoNulls() {
     final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
-            CorrelationUdaf.createCorrelation();
+            CorrelationUdaf.createCorrelationDouble();
 
     Struct agg = udaf.initialize();
     final List<Pair<Double, Double>> values = ImmutableList.of(
@@ -58,7 +58,7 @@ public class CorrelationUdafTest {
   @Test
   public void shouldCorrelateDoublesStrongPositiveNoNulls() {
     final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
-            CorrelationUdaf.createCorrelation();
+            CorrelationUdaf.createCorrelationDouble();
 
     Struct agg = udaf.initialize();
     final List<Pair<Double, Double>> values = ImmutableList.of(
@@ -86,7 +86,7 @@ public class CorrelationUdafTest {
   @Test
   public void shouldCorrelateDoublesWeakPositiveNoNulls() {
     final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
-            CorrelationUdaf.createCorrelation();
+            CorrelationUdaf.createCorrelationDouble();
 
     Struct agg = udaf.initialize();
     final List<Pair<Double, Double>> values = ImmutableList.of(
@@ -114,7 +114,7 @@ public class CorrelationUdafTest {
   @Test
   public void shouldCorrelateDoublesNoCorrelationNoNulls() {
     final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
-            CorrelationUdaf.createCorrelation();
+            CorrelationUdaf.createCorrelationDouble();
 
     Struct agg = udaf.initialize();
     final List<Pair<Double, Double>> values = ImmutableList.of(
@@ -142,7 +142,7 @@ public class CorrelationUdafTest {
   @Test
   public void shouldCorrelateDoublesWeakNegativeNoNulls() {
     final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
-            CorrelationUdaf.createCorrelation();
+            CorrelationUdaf.createCorrelationDouble();
 
     Struct agg = udaf.initialize();
     final List<Pair<Double, Double>> values = ImmutableList.of(
@@ -170,7 +170,7 @@ public class CorrelationUdafTest {
   @Test
   public void shouldCorrelateDoublesStrongNegativeNoNulls() {
     final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
-            CorrelationUdaf.createCorrelation();
+            CorrelationUdaf.createCorrelationDouble();
 
     Struct agg = udaf.initialize();
     final List<Pair<Double, Double>> values = ImmutableList.of(
@@ -198,7 +198,7 @@ public class CorrelationUdafTest {
   @Test
   public void shouldCorrelateDoublesPerfectNegativeNoNulls() {
     final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
-            CorrelationUdaf.createCorrelation();
+            CorrelationUdaf.createCorrelationDouble();
 
     Struct agg = udaf.initialize();
     final List<Pair<Double, Double>> values = ImmutableList.of(
@@ -226,7 +226,7 @@ public class CorrelationUdafTest {
   @Test
   public void shouldCorrelateDoublesOnlyPositiveValuesNoNulls() {
     final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
-            CorrelationUdaf.createCorrelation();
+            CorrelationUdaf.createCorrelationDouble();
 
     Struct agg = udaf.initialize();
     final List<Pair<Double, Double>> values = ImmutableList.of(
@@ -254,7 +254,7 @@ public class CorrelationUdafTest {
   @Test
   public void shouldCorrelateDoublesOnlyNegativeValuesNoNulls() {
     final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
-            CorrelationUdaf.createCorrelation();
+            CorrelationUdaf.createCorrelationDouble();
 
     Struct agg = udaf.initialize();
     final List<Pair<Double, Double>> values = ImmutableList.of(
@@ -282,7 +282,7 @@ public class CorrelationUdafTest {
   @Test
   public void shouldCorrelateDoublesIgnoresNulls() {
     final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
-            CorrelationUdaf.createCorrelation();
+            CorrelationUdaf.createCorrelationDouble();
 
     Struct agg = udaf.initialize();
     final List<Pair<Double, Double>> values = ImmutableList.of(
@@ -312,7 +312,7 @@ public class CorrelationUdafTest {
   @Test
   public void shouldCorrelateDoublesOnlyNulls() {
     final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
-            CorrelationUdaf.createCorrelation();
+            CorrelationUdaf.createCorrelationDouble();
 
     Struct agg = udaf.initialize();
     final List<Pair<Double, Double>> values = ImmutableList.of(
@@ -342,7 +342,7 @@ public class CorrelationUdafTest {
   @Test
   public void shouldCorrelateDoublesOnePoint() {
     final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
-            CorrelationUdaf.createCorrelation();
+            CorrelationUdaf.createCorrelationDouble();
 
     Struct agg = udaf.initialize();
     final List<Pair<Double, Double>> values = ImmutableList.of(
@@ -359,7 +359,7 @@ public class CorrelationUdafTest {
   @Test
   public void shouldCorrelateDoublesTwoPointsPositive() {
     final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
-            CorrelationUdaf.createCorrelation();
+            CorrelationUdaf.createCorrelationDouble();
 
     Struct agg = udaf.initialize();
     final List<Pair<Double, Double>> values = ImmutableList.of(
@@ -377,7 +377,7 @@ public class CorrelationUdafTest {
   @Test
   public void shouldCorrelateDoublesTwoPointsNegative() {
     final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
-            CorrelationUdaf.createCorrelation();
+            CorrelationUdaf.createCorrelationDouble();
 
     Struct agg = udaf.initialize();
     final List<Pair<Double, Double>> values = ImmutableList.of(
@@ -395,7 +395,7 @@ public class CorrelationUdafTest {
   @Test
   public void shouldCorrelateDoublesSameXValues() {
     final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
-            CorrelationUdaf.createCorrelation();
+            CorrelationUdaf.createCorrelationDouble();
 
     Struct agg = udaf.initialize();
     final List<Pair<Double, Double>> values = ImmutableList.of(
@@ -417,7 +417,7 @@ public class CorrelationUdafTest {
   @Test
   public void shouldCorrelateDoublesSameYValues() {
     final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
-            CorrelationUdaf.createCorrelation();
+            CorrelationUdaf.createCorrelationDouble();
 
     Struct agg = udaf.initialize();
     final List<Pair<Double, Double>> values = ImmutableList.of(
@@ -439,7 +439,7 @@ public class CorrelationUdafTest {
   @Test
   public void shouldMergeCorrelations() {
     final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
-            CorrelationUdaf.createCorrelation();
+            CorrelationUdaf.createCorrelationDouble();
 
     Struct leftAgg = udaf.initialize();
     final List<Pair<Double, Double>> leftValues = ImmutableList.of(
@@ -475,7 +475,7 @@ public class CorrelationUdafTest {
   @Test
   public void shouldUndoCorrelations() {
     final TableUdaf<Pair<Double, Double>, Struct, Double> udaf =
-            CorrelationUdaf.createCorrelation();
+            CorrelationUdaf.createCorrelationDouble();
 
     Struct agg = udaf.initialize();
     final List<Pair<Double, Double>> values = ImmutableList.of(
@@ -506,6 +506,66 @@ public class CorrelationUdafTest {
     final double correlation = udaf.map(agg);
 
     assertThat(0.9575, closeTo(correlation, 0.00005));
+  }
+
+  @Test
+  public void shouldCorrelateIntegersIgnoresNulls() {
+    final TableUdaf<Pair<Integer, Integer>, Struct, Double> udaf =
+            CorrelationUdaf.createCorrelationInteger();
+
+    Struct agg = udaf.initialize();
+    final List<Pair<Integer, Integer>> values = ImmutableList.of(
+            Pair.of(14, 215),
+            Pair.of(16, 325),
+            Pair.of(11, 185),
+            Pair.of(15, 332),
+            Pair.of(18, 406),
+            Pair.of(13, null),
+            Pair.of(22, 522),
+            Pair.of(19, 412),
+            Pair.of(25, 614),
+            Pair.of(23, 544),
+            Pair.of(18, 421),
+            Pair.of(22, 445),
+            Pair.of(null, 620),
+            Pair.of(17, 408)
+    );
+    for (final Pair<Integer, Integer> thisValue : values) {
+      agg = udaf.aggregate(thisValue, agg);
+    }
+    final double correlation = udaf.map(agg);
+
+    assertThat(0.9645, closeTo(correlation, 0.00005));
+  }
+
+  @Test
+  public void shouldCorrelateLongsIgnoresNulls() {
+    final TableUdaf<Pair<Long, Long>, Struct, Double> udaf =
+            CorrelationUdaf.createCorrelationLong();
+
+    Struct agg = udaf.initialize();
+    final List<Pair<Long, Long>> values = ImmutableList.of(
+            Pair.of(14L, 215L),
+            Pair.of(16L, 325L),
+            Pair.of(11L, 185L),
+            Pair.of(15L, 332L),
+            Pair.of(18L, 406L),
+            Pair.of(13L, null),
+            Pair.of(22L, 522L),
+            Pair.of(19L, 412L),
+            Pair.of(25L, 614L),
+            Pair.of(23L, 544L),
+            Pair.of(18L, 421L),
+            Pair.of(22L, 445L),
+            Pair.of(null, 620L),
+            Pair.of(17L, 408L)
+    );
+    for (final Pair<Long, Long> thisValue : values) {
+      agg = udaf.aggregate(thisValue, agg);
+    }
+    final double correlation = udaf.map(agg);
+
+    assertThat(0.9645, closeTo(correlation, 0.00005));
   }
 
 }

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/correlation-udaf_-_correlation_double/7.3.0_1659562540395/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/correlation-udaf_-_correlation_double/7.3.0_1659562540395/plan.json
@@ -1,0 +1,259 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID STRING KEY, X DOUBLE, Y DOUBLE) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` STRING KEY, `X` DOUBLE, `Y` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  CORRELATION(INPUT.X, INPUT.Y) CORRELATION\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `CORRELATION` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    }
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `X` DOUBLE, `Y` DOUBLE",
+                  "pseudoColumnVersion" : 1
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectedKeys" : null,
+                "selectExpressions" : [ "ID AS ID", "X AS X", "Y AS Y" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "JSON",
+                  "properties" : { }
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "X", "Y" ],
+            "aggregationFunctions" : [ "CORRELATION(X, Y)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS CORRELATION" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA",
+              "properties" : { }
+            },
+            "valueFormat" : {
+              "format" : "JSON",
+              "properties" : { }
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.websocket.connection.max.timeout.ms" : "0",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "true",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.json_sr.converter.deserializer.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/correlation-udaf_-_correlation_double/7.3.0_1659562540395/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/correlation-udaf_-_correlation_double/7.3.0_1659562540395/spec.json
@@ -1,0 +1,212 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1659562540395,
+  "path" : "query-validation-tests/correlation-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.Project" : {
+      "schema" : "`ID` STRING KEY, `CORRELATION` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` STRING KEY, `ID` STRING, `X` DOUBLE, `Y` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` STRING KEY, `X` DOUBLE, `Y` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` STRING KEY, `ID` STRING, `X` DOUBLE, `Y` DOUBLE, `KSQL_AGG_VARIABLE_0` STRUCT<`X_SUM` DOUBLE, `Y_SUM` DOUBLE, `X_SQUARED_SUM` DOUBLE, `Y_SQUARED_SUM` DOUBLE, `XY_SUM` DOUBLE, `COUNT` BIGINT>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` STRING KEY, `CORRELATION` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "correlation double",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "alice",
+      "value" : {
+        "x" : 1.5,
+        "y" : 8.0
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "bob",
+      "value" : {
+        "x" : -3.5,
+        "y" : -2.0
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "alice",
+      "value" : {
+        "x" : -1.0,
+        "y" : -2.0
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "alice",
+      "value" : {
+        "x" : -4.5,
+        "y" : -1.0
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "bob",
+      "value" : {
+        "x" : 13.1,
+        "y" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "bob",
+      "value" : {
+        "x" : 3.0,
+        "y" : 11.0
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "alice",
+      "value" : {
+        "x" : null,
+        "y" : -6.0
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "alice",
+      "value" : {
+        "CORRELATION" : "NaN"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "bob",
+      "value" : {
+        "CORRELATION" : "NaN"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "alice",
+      "value" : {
+        "CORRELATION" : 1.0
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "alice",
+      "value" : {
+        "CORRELATION" : 0.7580764521133173
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "bob",
+      "value" : {
+        "CORRELATION" : "NaN"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "bob",
+      "value" : {
+        "CORRELATION" : 1.0
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "alice",
+      "value" : {
+        "CORRELATION" : 0.7580764521133173
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID STRING KEY, X double, Y double) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, correlation(X, Y) AS correlation FROM INPUT group by ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `X` DOUBLE, `Y` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` STRING KEY, `CORRELATION` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/correlation-udaf_-_correlation_double/7.3.0_1659562540395/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/correlation-udaf_-_correlation_double/7.3.0_1659562540395/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/correlation-udaf_-_correlation_int/7.3.0_1659986544367/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/correlation-udaf_-_correlation_int/7.3.0_1659986544367/plan.json
@@ -1,0 +1,259 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID STRING KEY, X INTEGER, Y INTEGER) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` STRING KEY, `X` INTEGER, `Y` INTEGER",
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  CORRELATION(INPUT.X, INPUT.Y) CORRELATION\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `CORRELATION` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    }
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `X` INTEGER, `Y` INTEGER",
+                  "pseudoColumnVersion" : 1
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectedKeys" : null,
+                "selectExpressions" : [ "ID AS ID", "X AS X", "Y AS Y" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "JSON",
+                  "properties" : { }
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "X", "Y" ],
+            "aggregationFunctions" : [ "CORRELATION(X, Y)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS CORRELATION" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA",
+              "properties" : { }
+            },
+            "valueFormat" : {
+              "format" : "JSON",
+              "properties" : { }
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.websocket.connection.max.timeout.ms" : "0",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "true",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.json_sr.converter.deserializer.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/correlation-udaf_-_correlation_int/7.3.0_1659986544367/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/correlation-udaf_-_correlation_int/7.3.0_1659986544367/spec.json
@@ -1,0 +1,212 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1659986544367,
+  "path" : "query-validation-tests/correlation-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.Project" : {
+      "schema" : "`ID` STRING KEY, `CORRELATION` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` STRING KEY, `ID` STRING, `X` INTEGER, `Y` INTEGER",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` STRING KEY, `X` INTEGER, `Y` INTEGER",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` STRING KEY, `ID` STRING, `X` INTEGER, `Y` INTEGER, `KSQL_AGG_VARIABLE_0` STRUCT<`X_SUM` DOUBLE, `Y_SUM` DOUBLE, `X_SQUARED_SUM` DOUBLE, `Y_SQUARED_SUM` DOUBLE, `XY_SUM` DOUBLE, `COUNT` BIGINT>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` STRING KEY, `CORRELATION` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "correlation int",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "alice",
+      "value" : {
+        "x" : 1,
+        "y" : 8
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "bob",
+      "value" : {
+        "x" : -3,
+        "y" : -2
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "alice",
+      "value" : {
+        "x" : -1,
+        "y" : -2
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "alice",
+      "value" : {
+        "x" : -4,
+        "y" : -1
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "bob",
+      "value" : {
+        "x" : 13,
+        "y" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "bob",
+      "value" : {
+        "x" : 3,
+        "y" : 11
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "alice",
+      "value" : {
+        "x" : null,
+        "y" : -6
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "alice",
+      "value" : {
+        "CORRELATION" : "NaN"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "bob",
+      "value" : {
+        "CORRELATION" : "NaN"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "alice",
+      "value" : {
+        "CORRELATION" : 1.0
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "alice",
+      "value" : {
+        "CORRELATION" : 0.7455284088780169
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "bob",
+      "value" : {
+        "CORRELATION" : "NaN"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "bob",
+      "value" : {
+        "CORRELATION" : 1.0
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "alice",
+      "value" : {
+        "CORRELATION" : 0.7455284088780169
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID STRING KEY, X integer, Y integer) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, correlation(X, Y) AS correlation FROM INPUT group by ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `X` INTEGER, `Y` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` STRING KEY, `CORRELATION` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/correlation-udaf_-_correlation_int/7.3.0_1659986544367/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/correlation-udaf_-_correlation_int/7.3.0_1659986544367/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/correlation-udaf_-_correlation_long/7.3.0_1659986545310/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/correlation-udaf_-_correlation_long/7.3.0_1659986545310/plan.json
@@ -1,0 +1,259 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID STRING KEY, X BIGINT, Y BIGINT) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` STRING KEY, `X` BIGINT, `Y` BIGINT",
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  CORRELATION(INPUT.X, INPUT.Y) CORRELATION\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `CORRELATION` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    }
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `X` BIGINT, `Y` BIGINT",
+                  "pseudoColumnVersion" : 1
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectedKeys" : null,
+                "selectExpressions" : [ "ID AS ID", "X AS X", "Y AS Y" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "JSON",
+                  "properties" : { }
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "X", "Y" ],
+            "aggregationFunctions" : [ "CORRELATION(X, Y)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS CORRELATION" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA",
+              "properties" : { }
+            },
+            "valueFormat" : {
+              "format" : "JSON",
+              "properties" : { }
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.websocket.connection.max.timeout.ms" : "0",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "true",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.json_sr.converter.deserializer.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/correlation-udaf_-_correlation_long/7.3.0_1659986545310/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/correlation-udaf_-_correlation_long/7.3.0_1659986545310/spec.json
@@ -1,0 +1,212 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1659986545310,
+  "path" : "query-validation-tests/correlation-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.Project" : {
+      "schema" : "`ID` STRING KEY, `CORRELATION` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` STRING KEY, `ID` STRING, `X` BIGINT, `Y` BIGINT",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` STRING KEY, `X` BIGINT, `Y` BIGINT",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` STRING KEY, `ID` STRING, `X` BIGINT, `Y` BIGINT, `KSQL_AGG_VARIABLE_0` STRUCT<`X_SUM` DOUBLE, `Y_SUM` DOUBLE, `X_SQUARED_SUM` DOUBLE, `Y_SQUARED_SUM` DOUBLE, `XY_SUM` DOUBLE, `COUNT` BIGINT>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` STRING KEY, `CORRELATION` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "correlation long",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "alice",
+      "value" : {
+        "x" : 1,
+        "y" : 8
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "bob",
+      "value" : {
+        "x" : -3,
+        "y" : -2
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "alice",
+      "value" : {
+        "x" : -1,
+        "y" : -2
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "alice",
+      "value" : {
+        "x" : -4,
+        "y" : -1
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "bob",
+      "value" : {
+        "x" : 13,
+        "y" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "bob",
+      "value" : {
+        "x" : 3,
+        "y" : 11
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "alice",
+      "value" : {
+        "x" : null,
+        "y" : -6
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "alice",
+      "value" : {
+        "CORRELATION" : "NaN"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "bob",
+      "value" : {
+        "CORRELATION" : "NaN"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "alice",
+      "value" : {
+        "CORRELATION" : 1.0
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "alice",
+      "value" : {
+        "CORRELATION" : 0.7455284088780169
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "bob",
+      "value" : {
+        "CORRELATION" : "NaN"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "bob",
+      "value" : {
+        "CORRELATION" : 1.0
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "alice",
+      "value" : {
+        "CORRELATION" : 0.7455284088780169
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID STRING KEY, X bigint, Y bigint) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, correlation(X, Y) AS correlation FROM INPUT group by ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `X` BIGINT, `Y` BIGINT",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` STRING KEY, `CORRELATION` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/correlation-udaf_-_correlation_long/7.3.0_1659986545310/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/correlation-udaf_-_correlation_long/7.3.0_1659986545310/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/correlation-udaf_-_correlation_udaf_with_table/7.3.0_1659562541482/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/correlation-udaf_-_correlation_udaf_with_table/7.3.0_1659562541482/plan.json
@@ -1,0 +1,279 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE INPUT (ID STRING PRIMARY KEY, K STRING, X DOUBLE, Y DOUBLE) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` STRING KEY, `K` STRING, `X` DOUBLE, `Y` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.K K,\n  CORRELATION(INPUT.X, INPUT.Y) CORRELATION\nFROM INPUT INPUT\nGROUP BY INPUT.K\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `CORRELATION` DOUBLE",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV2",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV2",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    }
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` STRING KEY, `K` STRING, `X` DOUBLE, `Y` DOUBLE",
+                  "pseudoColumnVersion" : 1,
+                  "stateStoreFormats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    }
+                  }
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "K AS K", "X AS X", "Y AS Y" ],
+                "internalFormats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA",
+                    "properties" : { }
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON",
+                    "properties" : { }
+                  }
+                }
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "JSON",
+                  "properties" : { }
+                }
+              },
+              "groupByExpressions" : [ "K" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "nonAggregateColumns" : [ "K", "X", "Y" ],
+            "aggregationFunctions" : [ "CORRELATION(X, Y)" ]
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS CORRELATION" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA",
+              "properties" : { }
+            },
+            "valueFormat" : {
+              "format" : "JSON",
+              "properties" : { }
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.websocket.connection.max.timeout.ms" : "0",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "true",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.json_sr.converter.deserializer.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/correlation-udaf_-_correlation_udaf_with_table/7.3.0_1659562541482/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/correlation-udaf_-_correlation_udaf_with_table/7.3.0_1659562541482/spec.json
@@ -1,0 +1,217 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1659562541482,
+  "path" : "query-validation-tests/correlation-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.Project" : {
+      "schema" : "`K` STRING KEY, `CORRELATION` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`K` STRING KEY, `K` STRING, `X` DOUBLE, `Y` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source.Materialized" : {
+      "schema" : "`ID` STRING KEY, `K` STRING, `X` DOUBLE, `Y` DOUBLE, `ROWPARTITION` INTEGER, `ROWOFFSET` BIGINT",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` STRING KEY, `K` STRING, `X` DOUBLE, `Y` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`K` STRING KEY, `K` STRING, `X` DOUBLE, `Y` DOUBLE, `KSQL_AGG_VARIABLE_0` STRUCT<`X_SUM` DOUBLE, `Y_SUM` DOUBLE, `X_SQUARED_SUM` DOUBLE, `Y_SQUARED_SUM` DOUBLE, `XY_SUM` DOUBLE, `COUNT` BIGINT>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `CORRELATION` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.Prepare" : {
+      "schema" : "`ID` STRING KEY, `K` STRING, `X` DOUBLE, `Y` DOUBLE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "correlation udaf with table",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "alice",
+      "value" : {
+        "K" : "a",
+        "x" : 1.5,
+        "y" : 8.0
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "bob",
+      "value" : {
+        "K" : "a",
+        "x" : -3.5,
+        "y" : -2.0
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "alice",
+      "value" : {
+        "K" : "a",
+        "x" : -1.0,
+        "y" : -2.0
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "charlie",
+      "value" : {
+        "K" : "a",
+        "x" : -4.5,
+        "y" : -1.0
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "a",
+      "value" : {
+        "CORRELATION" : "NaN"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "a",
+      "value" : {
+        "CORRELATION" : 1.0
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "a",
+      "value" : {
+        "CORRELATION" : "NaN"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "a",
+      "value" : {
+        "CORRELATION" : "NaN"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "a",
+      "value" : {
+        "CORRELATION" : -0.7205766921228921
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE TABLE INPUT (ID STRING PRIMARY KEY, K STRING, X DOUBLE, Y DOUBLE) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT K, correlation(X, Y) AS correlation FROM INPUT group by K;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` STRING KEY, `K` STRING, `X` DOUBLE, `Y` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`K` STRING KEY, `CORRELATION` DOUBLE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-KsqlTopic-Reduce-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/correlation-udaf_-_correlation_udaf_with_table/7.3.0_1659562541482/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/correlation-udaf_-_correlation_udaf_with_table/7.3.0_1659562541482/topology
@@ -1,0 +1,43 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000001 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000002
+    Processor: KTABLE-SOURCE-0000000002 (stores: [])
+      --> KTABLE-TRANSFORMVALUES-0000000003
+      <-- KSTREAM-SOURCE-0000000001
+    Processor: KTABLE-TRANSFORMVALUES-0000000003 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000004
+      <-- KTABLE-SOURCE-0000000002
+    Processor: KTABLE-TRANSFORMVALUES-0000000004 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-TRANSFORMVALUES-0000000003
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000006
+      <-- KTABLE-TRANSFORMVALUES-0000000004
+    Processor: KTABLE-FILTER-0000000006 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- KTABLE-FILTER-0000000006
+    Sink: KSTREAM-SINK-0000000008 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000009 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000010
+    Processor: KTABLE-AGGREGATE-0000000010 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000009
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000010
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000013
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000013 (stores: [])
+      --> KSTREAM-SINK-0000000014
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000014 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000013
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/correlation-udaf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/correlation-udaf.json
@@ -29,6 +29,56 @@
       ]
     },
     {
+      "name": "correlation int",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, X integer, Y integer) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, correlation(X, Y) AS correlation FROM INPUT group by ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "alice", "value": {"x": 1, "y": 8}},
+        {"topic": "test_topic", "key": "bob", "value": {"x": -3, "y": -2}},
+        {"topic": "test_topic", "key": "alice", "value": {"x": -1, "y": -2}},
+        {"topic": "test_topic", "key": "alice", "value": {"x": -4, "y": -1}},
+        {"topic": "test_topic", "key": "bob", "value": {"x": 13, "y": null}},
+        {"topic": "test_topic", "key": "bob", "value": {"x": 3, "y": 11}},
+        {"topic": "test_topic", "key": "alice", "value": {"x": null, "y": -6}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "alice", "value": {"CORRELATION": "NaN"}},
+        {"topic": "OUTPUT", "key": "bob", "value": {"CORRELATION": "NaN"}},
+        {"topic": "OUTPUT", "key": "alice", "value": {"CORRELATION": 1.0}},
+        {"topic": "OUTPUT", "key": "alice", "value": {"CORRELATION": 0.7455284088780169}},
+        {"topic": "OUTPUT", "key": "bob", "value": {"CORRELATION": "NaN"}},
+        {"topic": "OUTPUT", "key": "bob", "value": {"CORRELATION": 1.0}},
+        {"topic": "OUTPUT", "key": "alice", "value": {"CORRELATION": 0.7455284088780169}}
+      ]
+    },
+    {
+      "name": "correlation long",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, X bigint, Y bigint) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, correlation(X, Y) AS correlation FROM INPUT group by ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "alice", "value": {"x": 1, "y": 8}},
+        {"topic": "test_topic", "key": "bob", "value": {"x": -3, "y": -2}},
+        {"topic": "test_topic", "key": "alice", "value": {"x": -1, "y": -2}},
+        {"topic": "test_topic", "key": "alice", "value": {"x": -4, "y": -1}},
+        {"topic": "test_topic", "key": "bob", "value": {"x": 13, "y": null}},
+        {"topic": "test_topic", "key": "bob", "value": {"x": 3, "y": 11}},
+        {"topic": "test_topic", "key": "alice", "value": {"x": null, "y": -6}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "alice", "value": {"CORRELATION": "NaN"}},
+        {"topic": "OUTPUT", "key": "bob", "value": {"CORRELATION": "NaN"}},
+        {"topic": "OUTPUT", "key": "alice", "value": {"CORRELATION": 1.0}},
+        {"topic": "OUTPUT", "key": "alice", "value": {"CORRELATION": 0.7455284088780169}},
+        {"topic": "OUTPUT", "key": "bob", "value": {"CORRELATION": "NaN"}},
+        {"topic": "OUTPUT", "key": "bob", "value": {"CORRELATION": 1.0}},
+        {"topic": "OUTPUT", "key": "alice", "value": {"CORRELATION": 0.7455284088780169}}
+      ]
+    },
+    {
       "name": "correlation - DELIMITED",
       "comment": "DELIMITED does not support STRUCT, so can't support CORRELATION until we use a different internal format",
       "statements": [

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/correlation-udaf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/correlation-udaf.json
@@ -1,6 +1,6 @@
 {
   "comments": [
-    "Tests covering the use of the AVERAGE aggregate function"
+    "Tests covering the use of the CORRELATION aggregate function"
   ],
   "tests": [
     {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/correlation-udaf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/correlation-udaf.json
@@ -1,0 +1,64 @@
+{
+  "comments": [
+    "Tests covering the use of the AVERAGE aggregate function"
+  ],
+  "tests": [
+    {
+      "name": "correlation double",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, X double, Y double) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, correlation(X, Y) AS correlation FROM INPUT group by ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "alice", "value": {"x": 1.5, "y": 8.0}},
+        {"topic": "test_topic", "key": "bob", "value": {"x": -3.5, "y": -2.0}},
+        {"topic": "test_topic", "key": "alice", "value": {"x": -1.0, "y": -2.0}},
+        {"topic": "test_topic", "key": "alice", "value": {"x": -4.5, "y": -1.0}},
+        {"topic": "test_topic", "key": "bob", "value": {"x": 13.1, "y": null}},
+        {"topic": "test_topic", "key": "bob", "value": {"x": 3.0, "y": 11.0}},
+        {"topic": "test_topic", "key": "alice", "value": {"x": null, "y": -6.0}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "alice", "value": {"CORRELATION": "NaN"}},
+        {"topic": "OUTPUT", "key": "bob", "value": {"CORRELATION": "NaN"}},
+        {"topic": "OUTPUT", "key": "alice", "value": {"CORRELATION": 1.0}},
+        {"topic": "OUTPUT", "key": "alice", "value": {"CORRELATION": 0.7580764521133173}},
+        {"topic": "OUTPUT", "key": "bob", "value": {"CORRELATION": "NaN"}},
+        {"topic": "OUTPUT", "key": "bob", "value": {"CORRELATION": 1.0}},
+        {"topic": "OUTPUT", "key": "alice", "value": {"CORRELATION": 0.7580764521133173}}
+      ]
+    },
+    {
+      "name": "correlation - DELIMITED",
+      "comment": "DELIMITED does not support STRUCT, so can't support CORRELATION until we use a different internal format",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, X double, Y double) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "CREATE TABLE OUTPUT AS SELECT ID, correlation(X, Y) AS correlation FROM INPUT group by ID;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "One of the functions used in the statement has an intermediate type that the value format can not handle. Please remove the function or change the format."
+      }
+    },
+    {
+      "name": "correlation udaf with table",
+      "statements": [
+        "CREATE TABLE INPUT (ID STRING PRIMARY KEY, K STRING, X DOUBLE, Y DOUBLE) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT K, correlation(X, Y) AS correlation FROM INPUT group by K;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "alice", "value": {"K": "a", "x": 1.5, "y": 8.0}},
+        {"topic": "test_topic", "key": "bob", "value": {"K": "a", "x": -3.5, "y": -2.0}},
+        {"topic": "test_topic", "key": "alice", "value": {"K": "a", "x": -1.0, "y": -2.0}},
+        {"topic": "test_topic", "key": "charlie", "value": {"K": "a", "x": -4.5, "y": -1.0}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "a", "value": {"CORRELATION": "NaN"}},
+        {"topic": "OUTPUT", "key": "a", "value": {"CORRELATION": 1.0}},
+        {"topic": "OUTPUT", "key": "a", "value": {"CORRELATION": "NaN"}},
+        {"topic": "OUTPUT", "key": "a", "value": {"CORRELATION": "NaN"}},
+        {"topic": "OUTPUT", "key": "a", "value": {"CORRELATION": -0.7205766921228921}}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Description 
Follow-up to #9361. Adds a new UDAF, `CORRELATION`, to compute the Pearson correlation coefficient between two `DOUBLE` columns in a stream or table.

### Testing done 
Added unit tests and QTTs for the new UDAF.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

