### PR TITLE
chore: add pause before running auth plugins

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/AuthHandlers.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/AuthHandlers.java
@@ -91,7 +91,7 @@ public final class AuthHandlers {
    * some handlers run code asynchronously from the event loop, which must be run while the
    * request is paused (see https://vertx.io/docs/vertx-web/java/#_request_body_handling).
    *
-   * the calls to #pauseHandler are defensive in case an underlying handler calls resume
+   * <p>the calls to #pauseHandler are defensive in case an underlying handler calls resume
    * on the context without our knowledge (which is what the default BasicAuthHandler in
    * vertx-web does as of version 4.x)
    */

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/AuthHandlers.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/AuthHandlers.java
@@ -55,28 +55,52 @@ public final class AuthHandlers {
     final Optional<SystemAuthenticationHandler> systemAuthenticationHandler
         = getSystemAuthenticationHandler(server, isInternalListener);
 
-    systemAuthenticationHandler.ifPresent(handler -> router.route().handler(handler));
+    systemAuthenticationHandler.ifPresent(handler -> registerAuthHandler(router, handler));
 
     if (jaas.isPresent() || authenticationPlugin.isPresent()) {
-      router.route().handler(rc -> selectHandler(rc, jaas.isPresent(), pluginHandler.isPresent()));
+      registerAuthHandler(
+          router,
+          rc -> selectHandler(rc, jaas.isPresent(), pluginHandler.isPresent()));
 
       // set up using JAAS
-      jaas.ifPresent(h -> router.route().handler(wrappedHandler(h, Provider.JAAS)));
-      router.route().handler(wrappedHandler(
-          new RoleBasedAuthZHandler(
+      jaas.ifPresent(h -> registerAuthHandler(router, wrappedHandler(h, Provider.JAAS)));
+
+      registerAuthHandler(
+          router,
+          wrappedHandler(new RoleBasedAuthZHandler(
               server.getConfig().getList(KsqlRestConfig.AUTHENTICATION_ROLES_CONFIG)),
-          Provider.JAAS));
+              Provider.JAAS));
 
       // set up using PLUGIN
-      pluginHandler.ifPresent(h -> router.route().handler(wrappedHandler(h, Provider.PLUGIN)));
+      pluginHandler.ifPresent(h -> registerAuthHandler(router, wrappedHandler(h, Provider.PLUGIN)));
 
-      router.route().handler(AuthHandlers::pauseHandler);
       // For authorization use auth provider configured via security extension (if any)
       securityExtension.getAuthorizationProvider()
-          .ifPresent(ksqlAuthorizationProvider -> router.route()
-              .handler(new KsqlAuthorizationProviderHandler(server, ksqlAuthorizationProvider)));
+          .ifPresent(ksqlAuthorizationProvider ->
+              registerAuthHandler(
+                  router,
+                  new KsqlAuthorizationProviderHandler(server, ksqlAuthorizationProvider)));
+
+      // since we're done with all the authorization plugins, we can resume the
+      // request context
       router.route().handler(AuthHandlers::resumeHandler);
     }
+  }
+
+  /**
+   * some handlers run code asynchronously from the event loop, which must be run while the
+   * request is paused (see https://vertx.io/docs/vertx-web/java/#_request_body_handling).
+   *
+   * the calls to #pauseHandler are defensive in case an underlying handler calls resume
+   * on the context without our knowledge (which is what the default BasicAuthHandler in
+   * vertx-web does as of version 4.x)
+   */
+  private static void registerAuthHandler(
+      final Router router,
+      final Handler<RoutingContext> routingContext
+  ) {
+    router.route().handler(AuthHandlers::pauseHandler);
+    router.route().handler(routingContext);
   }
 
   private static Handler<RoutingContext> wrappedHandler(


### PR DESCRIPTION
### Description 

What's happening is that if the request is a simple stream that only sends headers and no data vertx can end the request in the same event loop handling that it initiates the request.

some auth plugins, however, issue a call to executeBlocking which works on the worker thread and allows the event loop to continue in the background. The request, then "ends" before we return from the blocking action and when we try to pause it the request fails because you can't pause a finished request

if we pause the request before we issue the executeBlocking call, then when it tries to end the request instead it just enqueues it on a buffer to execute the end asyncrhonously once the request is unpaused (which is after execution of the thread).

### Testing done 

Added test and verified that it fails without this change.

I ran this through Confluent's security plugin which has this behavior and applied the fix. You can see in the stack traces below that the place where `handleEnd` is called is different - the first one (before the change) hits it from the event loop, synchronously with the main request (`Http2ServerConnection.onHeadersRead`) while the authentication plugin is doing its async thing. After the change, it's run on the event loop but asynchronously from the request.

Before the change:
```
Breakpoint reached at io.vertx.core.http.impl.Http2ServerRequest.handleEnd(Http2ServerRequest.java:215)
Breakpoint reached
	at io.vertx.core.http.impl.Http2ServerRequest.handleEnd(Http2ServerRequest.java:215)
	at io.vertx.core.http.impl.VertxHttp2Stream.lambda$new$1(VertxHttp2Stream.java:63)
	at io.vertx.core.http.impl.VertxHttp2Stream$$Lambda$2650/0x00000008016f7a38.handle(Unknown Source:-1)
	at io.vertx.core.streams.impl.InboundBuffer.handleEvent(InboundBuffer.java:239)
	at io.vertx.core.streams.impl.InboundBuffer.write(InboundBuffer.java:129)
	at io.vertx.core.http.impl.VertxHttp2Stream$$Lambda$2670/0x00000008017067d0.handle(Unknown Source:-1)
	at io.vertx.core.impl.EventLoopContext.emit(EventLoopContext.java:55)
	at io.vertx.core.impl.DuplicatedContext.emit(DuplicatedContext.java:158)
	at io.vertx.core.http.impl.VertxHttp2Stream.onEnd(VertxHttp2Stream.java:135)
	at io.vertx.core.http.impl.Http2ServerStream.onEnd(Http2ServerStream.java:105)
	at io.vertx.core.http.impl.VertxHttp2Stream.onEnd(VertxHttp2Stream.java:130)
	at io.vertx.core.http.impl.Http2ServerConnection.onHeadersRead(Http2ServerConnection.java:160)
	at io.vertx.core.http.impl.Http2ConnectionBase.onHeadersRead(Http2ConnectionBase.java:202)
	at io.vertx.core.http.impl.Http2ServerConnection.onHeadersRead(Http2ServerConnection.java:44)
	at io.netty.handler.codec.http2.Http2FrameListenerDecorator.onHeadersRead(Http2FrameListenerDecorator.java:48)
	at io.netty.handler.codec.http2.Http2EmptyDataFrameListener.onHeadersRead(Http2EmptyDataFrameListener.java:63)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:409)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader$1.processFragment(DefaultHttp2FrameReader.java:450)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readHeadersFrame(DefaultHttp2FrameReader.java:457)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.processPayloadState(DefaultHttp2FrameReader.java:253)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readFrame(DefaultHttp2FrameReader.java:159)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder.decodeFrame(DefaultHttp2ConnectionDecoder.java:173)
	at io.netty.handler.codec.http2.DecoratingHttp2ConnectionDecoder.decodeFrame(DecoratingHttp2ConnectionDecoder.java:63)
	at io.netty.handler.codec.http2.Http2ConnectionHandler$FrameDecoder.decode(Http2ConnectionHandler.java:393)
	at io.netty.handler.codec.http2.Http2ConnectionHandler.decode(Http2ConnectionHandler.java:453)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:510)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:449)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:279)
	at io.vertx.core.http.impl.VertxHttp2ConnectionHandler.channelRead(VertxHttp2ConnectionHandler.java:408)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:722)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:658)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:584)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:496)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:833)
```

After the change:
```
Breakpoint reached at io.vertx.core.http.impl.Http2ServerRequest.handleEnd(Http2ServerRequest.java:215)
Breakpoint reached
	at io.vertx.core.http.impl.Http2ServerRequest.handleEnd(Http2ServerRequest.java:215)
	at io.vertx.core.http.impl.VertxHttp2Stream.lambda$new$1(VertxHttp2Stream.java:63)
	at io.vertx.core.http.impl.VertxHttp2Stream$$Lambda$2650/0x00000008016fd3a8.handle(Unknown Source:-1)
	at io.vertx.core.streams.impl.InboundBuffer.handleEvent(InboundBuffer.java:239)
	at io.vertx.core.streams.impl.InboundBuffer.drain(InboundBuffer.java:226)
	at io.vertx.core.streams.impl.InboundBuffer.lambda$fetch$0(InboundBuffer.java:279)
	at io.vertx.core.streams.impl.InboundBuffer$$Lambda$2677/0x000000080170bca0.handle(Unknown Source:-1)
	at io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:264)
	at io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:246)
	at io.vertx.core.impl.EventLoopContext.lambda$runOnContext$0(EventLoopContext.java:43)
	at io.vertx.core.impl.EventLoopContext$$Lambda$1348/0x00000008014a0e08.run(Unknown Source:-1)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask$$$capture(AbstractEventExecutor.java:174)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:-1)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute$$$capture(AbstractEventExecutor.java:167)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:-1)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:503)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:833)
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

