### PR TITLE
feat: add support for JSON arrays

### DIFF
--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -1152,7 +1152,24 @@ JSON_RECORDS('123') => NULL
 JSON_RECORDS(NULL) => NULL
 JSON_RECORDS('abc') => NULL
 ```
+### `JSON_ITEMS`
 
+```sql title="Since: 0.28.0"
+JSON_ITEMS(json_string) => Array<String>
+```
+
+Given a string with JSON array, converts it to a ksqlDB array of JSON strings. 
+
+Returns `NULL` if the string can't be interpreted as a JSON array, for example, 
+when the string is `NULL` or it does not contain valid JSON, or the JSON value is not an array.
+
+```sql title="Examples"
+JSON_ITEMS('[{\"type\": \"A\", \"ts\": \"2022-01-27\"}, {\"type\": \"B\", \"ts\": \"2022-05-18\"}]') => ["{\"type\": \"A\", \"ts\": \"2022-01-27\"}", "{\"type\": \"B\", \"ts\": \"2022-05-18\"}"]
+JSON_ITEMS('[]') => []
+JSON_ITEMS('[1, 2, 3]') => ["1","2","3"]
+JSON_ITEMS(NULL) => NULL
+JSON_ITEMS('abc') => NULL
+```
 ### `TO_JSON_STRING`
 
 ```sql title="Since: 0.24.0"

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonItems.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonItems.java
@@ -27,8 +27,10 @@ import java.util.List;
 @UdfDescription(
     name = "JSON_ITEMS",
     category = FunctionCategory.JSON,
-    description = "Given a string with JSON array, converts it to an array of JSON strings and "
-        + "returns an array of String. Returns `NULL` if input is `NULL`.",
+    description = "Given a string with JSON array, converts it to a ksqlDB array of JSON strings. "
+        + "Returns `NULL` if the string can not be interpreted as a JSON array, for example, when "
+        + "the string is `NULL` or it does not contain valid JSON, or the JSON value is not an "
+        + "array.",
     author = KsqlConstants.CONFLUENT_AUTHOR
 )
 public class JsonItems {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonItems.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonItems.java
@@ -28,9 +28,7 @@ import java.util.List;
     name = "JSON_ITEMS",
     category = FunctionCategory.JSON,
     description = "Given a string with JSON array, converts it to an array of JSON strings and "
-        + "returns an array of String. Returns `NULL` if input is `NULL` or each array item can't "
-        + "be interpreted as a JSON object, i.e. it is `NULL` or it does not contain valid JSON, "
-        + "or the JSON value is not an object.",
+        + "returns an array of String. Returns `NULL` if input is `NULL`.",
     author = KsqlConstants.CONFLUENT_AUTHOR
 )
 public class JsonItems {
@@ -44,12 +42,9 @@ public class JsonItems {
 
     final List<JsonNode> objectList = UdfJsonMapper.readAsJsonArray(jsonItems);
     final List<String> res = new ArrayList<>();
-    for (JsonNode jsonNode: objectList) {
-      if (jsonNode.isMissingNode() || !jsonNode.isObject()) {
-        return null;
-      }
-      res.add(jsonNode.toString());
-    }
+    objectList.forEach(jsonObject -> {
+      res.add(jsonObject.toString());
+    });
     return res;
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonItems.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonItems.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.confluent.ksql.function.FunctionCategory;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import io.confluent.ksql.util.KsqlConstants;
+import java.util.ArrayList;
+import java.util.List;
+
+@UdfDescription(
+    name = "JSON_ITEMS",
+    category = FunctionCategory.JSON,
+    description = "Given a string with JSON array, converts it to an array of JSON strings and "
+        + "returns an array of String. Returns `NULL` if input is `NULL` or each array item can't "
+        + "be interpreted as a JSON object, i.e. it is `NULL` or it does not contain valid JSON, "
+        + "or the JSON value is not an object.",
+    author = KsqlConstants.CONFLUENT_AUTHOR
+)
+public class JsonItems {
+
+  @Udf
+  public List<String> items(@UdfParameter final String jsonItems) {
+    if (jsonItems == null) {
+      return null;
+    }
+
+
+    final List<JsonNode> objectList = UdfJsonMapper.readAsJsonArray(jsonItems);
+    final List<String> res = new ArrayList<>();
+    for (JsonNode jsonNode: objectList) {
+      if (jsonNode.isMissingNode() || !jsonNode.isObject()) {
+        return null;
+      }
+      res.add(jsonNode.toString());
+    }
+    return res;
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/json/UdfJsonMapper.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/json/UdfJsonMapper.java
@@ -18,12 +18,14 @@ package io.confluent.ksql.function.udf.json;
 import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.confluent.ksql.function.KsqlFunctionException;
+import java.util.List;
 
 /**
  * Shared Object mapper used by JSON processing UDFs
@@ -75,6 +77,14 @@ final class UdfJsonMapper {
       return UdfJsonMapper.INSTANCE.writeValueAsString(obj);
     } catch (JsonProcessingException e) {
       throw new KsqlFunctionException("JSON serialization error: " + e.getMessage());
+    }
+  }
+
+  public static List<JsonNode> readAsJsonArray(final String jsonString) {
+    try {
+      return UdfJsonMapper.INSTANCE.readValue(jsonString, new TypeReference<List<JsonNode>>() {});
+    } catch (JsonProcessingException e) {
+      throw new KsqlFunctionException("Invalid JSON format:" + jsonString, e);
     }
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/json/JsonItemsTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/json/JsonItemsTest.java
@@ -33,7 +33,7 @@ public class JsonItemsTest {
   @Test
   public void shouldExtractRecords() throws JsonProcessingException {
     // When
-    String jsonArrayStr = "[{\"type\": \"AAA\", \"timestamp\": \"2022-01-27\"}, {\"type\": \"BBB\", \"timestamp\": \"2022-05-18\"}]}";
+    String jsonArrayStr = "[{\"type\": \"AAA\", \"timestamp\": \"2022-01-27\"}, {\"type\": \"BBB\", \"timestamp\": \"2022-05-18\"}]";
 
     final List<String> result = udf.items(jsonArrayStr);
     // Then:

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/json/JsonItemsTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/json/JsonItemsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.json;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.function.KsqlFunctionException;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+
+public class JsonItemsTest {
+  private final JsonItems udf = new JsonItems();
+  private ObjectMapper mapper = new ObjectMapper();
+  @Test
+  public void shouldExtractRecords() throws JsonProcessingException {
+    // When
+    String jsonArrayStr = "[{\"type\": \"AAA\", \"timestamp\": \"2022-01-27\"}, {\"type\": \"BBB\", \"timestamp\": \"2022-05-18\"}]}";
+
+    final List<String> result = udf.items(jsonArrayStr);
+    // Then:
+    final List<String> expected = ImmutableList.of(
+        "{\"type\": \"AAA\", \"timestamp\": \"2022-01-27\"}", "{\"type\": \"BBB\", \"timestamp\": \"2022-05-18\"}");
+
+
+    assertEquals(mapper.readTree(expected.get(0)), mapper.readTree(result.get(0)));
+    assertEquals(mapper.readTree(expected.get(1)), mapper.readTree(result.get(1)));
+  }
+
+  @Test
+  public void shouldReturnEmptyListForEmptyArray() {
+    assertEquals(Collections.emptyList(), udf.items("[]"));
+  }
+
+  @Test
+  public void shouldReturnNullForNull() {
+    assertNull(udf.items(null));
+  }
+
+  @Test
+  public void shouldReturnNullForInvalidJsonObject() {
+    assertNull(udf.items("[\"abc\"]"));
+  }
+
+  @Test(expected = KsqlFunctionException.class)
+  public void shouldThrowForNonArray() {
+    udf.items("abc");
+  }
+
+
+
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/json/JsonItemsTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/json/JsonItemsTest.java
@@ -51,14 +51,15 @@ public class JsonItemsTest {
   }
 
   @Test
+  public void shouldSupportJsonIntegerType() {
+    assertEquals(ImmutableList.of("1","2","3"), udf.items("[1, 2, 3]"));
+  }
+
+  @Test
   public void shouldReturnNullForNull() {
     assertNull(udf.items(null));
   }
 
-  @Test
-  public void shouldReturnNullForInvalidJsonObject() {
-    assertNull(udf.items("[\"abc\"]"));
-  }
 
   @Test(expected = KsqlFunctionException.class)
   public void shouldThrowForNonArray() {

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/json_items_-_convert_a_json_array_string_to_an_array_of_json_objects/7.3.0_1659931620853/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/json_items_-_convert_a_json_array_string_to_an_array_of_json_objects/7.3.0_1659931620853/plan.json
@@ -1,0 +1,206 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (K STRING KEY, EVENTS STRING) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`K` STRING KEY, `EVENTS` STRING",
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  TEST.K K,\n  JSON_ITEMS(TEST.EVENTS) EVENTS\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `EVENTS` ARRAY<STRING>",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`K` STRING KEY, `EVENTS` STRING",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "JSON_ITEMS(EVENTS) AS EVENTS" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.websocket.connection.max.timeout.ms" : "0",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "true",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.json_sr.converter.deserializer.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/json_items_-_convert_a_json_array_string_to_an_array_of_json_objects/7.3.0_1659931620853/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/json_items_-_convert_a_json_array_string_to_an_array_of_json_objects/7.3.0_1659931620853/spec.json
@@ -1,0 +1,110 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1659931620853,
+  "path" : "query-validation-tests/json_items.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `EVENTS` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `EVENTS` ARRAY<STRING>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "convert a json array string to an array of json objects",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "1",
+      "value" : {
+        "events" : "[{\"type\": \"A\", \"timestamp\": \"2022-01-27\"}, {\"type\": \"B\", \"timestamp\": \"2022-05-18\"}]"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "1",
+      "value" : {
+        "events" : "[]"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "1",
+      "value" : {
+        "events" : [ "{\"type\":\"A\",\"timestamp\":\"2022-01-27\"}", "{\"type\":\"B\",\"timestamp\":\"2022-05-18\"}" ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "1",
+      "value" : {
+        "events" : [ ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM test (K STRING KEY, EVENTS STRING) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT K, JSON_ITEMS(EVENTS) AS EVENTS FROM test;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `EVENTS` ARRAY<STRING>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `EVENTS` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/json_items_-_convert_a_json_array_string_to_an_array_of_json_objects/7.3.0_1659931620853/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/json_items_-_convert_a_json_array_string_to_an_array_of_json_objects/7.3.0_1659931620853/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/json_items_-_extract_timestamps_from_json_objects/7.3.0_1659931620907/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/json_items_-_extract_timestamps_from_json_objects/7.3.0_1659931620907/plan.json
@@ -1,0 +1,206 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (K STRING KEY, EVENTS STRING) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`K` STRING KEY, `EVENTS` STRING",
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  TEST.K K,\n  TRANSFORM(JSON_ITEMS(TEST.EVENTS), (OBJ) => EXTRACTJSONFIELD(OBJ, '$.timestamp')) EVENTS\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `EVENTS` ARRAY<STRING>",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`K` STRING KEY, `EVENTS` STRING",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "TRANSFORM(JSON_ITEMS(EVENTS), (OBJ) => EXTRACTJSONFIELD(OBJ, '$.timestamp')) AS EVENTS" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.websocket.connection.max.timeout.ms" : "0",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "true",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.json_sr.converter.deserializer.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/json_items_-_extract_timestamps_from_json_objects/7.3.0_1659931620907/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/json_items_-_extract_timestamps_from_json_objects/7.3.0_1659931620907/spec.json
@@ -1,0 +1,110 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1659931620907,
+  "path" : "query-validation-tests/json_items.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `EVENTS` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `EVENTS` ARRAY<STRING>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "extract timestamps from json objects",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "1",
+      "value" : {
+        "events" : "[{\"type\": \"A\", \"timestamp\": \"2022-01-27\"}, {\"type\": \"B\", \"timestamp\": \"2022-05-18\"}]"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "1",
+      "value" : {
+        "events" : "[]"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "1",
+      "value" : {
+        "events" : [ "2022-01-27", "2022-05-18" ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "1",
+      "value" : {
+        "events" : [ ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM test (K STRING KEY, EVENTS STRING) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT K, TRANSFORM(JSON_ITEMS(EVENTS), (obj) => EXTRACTJSONFIELD(obj, '$.timestamp')) AS EVENTS FROM test;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `EVENTS` ARRAY<STRING>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `EVENTS` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/json_items_-_extract_timestamps_from_json_objects/7.3.0_1659931620907/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/json_items_-_extract_timestamps_from_json_objects/7.3.0_1659931620907/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/json_items.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/json_items.json
@@ -1,0 +1,37 @@
+{
+  "comments": [
+    "Tests covering the use of the JSON_ITEMS function."
+  ],
+  "tests": [
+    {
+      "name": "convert a json array string to an array of json objects",
+      "statements": [
+        "CREATE STREAM test (K STRING KEY, EVENTS STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT K, JSON_ITEMS(EVENTS) AS EVENTS FROM test;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "1", "value": {"events": "[{\"type\": \"A\", \"timestamp\": \"2022-01-27\"}, {\"type\": \"B\", \"timestamp\": \"2022-05-18\"}]"}},
+        {"topic": "test_topic", "key": "1", "value": {"events": "[]"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "1", "value": {"events": ["{\"type\":\"A\",\"timestamp\":\"2022-01-27\"}", "{\"type\":\"B\",\"timestamp\":\"2022-05-18\"}"]}},
+        {"topic": "OUTPUT", "key": "1", "value": {"events": []}}
+      ]
+    },
+    {
+      "name": "extract timestamps from json objects",
+      "statements": [
+        "CREATE STREAM test (K STRING KEY, EVENTS STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT K, TRANSFORM(JSON_ITEMS(EVENTS), (obj) => EXTRACTJSONFIELD(obj, '$.timestamp')) AS EVENTS FROM test;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "1", "value": {"events": "[{\"type\": \"A\", \"timestamp\": \"2022-01-27\"}, {\"type\": \"B\", \"timestamp\": \"2022-05-18\"}]"}},
+        {"topic": "test_topic", "key": "1", "value": {"events": "[]"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "1", "value": {"events": ["2022-01-27", "2022-05-18"]}},
+        {"topic": "OUTPUT", "key": "1", "value": {"events": []}}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Description 
This FEAT converts a string with JSON array to an array of JSON strings - JSON_ITEMS(String) -> Array[String]

Then, a user could do something like

TRANSFORM(JSON_ITEMS(message), (obj) => EXTRACTJSONFIELD(obj, '$.time`))

### Testing done 
Unit test
QTT

### Reviewer checklist
see #9062

