### PR TITLE
fix: compare topics not sources

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -564,7 +564,7 @@ public class KsqlConfig extends AbstractConfig {
           + "CREATE SOURCE [TABLE|STREAM] statements will continue being read-only.";
 
   public static final String KSQL_SHARED_RUNTIME_ENABLED = "ksql.runtime.feature.shared.enabled";
-  public static final Boolean KSQL_SHARED_RUNTIME_ENABLED_DEFAULT = false;
+  public static final Boolean KSQL_SHARED_RUNTIME_ENABLED_DEFAULT = true;
   public static final String KSQL_SHARED_RUNTIME_ENABLED_DOC =
       "Feature flag for sharing streams runtimes. "
           + "Default is false. If false, persistent queries will use separate "

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -564,7 +564,7 @@ public class KsqlConfig extends AbstractConfig {
           + "CREATE SOURCE [TABLE|STREAM] statements will continue being read-only.";
 
   public static final String KSQL_SHARED_RUNTIME_ENABLED = "ksql.runtime.feature.shared.enabled";
-  public static final Boolean KSQL_SHARED_RUNTIME_ENABLED_DEFAULT = true;
+  public static final Boolean KSQL_SHARED_RUNTIME_ENABLED_DEFAULT = false;
   public static final String KSQL_SHARED_RUNTIME_ENABLED_DOC =
       "Feature flag for sharing streams runtimes. "
           + "Default is false. If false, persistent queries will use separate "

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -602,7 +602,7 @@ final class EngineExecutor {
         plans.executionPlan.getPhysicalPlan(),
         plans.executionPlan.getQueryId(),
         getApplicationId(plans.executionPlan.getQueryId(),
-            getSourceNames(outputNode))
+            getSourceTopicNames(outputNode))
     );
 
     engineContext.createQueryValidator().validateQuery(
@@ -679,7 +679,7 @@ final class EngineExecutor {
           plans.executionPlan.getPhysicalPlan(),
           plans.executionPlan.getQueryId(),
           getApplicationId(plans.executionPlan.getQueryId(),
-              getSourceNames(outputNode))
+              getSourceTopicNames(outputNode))
       );
 
       engineContext.createQueryValidator().validateQuery(
@@ -701,7 +701,7 @@ final class EngineExecutor {
   }
 
   private Optional<String> getApplicationId(final QueryId queryId,
-                                            final Collection<SourceName> sources) {
+                                            final Collection<String> sources) {
     return config.getConfig(true).getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)
         ? Optional.of(
         engineContext.getRuntimeAssignor()
@@ -1094,6 +1094,14 @@ final class EngineExecutor {
     return outputNode.getSourceNodes()
         .map(DataSourceNode::getDataSource)
         .map(DataSource::getName)
+        .collect(Collectors.toSet());
+  }
+
+  private static Set<String> getSourceTopicNames(final PlanNode outputNode) {
+    return outputNode.getSourceNodes()
+        .map(DataSourceNode::getDataSource)
+        .map(DataSource::getKsqlTopic)
+        .map(KsqlTopic::getKafkaTopicName)
         .collect(Collectors.toSet());
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
@@ -34,7 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RuntimeAssignor {
-  private final Map<String, Collection<SourceName>> runtimesToSources;
+  private final Map<String, Collection<String>> runtimesToSources;
   private final Map<QueryId, String> idToRuntime;
   private final Logger log = LoggerFactory.getLogger(RuntimeAssignor.class);
   private final int numDefaultRuntimes;
@@ -53,7 +53,7 @@ public class RuntimeAssignor {
     numDefaultRuntimes = other.numDefaultRuntimes;
     this.runtimesToSources = new HashMap<>();
     this.idToRuntime = new HashMap<>(other.idToRuntime);
-    for (Map.Entry<String, Collection<SourceName>> runtime
+    for (Map.Entry<String, Collection<String>> runtime
         : other.runtimesToSources.entrySet()) {
       this.runtimesToSources.put(runtime.getKey(), new HashSet<>(runtime.getValue()));
     }
@@ -64,7 +64,7 @@ public class RuntimeAssignor {
   }
 
   public String getRuntimeAndMaybeAddRuntime(final QueryId queryId,
-                                             final Collection<SourceName> sources,
+                                             final Collection<String> sources,
                                              final KsqlConfig config) {
     if (idToRuntime.containsKey(queryId)) {
       return idToRuntime.get(queryId);
@@ -97,7 +97,7 @@ public class RuntimeAssignor {
             + " only possible with Gen 1 queries", queryMetadata);
       }
       runtimesToSources.get(queryMetadata.getQueryApplicationId())
-          .removeAll(queryMetadata.getSourceNames());
+          .removeAll(queryMetadata.getSourceTopicNames());
       idToRuntime.remove(queryMetadata.getQueryId());
       if (runtimesToSources.get(queryMetadata.getQueryApplicationId()).isEmpty()
           && runtimesToSources.size() > numDefaultRuntimes) {
@@ -123,7 +123,7 @@ public class RuntimeAssignor {
           runtimesToSources.put(queryMetadata.getQueryApplicationId(), new HashSet<>());
         }
         runtimesToSources.get(queryMetadata.getQueryApplicationId())
-            .addAll(queryMetadata.getSourceNames());
+            .addAll(queryMetadata.getSourceTopicNames());
         idToRuntime.put(queryMetadata.getQueryId(), queryMetadata.getQueryApplicationId());
       } else {
         gen1Queries.add(queryMetadata.getQueryId());
@@ -149,7 +149,7 @@ public class RuntimeAssignor {
     }
   }
 
-  public Map<String, Collection<SourceName>> getRuntimesToSources() {
+  public Map<String, Collection<String>> getRuntimesToSources() {
     return ImmutableMap.copyOf(runtimesToSources);
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
@@ -63,7 +63,7 @@ public class RuntimeAssignor {
   }
 
   public String getRuntimeAndMaybeAddRuntime(final QueryId queryId,
-                                             final Collection<String> sources,
+                                             final Collection<String> sourceTopics,
                                              final KsqlConfig config) {
     if (idToRuntime.containsKey(queryId)) {
       return idToRuntime.get(queryId);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
@@ -70,7 +70,7 @@ public class RuntimeAssignor {
     }
     final List<String> possibleRuntimes = runtimesToSourceTopics.entrySet()
         .stream()
-        .filter(t -> t.getValue().stream().noneMatch(sources::contains))
+        .filter(t -> t.getValue().stream().noneMatch(sourceTopics::contains))
         .map(Map.Entry::getKey)
         .collect(Collectors.toList());
     final String runtime;
@@ -79,7 +79,7 @@ public class RuntimeAssignor {
     } else {
       runtime = possibleRuntimes.get(Math.abs(queryId.hashCode() % possibleRuntimes.size()));
     }
-    runtimesToSourceTopics.get(runtime).addAll(sources);
+    runtimesToSourceTopics.get(runtime).addAll(sourceTopics);
     idToRuntime.put(queryId, runtime);
     log.info("Assigning query {} to runtime {}", queryId, runtime);
     return runtime;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.engine;
 import static io.confluent.ksql.util.QueryApplicationId.buildSharedRuntimeId;
 
 import com.google.common.collect.ImmutableMap;
-import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.util.BinPackedPersistentQueryMetadataImpl;
 import io.confluent.ksql.util.KsqlConfig;
@@ -34,28 +33,28 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RuntimeAssignor {
-  private final Map<String, Collection<String>> runtimesToSources;
+  private final Map<String, Collection<String>> runtimesToSourceTopics;
   private final Map<QueryId, String> idToRuntime;
   private final Logger log = LoggerFactory.getLogger(RuntimeAssignor.class);
   private final int numDefaultRuntimes;
 
   public RuntimeAssignor(final KsqlConfig config) {
-    runtimesToSources = new HashMap<>();
+    runtimesToSourceTopics = new HashMap<>();
     idToRuntime = new HashMap<>();
     numDefaultRuntimes = config.getInt(KsqlConfig.KSQL_SHARED_RUNTIMES_COUNT);
     for (int i = 0; i < numDefaultRuntimes; i++) {
       final String runtime = buildSharedRuntimeId(config, true, i);
-      runtimesToSources.put(runtime, new HashSet<>());
+      runtimesToSourceTopics.put(runtime, new HashSet<>());
     }
   }
 
   private RuntimeAssignor(final RuntimeAssignor other) {
     numDefaultRuntimes = other.numDefaultRuntimes;
-    this.runtimesToSources = new HashMap<>();
+    this.runtimesToSourceTopics = new HashMap<>();
     this.idToRuntime = new HashMap<>(other.idToRuntime);
     for (Map.Entry<String, Collection<String>> runtime
-        : other.runtimesToSources.entrySet()) {
-      this.runtimesToSources.put(runtime.getKey(), new HashSet<>(runtime.getValue()));
+        : other.runtimesToSourceTopics.entrySet()) {
+      this.runtimesToSourceTopics.put(runtime.getKey(), new HashSet<>(runtime.getValue()));
     }
   }
 
@@ -69,7 +68,7 @@ public class RuntimeAssignor {
     if (idToRuntime.containsKey(queryId)) {
       return idToRuntime.get(queryId);
     }
-    final List<String> possibleRuntimes = runtimesToSources.entrySet()
+    final List<String> possibleRuntimes = runtimesToSourceTopics.entrySet()
         .stream()
         .filter(t -> t.getValue().stream().noneMatch(sources::contains))
         .map(Map.Entry::getKey)
@@ -80,7 +79,7 @@ public class RuntimeAssignor {
     } else {
       runtime = possibleRuntimes.get(Math.abs(queryId.hashCode() % possibleRuntimes.size()));
     }
-    runtimesToSources.get(runtime).addAll(sources);
+    runtimesToSourceTopics.get(runtime).addAll(sources);
     idToRuntime.put(queryId, runtime);
     log.info("Assigning query {} to runtime {}", queryId, runtime);
     return runtime;
@@ -96,12 +95,12 @@ public class RuntimeAssignor {
         log.warn("Dropping an unassigned query {}, this should"
             + " only possible with Gen 1 queries", queryMetadata);
       }
-      runtimesToSources.get(queryMetadata.getQueryApplicationId())
+      runtimesToSourceTopics.get(queryMetadata.getQueryApplicationId())
           .removeAll(queryMetadata.getSourceTopicNames());
       idToRuntime.remove(queryMetadata.getQueryId());
-      if (runtimesToSources.get(queryMetadata.getQueryApplicationId()).isEmpty()
-          && runtimesToSources.size() > numDefaultRuntimes) {
-        runtimesToSources.remove(queryMetadata.getQueryApplicationId());
+      if (runtimesToSourceTopics.get(queryMetadata.getQueryApplicationId()).isEmpty()
+          && runtimesToSourceTopics.size() > numDefaultRuntimes) {
+        runtimesToSourceTopics.remove(queryMetadata.getQueryApplicationId());
         log.info("Removing runtime {} form selection of possible runtimes",
             queryMetadata.getQueryApplicationId());
       }
@@ -110,8 +109,8 @@ public class RuntimeAssignor {
 
 
   private String makeNewRuntime(final KsqlConfig config) {
-    final String runtime = buildSharedRuntimeId(config, true, runtimesToSources.size());
-    runtimesToSources.put(runtime, new HashSet<>());
+    final String runtime = buildSharedRuntimeId(config, true, runtimesToSourceTopics.size());
+    runtimesToSourceTopics.put(runtime, new HashSet<>());
     return runtime;
   }
 
@@ -119,10 +118,10 @@ public class RuntimeAssignor {
     final Set<QueryId> gen1Queries = new HashSet<>();
     for (PersistentQueryMetadata queryMetadata: queries) {
       if (queryMetadata instanceof BinPackedPersistentQueryMetadataImpl) {
-        if (!runtimesToSources.containsKey(queryMetadata.getQueryApplicationId())) {
-          runtimesToSources.put(queryMetadata.getQueryApplicationId(), new HashSet<>());
+        if (!runtimesToSourceTopics.containsKey(queryMetadata.getQueryApplicationId())) {
+          runtimesToSourceTopics.put(queryMetadata.getQueryApplicationId(), new HashSet<>());
         }
-        runtimesToSources.get(queryMetadata.getQueryApplicationId())
+        runtimesToSourceTopics.get(queryMetadata.getQueryApplicationId())
             .addAll(queryMetadata.getSourceTopicNames());
         idToRuntime.put(queryMetadata.getQueryId(), queryMetadata.getQueryApplicationId());
       } else {
@@ -149,8 +148,8 @@ public class RuntimeAssignor {
     }
   }
 
-  public Map<String, Collection<String>> getRuntimesToSources() {
-    return ImmutableMap.copyOf(runtimesToSources);
+  public Map<String, Collection<String>> getRuntimesToSourceTopics() {
+    return ImmutableMap.copyOf(runtimesToSourceTopics);
   }
 
   public Map<QueryId, String> getIdToRuntime() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
@@ -452,4 +452,9 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
     return listener;
   }
 
+  @Override
+  public Collection<String> getSourceTopicNames() {
+    return topology.sourceTopics();
+  }
+
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -27,6 +27,8 @@ import io.confluent.ksql.query.QueryError;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.query.QuerySchemas;
+
+import java.util.Collection;
 import java.util.Optional;
 import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
@@ -67,6 +69,8 @@ public interface PersistentQueryMetadata extends QueryMetadata {
   );
 
   Optional<ScalablePushRegistry> getScalablePushRegistry();
+
+  Collection<String> getSourceTopicNames();
 
   final class QueryListenerWrapper implements Listener {
     private final Listener listener;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -27,7 +27,6 @@ import io.confluent.ksql.query.QueryError;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.query.QuerySchemas;
-
 import java.util.Collection;
 import java.util.Optional;
 import org.apache.kafka.streams.KafkaStreams.State;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
@@ -36,7 +36,6 @@ import io.confluent.ksql.query.QueryErrorClassifier;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.query.QuerySchemas;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
@@ -36,6 +36,9 @@ import io.confluent.ksql.query.QueryErrorClassifier;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.query.QuerySchemas;
+
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -236,6 +239,10 @@ public class PersistentQueryMetadataImpl
 
   public Optional<ScalablePushRegistry> getScalablePushRegistry() {
     return scalablePushRegistry;
+  }
+
+  public Collection<String> getSourceTopicNames() {
+    return Collections.emptySet();
   }
 
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/RuntimeAssignorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/RuntimeAssignorTest.java
@@ -30,8 +30,8 @@ public class RuntimeAssignorTest {
   public BinPackedPersistentQueryMetadataImpl queryMetadata;
   private final QueryId query1 = new QueryId("Test1");
   private final QueryId query2 = new QueryId("Test2");
-  private final Collection<SourceName> sources1 = Collections.singleton(SourceName.of("test1"));
-  private final Collection<SourceName> sources2 = Collections.singleton(SourceName.of("test2"));
+  private final Collection<String> sources1 = Collections.singleton("test1");
+  private final Collection<String> sources2 = Collections.singleton("test2");
 
   private String firstRuntime;
   private RuntimeAssignor runtimeAssignor;
@@ -48,7 +48,7 @@ public class RuntimeAssignorTest {
     );
     when(queryMetadata.getQueryApplicationId()).thenReturn(firstRuntime);
     when(queryMetadata.getQueryId()).thenReturn(query1);
-    when(queryMetadata.getSourceNames()).thenReturn(ImmutableSet.copyOf(new HashSet<>(sources1)));
+    when(queryMetadata.getSourceTopicNames()).thenReturn(ImmutableSet.copyOf(new HashSet<>(sources1)));
   }
 
   @Test
@@ -193,7 +193,7 @@ public class RuntimeAssignorTest {
           KSQL_CONFIG
       ));
       when(query.getQueryId()).thenReturn(query1);
-      when(query.getSourceNames()).thenReturn(ImmutableSet.copyOf(new HashSet<>(sources1)));
+      when(query.getSourceTopicNames()).thenReturn(ImmutableSet.copyOf(new HashSet<>(sources1)));
       queries.add(query);
     }
     return queries;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/RuntimeAssignorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/RuntimeAssignorTest.java
@@ -1,7 +1,6 @@
 package io.confluent.ksql.engine;
 
 import com.google.common.collect.ImmutableSet;
-import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.util.BinPackedPersistentQueryMetadataImpl;
 import io.confluent.ksql.util.KsqlConfig;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/RuntimeAssignorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/RuntimeAssignorTest.java
@@ -110,18 +110,6 @@ public class RuntimeAssignorTest {
   }
 
   @Test
-  public void shouldAddingAQueryWithSameSourcesWillAddARuntime() {
-    when(queryMetadata.getSourceNames()).thenReturn(Collections.singleton(SourceName.of("Same")));
-    runtimeAssignor.getRuntimeAndMaybeAddRuntime(
-        query2,
-        sourceTopics1,
-        KSQL_CONFIG
-    );
-    assertThat("Query not added.", runtimeAssignor.getIdToRuntime().containsKey(query2));
-    assertThat("Added a new Runtime.", runtimeAssignor.getRuntimesToSourceTopics().size() == 2);
-  }
-
-  @Test
   public void shouldGetSameRuntimeForSameQueryId() {
     final String runtime = runtimeAssignor.getRuntimeAndMaybeAddRuntime(
         query1,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
@@ -793,7 +793,7 @@ public class QueryBuilderTest {
           queryListener,
           ArrayList::new,
           runtimeAssignor.getRuntimeAndMaybeAddRuntime(queryId,
-              sources.stream().map(DataSource::getName).collect(Collectors.toSet()),
+              sources.stream().map(s -> s.getName().toString()).collect(Collectors.toSet()),
               config.getConfig(true)),
           new MetricCollectors()
       );


### PR DESCRIPTION
### Description 
When packing we relied on the source names being mapped to a topic. but it turns out you can make duplicate sources from the same topics with different names. So we now will check the topics directly.

### Testing done 
updated the unit testing to use topics instead of sources
This set of cmds now works
```
create` stream t1_stream (id varchar key, foo varchar) with (kafka_topic='t1', value_format='json', PARTITIONS=1);
create table t1_table (id varchar primary key, foo varchar) with (kafka_topic='t1', value_format='json');
create stream t1_stream_copy as select * from t1_stream;
create stream t1_stream_copy_2 as select * from t1_stream;
create table t1_table_copy as select * from t1_table;
```


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

