### PR TITLE
fix: use internal topic config for transient queries too

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -575,11 +575,15 @@ final class QueryBuilder {
         ThroughputMetricsReporter.class.getName()
     );
 
+    final String type = queryId.isPresent() && queryId.get().toString().contains("transient")
+        ? queryId.get().toString()
+        : "query";
+
     if (config.getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)) {
       newStreamsProperties.put(StreamsConfig.InternalConfig.TOPIC_PREFIX_ALTERNATIVE,
           ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX
               + config.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)
-              + "query");
+              + type);
     }
 
     // Passing shared state into managed components


### PR DESCRIPTION
Signed-off-by: Walker Carlson <wcarlson@confluent.io>

### Description 
For when shared runtimes are on we should use the internal topics prefix for transient queries as well.

### Testing done 
run with the shared runtimes turned on

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

