### PR TITLE
chore: manually update pinned nanos for 7.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>[7.4.0-0, 7.4.1-0)</version>
+        <version>7.4.0-15</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>
@@ -291,25 +291,25 @@
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-avro-converter</artifactId>
-                <version>7.3.0-750</version>
+                <version>7.4.0-14</version>
             </dependency>
 
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-json-serializer</artifactId>
-                <version>7.3.0-750</version>
+                <version>7.4.0-14</version>
             </dependency>
 
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-avro-serializer</artifactId>
-                <version>7.3.0-750</version>
+                <version>7.4.0-14</version>
             </dependency>
 
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-schema-registry-client</artifactId>
-                <version>7.3.0-750</version>
+                <version>7.4.0-14</version>
             </dependency>
 
             <dependency>
@@ -333,25 +333,25 @@
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-json-schema-provider</artifactId>
-                <version>7.3.0-750</version>
+                <version>7.4.0-14</version>
             </dependency>
 
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-protobuf-provider</artifactId>
-                <version>7.3.0-750</version>
+                <version>7.4.0-14</version>
             </dependency>
 
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-json-schema-converter</artifactId>
-                <version>7.3.0-750</version>
+                <version>7.4.0-14</version>
             </dependency>
 
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-protobuf-converter</artifactId>
-                <version>7.3.0-750</version>
+                <version>7.4.0-14</version>
             </dependency>
 
             <!-- End Confluent dependencies -->


### PR DESCRIPTION
Stopgap until the release tooling is fixed: we have to manually bump the versions to the 7.4.0 series.

