### PR TITLE
fix: fix regex used to extract queryId from threadId metrics tag

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/MetricsTagUtils.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/MetricsTagUtils.java
@@ -27,7 +27,29 @@ public final class MetricsTagUtils {
   public static final String KSQL_TOPIC_TAG = "topic";
   public static final String KSQL_QUERY_ID_TAG = "query-id";
 
-  public static final Pattern NAMED_TOPOLOGY_PATTERN = Pattern.compile("(.*?)__\\d*_\\d*");
-  public static final Pattern QUERY_ID_PATTERN =
-      Pattern.compile("(?<=query_|transient_)(.*?)(?=-)");
+  public static final Pattern SHARED_RUNTIME_THREAD_ID_PATTERN = Pattern.compile("(.*?)__\\d*_\\d*");
+
+  /*
+   For non-shared runtimes, the thread id will look something like this:
+
+   _confluent-ksql-pksqlc-d1m0zquery_ +                  // thread id prefix
+   CSAS_TEST_COPY-STREAM_1_23 +                          // query id
+   -3d62ddb9-d520-4cb3-9c23-968f8e61e201-StreamThread-1  // thread id suffix
+   */
+  public static final String UUID_PATTERN = "-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}";
+  public static final String THREAD_ID_SUFFIX_PATTERN = UUID_PATTERN + "-StreamThread-\\d";
+  public static final String THREAD_ID_PREFIX_PATTERN = "query_|transient_";
+
+  public static final String QUERY_ID_PATTERN = ".*";
+
+  public static final Pattern UNSHARED_RUNTIME_THREAD_ID_PATTERN =
+      Pattern.compile(
+          // group 1: the lookbehind (?<=) matches the prefix and discards everything before it
+          "(?<=" + THREAD_ID_PREFIX_PATTERN + ")"
+              // group 2: just matches anything/everything that's between group 1 and group 3
+              + "(" + QUERY_ID_PATTERN +")"
+              // group 3: matches the suffix & lookahead to discard the rest (in case we add to it)
+              + "(?=(" + THREAD_ID_SUFFIX_PATTERN + "))"
+      );
+
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/MetricsTagUtils.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/MetricsTagUtils.java
@@ -27,7 +27,7 @@ public final class MetricsTagUtils {
   public static final String KSQL_TOPIC_TAG = "topic";
   public static final String KSQL_QUERY_ID_TAG = "query-id";
 
-  public static final Pattern SHARED_RUNTIME_THREAD_ID_PATTERN = Pattern.compile("(.*?)__\\d*_\\d*");
+  public static final Pattern SHARED_RUNTIME_THREAD_PATTERN = Pattern.compile("(.*?)__\\d*_\\d*");
 
   /*
    For non-shared runtimes, the thread id will look something like this:
@@ -36,18 +36,19 @@ public final class MetricsTagUtils {
    CSAS_TEST_COPY-STREAM_1_23 +                          // query id
    -3d62ddb9-d520-4cb3-9c23-968f8e61e201-StreamThread-1  // thread id suffix
    */
-  public static final String UUID_PATTERN = "-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}";
+  public static final String UUID_PATTERN =
+      "-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}";
   public static final String THREAD_ID_SUFFIX_PATTERN = UUID_PATTERN + "-StreamThread-\\d";
   public static final String THREAD_ID_PREFIX_PATTERN = "query_|transient_";
 
   public static final String QUERY_ID_PATTERN = ".*";
 
-  public static final Pattern UNSHARED_RUNTIME_THREAD_ID_PATTERN =
+  public static final Pattern UNSHARED_RUNTIME_THREAD_PATTERN =
       Pattern.compile(
           // group 1: the lookbehind (?<=) matches the prefix and discards everything before it
           "(?<=" + THREAD_ID_PREFIX_PATTERN + ")"
               // group 2: just matches anything/everything that's between group 1 and group 3
-              + "(" + QUERY_ID_PATTERN +")"
+              + "(" + QUERY_ID_PATTERN + ")"
               // group 3: matches the suffix & lookahead to discard the rest (in case we add to it)
               + "(?=(" + THREAD_ID_SUFFIX_PATTERN + "))"
       );

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
@@ -17,8 +17,8 @@ package io.confluent.ksql.internal;
 
 import static io.confluent.ksql.internal.MetricsTagUtils.KSQL_QUERY_ID_TAG;
 import static io.confluent.ksql.internal.MetricsTagUtils.KSQL_TASK_ID_TAG;
-import static io.confluent.ksql.internal.MetricsTagUtils.NAMED_TOPOLOGY_PATTERN;
-import static io.confluent.ksql.internal.MetricsTagUtils.QUERY_ID_PATTERN;
+import static io.confluent.ksql.internal.MetricsTagUtils.SHARED_RUNTIME_THREAD_ID_PATTERN;
+import static io.confluent.ksql.internal.MetricsTagUtils.UNSHARED_RUNTIME_THREAD_ID_PATTERN;
 import static java.util.Objects.requireNonNull;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TASK_ID_TAG;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.THREAD_ID_TAG;
@@ -270,13 +270,13 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
 
   private String getQueryId(final KafkaMetric metric) {
     final String taskName = metric.metricName().tags().getOrDefault(TASK_ID_TAG, "");
-    final Matcher namedTopologyMatcher = NAMED_TOPOLOGY_PATTERN.matcher(taskName);
+    final Matcher namedTopologyMatcher = SHARED_RUNTIME_THREAD_ID_PATTERN.matcher(taskName);
     if (namedTopologyMatcher.find()) {
       return namedTopologyMatcher.group(1);
     }
 
     final String queryIdTag = metric.metricName().tags().getOrDefault(THREAD_ID_TAG, "");
-    final Matcher matcher = QUERY_ID_PATTERN.matcher(queryIdTag);
+    final Matcher matcher = UNSHARED_RUNTIME_THREAD_ID_PATTERN.matcher(queryIdTag);
     if (matcher.find()) {
       return matcher.group(1);
     } else {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
@@ -17,8 +17,8 @@ package io.confluent.ksql.internal;
 
 import static io.confluent.ksql.internal.MetricsTagUtils.KSQL_QUERY_ID_TAG;
 import static io.confluent.ksql.internal.MetricsTagUtils.KSQL_TASK_ID_TAG;
-import static io.confluent.ksql.internal.MetricsTagUtils.SHARED_RUNTIME_THREAD_ID_PATTERN;
-import static io.confluent.ksql.internal.MetricsTagUtils.UNSHARED_RUNTIME_THREAD_ID_PATTERN;
+import static io.confluent.ksql.internal.MetricsTagUtils.SHARED_RUNTIME_THREAD_PATTERN;
+import static io.confluent.ksql.internal.MetricsTagUtils.UNSHARED_RUNTIME_THREAD_PATTERN;
 import static java.util.Objects.requireNonNull;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TASK_ID_TAG;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.THREAD_ID_TAG;
@@ -270,13 +270,13 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
 
   private String getQueryId(final KafkaMetric metric) {
     final String taskName = metric.metricName().tags().getOrDefault(TASK_ID_TAG, "");
-    final Matcher namedTopologyMatcher = SHARED_RUNTIME_THREAD_ID_PATTERN.matcher(taskName);
+    final Matcher namedTopologyMatcher = SHARED_RUNTIME_THREAD_PATTERN.matcher(taskName);
     if (namedTopologyMatcher.find()) {
       return namedTopologyMatcher.group(1);
     }
 
     final String queryIdTag = metric.metricName().tags().getOrDefault(THREAD_ID_TAG, "");
-    final Matcher matcher = UNSHARED_RUNTIME_THREAD_ID_PATTERN.matcher(queryIdTag);
+    final Matcher matcher = UNSHARED_RUNTIME_THREAD_PATTERN.matcher(queryIdTag);
     if (matcher.find()) {
       return matcher.group(1);
     } else {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/ThroughputMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/ThroughputMetricsReporter.java
@@ -18,8 +18,8 @@ package io.confluent.ksql.internal;
 import static io.confluent.ksql.internal.MetricsTagUtils.KSQL_CONSUMER_GROUP_MEMBER_ID_TAG;
 import static io.confluent.ksql.internal.MetricsTagUtils.KSQL_QUERY_ID_TAG;
 import static io.confluent.ksql.internal.MetricsTagUtils.KSQL_TOPIC_TAG;
-import static io.confluent.ksql.internal.MetricsTagUtils.SHARED_RUNTIME_THREAD_ID_PATTERN;
-import static io.confluent.ksql.internal.MetricsTagUtils.UNSHARED_RUNTIME_THREAD_ID_PATTERN;
+import static io.confluent.ksql.internal.MetricsTagUtils.SHARED_RUNTIME_THREAD_PATTERN;
+import static io.confluent.ksql.internal.MetricsTagUtils.UNSHARED_RUNTIME_THREAD_PATTERN;
 import static java.util.Objects.requireNonNull;
 import static org.apache.kafka.common.utils.Utils.mkSet;
 
@@ -208,14 +208,14 @@ public class ThroughputMetricsReporter implements MetricsReporter {
 
     final String taskName =
         metric.metricName().tags().getOrDefault(StreamsMetricsImpl.TASK_ID_TAG, "");
-    final Matcher namedTopologyMatcher = SHARED_RUNTIME_THREAD_ID_PATTERN.matcher(taskName);
+    final Matcher namedTopologyMatcher = SHARED_RUNTIME_THREAD_PATTERN.matcher(taskName);
     if (namedTopologyMatcher.find()) {
       return namedTopologyMatcher.group(1);
     }
 
     final String queryIdTag =
         metric.metricName().tags().getOrDefault(StreamsMetricsImpl.THREAD_ID_TAG, "");
-    final Matcher matcher = UNSHARED_RUNTIME_THREAD_ID_PATTERN.matcher(queryIdTag);
+    final Matcher matcher = UNSHARED_RUNTIME_THREAD_PATTERN.matcher(queryIdTag);
 
     if (matcher.find()) {
       return matcher.group(1);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/ThroughputMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/ThroughputMetricsReporter.java
@@ -18,8 +18,8 @@ package io.confluent.ksql.internal;
 import static io.confluent.ksql.internal.MetricsTagUtils.KSQL_CONSUMER_GROUP_MEMBER_ID_TAG;
 import static io.confluent.ksql.internal.MetricsTagUtils.KSQL_QUERY_ID_TAG;
 import static io.confluent.ksql.internal.MetricsTagUtils.KSQL_TOPIC_TAG;
-import static io.confluent.ksql.internal.MetricsTagUtils.NAMED_TOPOLOGY_PATTERN;
-import static io.confluent.ksql.internal.MetricsTagUtils.QUERY_ID_PATTERN;
+import static io.confluent.ksql.internal.MetricsTagUtils.SHARED_RUNTIME_THREAD_ID_PATTERN;
+import static io.confluent.ksql.internal.MetricsTagUtils.UNSHARED_RUNTIME_THREAD_ID_PATTERN;
 import static java.util.Objects.requireNonNull;
 import static org.apache.kafka.common.utils.Utils.mkSet;
 
@@ -208,14 +208,15 @@ public class ThroughputMetricsReporter implements MetricsReporter {
 
     final String taskName =
         metric.metricName().tags().getOrDefault(StreamsMetricsImpl.TASK_ID_TAG, "");
-    final Matcher namedTopologyMatcher = NAMED_TOPOLOGY_PATTERN.matcher(taskName);
+    final Matcher namedTopologyMatcher = SHARED_RUNTIME_THREAD_ID_PATTERN.matcher(taskName);
     if (namedTopologyMatcher.find()) {
       return namedTopologyMatcher.group(1);
     }
 
     final String queryIdTag =
         metric.metricName().tags().getOrDefault(StreamsMetricsImpl.THREAD_ID_TAG, "");
-    final Matcher matcher = QUERY_ID_PATTERN.matcher(queryIdTag);
+    final Matcher matcher = UNSHARED_RUNTIME_THREAD_ID_PATTERN.matcher(queryIdTag);
+
     if (matcher.find()) {
       return matcher.group(1);
     } else {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporterTest.java
@@ -39,8 +39,9 @@ public class StorageUtilizationMetricsReporterTest {
   private static final String KAFKA_METRIC_NAME = "total-sst-files-size";
   private static final String KAFKA_METRIC_GROUP = "streams-metric";
   private static final String KSQL_METRIC_GROUP = "ksqldb_utilization";
-  private static final String THREAD_ID = "_confluent_blahblah_query_CTAS_TEST_1-blahblah";
-  private static final String TRANSIENT_THREAD_ID = "_confluent_blahblah_transient_blahblah_4-blahblah";
+  private static final String THREAD_ID_SUFFIX = "3d62ddb9-d520-4cb3-9c23-968f8e61e201-StreamThread-1";
+  private static final String THREAD_ID = "_confluent_blahblah_query_CTAS_TEST_1-" + THREAD_ID_SUFFIX;
+  private static final String TRANSIENT_THREAD_ID = "_confluent_blahblah_transient_blahblah_4-" + THREAD_ID_SUFFIX;
   private static final String TASK_STORAGE_METRIC = "task_storage_used_bytes";
   private static final String QUERY_STORAGE_METRIC = "query_storage_used_bytes";
   private static final Map<String, String> BASE_TAGS = ImmutableMap.of("logical_cluster_id", "logical-id");

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/ThroughputMetricsReporterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/ThroughputMetricsReporterTest.java
@@ -32,9 +32,10 @@ public class ThroughputMetricsReporterTest {
   private static final String RECORDS_PRODUCED_TOTAL = "records-produced-total";
   private static final String BYTES_PRODUCED_TOTAL = "bytes-produced-total";
   private static final String QUERY_ID = "CTAS_TEST";
-  private static final String THREAD_ID = "_confluent_blahblah_query_CTAS_TEST_1-blahblah";
-  private static final String THREAD_ID_2 = "_confluent_blahblah_query_CTAS_TEST_2-blahblah";
-  private static final String TRANSIENT_THREAD_ID = "_confluent_blahblah_transient_blahblah_4-blahblah";
+  private static final String THREAD_ID_SUFFIX = "3d62ddb9-d520-4cb3-9c23-968f8e61e201-StreamThread-1";
+  private static final String THREAD_ID = "_confluent_blahblah_query_CTAS_TEST_1-" + THREAD_ID_SUFFIX;
+  private static final String THREAD_ID_2 = "_confluent_blahblah_query_CTAS_TEST_2-" + THREAD_ID_SUFFIX;
+  private static final String TRANSIENT_THREAD_ID = "_confluent_blahblah_transient_blahblah_4-" + THREAD_ID_SUFFIX;
   private static final String TASK_ID_1 = "0_1";
   private static final String TASK_ID_2 = "0_2";
   private static final String PROCESSOR_NODE_ID = "sink-node";

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/ThroughputMetricsReporterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/ThroughputMetricsReporterTest.java
@@ -362,7 +362,7 @@ public class ThroughputMetricsReporterTest {
     final Map<String, String> sharedRuntimeQueryTags = ImmutableMap.of(
         "logical_cluster_id", "lksqlc-12345",
         "query-id", "CSAS_TEST_COPY-STREAM_1_23",
-        "consumer_group_member_id", "_confluent_blahblah_query-1-blahblah",
+        "member", "_confluent_blahblah_query-1-blahblah",
         "topic", TOPIC_NAME
     );
     listener.metricChange(mockMetric(
@@ -391,7 +391,7 @@ public class ThroughputMetricsReporterTest {
     final Map<String, String> sharedRuntimeQueryTags = ImmutableMap.of(
         "logical_cluster_id", "lksqlc-12345",
         "query-id", "CSAS_TEST_COPY-STREAM_1_23",
-        "consumer_group_member_id", threadId,
+        "member", threadId,
         "topic", TOPIC_NAME
     );
     listener.metricChange(mockMetric(


### PR DESCRIPTION
Fixes a bug wherein the throughput metrics fail to extract the full query id for Stream names that contain one or more hyphen characters

