### PR TITLE
chore: terminate websocket connections after token expiration

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -285,6 +285,15 @@ public class KsqlConfig extends AbstractConfig {
       + " and the regex pattern will be matched against the error class name and message of any "
       + "uncaught error and subsequent error causes in the Kafka Streams applications.";
 
+  public static final String KSQL_WEBSOCKET_CONNECTION_MAX_TIMEOUT_MS
+      = "ksql.websocket.connection.max.timeout.ms";
+  public static final long KSQL_WEBSOCKET_CONNECTION_MAX_TIMEOUT_MS_DEFAULT = 0;
+  public static final String KSQL_WEBSOCKET_CONNECTION_MAX_TIMEOUT_MS_DOC
+      = "If this config is set to a positive number, then ksqlDB will terminate websocket"
+      + " connections after a timeout. The timeout will be the lower of the auth token's "
+      + "lifespan (if present) and the value of this config. If this config is set to 0, then "
+      + "ksqlDB will not close websockets even if the token has an expiration time.";
+
   private enum ConfigGeneration {
     LEGACY,
     CURRENT
@@ -653,6 +662,13 @@ public class KsqlConfig extends AbstractConfig {
             "",
             Importance.LOW,
             KSQL_ERROR_CLASSIFIER_REGEX_PREFIX_DOC
+        )
+        .define(
+            KSQL_WEBSOCKET_CONNECTION_MAX_TIMEOUT_MS,
+            Type.LONG,
+            KSQL_WEBSOCKET_CONNECTION_MAX_TIMEOUT_MS_DEFAULT,
+            Importance.LOW,
+            KSQL_WEBSOCKET_CONNECTION_MAX_TIMEOUT_MS_DOC
         )
         .withClientSslSupport();
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -287,7 +287,7 @@ public class KsqlConfig extends AbstractConfig {
 
   public static final String KSQL_WEBSOCKET_CONNECTION_MAX_TIMEOUT_MS
       = "ksql.websocket.connection.max.timeout.ms";
-  public static final long KSQL_WEBSOCKET_CONNECTION_MAX_TIMEOUT_MS_DEFAULT = 0;
+  public static final long KSQL_WEBSOCKET_CONNECTION_MAX_TIMEOUT_MS_DEFAULT = 3600000;
   public static final String KSQL_WEBSOCKET_CONNECTION_MAX_TIMEOUT_MS_DOC
       = "If this config is set to a positive number, then ksqlDB will terminate websocket"
       + " connections after a timeout. The timeout will be the lower of the auth token's "

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlAuthTokenProvider.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlAuthTokenProvider.java
@@ -25,8 +25,8 @@ public interface KsqlAuthTokenProvider {
   /**
    * Extract the lifetime of a token from the Principal.
    *
-   * @param principal The {@link Principal} that's carrying the auth token.
-   * @return An {@Optional} containing the expiration time of the token in ms if there is one
+   * @param token The auth token.
+   * @return The expiration time of the token in ms
    */
-  long getLifetimeMs(String principal);
+  long getLifetimeMs(String token);
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlAuthTokenProvider.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlAuthTokenProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.security;
+
+import java.security.Principal;
+
+/**
+ * Interface to extract auth token information to ksqlDB
+ */
+public interface KsqlAuthTokenProvider {
+
+  /**
+   * Extract the lifetime of a token from the Principal.
+   *
+   * @param principal The {@link Principal} that's carrying the auth token.
+   * @return An {@Optional} containing the expiration time of the token in ms if there is one
+   */
+  long getLifetimeMs(String principal);
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlAuthTokenProvider.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlAuthTokenProvider.java
@@ -15,8 +15,6 @@
 
 package io.confluent.ksql.security;
 
-import java.security.Principal;
-
 /**
  * Interface to extract auth token information to ksqlDB
  */

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlDefaultSecurityExtension.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlDefaultSecurityExtension.java
@@ -39,6 +39,11 @@ public class KsqlDefaultSecurityExtension implements KsqlSecurityExtension {
   }
 
   @Override
+  public Optional<KsqlAuthTokenProvider> getAuthTokenProvider() {
+    return Optional.empty();
+  }
+
+  @Override
   public void close() {
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlSecurityExtension.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlSecurityExtension.java
@@ -61,6 +61,16 @@ public interface KsqlSecurityExtension extends AutoCloseable {
   Optional<KsqlUserContextProvider> getUserContextProvider();
 
   /**
+   * Returns a {@link KsqlAuthTokenProvider} object, which is used to extract information
+   * from the auth token.
+   * </p>
+   * If token authentication is not used for ksqlDB, then return {@code Optional.empty()}.
+   *
+   * @return An Optional {@link KsqlAuthTokenProvider} object.
+   */
+  Optional<KsqlAuthTokenProvider> getAuthTokenProvider();
+
+  /**
    * Closes the current security extension. This is called in case the implementation requires
    * to clean any security data in memory, files, and/or close connections to external security
    * services.

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -316,7 +316,8 @@ public final class KsqlRestApplication implements Executable {
           lagReportingResource,
           healthCheckResource,
           serverMetadataResource,
-          wsQueryEndpoint
+          wsQueryEndpoint,
+          securityExtension.getAuthTokenProvider()
       );
       apiServer = new Server(vertx, ksqlRestConfig, endpoints, securityExtension,
           authenticationPlugin, serverState);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/AuthenticationUtil.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/AuthenticationUtil.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.util;
+
+import io.confluent.ksql.security.KsqlAuthTokenProvider;
+import io.confluent.ksql.util.KsqlConfig;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import java.time.Clock;
+import java.util.Objects;
+import java.util.Optional;
+
+public class AuthenticationUtil {
+
+  final Clock clock;
+  private static final Logger log = LoggerFactory.getLogger(AuthenticationUtil.class);
+
+  public AuthenticationUtil(final Clock clock) {
+    this.clock = Objects.requireNonNull(clock);
+  }
+
+  public Optional<Long> getTokenTimeout(
+      final String authToken,
+      final KsqlConfig ksqlConfig,
+      final Optional<KsqlAuthTokenProvider> authTokenProvider
+  ) {
+    final long maxTimeout =
+        ksqlConfig.getLong(KsqlConfig.KSQL_WEBSOCKET_CONNECTION_MAX_TIMEOUT_MS);
+    if (maxTimeout > 0) {
+      if (authTokenProvider.isPresent() && authToken != null) {
+        try {
+          final long tokenTimeout = authTokenProvider.get().getLifetimeMs(authToken)
+              - clock.millis();
+          return Optional.of(Math.min(tokenTimeout, maxTimeout));
+        } catch (final Exception e) {
+          log.error(e.getMessage());
+        }
+      }
+      return Optional.of(maxTimeout);
+    } else {
+      return Optional.empty();
+    }
+  }
+
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/AuthTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/AuthTest.java
@@ -27,6 +27,7 @@ import io.confluent.ksql.api.server.Server;
 import io.confluent.ksql.api.utils.InsertsResponse;
 import io.confluent.ksql.api.utils.QueryResponse;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
+import io.confluent.ksql.security.KsqlAuthTokenProvider;
 import io.confluent.ksql.security.KsqlAuthorizationProvider;
 import io.confluent.ksql.security.KsqlSecurityExtension;
 import io.confluent.ksql.security.KsqlUserContextProvider;
@@ -128,6 +129,11 @@ public class AuthTest extends ApiTest {
           @Override
           public Optional<KsqlUserContextProvider> getUserContextProvider() {
             return Optional.ofNullable(userContextProvider);
+          }
+
+          @Override
+          public Optional<KsqlAuthTokenProvider> getAuthTokenProvider() {
+            return Optional.empty();
           }
 
           @Override

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/MockKsqlSecurityExtension.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/MockKsqlSecurityExtension.java
@@ -1,5 +1,6 @@
 package io.confluent.ksql.rest.integration;
 
+import io.confluent.ksql.security.KsqlAuthTokenProvider;
 import io.confluent.ksql.security.KsqlAuthorizationProvider;
 import io.confluent.ksql.security.KsqlSecurityExtension;
 import io.confluent.ksql.security.KsqlUserContextProvider;
@@ -29,6 +30,11 @@ public class MockKsqlSecurityExtension implements KsqlSecurityExtension {
 
   @Override
   public Optional<KsqlUserContextProvider> getUserContextProvider() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<KsqlAuthTokenProvider> getAuthTokenProvider() {
     return Optional.empty();
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/WSQueryEndpointTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/WSQueryEndpointTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.resources;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import io.confluent.ksql.engine.KsqlEngine;
+import io.confluent.ksql.rest.ApiJsonMapper;
+import io.confluent.ksql.rest.Errors;
+import io.confluent.ksql.rest.entity.KsqlRequest;
+import io.confluent.ksql.rest.server.StatementParser;
+import io.confluent.ksql.rest.server.computation.CommandQueue;
+import io.confluent.ksql.rest.server.execution.PullQueryExecutor;
+import io.confluent.ksql.rest.server.resources.streaming.WSQueryEndpoint;
+import io.confluent.ksql.security.KsqlSecurityContext;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.version.metrics.ActivenessRegistrar;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.ServerWebSocket;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.streams.StreamsConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WSQueryEndpointTest {
+  private static final ObjectMapper OBJECT_MAPPER = ApiJsonMapper.INSTANCE.get();
+
+  @Mock
+  private ServerWebSocket serverWebSocket;
+  @Mock
+  private KsqlSecurityContext ksqlSecurityContext;
+  @Mock
+  private ListeningScheduledExecutorService exec;
+
+  private WSQueryEndpoint wsQueryEndpoint;
+
+  @Before
+  public void setUp() {
+    wsQueryEndpoint = new WSQueryEndpoint(
+        mock(KsqlConfig.class),
+        mock(StatementParser.class),
+        mock(KsqlEngine.class),
+        mock(CommandQueue.class),
+        exec,
+        mock(ActivenessRegistrar.class),
+        mock(Duration.class),
+        Optional.empty(),
+        mock(Errors.class),
+        mock(PullQueryExecutor.class)
+    );
+  }
+
+  @Test
+  public void shouldScheduleCloseOnTimeout() throws JsonProcessingException {
+    // When
+    executeStreamQuery(buildRequestParams("show streams;", ImmutableMap.of()), Optional.of(10L));
+
+    // Then
+    verify(exec).schedule(any(Runnable.class), eq(10L), eq(TimeUnit.MILLISECONDS));
+  }
+
+  @Test
+  public void shouldNotScheduleCloseOnTimeout() throws JsonProcessingException {
+    // When
+    executeStreamQuery(buildRequestParams("show streams;", ImmutableMap.of()), Optional.empty());
+
+    // Then
+    verify(exec, never()).schedule(any(Runnable.class), anyLong(), any());
+  }
+
+  private MultiMap buildRequestParams(final String command, final Map<String, Object> streamProps)
+      throws JsonProcessingException {
+    final MultiMap params = MultiMap.caseInsensitiveMultiMap();
+    final KsqlRequest request = new KsqlRequest(
+        command, streamProps, Collections.emptyMap(), 1L);
+
+    params.add("request", OBJECT_MAPPER.writeValueAsString(request));
+    return params;
+  }
+
+  private void executeStreamQuery(final MultiMap params, final Optional<Long> timeout) {
+    wsQueryEndpoint.executeStreamQuery(serverWebSocket, params, ksqlSecurityContext, timeout);
+  }
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/AuthenticationUtilTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/AuthenticationUtilTest.java
@@ -38,7 +38,7 @@ public class AuthenticationUtilTest {
   private KsqlConfig ksqlConfig;
   @Mock
   private KsqlAuthTokenProvider authTokenProvider;
-  private final String TOKEN = "token";
+  private static final String TOKEN = "token";
   private final AuthenticationUtil authenticationUtil
       = new AuthenticationUtil(Clock.fixed(Instant.ofEpochMilli(0), ZoneId.of("UTC")));
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/AuthenticationUtilTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/AuthenticationUtilTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.when;
+
+import io.confluent.ksql.security.KsqlAuthTokenProvider;
+import io.confluent.ksql.util.KsqlConfig;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AuthenticationUtilTest {
+
+  @Mock
+  private KsqlConfig ksqlConfig;
+  @Mock
+  private KsqlAuthTokenProvider authTokenProvider;
+  private final String TOKEN = "token";
+  private final AuthenticationUtil authenticationUtil
+      = new AuthenticationUtil(Clock.fixed(Instant.ofEpochMilli(0), ZoneId.of("UTC")));
+
+  @Before
+  public void init() {
+    when(authTokenProvider.getLifetimeMs(TOKEN)).thenReturn(50000L);
+    when(ksqlConfig.getLong(KsqlConfig.KSQL_WEBSOCKET_CONNECTION_MAX_TIMEOUT_MS)).thenReturn(60000L);
+  }
+
+  @Test
+  public void shouldReturnEmptyWhenConfigSetToZero() {
+    // Given:
+    when(ksqlConfig.getLong(KsqlConfig.KSQL_WEBSOCKET_CONNECTION_MAX_TIMEOUT_MS)).thenReturn(0L);
+
+    // Then:
+    assertThat(authenticationUtil.getTokenTimeout(TOKEN, ksqlConfig, Optional.of(authTokenProvider)), equalTo(Optional.empty()));
+  }
+
+  @Test
+  public void shouldReturnDefaultWhenNoAuthTokenProviderPresent() {
+    assertThat(authenticationUtil.getTokenTimeout(TOKEN, ksqlConfig, Optional.empty()), equalTo(Optional.of(60000L)));
+  }
+
+  @Test
+  public void shouldReturnDefaultWhenProviderThrows() {
+    // Given:
+    when(authTokenProvider.getLifetimeMs(TOKEN)).then(invokation -> { throw new Exception();});
+
+    // Then:
+    assertThat(authenticationUtil.getTokenTimeout(TOKEN, ksqlConfig, Optional.of(authTokenProvider)), equalTo(Optional.of(60000L)));
+  }
+
+  @Test
+  public void shouldReturnTokenExpiryTime() {
+    assertThat(authenticationUtil.getTokenTimeout(TOKEN, ksqlConfig, Optional.of(authTokenProvider)), equalTo(Optional.of(50000L)));
+  }
+
+  @Test
+  public void shouldReturnMaxTimeout() {
+    // Given:
+    when(authTokenProvider.getLifetimeMs(TOKEN)).thenReturn(50000000L);
+
+    // Then:
+    assertThat(authenticationUtil.getTokenTimeout(TOKEN, ksqlConfig, Optional.of(authTokenProvider)), equalTo(Optional.of(60000L)));
+  }
+}


### PR DESCRIPTION
### Description 
Backport https://github.com/confluentinc/ksql/pull/9147 to 6.0

Starting in 6.0, the KsqlAuthTokenProvider will accept a string token instead of a principal.

### Testing done 
manually tested

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

