### PR TITLE
chore: turn on websocket ff

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -681,7 +681,7 @@ public class KsqlConfig extends AbstractConfig {
 
   public static final String KSQL_WEBSOCKET_CONNECTION_MAX_TIMEOUT_MS
       = "ksql.websocket.connection.max.timeout.ms";
-  public static final long KSQL_WEBSOCKET_CONNECTION_MAX_TIMEOUT_MS_DEFAULT = 0;
+  public static final long KSQL_WEBSOCKET_CONNECTION_MAX_TIMEOUT_MS_DEFAULT = 3600000;
   public static final String KSQL_WEBSOCKET_CONNECTION_MAX_TIMEOUT_MS_DOC
       = "If this config is set to a positive number, then ksqlDB will terminate websocket"
       + " connections after a timeout. The timeout will be the lower of the auth token's "


### PR DESCRIPTION
### Description 
Set the default max timeout to 1 hour. 5.4.x - 7.2.x have the same default, it just got lost in a merge.

### Testing done 
Manually tested

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

