### PR TITLE
refactor: refactor TestCaseBuilderUtil class

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilderUtil.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilderUtil.java
@@ -56,7 +56,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -130,8 +129,7 @@ public final class TestCaseBuilderUtil {
     for (String sql : statements) {
       // Creates the `Topic` object when a schema is declared in the CREATE statement
       // and updates the `allTopics` with the schema and features found in the statement
-      final Topic topicFromStatement = createTopicFromStatement(sql, metaStore, ksqlConfig);
-      if (topicFromStatement != null) {
+      createTopicFromStatement(sql, metaStore, ksqlConfig).ifPresent(topicFromStatement -> {
         topicsByName.compute(topicFromStatement.getName(), (key, topic) -> {
           if (topic == null) {
             return topicFromStatement;
@@ -160,7 +158,7 @@ public final class TestCaseBuilderUtil {
             return topic;
           }
         });
-      }
+      });
     }
 
     // If the `Topic` information is not found or resolved directly from the statement, then
@@ -173,56 +171,13 @@ public final class TestCaseBuilderUtil {
   }
 
   // CHECKSTYLE_RULES.OFF: NPathComplexity
-  private static Topic createTopicFromStatement(
+  private static Optional<Topic> createTopicFromStatement(
       final String sql,
       final MutableMetaStore metaStore,
       final KsqlConfig ksqlConfig
   ) {
     // CHECKSTYLE_RULES.ON: NPathComplexity
     final KsqlParser parser = new DefaultKsqlParser();
-
-    final Function<ConfiguredStatement<?>, Topic> extractTopic = (ConfiguredStatement<?> stmt) -> {
-      final CreateSource statement = (CreateSource) stmt.getStatement();
-      final CreateSourceProperties props = statement.getProperties();
-      final TableElements tableElements = statement.getElements();
-
-      if (Iterators.size(tableElements.iterator()) == 0) {
-        return null;
-      }
-
-      final LogicalSchema logicalSchema = tableElements.toLogicalSchema();
-
-      final FormatInfo keyFormatInfo = SourcePropertiesUtil.getKeyFormat(
-          props, statement.getName());
-      final Format keyFormat = FormatFactory.fromName(keyFormatInfo.getFormat());
-      final SerdeFeatures keySerdeFeats = buildKeyFeatures(
-          keyFormat, logicalSchema);
-
-      final Optional<ParsedSchema> keySchema =
-          keyFormat.supportsFeature(SerdeFeature.SCHEMA_INFERENCE)
-              ? buildSchema(sql, logicalSchema.key(), keyFormatInfo, keyFormat, keySerdeFeats)
-              : Optional.empty();
-
-      final FormatInfo valFormatInfo = SourcePropertiesUtil.getValueFormat(props);
-      final Format valFormat = FormatFactory.fromName(valFormatInfo.getFormat());
-      final SerdeFeatures valSerdeFeats = buildValueFeatures(
-          ksqlConfig, props, valFormat, logicalSchema);
-
-      final Optional<ParsedSchema> valueSchema =
-          valFormat.supportsFeature(SerdeFeature.SCHEMA_INFERENCE)
-              ? buildSchema(
-                  sql, logicalSchema.value(), valFormatInfo, valFormat, valSerdeFeats)
-              : Optional.empty();
-
-      final int partitions = props.getPartitions()
-          .orElse(Topic.DEFAULT_PARTITIONS);
-
-      final short rf = props.getReplicas()
-          .orElse(Topic.DEFAULT_RF);
-
-      return new Topic(props.getKafkaTopic(), partitions, rf, keySchema, valueSchema,
-          keySerdeFeats, valSerdeFeats);
-    };
 
     try {
       final List<ParsedStatement> parsed = parser.parse(sql);
@@ -235,7 +190,7 @@ public final class TestCaseBuilderUtil {
         if (stmt.getStatement().statement() instanceof SqlBaseParser.RegisterTypeContext) {
           final PreparedStatement<?> prepare = parser.prepare(stmt, metaStore);
           registerType(prepare, metaStore);
-          return null;
+          return Optional.empty();
         }
 
         if (isCsOrCT(stmt)) {
@@ -245,17 +200,64 @@ public final class TestCaseBuilderUtil {
           final ConfiguredStatement<?> withFormats = new DefaultFormatInjector().inject(configured);
           final ConfiguredStatement<?> withSourceProps =
               new SourcePropertyInjector().inject(withFormats);
-          return extractTopic.apply(withSourceProps);
+          return createTopicFromCreateSource(sql, ksqlConfig, withSourceProps);
         }
       }
 
-      return null;
+      return Optional.empty();
     } catch (final Exception e) {
       // Statement won't parse: this will be detected/handled later.
       System.out.println("Error parsing statement (which may be expected): " + sql);
       e.printStackTrace(System.out);
-      return null;
+      return Optional.empty();
     }
+  }
+
+  private static Optional<Topic> createTopicFromCreateSource(
+      final String sql,
+      final KsqlConfig ksqlConfig,
+      final ConfiguredStatement<?> stmt
+  ) {
+    final CreateSource statement = (CreateSource) stmt.getStatement();
+    final CreateSourceProperties props = statement.getProperties();
+    final TableElements tableElements = statement.getElements();
+
+    if (Iterators.size(tableElements.iterator()) == 0) {
+      return Optional.empty();
+    }
+
+    final LogicalSchema logicalSchema = tableElements.toLogicalSchema();
+
+    final FormatInfo keyFormatInfo = SourcePropertiesUtil.getKeyFormat(
+        props, statement.getName());
+    final Format keyFormat = FormatFactory.fromName(keyFormatInfo.getFormat());
+    final SerdeFeatures keySerdeFeats = buildKeyFeatures(
+        keyFormat, logicalSchema);
+
+    final Optional<ParsedSchema> keySchema =
+        keyFormat.supportsFeature(SerdeFeature.SCHEMA_INFERENCE)
+            ? buildSchema(sql, logicalSchema.key(), keyFormatInfo, keyFormat, keySerdeFeats)
+            : Optional.empty();
+
+    final FormatInfo valFormatInfo = SourcePropertiesUtil.getValueFormat(props);
+    final Format valFormat = FormatFactory.fromName(valFormatInfo.getFormat());
+    final SerdeFeatures valSerdeFeats = buildValueFeatures(
+        ksqlConfig, props, valFormat, logicalSchema);
+
+    final Optional<ParsedSchema> valueSchema =
+        valFormat.supportsFeature(SerdeFeature.SCHEMA_INFERENCE)
+            ? buildSchema(
+            sql, logicalSchema.value(), valFormatInfo, valFormat, valSerdeFeats)
+            : Optional.empty();
+
+    final int partitions = props.getPartitions()
+        .orElse(Topic.DEFAULT_PARTITIONS);
+
+    final short rf = props.getReplicas()
+        .orElse(Topic.DEFAULT_RF);
+
+    return Optional.of(new Topic(props.getKafkaTopic(), partitions, rf, keySchema, valueSchema,
+        keySerdeFeats, valSerdeFeats));
   }
 
   private static Optional<ParsedSchema> buildSchema(


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_
Another minor refactor on the `TestCaseBuilderUtil` class. The `createTopicFromStatement` method was a little confusing. It was using a for loop when only one statement was allowed; registering types when the method name intent was to create topic from a create statement. This was causing some confusion while debugging the code.

I moved the majority of the code from `createTopicFromStatement` to the caller which is the one that loops through each SQL statement and decides what to do with it.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

