### PR TITLE
fix: apply custom error handler to KsqlStatementException (MINOR)

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -339,7 +339,10 @@ public class KsqlResource implements KsqlConfigurable {
       throw e;
     } catch (final KsqlStatementException e) {
       LOG.info("Processed unsuccessfully: " + request + ", reason: ", e);
-      return Errors.badStatement(e.getRawMessage(), e.getSqlStatement());
+      return errorHandler.generateResponse(
+          e,
+          Errors.badStatement(e.getRawMessage(), e.getSqlStatement())
+      );
     } catch (final KsqlException e) {
       LOG.info("Processed unsuccessfully: " + request + ", reason: ", e);
       return errorHandler.generateResponse(e, Errors.badRequest(e));


### PR DESCRIPTION
### Description 

The custom error handler in KsqlResource is currently only applied to raw exceptions and KsqlExceptions, but not KsqlStatementExceptions. This means the error handler misses cases such as when Schema Registry is not enabled, because the DefaultSchemaInjector has [logic](https://github.com/confluentinc/ksql/blob/f1d1757faec4a14728e48d8065be64d11aa4ab6d/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java#L133-L138) to wrap the KsqlException in a KsqlStatementException. 

We could fix this by not having injectors (and other parts of the code) wrap KsqlExceptions, but it seems better to leave that flexibility and instead apply the error handler to KsqlStatementExceptions from KsqlResource. At least, I see no reason not to.

### Testing done 

Added unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

