### PR TITLE
chore: add server state to healthcheck

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgent.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgent.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.ServerUtil;
 import io.confluent.ksql.rest.server.computation.CommandRunner;
+import io.confluent.ksql.rest.server.state.ServerState.State;
 import io.confluent.ksql.services.SimpleKsqlClient;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlRequestConfig;
@@ -84,7 +85,8 @@ public class HealthCheckAgent {
         ));
     final boolean allHealthy = results.values().stream()
         .allMatch(HealthCheckResponseDetail::getIsHealthy);
-    return new HealthCheckResponse(allHealthy, results);
+    State serverState = commandRunner.checkServerState();
+    return new HealthCheckResponse(allHealthy, results, serverState.toString());
   }
 
   private interface Check {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgent.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgent.java
@@ -86,7 +86,7 @@ public class HealthCheckAgent {
         ));
     final boolean allHealthy = results.values().stream()
         .allMatch(HealthCheckResponseDetail::getIsHealthy);
-    State serverState = commandRunner.checkServerState();
+    final State serverState = commandRunner.checkServerState();
     return new HealthCheckResponse(allHealthy, results, Optional.of(serverState.toString()));
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgent.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgent.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.kafka.clients.admin.Admin;
@@ -86,7 +87,7 @@ public class HealthCheckAgent {
     final boolean allHealthy = results.values().stream()
         .allMatch(HealthCheckResponseDetail::getIsHealthy);
     State serverState = commandRunner.checkServerState();
-    return new HealthCheckResponse(allHealthy, results, serverState.toString());
+    return new HealthCheckResponse(allHealthy, results, Optional.of(serverState.toString()));
   }
 
   private interface Check {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
@@ -21,6 +21,7 @@ import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.entity.ClusterTerminateRequest;
 import io.confluent.ksql.rest.server.resources.IncompatibleKsqlCommandVersionException;
 import io.confluent.ksql.rest.server.state.ServerState;
+import io.confluent.ksql.rest.server.state.ServerState.State;
 import io.confluent.ksql.rest.util.ClusterTerminator;
 import io.confluent.ksql.rest.util.PersistentQueryCleanupImpl;
 import io.confluent.ksql.rest.util.TerminateCluster;
@@ -427,6 +428,10 @@ public class CommandRunner implements Closeable {
     }
 
     return state.getStatus();
+  }
+
+  public State checkServerState() {
+    return this.serverState.getState();
   }
 
   public CommandRunnerDegradedReason getCommandRunnerDegradedReason() {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/state/ServerState.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/state/ServerState.java
@@ -121,4 +121,8 @@ public class ServerState {
     }
     return Optional.empty();
   }
+
+  public State getState() {
+    return this.state.get().state;
+  }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java
@@ -38,6 +38,7 @@ import io.confluent.ksql.rest.entity.HealthCheckResponse;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.computation.CommandRunner;
+import io.confluent.ksql.rest.server.state.ServerState.State;
 import io.confluent.ksql.services.SimpleKsqlClient;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlRequestConfig;
@@ -97,7 +98,7 @@ public class HealthCheckAgentTest {
     givenDescribeTopicsReturns(topicsResult);
     when(topicsResult.allTopicNames()).thenReturn(KafkaFuture.completedFuture(Collections.emptyMap()));
     when(commandRunner.checkCommandRunnerStatus()).thenReturn(CommandRunner.CommandRunnerStatus.RUNNING);
-
+    when(commandRunner.checkServerState()).thenReturn(State.READY);
     final KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of(
         KsqlConfig.KSQL_SERVICE_ID_CONFIG,
         "default_"

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckResponseTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckResponseTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.healthcheck;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.ksql.execution.json.PlanJsonMapper;
+import io.confluent.ksql.rest.entity.HealthCheckResponse;
+import io.confluent.ksql.rest.entity.HealthCheckResponseDetail;
+import java.io.IOException;
+import java.util.HashMap;
+import org.junit.Test;
+
+public class HealthCheckResponseTest {
+  private static final boolean IS_HEALTHY_BOOLEAN =  true;
+  private static final HealthCheckResponseDetail IS_HEALTHY_DETAIL =  new HealthCheckResponseDetail(IS_HEALTHY_BOOLEAN);
+
+  @Test
+  public void shouldDeserializeCorrectly() throws IOException {
+    final String healthCheckResponseStr = "{" +
+        "\"isHealthy\": true, " +
+        "\"details\": {\"metastore\": {\"isHealthy\": true}, \"kafka\": {\"isHealthy\": true}}, " +
+        "\"serverState\": \"RUNNING\"" +
+        "}";
+    final ObjectMapper mapper = PlanJsonMapper.INSTANCE.get();
+    final HealthCheckResponse healthCheckResponse = mapper.readValue(healthCheckResponseStr, HealthCheckResponse.class);
+    assertThat(healthCheckResponse.getIsHealthy(), equalTo(IS_HEALTHY_BOOLEAN));
+    final HashMap<String, HealthCheckResponseDetail> details = new HashMap<>();
+    details.put("metastore",IS_HEALTHY_DETAIL);
+    details.put("kafka", IS_HEALTHY_DETAIL);
+    assertThat(healthCheckResponse.getDetails(), equalTo(details));
+    final String serverState = "RUNNING";
+    assertThat(healthCheckResponse.getServerState(), equalTo(serverState));
+  }
+
+  private void grep(final String string, final String regex) {
+    assertThat(String.format("[%s] does not match [%s]", string, regex), string.matches(regex), is(true));
+
+  }
+
+  @Test
+  public void shouldSerializeDeserializeCorrectly() throws IOException {
+    final HashMap<String, HealthCheckResponseDetail> details = new HashMap<>();
+    details.put("metastore", IS_HEALTHY_DETAIL);
+    details.put("kafka", IS_HEALTHY_DETAIL);
+    final String serverState = "RUNNING";
+
+    final HealthCheckResponse healthCheckResponse = new HealthCheckResponse(
+        IS_HEALTHY_BOOLEAN,
+        details,
+        serverState
+    );
+    final ObjectMapper mapper = PlanJsonMapper.INSTANCE.get();
+    final String serialized = mapper.writeValueAsString(healthCheckResponse);
+    grep(serialized, ".*\"isHealthy\":true.*");
+    grep(serialized, ".*\"details\":\\{\"metastore\":\\{\"isHealthy\":true\\},\"kafka\":\\{\"isHealthy\":true\\}\\}.*");
+    grep(serialized, ".*\"serverState\":\"RUNNING\".*");
+    final HealthCheckResponse deserialized = mapper.readValue(serialized, HealthCheckResponse.class);
+    assertThat(deserialized, equalTo(healthCheckResponse));
+  }
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckResponseTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckResponseTest.java
@@ -31,13 +31,13 @@ import org.junit.Test;
 public class HealthCheckResponseTest {
   private static final boolean IS_HEALTHY_BOOLEAN =  true;
   private static final HealthCheckResponseDetail IS_HEALTHY_DETAIL =  new HealthCheckResponseDetail(IS_HEALTHY_BOOLEAN);
-
+  private static final String SERVER_STATE = "READY";
   @Test
   public void shouldDeserializeCorrectly() throws IOException {
     final String healthCheckResponseStr = "{" +
         "\"isHealthy\": true, " +
         "\"details\": {\"metastore\": {\"isHealthy\": true}, \"kafka\": {\"isHealthy\": true}}, " +
-        "\"serverState\": \"RUNNING\"" +
+        "\"serverState\": \"READY\"" +
         "}";
     final ObjectMapper mapper = PlanJsonMapper.INSTANCE.get();
     final HealthCheckResponse healthCheckResponse = mapper.readValue(healthCheckResponseStr, HealthCheckResponse.class);
@@ -46,7 +46,7 @@ public class HealthCheckResponseTest {
     details.put("metastore",IS_HEALTHY_DETAIL);
     details.put("kafka", IS_HEALTHY_DETAIL);
     assertThat(healthCheckResponse.getDetails(), equalTo(details));
-    final String serverState = "RUNNING";
+    final Optional<String> serverState = Optional.of(SERVER_STATE);
     assertThat(healthCheckResponse.getServerState(), equalTo(serverState));
   }
 
@@ -77,7 +77,7 @@ public class HealthCheckResponseTest {
     final HashMap<String, HealthCheckResponseDetail> details = new HashMap<>();
     details.put("metastore", IS_HEALTHY_DETAIL);
     details.put("kafka", IS_HEALTHY_DETAIL);
-    final Optional<String> serverState = Optional.of("RUNNING");
+    final Optional<String> serverState = Optional.of(SERVER_STATE);
 
     final HealthCheckResponse healthCheckResponse = new HealthCheckResponse(
         IS_HEALTHY_BOOLEAN,
@@ -88,7 +88,7 @@ public class HealthCheckResponseTest {
     final String serialized = mapper.writeValueAsString(healthCheckResponse);
     grep(serialized, ".*\"isHealthy\":true.*");
     grep(serialized, ".*\"details\":\\{\"metastore\":\\{\"isHealthy\":true\\},\"kafka\":\\{\"isHealthy\":true\\}\\}.*");
-    grep(serialized, ".*\"serverState\":\"RUNNING\".*");
+    grep(serialized, ".*\"serverState\":\"READY\".*");
     final HealthCheckResponse deserialized = mapper.readValue(serialized, HealthCheckResponse.class);
     assertThat(deserialized, equalTo(healthCheckResponse));
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckResponseTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckResponseTest.java
@@ -25,6 +25,7 @@ import io.confluent.ksql.rest.entity.HealthCheckResponse;
 import io.confluent.ksql.rest.entity.HealthCheckResponseDetail;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Optional;
 import org.junit.Test;
 
 public class HealthCheckResponseTest {
@@ -49,6 +50,23 @@ public class HealthCheckResponseTest {
     assertThat(healthCheckResponse.getServerState(), equalTo(serverState));
   }
 
+  @Test
+  public void shouldDeserializeCorrectlyWithoutServerState() throws IOException {
+    final String healthCheckResponseStr = "{" +
+        "\"isHealthy\": true, " +
+        "\"details\": {\"metastore\": {\"isHealthy\": true}, \"kafka\": {\"isHealthy\": true}}" +
+        "}";
+    final ObjectMapper mapper = PlanJsonMapper.INSTANCE.get();
+    final HealthCheckResponse healthCheckResponse = mapper.readValue(healthCheckResponseStr, HealthCheckResponse.class);
+    assertThat(healthCheckResponse.getIsHealthy(), equalTo(IS_HEALTHY_BOOLEAN));
+    final HashMap<String, HealthCheckResponseDetail> details = new HashMap<>();
+    details.put("metastore",IS_HEALTHY_DETAIL);
+    details.put("kafka", IS_HEALTHY_DETAIL);
+    assertThat(healthCheckResponse.getDetails(), equalTo(details));
+    final Optional<String> serverState = Optional.empty();
+    assertThat(healthCheckResponse.getServerState(), equalTo(serverState));
+  }
+
   private void grep(final String string, final String regex) {
     assertThat(String.format("[%s] does not match [%s]", string, regex), string.matches(regex), is(true));
 
@@ -59,7 +77,7 @@ public class HealthCheckResponseTest {
     final HashMap<String, HealthCheckResponseDetail> details = new HashMap<>();
     details.put("metastore", IS_HEALTHY_DETAIL);
     details.put("kafka", IS_HEALTHY_DETAIL);
-    final String serverState = "RUNNING";
+    final Optional<String> serverState = Optional.of("RUNNING");
 
     final HealthCheckResponse healthCheckResponse = new HealthCheckResponse(
         IS_HEALTHY_BOOLEAN,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HealthCheckResourceFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HealthCheckResourceFunctionalTest.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.integration.IntegrationTestHarness;
 import io.confluent.ksql.integration.Retry;
 import io.confluent.ksql.rest.entity.HealthCheckResponse;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
+import io.confluent.ksql.rest.server.state.ServerState.State;
 import java.util.concurrent.TimeUnit;
 import kafka.zookeeper.ZooKeeperClientException;
 import org.junit.ClassRule;
@@ -59,5 +60,6 @@ public class HealthCheckResourceFunctionalTest {
     assertThat(response.getDetails().get(KAFKA_CHECK_NAME).getIsHealthy(), is(true));
     assertThat(response.getDetails().get(METASTORE_CHECK_NAME).getIsHealthy(), is(true));
     assertThat(response.getDetails().get(COMMAND_RUNNER_CHECK_NAME).getIsHealthy(), is(true));
+    assertThat(response.getServerState(), is(State.READY.toString()));
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HealthCheckResourceFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HealthCheckResourceFunctionalTest.java
@@ -27,6 +27,7 @@ import io.confluent.ksql.integration.Retry;
 import io.confluent.ksql.rest.entity.HealthCheckResponse;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.rest.server.state.ServerState.State;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import kafka.zookeeper.ZooKeeperClientException;
 import org.junit.ClassRule;
@@ -60,6 +61,6 @@ public class HealthCheckResourceFunctionalTest {
     assertThat(response.getDetails().get(KAFKA_CHECK_NAME).getIsHealthy(), is(true));
     assertThat(response.getDetails().get(METASTORE_CHECK_NAME).getIsHealthy(), is(true));
     assertThat(response.getDetails().get(COMMAND_RUNNER_CHECK_NAME).getIsHealthy(), is(true));
-    assertThat(response.getServerState(), is(State.READY.toString()));
+    assertThat(response.getServerState(), is(Optional.of(State.READY.toString())));
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -71,7 +71,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;

--- a/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientTest.java
+++ b/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientTest.java
@@ -218,7 +218,7 @@ public class KsqlClientTest {
     // Given:
     Map<String, HealthCheckResponseDetail> map = new HashMap<>();
     map.put("foo", new HealthCheckResponseDetail(true));
-    HealthCheckResponse healthCheckResponse = new HealthCheckResponse(true, map);
+    HealthCheckResponse healthCheckResponse = new HealthCheckResponse(true, map, null);
     server.setResponseObject(healthCheckResponse);
 
     // When:

--- a/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientTest.java
+++ b/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientTest.java
@@ -218,7 +218,7 @@ public class KsqlClientTest {
     // Given:
     Map<String, HealthCheckResponseDetail> map = new HashMap<>();
     map.put("foo", new HealthCheckResponseDetail(true));
-    HealthCheckResponse healthCheckResponse = new HealthCheckResponse(true, map, null);
+    HealthCheckResponse healthCheckResponse = new HealthCheckResponse(true, map, Optional.empty());
     server.setResponseObject(healthCheckResponse);
 
     // When:

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/HealthCheckResponse.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/HealthCheckResponse.java
@@ -25,20 +25,22 @@ import com.google.errorprone.annotations.Immutable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
+//@JsonSerialize(include = JsonSerialize.Inclusion.NON_DEFAULT)
+@JsonIgnoreProperties()
 @Immutable
 public final class HealthCheckResponse {
 
   private final boolean isHealthy;
   private final ImmutableMap<String, HealthCheckResponseDetail> details;
-  private final String serverState;
+  private final Optional<String> serverState;
 
   @JsonCreator
   public HealthCheckResponse(
       @JsonProperty("isHealthy") final boolean isHealthy,
       @JsonProperty("details") final Map<String, HealthCheckResponseDetail> details,
-      @JsonProperty("serverState") final String serverState
+      @JsonProperty(value = "serverState") final Optional<String> serverState
   ) {
     this.isHealthy = isHealthy;
     this.details = ImmutableMap.copyOf(requireNonNull(details, "details"));
@@ -54,7 +56,7 @@ public final class HealthCheckResponse {
     return details;
   }
 
-  public String getServerState() {
+  public Optional<String> getServerState() {
     return serverState;
   }
 

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/HealthCheckResponse.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/HealthCheckResponse.java
@@ -32,14 +32,17 @@ public final class HealthCheckResponse {
 
   private final boolean isHealthy;
   private final ImmutableMap<String, HealthCheckResponseDetail> details;
+  private final String serverState;
 
   @JsonCreator
   public HealthCheckResponse(
       @JsonProperty("isHealthy") final boolean isHealthy,
-      @JsonProperty("details") final Map<String, HealthCheckResponseDetail> details
+      @JsonProperty("details") final Map<String, HealthCheckResponseDetail> details,
+      @JsonProperty("serverState") final String serverState
   ) {
     this.isHealthy = isHealthy;
     this.details = ImmutableMap.copyOf(requireNonNull(details, "details"));
+    this.serverState = serverState;
   }
 
   public boolean getIsHealthy() {
@@ -49,6 +52,10 @@ public final class HealthCheckResponse {
   @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "details is ImmutableMap")
   public Map<String, HealthCheckResponseDetail> getDetails() {
     return details;
+  }
+
+  public String getServerState() {
+    return serverState;
   }
 
   @Override
@@ -63,11 +70,12 @@ public final class HealthCheckResponse {
 
     final HealthCheckResponse that = (HealthCheckResponse) o;
     return isHealthy == that.isHealthy
-        && Objects.equals(details, that.details);
+        && Objects.equals(details, that.details)
+        && Objects.equals(serverState, that.serverState);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(isHealthy, details);
+    return Objects.hash(isHealthy, details, serverState);
   }
 }

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/HealthCheckResponse.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/HealthCheckResponse.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-//@JsonSerialize(include = JsonSerialize.Inclusion.NON_DEFAULT)
 @JsonIgnoreProperties()
 @Immutable
 public final class HealthCheckResponse {
@@ -40,7 +39,7 @@ public final class HealthCheckResponse {
   public HealthCheckResponse(
       @JsonProperty("isHealthy") final boolean isHealthy,
       @JsonProperty("details") final Map<String, HealthCheckResponseDetail> details,
-      @JsonProperty(value = "serverState") final Optional<String> serverState
+      @JsonProperty("serverState") final Optional<String> serverState
   ) {
     this.isHealthy = isHealthy;
     this.details = ImmutableMap.copyOf(requireNonNull(details, "details"));

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/HealthCheckResponse.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/HealthCheckResponse.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-@JsonIgnoreProperties()
+@JsonIgnoreProperties(ignoreUnknown = true)
 @Immutable
 public final class HealthCheckResponse {
 


### PR DESCRIPTION
### Description 
Add the server state to the` /healthcheck` endpoint of the KSQL server since that endpoint isn’t currently authenticated. This is so the pre-stop cleanup hook can tell when the server has finished cleaning up state since it will wait until server state is `TERMINATED`. 

### Testing done 
Updated tests
