### PR TITLE
chore: improve logging for master

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
@@ -209,7 +209,8 @@ final class EngineContext {
       throw e;
     } catch (final Exception e) {
       throw new KsqlStatementException(
-          "Exception while preparing statement: " + e.getMessage(), stmt.getStatementText(), e);
+          "Exception while preparing statement: " + e.getMessage(), stmt.getMaskedStatementText(),
+          e);
     }
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -115,7 +115,6 @@ import io.confluent.ksql.util.PlanSummary;
 import io.confluent.ksql.util.PushOffsetRange;
 import io.confluent.ksql.util.PushQueryMetadata;
 import io.confluent.ksql.util.PushQueryMetadata.ResultType;
-import io.confluent.ksql.util.QueryMask;
 import io.confluent.ksql.util.ScalablePushQueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import io.vertx.core.Context;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -115,6 +115,7 @@ import io.confluent.ksql.util.PlanSummary;
 import io.confluent.ksql.util.PushOffsetRange;
 import io.confluent.ksql.util.PushQueryMetadata;
 import io.confluent.ksql.util.PushQueryMetadata.ResultType;
+import io.confluent.ksql.util.QueryMask;
 import io.confluent.ksql.util.ScalablePushQueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import io.vertx.core.Context;
@@ -178,10 +179,11 @@ final class EngineExecutor {
   }
 
   ExecuteResult execute(final KsqlPlan plan, final boolean restoreInProgress) {
+    final String maskedStatement = QueryMask.getMaskedStatement(plan.getStatementText());
     if (!plan.getQueryPlan().isPresent()) {
       final String ddlResult = plan
           .getDdlCommand()
-          .map(ddl -> executeDdl(ddl, plan.getStatementText(), false, Collections.emptySet(),
+          .map(ddl -> executeDdl(ddl, maskedStatement, false, Collections.emptySet(),
               restoreInProgress))
           .orElseThrow(
               () -> new IllegalStateException(
@@ -207,7 +209,7 @@ final class EngineExecutor {
     }
 
     final Optional<String> ddlResult = plan.getDdlCommand().map(ddl ->
-        executeDdl(ddl, plan.getStatementText(), true, queryPlan.getSources(),
+        executeDdl(ddl, maskedStatement, true, queryPlan.getSources(),
             restoreInProgress));
 
     // Return if the source to create already exists.
@@ -222,14 +224,14 @@ final class EngineExecutor {
         && !isSourceTableMaterializationEnabled()) {
       LOG.info(String.format(
           "Source table query '%s' won't be materialized because '%s' is disabled.",
-          plan.getStatementText(),
+          maskedStatement,
           KsqlConfig.KSQL_SOURCE_TABLE_MATERIALIZATION_ENABLED));
       return ExecuteResult.of(ddlResult.get());
     }
 
     return ExecuteResult.of(executePersistentQuery(
         queryPlan,
-        plan.getStatementText(),
+        maskedStatement,
         persistentQueryType)
     );
   }
@@ -319,7 +321,7 @@ final class EngineExecutor {
         ));
       }
 
-      final String stmtLower = statement.getStatementText().toLowerCase(Locale.ROOT);
+      final String stmtLower = statement.getMaskedStatementText().toLowerCase(Locale.ROOT);
       final String messageLower = e.getMessage().toLowerCase(Locale.ROOT);
       final String stackLower = Throwables.getStackTraceAsString(e).toLowerCase(Locale.ROOT);
 
@@ -343,13 +345,13 @@ final class EngineExecutor {
             queryPlannerOptions.debugString(),
             e);
       }
-      LOG.debug("Failed pull query text {}, {}", statement.getStatementText(), e);
+      LOG.debug("Failed pull query text {}, {}", statement.getMaskedStatementText(), e);
 
       throw new KsqlStatementException(
           e.getMessage() == null
               ? "Server Error" + Arrays.toString(e.getStackTrace())
               : e.getMessage(),
-          statement.getStatementText(),
+          statement.getMaskedStatementText(),
           e
       );
     }
@@ -432,7 +434,7 @@ final class EngineExecutor {
         ));
       }
 
-      final String stmtLower = statement.getStatementText().toLowerCase(Locale.ROOT);
+      final String stmtLower = statement.getMaskedStatementText().toLowerCase(Locale.ROOT);
       final String messageLower = e.getMessage().toLowerCase(Locale.ROOT);
       final String stackLower = Throwables.getStackTraceAsString(e).toLowerCase(Locale.ROOT);
 
@@ -456,13 +458,13 @@ final class EngineExecutor {
                 queryPlannerOptions.debugString(),
                 e);
       }
-      LOG.debug("Failed push query V2 text {}, {}", statement.getStatementText(), e);
+      LOG.debug("Failed push query V2 text {}, {}", statement.getMaskedStatementText(), e);
 
       throw new KsqlStatementException(
               e.getMessage() == null
                       ? "Server Error" + Arrays.toString(e.getStackTrace())
                       : e.getMessage(),
-              statement.getStatementText(),
+              statement.getMaskedStatementText(),
               e
       );
     }
@@ -485,7 +487,7 @@ final class EngineExecutor {
         serviceContext,
         engineContext.getProcessingLogContext(),
         engineContext.getMetaStore(),
-        statement.getStatementText(),
+        statement.getMaskedStatementText(),
         plans.executionPlan.getQueryId(),
         getSourceNames(outputNode),
         plans.executionPlan.getPhysicalPlan(),
@@ -517,7 +519,7 @@ final class EngineExecutor {
         serviceContext,
         engineContext.getProcessingLogContext(),
         engineContext.getMetaStore(),
-        statement.getStatementText(),
+        statement.getMaskedStatementText(),
         plans.executionPlan.getQueryId(),
         getSourceNames(outputNode),
         plans.executionPlan.getPhysicalPlan(),
@@ -537,7 +539,7 @@ final class EngineExecutor {
       final ConfiguredStatement<?> statement) {
     final CreateTable createTable = (CreateTable) statement.getStatement();
     final CreateTableCommand ddlCommand = (CreateTableCommand) engineContext.createDdlCommand(
-        statement.getStatementText(),
+        statement.getMaskedStatementText(),
         (ExecutableDdlStatement) statement.getStatement(),
         config
     );
@@ -582,7 +584,7 @@ final class EngineExecutor {
     final MutableMetaStore tempMetastore = new MetaStoreImpl(new InternalFunctionRegistry());
     final Formats formats = ddlCommand.getFormats();
     tempMetastore.putSource(new KsqlTable<>(
-        statement.getStatementText(),
+        statement.getMaskedStatementText(),
         createTable.getName(),
         ddlCommand.getSchema(),
         Optional.empty(),
@@ -622,7 +624,7 @@ final class EngineExecutor {
     );
 
     return KsqlPlan.queryPlanCurrent(
-        statement.getStatementText(),
+        statement.getMaskedStatementText(),
         Optional.of(ddlCommand),
         queryPlan);
   }
@@ -646,20 +648,20 @@ final class EngineExecutor {
 
         if ((isSourceStream || isSourceTable) && !isSourceTableMaterializationEnabled()) {
           throw new KsqlStatementException("Cannot execute command because source table "
-              + "materialization is disabled.", statement.getStatementText());
+              + "materialization is disabled.", statement.getMaskedStatementText());
         }
 
         if (isSourceTable) {
           return sourceTablePlan(statement);
         } else {
           final DdlCommand ddlCommand = engineContext.createDdlCommand(
-              statement.getStatementText(),
+              statement.getMaskedStatementText(),
               (ExecutableDdlStatement) statement.getStatement(),
               config
           );
 
           return KsqlPlan.ddlPlanCurrent(
-              statement.getStatementText(),
+              statement.getMaskedStatementText(),
               ddlCommand);
         }
       }
@@ -699,14 +701,14 @@ final class EngineExecutor {
       );
 
       return KsqlPlan.queryPlanCurrent(
-          statement.getStatementText(),
+          statement.getMaskedStatementText(),
           ddlCommand,
           queryPlan
       );
     } catch (final KsqlStatementException e) {
       throw e;
     } catch (final Exception e) {
-      throw new KsqlStatementException(e.getMessage(), statement.getStatementText(), e);
+      throw new KsqlStatementException(e.getMessage(), statement.getMaskedStatementText(), e);
     }
   }
 
@@ -812,7 +814,7 @@ final class EngineExecutor {
           sink,
           metaStore,
           ksqlConfig,
-          statement.getStatementText()
+          statement.getMaskedStatementText()
       );
 
       final LogicalPlanNode logicalPlan = new LogicalPlanNode(Optional.of(outputNode));
@@ -1082,7 +1084,7 @@ final class EngineExecutor {
       throw new KsqlStatementException("Invalid result type. "
                                            + "Your SELECT query produces a TABLE. "
                                            + "Please use CREATE TABLE AS SELECT statement instead.",
-                                       statement.getStatementText());
+                                       statement.getMaskedStatementText());
     }
 
     if (statement.getStatement() instanceof CreateTableAsSelect
@@ -1090,13 +1092,14 @@ final class EngineExecutor {
       throw new KsqlStatementException(
           "Invalid result type. Your SELECT query produces a STREAM. "
            + "Please use CREATE STREAM AS SELECT statement instead.",
-          statement.getStatementText());
+          statement.getMaskedStatementText());
     }
   }
 
   private static void throwOnNonExecutableStatement(final ConfiguredStatement<?> statement) {
     if (!KsqlEngine.isExecutableStatement(statement.getStatement())) {
-      throw new KsqlStatementException("Statement not executable", statement.getStatementText());
+      throw new KsqlStatementException("Statement not executable",
+          statement.getMaskedStatementText());
     }
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -352,7 +352,8 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable, KsqlConfigur
       throw e;
     } catch (final KsqlException e) {
       // add the statement text to the KsqlException
-      throw new KsqlStatementException(e.getMessage(), statement.getStatementText(), e.getCause());
+      throw new KsqlStatementException(e.getMessage(), statement.getMaskedStatementText(),
+          e.getCause());
     }
   }
 
@@ -398,7 +399,7 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable, KsqlConfigur
           "Pull queries on streams are disabled. To create a push query on the stream,"
               + " add EMIT CHANGES to the end. To enable pull queries on streams, set"
               + " the " + KsqlConfig.KSQL_QUERY_STREAM_PULL_QUERY_ENABLED + " config to 'true'.",
-          statementOrig.getStatementText()
+          statementOrig.getMaskedStatementText()
       );
     }
 
@@ -423,7 +424,7 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable, KsqlConfigur
 
     QueryLogger.info(
         "Streaming stream pull query results '{}' from earliest to " + endOffsets,
-        statement.getStatementText()
+        statement.getMaskedStatementText()
     );
 
     return new StreamPullQueryMetadata(transientQueryMetadata, endOffsets);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlPlan.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlPlan.java
@@ -45,10 +45,10 @@ public interface KsqlPlan {
   }
 
   static KsqlPlan queryPlanCurrent(
-      final String statementText,
+      final String maskedStatement,
       final Optional<DdlCommand> ddlCommand,
       final QueryPlan queryPlan
   ) {
-    return new KsqlPlanV1(statementText, ddlCommand, Optional.of(queryPlan));
+    return new KsqlPlanV1(maskedStatement, ddlCommand, Optional.of(queryPlan));
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlPlanV1.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlPlanV1.java
@@ -38,11 +38,11 @@ final class KsqlPlanV1 implements KsqlPlan {
   private final Optional<QueryPlan> queryPlan;
 
   KsqlPlanV1(
-      @JsonProperty(value = "statementText", required = true) final String statementText,
+      @JsonProperty(value = "statementText", required = true) final String maskedStatement,
       @JsonProperty(value = "ddlCommand") final Optional<DdlCommand> ddlCommand,
       @JsonProperty(value = "queryPlan") final Optional<QueryPlan> queryPlan
   ) {
-    this.statementText = Objects.requireNonNull(statementText, "statementText");
+    this.statementText = Objects.requireNonNull(maskedStatement, "statementText");
     this.ddlCommand = Objects.requireNonNull(ddlCommand, "ddlCommand");
     this.queryPlan = Objects.requireNonNull(queryPlan, "queryPlan");
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/execution/scalablepush/PushRouting.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/execution/scalablepush/PushRouting.java
@@ -171,10 +171,10 @@ public class PushRouting implements AutoCloseable {
 
     if (hosts.isEmpty()) {
       LOG.error("Unable to execute push query: {}. No nodes executing persistent queries",
-          statement.getStatementText());
+          statement.getMaskedStatementText());
       throw new KsqlException(String.format(
           "Unable to execute push query. No nodes executing persistent queries %s",
-          statement.getStatementText()));
+          statement.getMaskedStatementText()));
     }
     return hosts;
   }
@@ -255,7 +255,7 @@ public class PushRouting implements AutoCloseable {
             }
           }
           LOG.warn("Error routing query {} id {} to host {} at timestamp {} with exception {}",
-              statement.getStatementText(), pushPhysicalPlanManager.getQueryId(), node,
+              statement.getMaskedStatementText(), pushPhysicalPlanManager.getQueryId(), node,
               System.currentTimeMillis(), t.getCause());
 
           // We only fail the whole thing if this is not a new dynamically added node. We allow
@@ -264,7 +264,7 @@ public class PushRouting implements AutoCloseable {
             pushConnectionsHandle.completeExceptionally(
                 new KsqlException(String.format(
                     "Unable to execute push query \"%s\". %s",
-                    statement.getStatementText(), t.getCause().getMessage())));
+                    statement.getMaskedStatementText(), t.getCause().getMessage())));
           }
           return pushConnectionsHandle;
         })
@@ -320,7 +320,7 @@ public class PushRouting implements AutoCloseable {
           })
           .exceptionally(t -> {
             LOG.error("Error executing query {} locally at node {}",
-                statement.getStatementText(), node.location(), t.getCause());
+                statement.getMaskedStatementText(), node.location(), t.getCause());
             final BufferedPublisher<QueryRow> publisher = publisherRef.get();
             closeable.get().run();
             if (publisher != null) {
@@ -334,7 +334,7 @@ public class PushRouting implements AutoCloseable {
           });
     } else {
       LOG.info("Query {} routed to host {} at timestamp {}.",
-          statement.getStatementText(), node.location(), System.currentTimeMillis());
+          statement.getMaskedStatementText(), node.location(), System.currentTimeMillis());
       scalablePushQueryMetrics
               .ifPresent(metrics -> metrics.recordRemoteRequests(1));
       final AtomicReference<BufferedPublisher<StreamedRow>> publisherRef
@@ -351,7 +351,7 @@ public class PushRouting implements AutoCloseable {
         return new RoutingResult(RoutingResultStatus.SUCCESS, publisher::close);
       }).exceptionally(t -> {
         LOG.error("Error forwarding query {} to node {}",
-            statement.getStatementText(), node, t.getCause());
+            statement.getMaskedStatementText(), node, t.getCause());
         final BufferedPublisher<StreamedRow> publisher = publisherRef.get();
         if (publisher != null) {
           publisher.close();

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/format/DefaultFormatInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/format/DefaultFormatInjector.java
@@ -76,7 +76,7 @@ public class DefaultFormatInjector implements Injector {
     } catch (final KsqlException e) {
       throw new KsqlStatementException(
           e.getMessage(),
-          statement.getStatementText(),
+          statement.getMaskedStatementText(),
           e.getCause());
     }
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/properties/PropertyOverrider.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/properties/PropertyOverrider.java
@@ -34,7 +34,7 @@ public final class PropertyOverrider {
       final Map<String, Object> mutableProperties
   ) {
     final SetProperty setProperty = statement.getStatement();
-    throwIfInvalidProperty(setProperty.getPropertyName(), statement.getStatementText());
+    throwIfInvalidProperty(setProperty.getPropertyName(), statement.getMaskedStatementText());
     throwIfInvalidPropertyValues(setProperty, statement);
     mutableProperties.put(setProperty.getPropertyName(), setProperty.getPropertyValue());
   }
@@ -44,7 +44,7 @@ public final class PropertyOverrider {
       final Map<String, Object> mutableProperties
   ) {
     final UnsetProperty unsetProperty = statement.getStatement();
-    throwIfInvalidProperty(unsetProperty.getPropertyName(), statement.getStatementText());
+    throwIfInvalidProperty(unsetProperty.getPropertyName(), statement.getMaskedStatementText());
     mutableProperties.remove(unsetProperty.getPropertyName());
   }
 
@@ -62,7 +62,7 @@ public final class PropertyOverrider {
           ));
     } catch (final Exception e) {
       throw new KsqlStatementException(
-          e.getMessage(), statement.getStatementText(), e.getCause());
+          e.getMessage(), statement.getMaskedStatementText(), e.getCause());
     }
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
@@ -133,7 +133,7 @@ public class DefaultSchemaInjector implements Injector {
     } catch (final KsqlException e) {
       throw new KsqlStatementException(
           ErrorMessageUtil.buildErrorMessage(e),
-          statement.getStatementText(),
+          statement.getMaskedStatementText(),
           e.getCause());
     }
   }
@@ -160,7 +160,7 @@ public class DefaultSchemaInjector implements Injector {
     } catch (final Exception e) {
       throw new KsqlStatementException(
           "Could not determine output schema for query due to error: "
-              + e.getMessage(), statement.getStatementText(), e);
+              + e.getMessage(), statement.getMaskedStatementText(), e);
     }
 
     final Optional<SchemaAndId> keySchema = getCreateAsKeySchema(statement, createSourceCommand);
@@ -216,7 +216,7 @@ public class DefaultSchemaInjector implements Injector {
         props.getKeySchemaId(),
         keyFormat,
         serdeFeatures,
-        statement.getStatementText(),
+        statement.getMaskedStatementText(),
         true
     );
 
@@ -243,7 +243,7 @@ public class DefaultSchemaInjector implements Injector {
         props.getValueSchemaId(),
         valueFormat,
         createSourceCommand.getFormats().getValueFeatures(),
-        statement.getStatementText(),
+        statement.getMaskedStatementText(),
         false
     );
 
@@ -302,7 +302,7 @@ public class DefaultSchemaInjector implements Injector {
         // until we support user-configuration of single key wrapping/unwrapping, we choose
         // to have key schema inference always result in an unwrapped key
         SerdeFeaturesFactory.buildKeyFeatures(FormatFactory.of(keyFormat), true),
-        statement.getStatementText(),
+        statement.getMaskedStatementText(),
         true
     ));
   }
@@ -322,7 +322,7 @@ public class DefaultSchemaInjector implements Injector {
         props.getValueSchemaId(),
         valueFormat,
         props.getValueSerdeFeatures(),
-        statement.getStatementText(),
+        statement.getMaskedStatementText(),
         false
     ));
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjector.java
@@ -84,7 +84,7 @@ public class SchemaRegisterInjector implements Injector {
     } catch (final KsqlException e) {
       throw new KsqlStatementException(
           ErrorMessageUtil.buildErrorMessage(e),
-          statement.getStatementText(),
+          statement.getMaskedStatementText(),
           e.getCause());
     }
     // Remove schema id from SessionConfig
@@ -118,7 +118,7 @@ public class SchemaRegisterInjector implements Injector {
 
     final FormatInfo keyFormatInfo = SourcePropertiesUtil.getKeyFormat(
         statement.getProperties(), statement.getName());
-    final Format keyFormat = tryGetFormat(keyFormatInfo, true, cs.getStatementText());
+    final Format keyFormat = tryGetFormat(keyFormatInfo, true, cs.getMaskedStatementText());
     final SerdeFeatures keyFeatures = SerdeFeaturesFactory.buildKeyFeatures(
         schema,
         keyFormat
@@ -126,7 +126,7 @@ public class SchemaRegisterInjector implements Injector {
 
     final FormatInfo valueFormatInfo = SourcePropertiesUtil.getValueFormat(
         statement.getProperties());
-    final Format valueFormat = tryGetFormat(valueFormatInfo, false, cs.getStatementText());
+    final Format valueFormat = tryGetFormat(valueFormatInfo, false, cs.getMaskedStatementText());
     final SerdeFeatures valFeatures = SerdeFeaturesFactory.buildValueFeatures(
         schema,
         valueFormat,
@@ -148,7 +148,7 @@ public class SchemaRegisterInjector implements Injector {
         valueFormatInfo,
         valFeatures,
         cs.getSessionConfig().getConfig(false),
-        cs.getStatementText(),
+        cs.getMaskedStatementText(),
         false
     );
   }
@@ -186,7 +186,7 @@ public class SchemaRegisterInjector implements Injector {
     } catch (final Exception e) {
       throw new KsqlStatementException(
           "Could not determine output schema for query due to error: "
-              + e.getMessage(), cas.getStatementText(), e);
+              + e.getMessage(), cas.getMaskedStatementText(), e);
     }
 
     final SchemaAndId rawKeySchema = (SchemaAndId) cas.getSessionConfig().getOverrides()
@@ -203,7 +203,7 @@ public class SchemaRegisterInjector implements Injector {
         createSourceCommand.getFormats().getValueFormat(),
         createSourceCommand.getFormats().getValueFeatures(),
         cas.getSessionConfig().getConfig(false),
-        cas.getStatementText(),
+        cas.getMaskedStatementText(),
         true
     );
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/statement/ConfiguredStatement.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/statement/ConfiguredStatement.java
@@ -69,12 +69,6 @@ public final class ConfiguredStatement<T extends Statement> {
    * needs unmasked statement text, please use {@code getUnMaskedStatementText}
    * @return Masked statement text
    */
-  /**
-   * Use masked statement for logging and other output places it could be read by human. It
-   * masked sensitive information such as passwords, keys etc. For normal processing which
-   * needs unmasked statement text, please use {@code getUnMaskedStatementText}
-   * @return Masked statement text
-   */
   public String getMaskedStatementText() {
     return statement.getMaskedStatementText();
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/statement/ConfiguredStatement.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/statement/ConfiguredStatement.java
@@ -69,8 +69,14 @@ public final class ConfiguredStatement<T extends Statement> {
    * needs unmasked statement text, please use {@code getUnMaskedStatementText}
    * @return Masked statement text
    */
-  public String getStatementText() {
-    return statement.getStatementText();
+  /**
+   * Use masked statement for logging and other output places it could be read by human. It
+   * masked sensitive information such as passwords, keys etc. For normal processing which
+   * needs unmasked statement text, please use {@code getUnMaskedStatementText}
+   * @return Masked statement text
+   */
+  public String getMaskedStatementText() {
+    return statement.getMaskedStatementText();
   }
 
   /**

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/statement/SourcePropertyInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/statement/SourcePropertyInjector.java
@@ -61,7 +61,7 @@ public class SourcePropertyInjector implements Injector {
     } catch (final KsqlException e) {
       throw new KsqlStatementException(
           ErrorMessageUtil.buildErrorMessage(e),
-          statement.getStatementText(),
+          statement.getMaskedStatementText(),
           e.getCause());
     }
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -2358,7 +2358,7 @@ public class KsqlEngineTest {
   public void shouldCheckStreamPullQueryEnabledFlag() {
     @SuppressWarnings("unchecked") final ConfiguredStatement<Query> statementOrig =
         mock(ConfiguredStatement.class);
-    when(statementOrig.getStatementText()).thenReturn("TEXT");
+    when(statementOrig.getMaskedStatementText()).thenReturn("TEXT");
 
     final SessionConfig mockSessionConfig = mock(SessionConfig.class);
     final KsqlConfig mockConfig = mock(KsqlConfig.class);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTestUtil.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTestUtil.java
@@ -132,7 +132,8 @@ public final class KsqlEngineTestUtil {
     } catch (final KsqlStatementException e) {
       // use the original statement text in the exception so that tests
       // can easily check that the failed statement is the input statement
-      throw new KsqlStatementException(e.getRawMessage(), stmt.getStatementText(), e.getCause());
+      throw new KsqlStatementException(e.getRawMessage(), stmt.getMaskedStatementText(),
+          e.getCause());
     }
   }
 
@@ -185,7 +186,8 @@ public final class KsqlEngineTestUtil {
     } catch (final KsqlStatementException e) {
       // use the original statement text in the exception so that tests
       // can easily check that the failed statement is the input statement
-      throw new KsqlStatementException(e.getRawMessage(), stmt.getStatementText(), e.getCause());
+      throw new KsqlStatementException(e.getRawMessage(), stmt.getMaskedStatementText(),
+          e.getCause());
     }
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/execution/scalablepush/PushRoutingTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/execution/scalablepush/PushRoutingTest.java
@@ -147,7 +147,7 @@ public class PushRoutingTest {
   public void setUp() {
     vertx = Vertx.vertx();
     context = vertx.getOrCreateContext();
-    when(statement.getStatementText()).thenReturn("SELECT * FROM STREAM EMIT CHANGES");
+    when(statement.getMaskedStatementText()).thenReturn("SELECT * FROM STREAM EMIT CHANGES");
     when(statement.getUnMaskedStatementText()).thenReturn("SELECT * FROM STREAM EMIT CHANGES");
     when(statement.getSessionConfig()).thenReturn(sessionConfig);
     when(sessionConfig.getOverrides()).thenReturn(ImmutableMap.of());

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/format/DefaultFormatInjectorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/format/DefaultFormatInjectorTest.java
@@ -78,7 +78,7 @@ public class DefaultFormatInjectorTest {
     final ConfiguredStatement<?> result = injector.inject(csStatement);
 
     // Then
-    assertThat(result.getStatementText(), containsString("KEY_FORMAT='KAFKA'"));
+    assertThat(result.getMaskedStatementText(), containsString("KEY_FORMAT='KAFKA'"));
   }
 
   @Test
@@ -95,7 +95,7 @@ public class DefaultFormatInjectorTest {
     final ConfiguredStatement<?> result = injector.inject(csStatement);
 
     // Then
-    assertThat(result.getStatementText(), containsString("VALUE_FORMAT='JSON'"));
+    assertThat(result.getMaskedStatementText(), containsString("VALUE_FORMAT='JSON'"));
   }
 
   @Test
@@ -111,8 +111,8 @@ public class DefaultFormatInjectorTest {
     final ConfiguredStatement<?> result = injector.inject(csStatement);
 
     // Then
-    assertThat(result.getStatementText(), containsString("KEY_FORMAT='KAFKA'"));
-    assertThat(result.getStatementText(), containsString("VALUE_FORMAT='JSON'"));
+    assertThat(result.getMaskedStatementText(), containsString("KEY_FORMAT='KAFKA'"));
+    assertThat(result.getMaskedStatementText(), containsString("VALUE_FORMAT='JSON'"));
   }
 
   @Test
@@ -158,7 +158,7 @@ public class DefaultFormatInjectorTest {
     final ConfiguredStatement<?> result = injector.inject(csStatement);
 
     // Then
-    assertThat(result.getStatementText(), containsString("KEY_FORMAT='KAFKA'"));
+    assertThat(result.getMaskedStatementText(), containsString("KEY_FORMAT='KAFKA'"));
   }
 
   @Test
@@ -197,7 +197,7 @@ public class DefaultFormatInjectorTest {
     final ConfiguredStatement<?> result = injector.inject(csStatement);
 
     // Then
-    assertThat(result.getStatementText(), containsString("VALUE_FORMAT='JSON'"));
+    assertThat(result.getMaskedStatementText(), containsString("VALUE_FORMAT='JSON'"));
   }
 
   private void givenConfig(final Map<String, Object> additionalConfigProps) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorFunctionalTest.java
@@ -644,7 +644,7 @@ public class DefaultSchemaInjectorFunctionalTest {
       validateCsasInference((ConfiguredStatement<CreateStreamAsSelect>) inferred, this.avroSchema);
     } else {
       final Statement withSchema = KsqlParserTestUtil
-          .buildSingleAst(inferred.getStatementText(), metaStore)
+          .buildSingleAst(inferred.getMaskedStatementText(), metaStore)
           .getStatement();
 
       final Schema actual = getSchemaForDdlStatement((CreateSource) withSchema);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorTest.java
@@ -439,7 +439,7 @@ public class DefaultSchemaInjectorTest {
     // Then:
     assertThat(result.getStatement().getElements(),
         is(combineElements(INFERRED_KSQL_KEY_SCHEMA_STREAM, INFERRED_KSQL_VALUE_SCHEMA)));
-    assertThat(result.getStatementText(), is(
+    assertThat(result.getMaskedStatementText(), is(
         "CREATE STREAM `cs` ("
             + "`key` STRING KEY, "
             + "`intField` INTEGER, "
@@ -466,7 +466,7 @@ public class DefaultSchemaInjectorTest {
     // Then:
     assertThat(result.getStatement().getElements(),
         is(combineElements(INFERRED_KSQL_KEY_SCHEMA_TABLE, INFERRED_KSQL_VALUE_SCHEMA)));
-    assertThat(result.getStatementText(), is(
+    assertThat(result.getMaskedStatementText(), is(
         "CREATE TABLE `ct` ("
             + "`key` STRING PRIMARY KEY, "
             + "`intField` INTEGER, "
@@ -494,7 +494,7 @@ public class DefaultSchemaInjectorTest {
     // Then:
     assertThat(result.getStatement().getElements(),
         is(combineElements(SOME_KEY_ELEMENTS_STREAM, INFERRED_KSQL_VALUE_SCHEMA)));
-    assertThat(result.getStatementText(), is(
+    assertThat(result.getMaskedStatementText(), is(
         "CREATE STREAM `cs` ("
             + "`bob` STRING KEY, "
             + "`intField` INTEGER, "
@@ -522,7 +522,7 @@ public class DefaultSchemaInjectorTest {
     // Then:
     assertThat(result.getStatement().getElements(),
         is(combineElements(SOME_KEY_ELEMENTS_TABLE, INFERRED_KSQL_VALUE_SCHEMA)));
-    assertThat(result.getStatementText(), is(
+    assertThat(result.getMaskedStatementText(), is(
         "CREATE TABLE `ct` ("
             + "`bob` STRING PRIMARY KEY, "
             + "`intField` INTEGER, "
@@ -550,7 +550,7 @@ public class DefaultSchemaInjectorTest {
     // Then:
     assertThat(result.getStatement().getElements(),
         is(combineElements(INFERRED_KSQL_KEY_SCHEMA_STREAM, SOME_VALUE_ELEMENTS)));
-    assertThat(result.getStatementText(), is(
+    assertThat(result.getMaskedStatementText(), is(
         "CREATE STREAM `cs` ("
             + "`key` STRING KEY, "
             + "`bob` STRING) "
@@ -570,7 +570,7 @@ public class DefaultSchemaInjectorTest {
     // Then:
     assertThat(result.getStatement().getElements(),
         is(combineElements(INFERRED_KSQL_KEY_SCHEMA_TABLE, SOME_VALUE_ELEMENTS)));
-    assertThat(result.getStatementText(), is(
+    assertThat(result.getMaskedStatementText(), is(
         "CREATE TABLE `ct` ("
             + "`key` STRING PRIMARY KEY, "
             + "`bob` STRING) "
@@ -590,7 +590,7 @@ public class DefaultSchemaInjectorTest {
     // Then:
     assertThat(result.getStatement().getElements(),
         is(combineElements(HEADER_ELEMENTS, INFERRED_KSQL_KEY_SCHEMA_STREAM, INFERRED_KSQL_VALUE_SCHEMA)));
-    assertThat(result.getStatementText(), is(
+    assertThat(result.getMaskedStatementText(), is(
         "CREATE STREAM `cs` ("
             + "`head` BYTES HEADER('header'), "
             + "`key` STRING KEY, "
@@ -619,7 +619,7 @@ public class DefaultSchemaInjectorTest {
     // Then:
     assertThat(result.getStatement().getElements(),
         is(combineElements(HEADER_ELEMENTS, INFERRED_KSQL_KEY_SCHEMA_TABLE, INFERRED_KSQL_VALUE_SCHEMA)));
-    assertThat(result.getStatementText(), is(
+    assertThat(result.getMaskedStatementText(), is(
         "CREATE TABLE `ct` ("
             + "`head` BYTES HEADER('header'), "
             + "`key` STRING PRIMARY KEY, "
@@ -648,7 +648,7 @@ public class DefaultSchemaInjectorTest {
     // Then:
     assertThat(result.getStatement().getElements(),
         is(combineElements(HEADER_ELEMENTS, INFERRED_KSQL_KEY_SCHEMA_STREAM, SOME_VALUE_ELEMENTS)));
-    assertThat(result.getStatementText(), is(
+    assertThat(result.getMaskedStatementText(), is(
         "CREATE STREAM `cs` ("
             + "`head` BYTES HEADER('header'), "
             + "`key` STRING KEY, "
@@ -669,7 +669,7 @@ public class DefaultSchemaInjectorTest {
     // Then:
     assertThat(result.getStatement().getElements(),
         is(combineElements(HEADER_ELEMENTS, INFERRED_KSQL_KEY_SCHEMA_TABLE, SOME_VALUE_ELEMENTS)));
-    assertThat(result.getStatementText(), is(
+    assertThat(result.getMaskedStatementText(), is(
         "CREATE TABLE `ct` ("
             + "`head` BYTES HEADER('header'), "
             + "`key` STRING PRIMARY KEY, "
@@ -690,7 +690,7 @@ public class DefaultSchemaInjectorTest {
     final ConfiguredStatement<CreateStreamAsSelect> result = injector.inject(csasStatement);
 
     // Then:
-    assertThat(result.getStatementText(), is(
+    assertThat(result.getMaskedStatementText(), is(
         "CREATE STREAM `csas` "
             + "WITH (KAFKA_TOPIC='some-topic', KEY_FORMAT='avro', KEY_SCHEMA_FULL_NAME='myrecord', "
             + "KEY_SCHEMA_ID=42, VALUE_FORMAT='delimited') AS SELECT *\nFROM TABLE `sink`"
@@ -709,7 +709,7 @@ public class DefaultSchemaInjectorTest {
     final ConfiguredStatement<CreateTableAsSelect> result = injector.inject(ctasStatement);
 
     // Then:
-    assertThat(result.getStatementText(), is(
+    assertThat(result.getMaskedStatementText(), is(
         "CREATE TABLE `ctas` "
             + "WITH (KAFKA_TOPIC='some-topic', KEY_FORMAT='avro', KEY_SCHEMA_FULL_NAME='myrecord', "
             + "KEY_SCHEMA_ID=42, VALUE_FORMAT='delimited') AS SELECT *\nFROM TABLE `sink`"
@@ -728,7 +728,7 @@ public class DefaultSchemaInjectorTest {
     final ConfiguredStatement<CreateStreamAsSelect> result = injector.inject(csasStatement);
 
     // Then:
-    assertThat(result.getStatementText(), is(
+    assertThat(result.getMaskedStatementText(), is(
         "CREATE STREAM `csas` "
             + "WITH (KAFKA_TOPIC='some-topic', KEY_FORMAT='kafka', VALUE_FORMAT='protobuf', "
             + "VALUE_SCHEMA_FULL_NAME='myrecord', VALUE_SCHEMA_ID=42) AS SELECT *\nFROM TABLE `sink`"
@@ -1007,8 +1007,8 @@ public class DefaultSchemaInjectorTest {
     final ConfiguredStatement<CreateTable> result = injector.inject(ctStatement);
 
     // Then:
-    assertThat(result.getStatementText(), not(containsString("KEY_SCHEMA_ID=18")));
-    assertThat(result.getStatementText(), not(containsString("VALUE_SCHEMA_ID=5")));
+    assertThat(result.getMaskedStatementText(), not(containsString("KEY_SCHEMA_ID=18")));
+    assertThat(result.getMaskedStatementText(), not(containsString("VALUE_SCHEMA_ID=5")));
 
     verify(schemaSupplier).getKeySchema(Optional.of(KAFKA_TOPIC), Optional.empty(), FormatInfo.of("PROTOBUF"), SerdeFeatures.of());
     verify(schemaSupplier).getValueSchema(Optional.of(KAFKA_TOPIC), Optional.empty(), FormatInfo.of("AVRO"), SerdeFeatures.of());
@@ -1023,7 +1023,7 @@ public class DefaultSchemaInjectorTest {
     final ConfiguredStatement<CreateStream> result = injector.inject(csStatement);
 
     // Then:
-    assertThat(result.getStatementText(), is(
+    assertThat(result.getMaskedStatementText(), is(
         "CREATE STREAM `cs` ("
         + "`intField` INTEGER, "
         + "`bigIntField` BIGINT, "
@@ -1053,7 +1053,7 @@ public class DefaultSchemaInjectorTest {
     final ConfiguredStatement<CreateStream> result = injector.inject(csStatement);
 
     // Then:
-    assertThat(result.getStatementText(), is(
+    assertThat(result.getMaskedStatementText(), is(
         "CREATE STREAM `cs` ("
             + "`key` STRING KEY) WITH ("
             + "KAFKA_TOPIC='some-topic', "
@@ -1096,7 +1096,7 @@ public class DefaultSchemaInjectorTest {
     final ConfiguredStatement<CreateTable> inject = injector.inject(ctStatement);
 
     // Then:
-    assertThat(inject.getStatementText(), containsString("`CREATE`"));
+    assertThat(inject.getMaskedStatementText(), containsString("`CREATE`"));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/statement/ConfiguredStatementTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/statement/ConfiguredStatementTest.java
@@ -44,7 +44,7 @@ public class ConfiguredStatementTest {
         ConfiguredStatement.of(preparedStatement, mock(SessionConfig.class));
 
     // Then
-    assertThat(configuredStatement.getStatementText(), is(masked));
+    assertThat(configuredStatement.getMaskedStatementText(), is(masked));
     assertThat(configuredStatement.getUnMaskedStatementText(), is(query));
     assertThat(configuredStatement.toString(), containsString(maskedToString));
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
@@ -326,7 +326,7 @@ public class TopicCreateInjectorTest {
     final ConfiguredStatement<?> result = injector.inject(statement, builder);
 
     // Then:
-    assertThat(result.getStatementText(),
+    assertThat(result.getMaskedStatementText(),
         equalTo(
             "CREATE STREAM X WITH (KAFKA_TOPIC='name', PARTITIONS=1, REPLICAS=1) AS SELECT *"
                 + "\nFROM SOURCE SOURCE\n"

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicDeleteInjectorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicDeleteInjectorTest.java
@@ -128,7 +128,7 @@ public class TopicDeleteInjectorTest {
     final ConfiguredStatement<DropStream> injected = deleteInjector.inject(DROP_WITH_DELETE_TOPIC);
 
     // Then:
-    assertThat(injected.getStatementText(), is("DROP STREAM SOMETHING;"));
+    assertThat(injected.getMaskedStatementText(), is("DROP STREAM SOMETHING;"));
     assertThat("expected !isDeleteTopic", !injected.getStatement().isDeleteTopic());
   }
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/KsqlTestException.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/KsqlTestException.java
@@ -78,7 +78,7 @@ public class KsqlTestException extends KsqlException {
 
     return String.format(
         "Test failure for statement `%s` (%s):%n\t%s%n\t%s",
-        parsedStatement.getStatementText(),
+        parsedStatement.getMaskedStatementText(),
         loc.map(NodeLocation::toString).orElse("unknown"),
         message,
         new LocationWithinFile(

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/parser/SqlTestReaderTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/parser/SqlTestReaderTest.java
@@ -62,21 +62,21 @@ public class SqlTestReaderTest {
 
     assertThat(reader.hasNext(), is(true));
     reader.next().consume(
-        s -> assertThat(s.getStatementText(), containsString("CREATE STREAM foo")),
+        s -> assertThat(s.getMaskedStatementText(), containsString("CREATE STREAM foo")),
         s -> fail("unexpected statement " + s),
         s -> fail("unexpected statement " + s)
     );
 
     assertThat(reader.hasNext(), is(true));
     reader.next().consume(
-        s -> assertThat(s.getStatementText(), containsString("CREATE STREAM bar")),
+        s -> assertThat(s.getMaskedStatementText(), containsString("CREATE STREAM bar")),
         s -> fail("unexpected statement " + s),
         s -> fail("unexpected statement " + s)
     );
 
     assertThat(reader.hasNext(), is(true));
     reader.next().consume(
-        s -> assertThat(s.getStatementText(), containsString("INSERT INTO")),
+        s -> assertThat(s.getMaskedStatementText(), containsString("INSERT INTO")),
         s -> fail("unexpected statement " + s),
         s -> fail("unexpected statement " + s)
     );
@@ -105,14 +105,14 @@ public class SqlTestReaderTest {
 
     assertThat(reader.hasNext(), is(true));
     reader.next().consume(
-        s -> assertThat(s.getStatementText(), containsString("CREATE STREAM foo")),
+        s -> assertThat(s.getMaskedStatementText(), containsString("CREATE STREAM foo")),
         s -> fail("unexpected statement " + s),
         s -> fail("unexpected statement " + s)
     );
 
     assertThat(reader.hasNext(), is(true));
     reader.next().consume(
-        s -> assertThat(s.getStatementText(), containsString("CREATE STREAM bar")),
+        s -> assertThat(s.getMaskedStatementText(), containsString("CREATE STREAM bar")),
         s -> fail("unexpected statement " + s),
         s -> fail("unexpected statement " + s)
     );
@@ -136,7 +136,7 @@ public class SqlTestReaderTest {
 
     assertThat(reader.hasNext(), is(true));
     reader.next().consume(
-        s -> assertThat(s.getStatementText(), containsString("CREATE STREAM foo")),
+        s -> assertThat(s.getMaskedStatementText(), containsString("CREATE STREAM foo")),
         s -> fail("unexpected statement " + s),
         s -> fail("unexpected statement " + s)
     );
@@ -163,7 +163,7 @@ public class SqlTestReaderTest {
 
     assertThat(reader.hasNext(), is(true));
     reader.next().consume(
-        s -> assertThat(s.getStatementText(), containsString("CREATE STREAM foo")),
+        s -> assertThat(s.getMaskedStatementText(), containsString("CREATE STREAM foo")),
         s -> fail("unexpected statement " + s),
         s -> fail("unexpected statement " + s)
     );
@@ -203,14 +203,14 @@ public class SqlTestReaderTest {
 
     assertThat(reader.hasNext(), is(true));
     reader.next().consume(
-        s -> assertThat(s.getStatementText(), containsString("CREATE STREAM foo")),
+        s -> assertThat(s.getMaskedStatementText(), containsString("CREATE STREAM foo")),
         s -> fail("unexpected statement " + s),
         s -> fail("unexpected statement " + s)
     );
 
     assertThat(reader.hasNext(), is(true));
     reader.next().consume(
-        s -> assertThat(s.getStatementText(), containsString("CREATE STREAM bar")),
+        s -> assertThat(s.getMaskedStatementText(), containsString("CREATE STREAM bar")),
         s -> fail("unexpected statement " + s),
         s -> fail("unexpected statement " + s)
     );

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/model/ExpectedErrorNode.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/model/ExpectedErrorNode.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.rest.entity.KsqlStatementErrorMessage;
 import io.confluent.ksql.rest.entity.KsqlStatementErrorMessageMatchers;
 import io.confluent.ksql.test.tools.exceptions.InvalidFieldException;
 import io.confluent.ksql.test.tools.exceptions.MissingFieldException;
+import io.confluent.ksql.util.QueryMask;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -97,7 +98,8 @@ public final class ExpectedErrorNode {
           // Ensure exception contains last statement, otherwise the test case is invalid:
           matchers.add(
               RestResponseMatchers.hasErrorMessage(
-                  (Matcher)KsqlStatementErrorMessageMatchers.statement(containsString(lastStatement))
+                  (Matcher)KsqlStatementErrorMessageMatchers.statement(containsString(
+                      QueryMask.getMaskedStatement(lastStatement)))
               )
           );
       }

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
@@ -146,7 +146,7 @@
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "Failed to prepare statement: Expected number columns and values to match: [K, ID], ['10']",
+        "message": "Failed to prepare statement: Expected number columns and values to match: 2, 1",
         "status": 400
       }
     },

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/DefaultKsqlParser.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/DefaultKsqlParser.java
@@ -78,10 +78,10 @@ public class DefaultKsqlParser implements KsqlParser {
         throw e;
       }
       throw new ParseFailedException(
-          e.getRawMessage(), stmt.getStatementText(), e.getCause());
+          e.getRawMessage(), stmt.getMaskedStatementText(), e.getCause());
     } catch (final Exception e) {
       throw new ParseFailedException(
-          "Failed to prepare statement: " + e.getMessage(), stmt.getStatementText(), e);
+          "Failed to prepare statement: " + e.getMessage(), stmt.getMaskedStatementText(), e);
     }
   }
 

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/KsqlParser.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/KsqlParser.java
@@ -70,7 +70,7 @@ public interface KsqlParser {
      * needs unmasked statement text, please use {@code getUnMaskedStatementText}
      * @return Masked statement text
      */
-    public String getStatementText() {
+    public String getMaskedStatementText() {
       return maskedStatementText;
     }
 
@@ -129,7 +129,7 @@ public interface KsqlParser {
      * needs unmasked statement text, please use {@code getUnMaskedStatementText}
      * @return Masked statement text
      */
-    public String getStatementText() {
+    public String getMaskedStatementText() {
       return maskedStatementText;
     }
 

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/InsertValues.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/InsertValues.java
@@ -61,8 +61,8 @@ public class InsertValues extends Statement {
     if (!columns.isEmpty() && columns.size() != values.size()) {
       throw new KsqlException(
           "Expected number columns and values to match: "
-              + columns.stream().map(ColumnName::text).collect(Collectors.toList()) + ", "
-              + values);
+              + columns.stream().map(ColumnName::text).collect(Collectors.toList()).size() + ", "
+              + values.size());
     }
   }
 
@@ -109,7 +109,7 @@ public class InsertValues extends Statement {
     return "InsertValues{"
         + "target=" + target
         + ", columns=" + columns
-        + ", values=" + values
+        + ", values=<redacted>"
         + '}';
   }
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/util/QueryMask.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/util/QueryMask.java
@@ -13,14 +13,17 @@
 package io.confluent.ksql.util;
 
 import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.DefaultKsqlParser;
 import io.confluent.ksql.parser.SqlBaseBaseVisitor;
 import io.confluent.ksql.parser.SqlBaseParser.CreateConnectorContext;
+import io.confluent.ksql.parser.SqlBaseParser.InsertValuesContext;
 import io.confluent.ksql.parser.SqlBaseParser.SingleStatementContext;
 import io.confluent.ksql.parser.SqlBaseParser.StatementsContext;
 import io.confluent.ksql.parser.SqlBaseParser.TablePropertiesContext;
 import io.confluent.ksql.parser.SqlBaseParser.TablePropertyContext;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -34,7 +37,8 @@ import org.apache.commons.lang3.StringUtils;
 public final class QueryMask {
 
   private static final ImmutableSet<String> ALLOWED_KEYS = ImmutableSet.of("connector.class");
-  private static final String MASKED_VALUE = "'[string]'";
+  private static final String MASKED_STRING = "'[string]'";
+  private static final String MASKED_VALUE = "'[value]'";
 
   private QueryMask() {}
 
@@ -43,7 +47,7 @@ public final class QueryMask {
       final ParseTree tree = DefaultKsqlParser.getParseTree(query);
       return new Visitor().visit(tree);
     } catch (final Exception | StackOverflowError e) {
-      return maskConnectProperties(query);
+      return fallbackMasking(query);
     }
   }
 
@@ -52,11 +56,42 @@ public final class QueryMask {
       if (ALLOWED_KEYS.contains(e.getKey())) {
         return e.getValue();
       }
-      return MASKED_VALUE;
+      return MASKED_STRING;
     }));
   }
 
-  private static String maskConnectProperties(final String query) {
+  private static String fallbackMasking(final String query) {
+    return fallbackMaskConnectProperties(fallbackMaskValues(query));
+  }
+
+  private static String fallbackMaskValues(final String query) {
+    /*
+       Failed to parse statement. Mask Insert values by string replacement in a best effort manner.
+       The assumption is that parenthesis around VALUES are not missing.
+       Regex matches sequences of characters that are not in '(' ',' ';' ')' and are not be followed
+       by a '(' anywhere further down the string (since VALUES is always last in a statement).
+     */
+    if (StringUtils.indexOfIgnoreCase(query.replaceAll("\\s+", ""), ")VALUES(") < 0) {
+      return query;
+    }
+    final int valueIdx = StringUtils.indexOfIgnoreCase(query, "VALUES");
+
+    final StringBuffer sb = new StringBuffer();
+    final Pattern pattern = Pattern.compile("([^(,;)]+)(?!.*\\()",
+        Pattern.DOTALL | Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
+
+    final Matcher matcher = pattern.matcher(query);
+    while (matcher.find()) {
+      if (matcher.start() > valueIdx) {
+        matcher.appendReplacement(sb, MASKED_VALUE);
+      }
+    }
+
+    matcher.appendTail(sb);
+    return sb.toString();
+  }
+
+  private static String fallbackMaskConnectProperties(final String query) {
     /*
       Failed to parse statement. Mask disallowed keys by string replacing. This is a best effort
       attempt. The assumption is that properties are in right format: it matches key wrapped in
@@ -74,7 +109,7 @@ public final class QueryMask {
       final String key = matcher.group(1).substring(1, matcher.group(1).length() - 1);
 
       if (!ALLOWED_KEYS.contains(key)) {
-        final String replacement = quote + key + quote + "=" + MASKED_VALUE;
+        final String replacement = quote + key + quote + "=" + MASKED_STRING;
         matcher.appendReplacement(sb, replacement);
       } else {
         matcher.appendReplacement(sb, matchedString);
@@ -114,6 +149,32 @@ public final class QueryMask {
     @Override
     public String visitSingleStatement(final SingleStatementContext context) {
       return String.format("%s;", visit(context.statement()));
+    }
+
+    @Override
+    public String visitInsertValues(final InsertValuesContext context) {
+      final StringBuilder stringBuilder = new StringBuilder("INSERT INTO ");
+
+      if (context.sourceName() != null) {
+        stringBuilder.append(ParserUtil.getSourceName(context.sourceName()));
+      }
+
+      // columns
+      if (context.columns() != null) {
+        stringBuilder.append(String.format(" (%s)",
+            StringUtils.join(context.columns().identifier().stream()
+                .map(ParserUtil::getIdentifierText)
+                .map(ColumnName::of)
+                .map(ColumnName::toString).collect(Collectors.toList()), ", ")));
+      }
+
+      // masked values
+      final String values = String.join(", ",
+          Collections.nCopies(context.values().valueExpression().size(), MASKED_VALUE));
+      stringBuilder.append(String.format(" VALUES (%s)", values));
+
+      masked = true;
+      return stringBuilder.toString();
     }
 
     @Override
@@ -166,7 +227,7 @@ public final class QueryMask {
 
         formattedProp.append(key);
         final String value = ALLOWED_KEYS.contains(unquotedLowerKey) ? prop.literal().getText() :
-            MASKED_VALUE;
+            MASKED_STRING;
         formattedProp.append("=").append(value);
         tableProperties.add(formattedProp.toString());
       }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -120,7 +120,7 @@ public class KsqlParserTest {
     final String simpleQuery = "SELECT col0, col2, col3 FROM test1 WHERE col0 > 100;";
     final PreparedStatement<?> statement = KsqlParserTestUtil.buildSingleAst(simpleQuery, metaStore);
 
-    assertThat(statement.getStatementText(), is(simpleQuery));
+    assertThat(statement.getMaskedStatementText(), is(simpleQuery));
     assertThat(statement.getStatement(), is(instanceOf(Query.class)));
     final Query query = (Query) statement.getStatement();
     assertThat(query.getSelect().getSelectItems(), hasSize(3));
@@ -1473,7 +1473,7 @@ public class KsqlParserTest {
     final ParsedStatement parsedStatement = ParsedStatement.of(query, mock(SingleStatementContext.class));
 
     // Then
-    assertThat(parsedStatement.getStatementText(), is(masked));
+    assertThat(parsedStatement.getMaskedStatementText(), is(masked));
     assertThat(parsedStatement.getUnMaskedStatementText(), is(query));
     assertThat(parsedStatement.toString(), is(masked));
   }
@@ -1503,7 +1503,7 @@ public class KsqlParserTest {
         PreparedStatement.of(query, mock(CreateConnector.class));
 
     // Then
-    assertThat(preparedStatement.getStatementText(), is(masked));
+    assertThat(preparedStatement.getMaskedStatementText(), is(masked));
     assertThat(preparedStatement.getUnMaskedStatementText(), is(query));
     assertThat(preparedStatement.toString(), is(masked));
   }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/VariableSubstitutorTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/VariableSubstitutorTest.java
@@ -282,7 +282,7 @@ public class VariableSubstitutorTest {
       final String sqlResult = VariableSubstitutor.substitute(sqlStatement, variablesMap);
 
       // Then
-      assertThat("Should replace: " + sqlStatement.getStatementText(), sqlResult, equalTo(sqlReplaced));
+      assertThat("Should replace: " + sqlStatement.getUnMaskedStatementText(), sqlResult, equalTo(sqlReplaced));
     }
   }
 
@@ -301,7 +301,7 @@ public class VariableSubstitutorTest {
       );
 
       // Then
-      assertThat("Should fail replace: " + sqlStatement.getStatementText(),
+      assertThat("Should fail replace: " + sqlStatement.getUnMaskedStatementText(),
           e.getMessage(), containsString(sqlError));
     }
   }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/util/QueryMaskTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/util/QueryMaskTest.java
@@ -276,4 +276,38 @@ public class QueryMaskTest {
 
     assertThat(maskedQuery, is(expected));
   }
+
+  @Test
+  public void shouldMaskInsertStatement() {
+    // Given
+    final String query = "--this is a comment. \n"
+        + "INSERT INTO foo (KEY_COL, COL_A) VALUES (\"key\", \"A\");";
+
+    // When
+    final String maskedQuery = QueryMask.getMaskedStatement(query);
+
+    // Then
+    final String expected = "INSERT INTO `FOO` (`KEY_COL`, `COL_A`) VALUES ('[value]', '[value]');";
+
+    assertThat(maskedQuery, is(expected));
+  }
+
+  @Test
+  public void shouldMaskFallbackInsertStatement() {
+    // Given
+    final String query = "--this is a comment. \n"
+        + "INSERT INTO foo (KEY_COL, COL_A) VALUES"
+        + "(\"key\", 0.125, '{something}', 1, C, 2.3E);";
+
+    // When
+    final String maskedQuery = QueryMask.getMaskedStatement(query);
+
+    // Then
+    final String expected = "--this is a comment. \n"
+        + "INSERT INTO foo (KEY_COL, COL_A) VALUES"
+        + "('[value]','[value]','[value]','[value]','[value]','[value]');";
+
+    // Then
+    assertThat(maskedQuery, is(expected));
+  }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/KeyValueExtractor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/KeyValueExtractor.java
@@ -96,8 +96,8 @@ public final class KeyValueExtractor {
   ) {
     return sqlValueCoercer.coerce(value, sqlType)
         .orElseThrow(() -> new KsqlApiException(
-            String.format("Can't coerce a field of type %s (%s) into type %s", value.getClass(),
-                value, sqlType),
+            String.format("Can't coerce a field of type %s into type %s", value.getClass(),
+                sqlType),
             Errors.ERROR_CODE_BAD_REQUEST))
         .orElse(null);
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
@@ -110,7 +110,7 @@ public class QueryEndpoint {
       final BlockingQueryPublisher publisher = new BlockingQueryPublisher(context, workerExecutor);
 
       publisher.setQueryHandle(new KsqlPullQueryHandle(result, pullQueryMetrics,
-          statement.getPreparedStatement().getStatementText()), true, false);
+          statement.getPreparedStatement().getMaskedStatementText()), true, false);
 
       // Start from the worker thread so that errors can bubble up, and we can get a proper response
       // code rather than waiting until later after the header has been written and all we can do
@@ -130,7 +130,7 @@ public class QueryEndpoint {
     } else {
       throw new KsqlStatementException(
           "Unexpected metadata for query",
-          statement.getStatementText()
+          statement.getMaskedStatementText()
       );
     }
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
@@ -308,7 +308,7 @@ public class StandaloneExecutor implements Executable {
             + "Only the following statements are supporting in standalone mode:"
             + System.lineSeparator()
             + SUPPORTED_STATEMENTS,
-            statement.getStatementText());
+            statement.getMaskedStatementText());
       }
 
       handler.handle(this, (ConfiguredStatement<Statement>) configured);
@@ -338,7 +338,7 @@ public class StandaloneExecutor implements Executable {
 
       throw new KsqlStatementException("statement does not define the schema "
           + "and the supplied format does not support schema inference",
-          statement.getStatementText());
+          statement.getMaskedStatementText());
     }
 
     private void handleSetProperty(final ConfiguredStatement<SetProperty> statement) {
@@ -359,7 +359,7 @@ public class StandaloneExecutor implements Executable {
           .filter(q -> q instanceof PersistentQueryMetadata)
           .orElseThrow((() -> new KsqlStatementException(
               "Could not build the query",
-              statement.getStatementText())));
+              statement.getMaskedStatementText())));
     }
 
     private static String generateSupportedMessage() {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java
@@ -152,7 +152,7 @@ public class Command {
     final SessionConfig sessionConfig = configuredStatement.getSessionConfig();
 
     return new Command(
-        configuredStatement.getStatementText(),
+        configuredStatement.getUnMaskedStatementText(),
         sessionConfig.getOverrides(),
         sessionConfig.getConfig(false).getAllConfigPropsWithSecretsObfuscated(),
         Optional.empty(),

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
@@ -337,9 +337,8 @@ public class CommandRunner implements Closeable {
     }
   }
 
-  @SuppressFBWarnings("DMI_INVOKING_TOSTRING_ON_ARRAY")
   private void executeStatement(final QueuedCommand queuedCommand) {
-    final String commandId = queuedCommand.getCommandId().toString();
+    final String commandId = queuedCommand.getAndDeserializeCommandId().toString();
     LOG.info("Executing statement: " + commandId);
 
     final Runnable task = () -> {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
@@ -337,17 +337,17 @@ public class CommandRunner implements Closeable {
     }
   }
 
+  @SuppressFBWarnings("DMI_INVOKING_TOSTRING_ON_ARRAY")
   private void executeStatement(final QueuedCommand queuedCommand) {
-    final String commandStatement =
-        queuedCommand.getAndDeserializeCommand(commandDeserializer).getStatement();
-    LOG.info("Executing statement: " + commandStatement);
+    final String commandId = queuedCommand.getCommandId().toString();
+    LOG.info("Executing statement: " + commandId);
 
     final Runnable task = () -> {
       if (closed) {
         LOG.info("Execution aborted as system is closing down");
       } else {
         statementExecutor.handleStatement(queuedCommand);
-        LOG.info("Executed statement: " + commandStatement);
+        LOG.info("Executed statement: " + commandId);
       }
     };
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandStore.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandStore.java
@@ -27,6 +27,7 @@ import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlServerException;
+import io.confluent.ksql.util.QueryMask;
 import java.io.Closeable;
 import java.time.Duration;
 import java.util.Collections;
@@ -228,7 +229,7 @@ public class CommandStore implements CommandQueue, Closeable {
           String.format(
               "Could not write the statement '%s' into the "
                   + "command topic"
-                  + ".", command.getStatement()
+                  + ".", QueryMask.getMaskedStatement(command.getStatement())
           ),
           e
       );

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DistributingExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DistributingExecutor.java
@@ -137,7 +137,7 @@ public class DistributingExecutor {
     if (sourceName != null
         && executionContext.getMetaStore().getSource(sourceName) != null) {
       return Optional.of(StatementExecutorResponse.handled(Optional.of(
-          new WarningEntity(statement.getStatementText(),
+          new WarningEntity(statement.getMaskedStatementText(),
               String.format("Cannot add %s %s: A %s with the same name already exists.",
                   type,
                   sourceName,
@@ -203,7 +203,7 @@ public class DistributingExecutor {
     } catch (final Exception e) {
       throw new KsqlServerException(String.format(
           "Could not write the statement '%s' into the command topic: " + e.getMessage(),
-          statement.getStatementText()), e);
+          statement.getMaskedStatementText()), e);
     }
 
     if (!rateLimiter.tryAcquire(1, TimeUnit.SECONDS)) {
@@ -231,7 +231,7 @@ public class DistributingExecutor {
           .tryWaitForFinalStatus(distributedCmdResponseTimeout);
 
       return StatementExecutorResponse.handled(Optional.of(new CommandStatusEntity(
-          injected.getStatementText(),
+          injected.getMaskedStatementText(),
           queuedCommandStatus.getCommandId(),
           commandStatus,
           queuedCommandStatus.getCommandSequenceNumber(),
@@ -248,7 +248,7 @@ public class DistributingExecutor {
       }
       throw new KsqlServerException(String.format(
           "Could not write the statement '%s' into the command topic.",
-          statement.getStatementText()), e);
+          statement.getMaskedStatementText()), e);
     } catch (final Exception e) {
       transactionalProducer.abortTransaction();
       if (commandId != null) {
@@ -256,7 +256,7 @@ public class DistributingExecutor {
       }
       throw new KsqlServerException(String.format(
           "Could not write the statement '%s' into the command topic.",
-          statement.getStatementText()), e);
+          statement.getMaskedStatementText()), e);
     } finally {
       transactionalProducer.close();
     }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactory.java
@@ -206,12 +206,12 @@ public final class ValidatedCommandFactory {
     final PersistentQueryMetadata queryMetadata = context.getPersistentQuery(queryId.get())
         .orElseThrow(() -> new KsqlStatementException(
             "Unknown queryId: " + queryId.get(),
-            statement.getStatementText()));
+            statement.getMaskedStatementText()));
 
     if (queryMetadata.getPersistentQueryType() == KsqlConstants.PersistentQueryType.CREATE_SOURCE) {
       throw new KsqlStatementException(
           String.format("Cannot pause query '%s' because it is linked to a source table.",
-              queryId.get()), statement.getStatementText());
+              queryId.get()), statement.getMaskedStatementText());
     }
 
     queryMetadata.pause();
@@ -236,12 +236,12 @@ public final class ValidatedCommandFactory {
     final PersistentQueryMetadata queryMetadata = context.getPersistentQuery(queryId.get())
         .orElseThrow(() -> new KsqlStatementException(
             "Unknown queryId: " + queryId.get(),
-            statement.getStatementText()));
+            statement.getMaskedStatementText()));
 
     if (queryMetadata.getPersistentQueryType() == KsqlConstants.PersistentQueryType.CREATE_SOURCE) {
       throw new KsqlStatementException(
           String.format("Cannot resume query '%s' because it is linked to a source table.",
-              queryId.get()), statement.getStatementText());
+              queryId.get()), statement.getMaskedStatementText());
     }
 
     queryMetadata.resume();
@@ -266,12 +266,12 @@ public final class ValidatedCommandFactory {
     final PersistentQueryMetadata queryMetadata = context.getPersistentQuery(queryId.get())
         .orElseThrow(() -> new KsqlStatementException(
             "Unknown queryId: " + queryId.get(),
-            statement.getStatementText()));
+            statement.getMaskedStatementText()));
 
     if (queryMetadata.getPersistentQueryType() == KsqlConstants.PersistentQueryType.CREATE_SOURCE) {
       throw new KsqlStatementException(
           String.format("Cannot terminate query '%s' because it is linked to a source table.",
-              queryId.get()), statement.getStatementText());
+              queryId.get()), statement.getMaskedStatementText());
     }
 
     queryMetadata.close();

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/AssertSchemaExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/AssertSchemaExecutor.java
@@ -45,7 +45,7 @@ public final class AssertSchemaExecutor {
       final ServiceContext serviceContext
   ) {
     return AssertExecutor.execute(
-        statement.getStatementText(),
+        statement.getMaskedStatementText(),
         statement.getStatement(),
         executionContext.getKsqlConfig().getInt(KSQL_ASSERT_SCHEMA_DEFAULT_TIMEOUT_MS),
         serviceContext,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/AssertTopicExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/AssertTopicExecutor.java
@@ -47,7 +47,7 @@ public final class AssertTopicExecutor {
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {
-    return AssertExecutor.execute(statement.getStatementText(),
+    return AssertExecutor.execute(statement.getMaskedStatementText(),
         statement.getStatement(),
         executionContext.getKsqlConfig().getInt(KSQL_ASSERT_TOPIC_DEFAULT_TIMEOUT_MS),
         serviceContext,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ConnectExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ConnectExecutor.java
@@ -75,7 +75,7 @@ public final class ConnectExecutor {
     if (response.datum().isPresent()) {
       return StatementExecutorResponse.handled(Optional.of(
           new CreateConnectorEntity(
-              statement.getStatementText(),
+              statement.getMaskedStatementText(),
               response.datum().get()
           )
       ));
@@ -119,7 +119,7 @@ public final class ConnectExecutor {
     }
 
     return StatementExecutorResponse.handled(Optional.of(new CreateConnectorEntity(
-        statement.getStatementText(),
+        statement.getMaskedStatementText(),
         DUMMY_CREATE_RESPONSE
     )));
   }
@@ -203,7 +203,7 @@ public final class ConnectExecutor {
       }
 
       if (connectorExists(createConnector, connectorsResponse)) {
-        return Optional.of(new WarningEntity(statement.getStatementText(),
+        return Optional.of(new WarningEntity(statement.getMaskedStatementText(),
             String.format("Connector %s already exists", createConnector.getName())));
       }
     }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutor.java
@@ -159,7 +159,7 @@ public final class DescribeConnectorExecutor {
     }
 
     final ConnectorDescription description = new ConnectorDescription(
-        configuredStatement.getStatementText(),
+        configuredStatement.getMaskedStatementText(),
         info.config().get(ConnectorConfig.CONNECTOR_CLASS_CONFIG),
         status,
         sources,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutor.java
@@ -60,18 +60,18 @@ public final class DescribeFunctionExecutor {
     if (executionContext.getMetaStore().isAggregate(functionName)) {
       return StatementExecutorResponse.handled(Optional.of(
           describeAggregateFunction(executionContext, functionName,
-              statement.getStatementText())));
+              statement.getMaskedStatementText())));
     }
 
     if (executionContext.getMetaStore().isTableFunction(functionName)) {
       return StatementExecutorResponse.handled(Optional.of(
           describeTableFunction(executionContext, functionName,
-              statement.getStatementText())));
+              statement.getMaskedStatementText())));
     }
 
     return StatementExecutorResponse.handled(Optional.of(
         describeNonAggregateFunction(executionContext, functionName,
-            statement.getStatementText())));
+            statement.getMaskedStatementText())));
   }
 
   private static FunctionDescriptionList describeAggregateFunction(

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DropConnectorExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DropConnectorExecutor.java
@@ -49,7 +49,7 @@ public final class DropConnectorExecutor {
     if (response.error().isPresent()) {
       if (ifExists && response.httpCode() == HttpStatus.SC_NOT_FOUND) {
         return StatementExecutorResponse.handled(Optional.of(
-            new WarningEntity(statement.getStatementText(),
+            new WarningEntity(statement.getMaskedStatementText(),
                 "Connector '" + connectorName + "' does not exist.")));
       } else {
         final String errorMsg = "Failed to drop connector: " + response.error().get();
@@ -62,6 +62,6 @@ public final class DropConnectorExecutor {
     }
 
     return StatementExecutorResponse.handled(Optional.of(
-        new DropConnectorEntity(statement.getStatementText(), connectorName)));
+        new DropConnectorEntity(statement.getMaskedStatementText(), connectorName)));
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ExplainExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ExplainExecutor.java
@@ -80,9 +80,9 @@ public final class ExplainExecutor {
           .orElseGet(() -> explainStatement(
               statement, executionContext, serviceContext));
 
-      return new QueryDescriptionEntity(statement.getStatementText(), queryDescription);
+      return new QueryDescriptionEntity(statement.getMaskedStatementText(), queryDescription);
     } catch (final KsqlException e) {
-      throw new KsqlStatementException(e.getMessage(), statement.getStatementText(), e);
+      throw new KsqlStatementException(e.getMessage(), statement.getMaskedStatementText(), e);
     }
   }
 
@@ -95,7 +95,7 @@ public final class ExplainExecutor {
         .getStatement()
         .orElseThrow(() -> new KsqlStatementException(
             "must have either queryID or statement",
-            explain.getStatementText()));
+            explain.getMaskedStatementText()));
 
     if (!(statement instanceof Query || statement instanceof QueryContainer)) {
       throw new KsqlException("The provided statement does not run a ksql query");

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
@@ -289,7 +289,7 @@ public class InsertValuesExecutor {
     } catch (final Exception e) {
       throw new KsqlStatementException(
           createInsertFailedExceptionMessage(insertValues) + " " + e.getMessage(),
-          statement.getStatementText(),
+          statement.getMaskedStatementText(),
           e);
     }
   }
@@ -366,7 +366,7 @@ public class InsertValuesExecutor {
             AclOperation.WRITE,
             e);
         LOG.error("Could not serialize key.", e);
-        throw new KsqlException("Could not serialize key: " + keyValue, e);
+        throw new KsqlException("Could not serialize key", e);
       }
     }
   }
@@ -498,7 +498,7 @@ public class InsertValuesExecutor {
             AclOperation.WRITE,
             e);
         LOG.error("Could not serialize value.", e);
-        throw new KsqlException("Could not serialize value: " + row + ". " + e.getMessage(), e);
+        throw new KsqlException("Could not serialize value" + e.getMessage(), e);
       }
     }
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListConnectorPluginsExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListConnectorPluginsExecutor.java
@@ -67,7 +67,7 @@ public final class ListConnectorPluginsExecutor {
 
     return StatementExecutorResponse.handled(Optional.of(
       new ConnectorPluginsList(
-        configuredStatement.getStatementText(),
+        configuredStatement.getMaskedStatementText(),
         Collections.emptyList(),
         pluginInfos
       )

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListConnectorsExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListConnectorsExecutor.java
@@ -89,7 +89,7 @@ public final class ListConnectorsExecutor {
 
     return StatementExecutorResponse.handled(Optional.of(
         new ConnectorList(
-            configuredStatement.getStatementText(),
+            configuredStatement.getMaskedStatementText(),
             warnings,
             infos)
     ));

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutor.java
@@ -67,7 +67,7 @@ public final class ListFunctionsExecutor {
         .forEach(all::add);
 
     return StatementExecutorResponse.handled(
-        Optional.of(new FunctionNameList(statement.getStatementText(), all)));
+        Optional.of(new FunctionNameList(statement.getMaskedStatementText(), all)));
   }
 
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutor.java
@@ -78,7 +78,7 @@ public final class ListPropertiesExecutor {
         .collect(Collectors.toList());
 
     return StatementExecutorResponse.handled(Optional.of(new PropertiesList(
-        statement.getStatementText(), mergedProperties, overwritten, defaultProps)));
+        statement.getMaskedStatementText(), mergedProperties, overwritten, defaultProps)));
   }
 
   private static List<Property> mergedProperties(

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
@@ -76,7 +76,7 @@ public final class ListQueriesExecutor {
         remoteHostExecutor.fetchAllRemoteResults()
     );
     return StatementExecutorResponse.handled(Optional.of(new Queries(
-        statement.getStatementText(),
+        statement.getMaskedStatementText(),
         runningQueries.values())));
   }
 
@@ -168,7 +168,7 @@ public final class ListQueriesExecutor {
     );
 
     return StatementExecutorResponse.handled(Optional.of(new QueryDescriptionList(
-        statement.getStatementText(),
+        statement.getMaskedStatementText(),
         queryDescriptions.values())));
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -119,7 +119,7 @@ public final class ListSourceExecutor {
         .collect(Collectors.toList());
     return Optional.of(
         new SourceDescriptionList(
-            statement.getStatementText(),
+            statement.getMaskedStatementText(),
             descriptions.stream().map(d -> d.description).collect(Collectors.toList()),
             descriptions.stream().flatMap(d -> d.warnings.stream()).collect(Collectors.toList())
         )
@@ -147,7 +147,7 @@ public final class ListSourceExecutor {
     }
 
     return StatementExecutorResponse.handled(Optional.of(new StreamsList(
-        statement.getStatementText(),
+        statement.getMaskedStatementText(),
         ksqlStreams.stream()
             .map(ListSourceExecutor::sourceSteam)
             .collect(Collectors.toList()))));
@@ -173,7 +173,7 @@ public final class ListSourceExecutor {
       ));
     }
     return StatementExecutorResponse.handled(Optional.of(new TablesList(
-        statement.getStatementText(),
+        statement.getMaskedStatementText(),
         ksqlTables.stream()
             .map(ListSourceExecutor::sourceTable)
             .collect(Collectors.toList()))));
@@ -234,7 +234,7 @@ public final class ListSourceExecutor {
     );
     return StatementExecutorResponse.handled(Optional.of(
         new SourceDescriptionEntity(
-            statement.getStatementText(),
+            statement.getMaskedStatementText(),
             descriptionWithWarnings.description,
             descriptionWithWarnings.warnings)));
   }
@@ -277,7 +277,7 @@ public final class ListSourceExecutor {
       throw new KsqlStatementException(String.format(
           "Could not find STREAM/TABLE '%s' in the Metastore",
           name.text()
-      ), statement.getStatementText());
+      ), statement.getMaskedStatementText());
     }
 
     final List<RunningQuery> readQueries = getQueries(ksqlExecutionContext,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutor.java
@@ -71,14 +71,14 @@ public final class ListTopicsExecutor {
           .collect(Collectors.toList());
 
       return StatementExecutorResponse.handled(Optional.of(
-          new KafkaTopicsListExtended(statement.getStatementText(), topicInfoExtendedList)));
+          new KafkaTopicsListExtended(statement.getMaskedStatementText(), topicInfoExtendedList)));
     } else {
       final List<KafkaTopicInfo> topicInfoList = topicDescriptions.values()
           .stream().map(ListTopicsExecutor::topicDescriptionToTopicInfo)
           .collect(Collectors.toList());
 
       return StatementExecutorResponse.handled(Optional.of(
-          new KafkaTopicsList(statement.getStatementText(), topicInfoList)));
+          new KafkaTopicsList(statement.getMaskedStatementText(), topicInfoList)));
     }
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTypesExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTypesExecutor.java
@@ -49,6 +49,6 @@ public final class ListTypesExecutor {
     }
 
     return StatementExecutorResponse.handled(Optional.of(
-        new TypeList(configuredStatement.getStatementText(), types.build())));
+        new TypeList(configuredStatement.getMaskedStatementText(), types.build())));
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListVariablesExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListVariablesExecutor.java
@@ -42,6 +42,6 @@ public final class ListVariablesExecutor {
         .collect(Collectors.toList());
 
     return StatementExecutorResponse.handled(Optional.of(
-        new VariablesList(statement.getStatementText(), sessionVariables)));
+        new VariablesList(statement.getMaskedStatementText(), sessionVariables)));
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/RemoteHostExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/RemoteHostExecutor.java
@@ -133,7 +133,7 @@ public final class RemoteHostExecutor {
           }
         } catch (final Exception cause) {
           LOG.warn("Failed to retrieve info from host: {}, statement: {}, cause: {}",
-              e.getKey(), statement.getStatementText(), cause.getMessage());
+              e.getKey(), statement.getMaskedStatementText(), cause.getMessage());
           unresponsiveHosts.add(e.getKey());
         }
       }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/TerminateQueryExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/TerminateQueryExecutor.java
@@ -74,7 +74,7 @@ public final class TerminateQueryExecutor {
         }
       }
       return StatementExecutorResponse.handled(Optional.of(
-          new TerminateQueryEntity(statement.getStatementText(), queryId.toString(), true)
+          new TerminateQueryEntity(statement.getMaskedStatementText(), queryId.toString(), true)
       ));
     }
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/VariableExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/VariableExecutor.java
@@ -53,7 +53,7 @@ public final class VariableExecutor {
 
     if (!sessionProperties.getSessionVariables().containsKey(variableName)) {
       return StatementExecutorResponse.handled(Optional.of(new WarningEntity(
-          statement.getStatementText(),
+          statement.getMaskedStatementText(),
           String.format("Cannot undefine variable '%s' which was never defined", variableName)
       )));
     }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/query/QueryExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/query/QueryExecutor.java
@@ -152,7 +152,7 @@ public class QueryExecutor {
     if (statement.getStatement().isPullQuery()) {
       final ImmutableAnalysis analysis = ksqlEngine
           .analyzeQueryWithNoOutputTopic(
-              statement.getStatement(), statement.getStatementText(), configOverrides);
+              statement.getStatement(), statement.getMaskedStatementText(), configOverrides);
       final DataSource dataSource = analysis.getFrom().getDataSource();
       final DataSource.DataSourceType dataSourceType = dataSource.getDataSourceType();
 
@@ -164,7 +164,7 @@ public class QueryExecutor {
                 + "Please set " + KsqlConfig.KSQL_PULL_QUERIES_ENABLE_CONFIG + "=true to enable "
                 + "this feature."
                 + System.lineSeparator(),
-            statement.getStatementText());
+            statement.getMaskedStatementText());
       }
 
       switch (dataSourceType) {
@@ -216,7 +216,7 @@ public class QueryExecutor {
         default:
           throw new KsqlStatementException(
               "Unexpected data source type for pull query: " + dataSourceType,
-              statement.getStatementText()
+              statement.getMaskedStatementText()
           );
       }
     } else if (ScalablePushUtil
@@ -231,11 +231,11 @@ public class QueryExecutor {
       final ImmutableAnalysis analysis = ksqlEngine
           .analyzeQueryWithNoOutputTopic(
               statement.getStatement(),
-              statement.getStatementText(),
+              statement.getMaskedStatementText(),
               configOverrides
           );
 
-      QueryLogger.info("Scalable push query created", statement.getStatementText());
+      QueryLogger.info("Scalable push query created", statement.getMaskedStatementText());
 
       return handleScalablePushQuery(
           analysis,
@@ -249,7 +249,7 @@ public class QueryExecutor {
       );
     } else {
       // log validated statements for query anonymization
-      QueryLogger.info("Transient query created", statement.getStatementText());
+      QueryLogger.info("Transient query created", statement.getMaskedStatementText());
       return handlePushQuery(
           serviceContext,
           statement,
@@ -351,7 +351,7 @@ public class QueryExecutor {
     query.prepare();
     resultForMetrics.set(query);
 
-    QueryLogger.info("Streaming scalable push query", statement.getStatementText());
+    QueryLogger.info("Streaming scalable push query", statement.getMaskedStatementText());
     return QueryMetadataHolder.of(query);
   }
 
@@ -393,7 +393,7 @@ public class QueryExecutor {
       QueryCapacityUtil.throwTooManyActivePushQueriesException(
           ksqlEngine,
           ksqlRestConfig,
-          statement.getStatementText()
+          statement.getMaskedStatementText()
       );
     }
 
@@ -402,7 +402,7 @@ public class QueryExecutor {
 
     localCommands.ifPresent(lc -> lc.write(query));
 
-    log.info("Streaming query '{}'", statement.getStatementText());
+    log.info("Streaming query '{}'", statement.getMaskedStatementText());
     return QueryMetadataHolder.of(query);
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -311,9 +311,9 @@ public class KsqlResource implements KsqlConfigurable {
       statements.forEach(s -> {
         if (s.getUnMaskedStatementText().toLowerCase().contains("terminate")
             || s.getUnMaskedStatementText().toLowerCase().contains("drop")) {
-          QueryLogger.info("Query terminated", s.getStatementText());
+          QueryLogger.info("Query terminated", s.getMaskedStatementText());
         } else {
-          QueryLogger.info("Query created", s.getStatementText());
+          QueryLogger.info("Query created", s.getMaskedStatementText());
         }
       });
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryStreamWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryStreamWriter.java
@@ -94,7 +94,7 @@ public class PullQueryStreamWriter implements StreamingOutput {
           e.getMessage() == null
               ? "Server Error" + Arrays.toString(e.getStackTrace())
               : e.getMessage(),
-          statement.getStatementText(),
+          statement.getMaskedStatementText(),
           e
       );
     }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
@@ -265,7 +265,7 @@ public class WSQueryEndpoint {
           startTimeNanos
       ).subscribe(streamSubscriber);
     } else {
-      throw new KsqlStatementException("Unknown query type", statement.getStatementText());
+      throw new KsqlStatementException("Unknown query type", statement.getMaskedStatementText());
     }
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
@@ -78,7 +78,7 @@ public enum CustomValidators {
           sessionProperties,
           executionContext,
           serviceContext) -> {
-        throw new KsqlRestException(Errors.queryEndpoint(statement.getStatementText()));
+        throw new KsqlRestException(Errors.queryEndpoint(statement.getMaskedStatementText()));
       }),
   PRINT_TOPIC(PrintTopic.class, PrintTopicValidator::validate),
   ALTER_SYSTEM_PROPERTY(AlterSystemProperty.class, StatementValidator.NO_VALIDATION),

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/PrintTopicValidator.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/PrintTopicValidator.java
@@ -34,7 +34,7 @@ public final class PrintTopicValidator {
       final KsqlExecutionContext context,
       final ServiceContext serviceContext
   ) {
-    throw new KsqlRestException(Errors.queryEndpoint(statement.getStatementText()));
+    throw new KsqlRestException(Errors.queryEndpoint(statement.getMaskedStatementText()));
   }
 
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/RequestValidator.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/RequestValidator.java
@@ -178,7 +178,7 @@ public class RequestValidator {
       throw new KsqlStatementException(
           "Do not know how to validate statement of type: " + statementClass
               + " Known types: " + customValidators.keySet(),
-          configured.getStatementText());
+          configured.getMaskedStatementText());
     }
 
     return (statement instanceof CreateAsSelect || statement instanceof InsertInto) ? 1 : 0;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
@@ -441,7 +441,7 @@ public class ApiIntegrationTest {
 
     // Then:
     shouldFailToInsert(row, ERROR_CODE_BAD_REQUEST,
-        "Can't coerce a field of type class java.lang.String (bad type) into type STRUCT<`F1` ARRAY<STRING>>");
+        "Can't coerce a field of type class java.lang.String into type STRUCT<`F1` ARRAY<STRING>>");
   }
 
   @Test
@@ -460,7 +460,7 @@ public class ApiIntegrationTest {
 
     // Then:
     shouldFailToInsert(row, ERROR_CODE_BAD_REQUEST,
-        "Can't coerce a field of type class java.lang.String (not a number) into type BIGINT");
+        "Can't coerce a field of type class java.lang.String into type BIGINT");
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/parser/ParserMatchers.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/parser/ParserMatchers.java
@@ -146,7 +146,7 @@ public final class ParserMatchers {
 
     @Override
     protected String featureValueOf(final PreparedStatement<T> actual) {
-      return actual.getStatementText();
+      return actual.getUnMaskedStatementText();
     }
 
     @Factory

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
@@ -861,7 +861,7 @@ public class StandaloneExecutorTest {
   private void givenQueryFileParsesTo(final PreparedStatement<?>... statements) {
     final List<ParsedStatement> parsedStmts = Arrays.stream(statements)
         .map(statement -> ParsedStatement
-            .of(statement.getStatementText(), mock(SingleStatementContext.class)))
+            .of(statement.getUnMaskedStatementText(), mock(SingleStatementContext.class)))
         .collect(Collectors.toList());
 
     when(ksqlEngine.parse(any())).thenReturn(parsedStmts);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
@@ -37,6 +37,9 @@ import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.rest.Errors;
+import io.confluent.ksql.rest.entity.CommandId;
+import io.confluent.ksql.rest.entity.CommandId.Action;
+import io.confluent.ksql.rest.entity.CommandId.Type;
 import io.confluent.ksql.rest.server.resources.IncompatibleKsqlCommandVersionException;
 import io.confluent.ksql.rest.server.state.ServerState;
 import io.confluent.ksql.rest.util.ClusterTerminator;
@@ -134,9 +137,12 @@ public class CommandRunnerTest {
     when(queuedCommand1.getAndDeserializeCommand(commandDeserializer)).thenReturn(command);
     when(queuedCommand2.getAndDeserializeCommand(commandDeserializer)).thenReturn(command);
     when(queuedCommand3.getAndDeserializeCommand(commandDeserializer)).thenReturn(command);
-    when(queuedCommand1.getCommandId()).thenReturn(new byte[0]);
-    when(queuedCommand2.getCommandId()).thenReturn(new byte[0]);
-    when(queuedCommand3.getCommandId()).thenReturn(new byte[0]);
+    when(queuedCommand1.getAndDeserializeCommandId()).thenReturn(
+        new CommandId(Type.STREAM, "foo1", Action.CREATE));
+    when(queuedCommand2.getAndDeserializeCommandId()).thenReturn(
+        new CommandId(Type.STREAM, "foo2", Action.CREATE));
+    when(queuedCommand3.getAndDeserializeCommandId()).thenReturn(
+        new CommandId(Type.STREAM, "foo3", Action.CREATE));
     doNothing().when(incompatibleCommandChecker).accept(queuedCommand1);
     doNothing().when(incompatibleCommandChecker).accept(queuedCommand2);
     doNothing().when(incompatibleCommandChecker).accept(queuedCommand3);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
@@ -134,6 +134,9 @@ public class CommandRunnerTest {
     when(queuedCommand1.getAndDeserializeCommand(commandDeserializer)).thenReturn(command);
     when(queuedCommand2.getAndDeserializeCommand(commandDeserializer)).thenReturn(command);
     when(queuedCommand3.getAndDeserializeCommand(commandDeserializer)).thenReturn(command);
+    when(queuedCommand1.getCommandId()).thenReturn(new byte[0]);
+    when(queuedCommand2.getCommandId()).thenReturn(new byte[0]);
+    when(queuedCommand3.getCommandId()).thenReturn(new byte[0]);
     doNothing().when(incompatibleCommandChecker).accept(queuedCommand1);
     doNothing().when(incompatibleCommandChecker).accept(queuedCommand2);
     doNothing().when(incompatibleCommandChecker).accept(queuedCommand3);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
@@ -743,8 +743,8 @@ public class InteractiveStatementExecutorTest {
 
     @Override
     public boolean matches(final ConfiguredStatement<T> matchStatement) {
-      return statement.getStatementText().equals(matchStatement.getStatementText()) &&
-          statement.getStatement().equals(matchStatement.getStatement());
+      return statement.getUnMaskedStatementText().equals(matchStatement.getUnMaskedStatementText())
+          && statement.getStatement().equals(matchStatement.getStatement());
     }
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListVariablesExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListVariablesExecutorTest.java
@@ -46,7 +46,7 @@ public class ListVariablesExecutorTest {
 
   private Optional<KsqlEntity> executeListVariables(final String sql) {
     final ConfiguredStatement<?> configuredStatement = mock(ConfiguredStatement.class);
-    when(configuredStatement.getStatementText()).thenReturn(sql);
+    when(configuredStatement.getMaskedStatementText()).thenReturn(sql);
 
     return CustomExecutors.LIST_VARIABLES.execute(
         configuredStatement,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/TerminateQueryExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/TerminateQueryExecutorTest.java
@@ -131,7 +131,7 @@ public class TerminateQueryExecutorTest {
     ).getEntity();
 
     // Then:
-    assertThat(ksqlEntity, is(Optional.of(new TerminateQueryEntity(terminateTransient.getStatementText(), transientQueryId.toString(), true))));
+    assertThat(ksqlEntity, is(Optional.of(new TerminateQueryEntity(terminateTransient.getMaskedStatementText(), transientQueryId.toString(), true))));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -1308,7 +1308,7 @@ public class KsqlResourceTest {
     verify(sandbox).plan(any(SandboxedServiceContext.class), eq(CFG_0_WITH_SCHEMA));
     verify(commandStore).enqueueCommand(
         any(),
-        argThat(is(commandWithStatement(CFG_1_WITH_SCHEMA.getStatementText()))),
+        argThat(is(commandWithStatement(CFG_1_WITH_SCHEMA.getUnMaskedStatementText()))),
         any()
     );
   }
@@ -1558,6 +1558,23 @@ public class KsqlResourceTest {
         "Unknown queryId: UNKNOWN_QUERY_ID"))));
     assertThat(e, exceptionStatementErrorMessage(statement(is(
         "TERMINATE unknown_query_id;"))));
+  }
+
+  @Test
+  public void shouldThrowOnInsertBadQuery() {
+    // When:
+    final String query = "--this is a comment. \n"
+        + "INSERT INTO foo (KEY_COL, COL_A) VALUES"
+        + "(\"key\", 0.125, 1);";
+    final KsqlRestException e = assertThrows(
+        KsqlRestException.class,
+        () -> makeRequest(query)
+    );
+
+    // Then:
+    assertThat(e, exceptionStatusCode(is(BAD_REQUEST.code())));
+    assertThat(e, exceptionStatementErrorMessage(statement(is(
+        "INSERT INTO `FOO` (`KEY_COL`, `COL_A`) VALUES ('[value]', '[value]', '[value]');"))));
   }
 
   @Test
@@ -2316,7 +2333,7 @@ public class KsqlResourceTest {
                 .prepare(invocation.getArgument(0), Collections.emptyMap()));
     when(sandbox.plan(any(), any())).thenAnswer(
         i -> KsqlPlan.ddlPlanCurrent(
-            ((ConfiguredStatement<?>) i.getArgument(1)).getStatementText(),
+            ((ConfiguredStatement<?>) i.getArgument(1)).getMaskedStatementText(),
             new DropSourceCommand(SourceName.of("bob"))
         )
     );


### PR DESCRIPTION
### Description 
We want to avoid logging the VALUES of INSERT INTO VALUES statements since they are considered sensitive information.

This PR extends QueryMask to visit Insert statements and mask sensitive information. The masked statements are stored as part of maskedStatements and they can then be used for logging.

This PR also replaces getStatementText with getMaskedStatementText method for Parsed, Prepared and Configured statements

Backports #9274 #9273 #9271 #9270 #9269 #9266 #9264 #9263 #9415

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

