### PR TITLE
fix: topologies with internal topics can not use get sources

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -467,7 +467,7 @@ final class QueryBuilder {
             persistentQueryType,
             statementText,
             querySchema,
-            sources.stream().map(DataSource::getName).collect(Collectors.toSet()),
+            sources,
             planSummary,
             applicationId,
             topology,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
@@ -49,6 +49,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.LagInfo;
@@ -73,7 +75,7 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
   private final SharedKafkaStreamsRuntime sharedKafkaStreamsRuntime;
   private final QuerySchemas schemas;
   private final ImmutableMap<String, Object> overriddenProperties;
-  private final Set<SourceName> sourceNames;
+  private final Set<DataSource> sources;
   private final QueryId queryId;
   private final Optional<DataSource> sinkDataSource;
   private final ProcessingLogger processingLogger;
@@ -97,7 +99,7 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
       final KsqlConstants.PersistentQueryType persistentQueryType,
       final String statementString,
       final PhysicalSchema schema,
-      final Set<SourceName> sourceNames,
+      final Set<DataSource> sources,
       final String executionPlan,
       final String applicationId,
       final NamedTopology topology,
@@ -128,7 +130,7 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
     this.overriddenProperties =
         ImmutableMap.copyOf(
             Objects.requireNonNull(overriddenProperties, "overriddenProperties"));
-    this.sourceNames = Objects.requireNonNull(sourceNames, "sourceNames");
+    this.sources = Objects.requireNonNull(sources, "sourceNames");
     this.queryId = Objects.requireNonNull(queryId, "queryId");
     this.processingLogger = requireNonNull(processingLogger, "processingLogger");
     this.physicalPlan = requireNonNull(physicalPlan, "physicalPlan");
@@ -159,7 +161,7 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
     this.schemas = original.schemas;
     this.overriddenProperties =
             ImmutableMap.copyOf(original.getOverriddenProperties());
-    this.sourceNames = original.getSourceNames();
+    this.sources = original.sources;
     this.queryId = original.getQueryId();
     this.processingLogger = original.processingLogger;
     this.physicalPlan = original.getPhysicalPlan();
@@ -349,7 +351,7 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
 
   @Override
   public Set<SourceName> getSourceNames() {
-    return ImmutableSet.copyOf(sourceNames);
+    return ImmutableSet.copyOf(sources.stream().map(DataSource::getName).collect(Collectors.toSet()));
   }
 
   @Override
@@ -454,7 +456,7 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
 
   @Override
   public Collection<String> getSourceTopicNames() {
-    return topology.sourceTopics();
+    return sources.stream().map(s-> s.getKsqlTopic().getKafkaTopicName()).collect(Collectors.toSet());
   }
 
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
@@ -50,7 +50,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.LagInfo;
@@ -351,7 +350,9 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
 
   @Override
   public Set<SourceName> getSourceNames() {
-    return ImmutableSet.copyOf(sources.stream().map(DataSource::getName).collect(Collectors.toSet()));
+    return ImmutableSet.copyOf(sources.stream()
+        .map(DataSource::getName)
+        .collect(Collectors.toSet()));
   }
 
   @Override
@@ -456,7 +457,10 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
 
   @Override
   public Collection<String> getSourceTopicNames() {
-    return sources.stream().map(s-> s.getKsqlTopic().getKafkaTopicName()).collect(Collectors.toSet());
+    return sources.stream()
+        .map(s -> s.getKsqlTopic()
+            .getKafkaTopicName())
+        .collect(Collectors.toSet());
   }
 
   private Set<DataSource> getSources() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
@@ -161,7 +161,7 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
     this.schemas = original.schemas;
     this.overriddenProperties =
             ImmutableMap.copyOf(original.getOverriddenProperties());
-    this.sources = original.sources;
+    this.sources = original.getSources();
     this.queryId = original.getQueryId();
     this.processingLogger = original.processingLogger;
     this.physicalPlan = original.getPhysicalPlan();
@@ -457,6 +457,10 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
   @Override
   public Collection<String> getSourceTopicNames() {
     return sources.stream().map(s-> s.getKsqlTopic().getKafkaTopicName()).collect(Collectors.toSet());
+  }
+
+  private Set<DataSource> getSources() {
+    return sources;
   }
 
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
@@ -551,10 +551,6 @@ public class QueryRegistryImplTest {
     return queryListenerCaptor.getValue();
   }
 
-  private DataSource toSource(final String name) {
-    return Mockito.mock(DataSource.class);
-  }
-
   @SuppressWarnings({"rawtypes", "unchecked"})
   private PersistentQueryMetadata givenCreate(
       final QueryRegistry registry,
@@ -582,11 +578,15 @@ public class QueryRegistryImplTest {
     when(newQuery.getPersistentQueryType()).thenReturn(persistentQueryType);
     when(newQuery.getPhysicalPlan()).thenReturn(physicalPlan);
     final SharedKafkaStreamsRuntime runtime = mock(SharedKafkaStreamsRuntimeImpl.class);
-
+    DataSource dataSource = mock(DataSource.class);
+    when(dataSource.getName()).thenReturn(SourceName.of(source));
     try {
       Field sharedRuntime = BinPackedPersistentQueryMetadataImpl.class.getDeclaredField("sharedKafkaStreamsRuntime");
       sharedRuntime.setAccessible(true);
       sharedRuntime.set(newQuery, runtime);
+      Field sourc = BinPackedPersistentQueryMetadataImpl.class.getDeclaredField("sources");
+      sourc.setAccessible(true);
+      sourc.set(newQuery, ImmutableSet.of(dataSource));
     } catch (final NoSuchFieldException | IllegalAccessException e) {
       e.printStackTrace();
     }
@@ -615,7 +615,7 @@ public class QueryRegistryImplTest {
         "sql",
         queryId,
         Optional.of(sinkSource),
-        ImmutableSet.of(toSource(source)),
+        ImmutableSet.of(dataSource),
         mock(ExecutionStep.class),
         "plan-summary",
         persistentQueryType,


### PR DESCRIPTION
Signed-off-by: Walker Carlson <wcarlson@confluent.io>

### Description 
A join int test was failing with shared runtimes on. And it seem the NamedTopology.sourceTopics doesn't work when not in an application

### Testing done 
testing already covered this

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

