### PR TITLE
fix: move udf loading to run before the precondition checker

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplicationMetrics.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplicationMetrics.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+
+package io.confluent.ksql.rest.server;
+
+import java.time.Duration;
+import java.util.Objects;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Metrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KsqlRestApplicationMetrics {
+  private static final Logger LOGGER = LoggerFactory.getLogger(KsqlRestApplicationMetrics.class);
+
+  private static final String GROUP = "ksql-rest-application";
+
+  private final Metrics metrics;
+
+  KsqlRestApplicationMetrics(final Metrics metrics) {
+    this.metrics = Objects.requireNonNull(metrics, "metrics");
+  }
+
+  void recordServerStartLatency(final Duration latency) {
+    final MetricName metricName = metrics.metricName(
+        "startup-time-ms",
+        GROUP
+    );
+    if (metrics.metric(metricName) != null) {
+      LOGGER.error("");
+      return;
+    }
+    LOGGER.info("ksql server took {} to become ready", latency.toString());
+    metrics.addMetric(metricName, (c, t) -> latency.toMillis());
+  }
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplicationMetrics.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplicationMetrics.java
@@ -40,7 +40,7 @@ public class KsqlRestApplicationMetrics {
         GROUP
     );
     if (metrics.metric(metricName) != null) {
-      LOGGER.error("");
+      LOGGER.error("ksql server startup latency already registered");
       return;
     }
     LOGGER.info("ksql server took {} to become ready", latency.toString());

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -201,7 +201,7 @@ public class KsqlRestApplicationTest {
     );
     assertThat(metric, not(nullValue()));
     // compare start time recorded to time around startKsql. add a second for clock jitter
-    assertThat((double) metric.metricValue(), lessThanOrEqualTo((double) (duration + 1000)));
+    assertThat((Double) metric.metricValue(), lessThanOrEqualTo((double) (duration + 1000)));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.properties.PropertiesUtil;
 import io.confluent.ksql.query.QueryId;
@@ -55,6 +56,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.net.SocketAddress;
 import java.net.URI;
 import java.net.URL;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -351,7 +353,9 @@ public class TestKsqlRestApp extends ExternalResource {
               vertx),
           TestRestServiceContextFactory.createDefault(internalSimpleKsqlClientFactory),
           TestRestServiceContextFactory.createUser(internalSimpleKsqlClientFactory),
-          new MetricCollectors()
+          new MetricCollectors(),
+          new InternalFunctionRegistry(),
+          Instant.now()
       );
 
     } catch (final Exception e) {


### PR DESCRIPTION
### Description 
moves udf loading to run before the precondition checker. this ensures
we can quickly start the main server once the precondition checker is
completed running. Also adds a metric to measure server start time

### Testing done 
unit test + test in devel
