### PR TITLE
fix: With shared runtimes, ALTER SYSTEM would cause paused queries to resume.

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -267,6 +267,9 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
       final BinPackedPersistentQueryMetadataImpl query = collocatedQueries
           .get(new QueryId(topology.name()));
       query.updateTopology(query.getTopologyCopy(this));
+      if (query.getQueryStatus() == KsqlConstants.KsqlQueryStatus.PAUSED) {
+        kafkaStreamsNamedTopologyWrapper.pauseNamedTopology(topology.name());
+      }
       kafkaStreamsNamedTopologyWrapper.addNamedTopology(query.getTopology());
     }
     setupAndStartKafkaStreams(kafkaStreamsNamedTopologyWrapper);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
@@ -224,10 +224,12 @@ public class SharedKafkaStreamsRuntimeImplTest {
     @Test
     public void shouldRestart() {
         //When:
+        when(binPackedPersistentQueryMetadata.getQueryStatus()).thenReturn(KsqlConstants.KsqlQueryStatus.PAUSED);
         sharedKafkaStreamsRuntimeImpl.restartStreamsRuntime();
 
         //Then:
         verify(kafkaStreamsNamedTopologyWrapper).close();
+        verify(kafkaStreamsNamedTopologyWrapper2).pauseNamedTopology(any());
         verify(kafkaStreamsNamedTopologyWrapper2).addNamedTopology(any());
         verify(kafkaStreamsNamedTopologyWrapper2).start();
         verify(kafkaStreamsNamedTopologyWrapper2).setUncaughtExceptionHandler((StreamsUncaughtExceptionHandler) any());


### PR DESCRIPTION
### Description 
Since a KafkaStreams runtime is created when ALTER SYSTEM commands are read with shared runtimes, any paused topologies need to be paused in the new runtime.


### Testing done 
Added a unit test.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

