### PR TITLE
fix: Update default to not delete consumer groups (#9407)

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -410,7 +410,7 @@ public class QueryRegistryImpl implements QueryRegistry {
       } else {
         // stop will not unregister the query, since it's possible for a query to be stopped
         // but still managed by the registry. So we explicitly unregister here.
-        ((PersistentQueryMetadata) queryMetadata).stop();
+        ((PersistentQueryMetadata) queryMetadata).stop(false);
         unregisterQuery(queryMetadata);
       }
     }
@@ -458,7 +458,7 @@ public class QueryRegistryImpl implements QueryRegistry {
       // topics and the state store, instead use QueryMetadata#stop
       log.info("Detected that query {} already exists so will replace it."
           + "First will stop without resetting offsets", oldQuery.getQueryId());
-      oldQuery.stop(true);
+      oldQuery.stop(false);
       unregisterQuery(oldQuery);
     }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
@@ -238,11 +238,11 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
 
   @Override
   public void stop() {
-    stop(false);
+    stop(true);
   }
 
-  public void stop(final boolean isCreateOrReplace) {
-    sharedKafkaStreamsRuntime.stop(queryId, isCreateOrReplace);
+  public void stop(final boolean resetOffsets) {
+    sharedKafkaStreamsRuntime.stop(queryId, resetOffsets);
     scalablePushRegistry.ifPresent(ScalablePushRegistry::close);
   }
 
@@ -403,7 +403,7 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
   @Override
   public void close() {
     loggerFactory.getLoggersWithPrefix(queryId.toString()).forEach(ProcessingLogger::close);
-    sharedKafkaStreamsRuntime.stop(queryId, false);
+    sharedKafkaStreamsRuntime.stop(queryId, true);
     scalablePushRegistry.ifPresent(ScalablePushRegistry::close);
     listener.onClose(this);
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -58,7 +58,7 @@ public interface PersistentQueryMetadata extends QueryMetadata {
 
   void stop();
 
-  void stop(boolean isCreateOrReplace);
+  void stop(boolean resetOffsets);
 
   void register();
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
@@ -123,7 +123,7 @@ public class SandboxedSharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRu
   }
 
   @Override
-  public void stop(final QueryId queryId, final boolean isCreateOrReplace) {
+  public void stop(final QueryId queryId, final boolean resetOffsets) {
   }
 
   public TimeBoundedQueue getNewQueryErrorQueue() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
@@ -67,7 +67,7 @@ public abstract class SharedKafkaStreamsRuntime {
 
   public abstract void close();
 
-  public abstract void stop(QueryId queryId, boolean isCreateOrReplace);
+  public abstract void stop(QueryId queryId, boolean resetOffsets);
 
   public abstract void start(QueryId queryId);
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -181,9 +181,9 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
   }
 
   @Override
-  public void stop(final QueryId queryId, final boolean isCreateOrReplace) {
-    log.info("Attempting to stop query: {} in runtime {} with isCreateOrReplace={}",
-             queryId, getApplicationId(), isCreateOrReplace);
+  public void stop(final QueryId queryId, final boolean resetOffsets) {
+    log.info("Attempting to stop query: {} in runtime {} with resetOffsets={}",
+             queryId, getApplicationId(), resetOffsets);
     if (kafkaStreams.getTopologyByName(queryId.toString()).isPresent()
         != collocatedQueries.containsKey(queryId)) {
       log.error("Non SandBoxed queries should not be registered and never started.");
@@ -195,10 +195,10 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
             toAdd.get();
           }
           topolgogiesToAdd.clear();
-          kafkaStreams.removeNamedTopology(queryId.toString(), !isCreateOrReplace)
+          kafkaStreams.removeNamedTopology(queryId.toString(), resetOffsets)
               .all()
               .get();
-          if (!isCreateOrReplace) {
+          if (resetOffsets) {
             kafkaStreams.cleanUpNamedTopology(queryId.toString());
           }
         } catch (ExecutionException | InterruptedException e) {
@@ -214,7 +214,7 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
             + kafkaStreams.state());
       }
     }
-    if (!isCreateOrReplace) {
+    if (resetOffsets) {
       // we don't want to lose it from this runtime
       collocatedQueries.remove(queryId);
     }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
@@ -46,10 +46,14 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.OrderDataProvider;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
+import io.confluent.ksql.util.QueryMetadata;
 import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -157,13 +161,14 @@ public class UdfIntTest {
     );
 
     // When:
-    ksqlContext.sql(queryString);
+    List<QueryMetadata> metadataList = ksqlContext.sql(queryString);
 
     // Then:
     final Map<GenericKey, GenericRow> results = consumeOutputMessages();
 
     assertThat(results, is(ImmutableMap.of(genericKey("ORDER_6"),
         genericRow("ITEM_8", 800.0, 1110.0, 12.0, true))));
+    metadataList.forEach(q -> q.close());
   }
 
   @Test
@@ -184,13 +189,14 @@ public class UdfIntTest {
     );
 
     // When:
-    ksqlContext.sql(queryString);
+    List<QueryMetadata> metadataList = ksqlContext.sql(queryString);
 
     // Then:
     final Map<GenericKey, GenericRow> results = consumeOutputMessages();
 
     assertThat(results, is(ImmutableMap.of(genericKey("ORDER_6"),
         genericRow(80, "true", 8.0, "80.0"))));
+    metadataList.forEach(q -> q.close());
   }
 
   @Test
@@ -209,7 +215,7 @@ public class UdfIntTest {
         intermediateStream, testData.sourceStreamName, resultStreamName, intermediateStream);
 
     // When:
-    ksqlContext.sql(queryString);
+    List<QueryMetadata> metadataList = ksqlContext.sql(queryString);
 
     // Then:
     final Map<GenericKey, GenericRow> results = consumeOutputMessages();
@@ -218,6 +224,7 @@ public class UdfIntTest {
 
     assertThat(results, equalTo(ImmutableMap.of(genericKey("ORDER_6"),
         genericRow(ts, ts + 10000, ts + 100, "ITEM_8"))));
+    metadataList.forEach(q -> q.close());
   }
 
   @Test
@@ -231,13 +238,14 @@ public class UdfIntTest {
     );
 
     // When:
-    ksqlContext.sql(queryString);
+    List<QueryMetadata> metadataList = ksqlContext.sql(queryString);
 
     // Then:
     final Map<GenericKey, GenericRow> results = consumeOutputMessages();
 
     assertThat(results, equalTo(Collections.singletonMap(genericKey("ITEM_1"),
         genericRow("home cinema"))));
+    metadataList.forEach(q -> q.close());
   }
 
   private void createSourceStream() {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
@@ -77,6 +77,7 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.WindowedSerdes;
 import org.apache.kafka.test.IntegrationTest;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -171,6 +172,15 @@ public class KsMaterializationFunctionalTest {
     toClose.clear();
 
     initializeKsql(ksqlContext);
+  }
+
+  @After
+  public void after() {
+    try {
+      toClose.forEach(q -> q.close());
+    } catch (Exception e) {
+
+    }
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImplTest.java
@@ -154,7 +154,19 @@ public class BinPackedPersistentQueryMetadataImplTest {
 
         // Then:
         final InOrder inOrder = inOrder(sharedKafkaStreamsRuntimeImpl);
-        inOrder.verify(sharedKafkaStreamsRuntimeImpl).stop(QUERY_ID, false);
+        inOrder.verify(sharedKafkaStreamsRuntimeImpl).stop(QUERY_ID, true);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
+    public void shouldCloseKafkaStreamsOnClose() {
+        // When:
+        query.close();
+
+        // Then:
+        final InOrder inOrder = inOrder(sharedKafkaStreamsRuntimeImpl);
+        inOrder.verify(sharedKafkaStreamsRuntimeImpl).stop(QUERY_ID, true);
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -173,7 +185,7 @@ public class BinPackedPersistentQueryMetadataImplTest {
         query.stop();
 
         // Then:
-        verify(sharedKafkaStreamsRuntimeImpl).stop(QUERY_ID, false);
+        verify(sharedKafkaStreamsRuntimeImpl).stop(QUERY_ID, true);
     }
 
     @Test


### PR DESCRIPTION
* fix: Update default to not delete consumer groups

Signed-off-by: Walker Carlson <wcarlson@confluent.io>

* fix: Update default to not delete consumer groups when closing

Signed-off-by: Walker Carlson <wcarlson@confluent.io>

* fix: Update default to not delete consumer groups when closing

Signed-off-by: Walker Carlson <wcarlson@confluent.io>

* fix: Update default to not delete consumer groups when closing

Signed-off-by: Walker Carlson <wcarlson@confluent.io>

* fix: Update default to not delete consumer groups when closing

Signed-off-by: Walker Carlson <wcarlson@confluent.io>

* do not change the stop default, just the call in query registry

Signed-off-by: Walker Carlson <wcarlson@confluent.io>

* do not change the stop default, just the call in query registry

Signed-off-by: Walker Carlson <wcarlson@confluent.io>

* fix tests

Signed-off-by: Walker Carlson <wcarlson@confluent.io>

* fix tests

Signed-off-by: Walker Carlson <wcarlson@confluent.io>

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

