### PR TITLE
fix: Use schema_id while serializing keySchema during INSERT

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/SchemaRegistryUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/SchemaRegistryUtil.java
@@ -115,7 +115,7 @@ public final class SchemaRegistryUtil {
     return getLatestSchema(srClient, subject).map(SchemaMetadata::getId);
   }
 
-  public static Optional<ParsedSchema> getLatestParsedSchema(
+  public static Optional<Integer> getSchemaId(
       final SchemaRegistryClient srClient,
       final String topic,
       final boolean isKey
@@ -128,9 +128,25 @@ public final class SchemaRegistryUtil {
     }
 
     final int schemaId = metadata.get().getId();
+    return Optional.of(schemaId);
+  }
+
+  public static SchemaWithId getLatestParsedSchema(
+      final SchemaRegistryClient srClient,
+      final String topic,
+      final boolean isKey
+  ) {
+    final String subject = KsqlConstants.getSRSubject(topic, isKey);
+
+    Optional<Integer> optSchemaId = getSchemaId(srClient, topic, isKey);
+    if (!optSchemaId.isPresent()) {
+      return new SchemaWithId(Optional.empty(), Optional.empty());
+    }
+
+    final int schemaId = optSchemaId.get();
 
     try {
-      return Optional.of(srClient.getSchemaById(schemaId));
+      return new SchemaWithId(Optional.of(srClient.getSchemaById(schemaId)), Optional.of(schemaId));
     } catch (final Exception e) {
       throwOnAuthError(e, subject);
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/SchemaWithId.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/SchemaWithId.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.schema.registry;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import java.util.Optional;
+
+public class SchemaWithId {
+
+  private Optional<ParsedSchema> schema;
+  private Optional<Integer> id;
+
+  public SchemaWithId(Optional<ParsedSchema> schema, Optional<Integer> id) {
+    this.schema = schema;
+    this.id = id;
+  }
+
+  public Optional<ParsedSchema> getSchema() {
+    return schema;
+  }
+
+  public Optional<Integer> getId() {
+    return id;
+  }
+
+}

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectFormatSchemaTranslator.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectFormatSchemaTranslator.java
@@ -25,6 +25,7 @@ import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.SimpleColumn;
 import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.schema.utils.FormatOptions;
 import io.confluent.ksql.serde.SchemaTranslator;
 import io.confluent.ksql.serde.SerdeFeature;
 import io.confluent.ksql.serde.SerdeFeatures;
@@ -133,6 +134,16 @@ class ConnectFormatSchemaTranslator implements SchemaTranslator {
     @Override
     public SqlType type() {
       return type;
+    }
+
+    public String toString() {
+      return toString(FormatOptions.none());
+    }
+
+    public String toString(final FormatOptions formatOptions) {
+      final String fmtType = type.toString(formatOptions);
+
+      return name.toString(formatOptions) + " " + fmtType;
     }
   }
 }


### PR DESCRIPTION
### Description 
- While serializing keySchema check if its compatible with the latest schema
  in Schema Registry. If its compatible use the schema_id of the compatible
  schema instead of auto-registring a new schema during INSERT
- Compatibility is checked as follows:
    - No of columns in parsed ksql schema should match the SR parsed schema
    - Order of columns along with the name and type of columns must match

### Testing done 
Updated Unit Tests
TODO: Integeration Tests (@aliehsaeedii has added a new integration test for Insert. I plan to add a few tests to it.)

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

