### PR TITLE
fix: cors handling for precondition server

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/KsqlCorsHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/KsqlCorsHandler.java
@@ -37,8 +37,7 @@ public class KsqlCorsHandler implements Handler<RoutingContext> {
       .asList("X-Requested-With", "Content-Type", "Accept", "Origin");
   private static final List<String> EXCLUDED_PATH_PREFIXES = Collections.singletonList("/ws/");
 
-  static void setupCorsHandler(final Server server, final Router router) {
-    final KsqlRestConfig ksqlRestConfig = server.getConfig();
+  static void setupCorsHandler(final KsqlRestConfig ksqlRestConfig, final Router router) {
     final String allowedOrigins = ksqlRestConfig
         .getString(KsqlRestConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG);
     if (allowedOrigins.trim().isEmpty()) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/PreconditionVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/PreconditionVerticle.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.api.server;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.api.util.ApiServerUtils;
+import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.state.ServerState;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
@@ -35,14 +36,17 @@ public class PreconditionVerticle extends AbstractVerticle {
   private final HttpServerOptions httpServerOptions;
   private final ServerState serverState;
   private HttpServer httpServer;
+  private KsqlRestConfig restConfig;
 
   @SuppressFBWarnings(value = "EI_EXPOSE_REP2")
   public PreconditionVerticle(
       final HttpServerOptions httpServerOptions,
-      final ServerState serverState
+      final ServerState serverState,
+      final KsqlRestConfig restConfig
   ) {
     this.httpServerOptions = Objects.requireNonNull(httpServerOptions);
     this.serverState = Objects.requireNonNull(serverState, "serverState");
+    this.restConfig = Objects.requireNonNull(restConfig, "restConfig");
   }
 
   @Override
@@ -69,6 +73,7 @@ public class PreconditionVerticle extends AbstractVerticle {
 
   private Router setupRouter() {
     final Router router = Router.router(vertx);
+    KsqlCorsHandler.setupCorsHandler(restConfig, router);
     router.route(HttpMethod.GET, "/chc/ready").handler(ApiServerUtils::chcHandler);
     router.route(HttpMethod.GET, "/chc/live").handler(ApiServerUtils::chcHandler);
     router.route().handler(new ServerStateHandler(serverState));

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -118,7 +118,7 @@ public class ServerVerticle extends AbstractVerticle {
       router.route().handler(new SniHandler());
     }
 
-    KsqlCorsHandler.setupCorsHandler(server, router);
+    KsqlCorsHandler.setupCorsHandler(server.getConfig(), router);
 
     // /chc endpoints need to be before server state handler but after CORS handler as they
     // need to be usable from browser with cross origin policy

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/PreconditionServer.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/PreconditionServer.java
@@ -83,7 +83,8 @@ public class PreconditionServer {
             createHttpServerOptions(config, listener.getHost(), listener.getPort(),
                 listener.getScheme().equalsIgnoreCase("https"),
                 idleConnectionTimeoutSeconds),
-            serverState
+            serverState,
+            config
         );
         vertx.deployVerticle(serverVerticle, vcf);
         deployFutures.add(vcf);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/CorsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/CorsTest.java
@@ -17,27 +17,34 @@ package io.confluent.ksql.api;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
+import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
-import io.confluent.ksql.rest.server.state.ServerState;
 import io.confluent.ksql.util.VertxCompletableFuture;
 import io.vertx.core.MultiMap;
-import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
-import org.junit.Before;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.Assert;
 import org.junit.Test;
 
-public class CorsTest extends BaseApiTest {
-
+public final class CorsTest {
   private static final String ACCESS_CONTROL_ALLOW_ORIGIN_HEADER = "Access-Control-Allow-Origin";
   private static final String ACCESS_CONTROL_ALLOW_METHODS_HEADER = "Access-Control-Allow-Methods";
   private static final String ACCESS_CONTROL_ALLOW_HEADERS_HEADER = "Access-Control-Allow-Headers";
@@ -48,162 +55,164 @@ public class CorsTest extends BaseApiTest {
   private static final String DEFAULT_ACCESS_CONTROL_ALLOW_HEADERS = "X-Requested-With,Content-Type,Accept,Origin";
   private static final String DEFAULT_ACCESS_CONTROL_ALLOW_METHODS = "GET,POST,HEAD";
 
+  protected static final String DEFAULT_PULL_QUERY = "select * from foo where rowkey='1234';";
+
   private static final String URI = "/query-stream";
   private static final String ORIGIN = "wibble.com";
 
-  private final Map<String, Object> config = new HashMap<>();
+  private final Function<Map<String, String>, WebClient> clientSupplier;
+  private final int successStatus;
 
-  @Before
-  public void setUp() {
-
-    vertx = Vertx.vertx();
-    vertx.exceptionHandler(t -> log.error("Unhandled exception in Vert.x", t));
-
-    testEndpoints = new TestEndpoints();
-    serverState = new ServerState();
-    serverState.setReady();
-    setDefaultRowGenerator();
+  public CorsTest(final Function<Map<String, String>, WebClient> clientSupplier) {
+    this(clientSupplier, HttpStatus.OK_200);
   }
 
-  @Test
+  public CorsTest(
+      final Function<Map<String, String>, WebClient> clientSupplier,
+      final int successStatus
+  ) {
+    this.clientSupplier = Objects.requireNonNull(clientSupplier, "clientSupplier");
+    this.successStatus = successStatus;
+  }
+
   public void shouldNotBeCorsResponseIfNoCorsConfigured() throws Exception {
 
     // Given:
-    init();
+    final WebClient client = clientSupplier.apply(Collections.emptyMap());
 
     // When
-    HttpResponse<Buffer> response = sendCorsRequest(HttpMethod.POST, ORIGIN);
+    HttpResponse<Buffer> response = sendCorsRequest(client, HttpMethod.POST, ORIGIN);
 
     // Then:
-    assertThat(response.statusCode(), is(200));
+    assertThat(response.statusCode(), is(successStatus));
     assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER), is(nullValue()));
     assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_METHODS_HEADER), is(nullValue()));
     assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_HEADERS_HEADER), is(nullValue()));
   }
 
-  @Test
-  public void shouldExcludePath() throws Exception {
+  public void shouldExcludePath(final int expectedCode) throws Exception {
 
     // Given:
-    init();
-    config.put(KsqlRestConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG, ORIGIN);
+    final WebClient client = clientSupplier.apply(
+        ImmutableMap.of(KsqlRestConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG, ORIGIN));
 
     // When
-    HttpResponse<Buffer> response = sendCorsRequest(HttpMethod.POST, "/ws/foo", ORIGIN);
+    HttpResponse<Buffer> response = sendCorsRequest(client, HttpMethod.POST, "/ws/foo", ORIGIN);
 
     // Then:
     // We should get a 404 as the security checks will be bypassed but the resource doesn't exist
-    assertThat(response.statusCode(), is(404));
+    assertThat(response.statusCode(), is(expectedCode));
     assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER), is(nullValue()));
     assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_METHODS_HEADER), is(nullValue()));
     assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_HEADERS_HEADER), is(nullValue()));
   }
 
-  @Test
   public void shouldNotBeCorsResponseIfNotCorsRequest() throws Exception {
 
     // Given:
-    init();
-    config.put(KsqlRestConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG, ORIGIN);
+    final WebClient client = clientSupplier.apply(
+        ImmutableMap.of(KsqlRestConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG, ORIGIN));
 
     // When
     VertxCompletableFuture<HttpResponse<Buffer>> requestFuture = new VertxCompletableFuture<>();
-    client
-        .request(HttpMethod.POST, URI)
+    client.request(HttpMethod.POST, URI)
         .sendJsonObject(new JsonObject().put("sql", DEFAULT_PULL_QUERY), requestFuture);
     HttpResponse<Buffer> response = requestFuture.get();
 
     // Then:
-    assertThat(response.statusCode(), is(200));
+    assertThat(response.statusCode(), is(successStatus));
     assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER), is(nullValue()));
     assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_METHODS_HEADER), is(nullValue()));
     assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_HEADERS_HEADER), is(nullValue()));
   }
 
-  @Test
   public void shouldAcceptCorsRequestOriginExactMatch() throws Exception {
     shouldAcceptCorsRequest(ORIGIN, ORIGIN);
   }
 
-  @Test
   public void shouldRejectCorsRequestOriginExactMatch() throws Exception {
     shouldRejectCorsRequest("foo.com", ORIGIN);
   }
 
-  @Test
   public void shouldAcceptCorsRequestOriginExactMatchOneOfList() throws Exception {
     shouldAcceptCorsRequest(ORIGIN, "foo.com,wibble.com");
   }
 
-  @Test
   public void shouldRejectCorsRequestOriginExactMatchOenOfList() throws Exception {
     shouldRejectCorsRequest("foo.com", "wibble.com,blah.com");
   }
 
-  @Test
   public void shouldAcceptCorsRequestAcceptAll() throws Exception {
     shouldAcceptCorsRequest(ORIGIN, "*");
   }
 
-  @Test
   public void shouldAcceptCorsRequestWildcardMatch() throws Exception {
     shouldAcceptCorsRequest("foo.wibble.com", "*.wibble.com");
   }
 
-  @Test
   public void shouldRejectCorsRequestWildcardMatch() throws Exception {
     shouldRejectCorsRequest("foo.wibble.com", "*.blibble.com");
   }
 
-  @Test
   public void shouldAcceptCorsRequestWilcardMatchList() throws Exception {
     shouldAcceptCorsRequest("foo.wibble.com", "blah.com,*.wibble.com,foo.com");
   }
 
-  @Test
   public void shouldRejectCorsRequestWilcardMatchList() throws Exception {
     shouldRejectCorsRequest("foo.wibble.com", "blah.com,*.blibble.com,foo.com");
   }
 
-  @Test
   public void shouldAcceptPreflightRequestOriginExactMatchDefaultHeaders() throws Exception {
     shouldAcceptPreflightRequest(ORIGIN, ORIGIN, DEFAULT_ACCESS_CONTROL_ALLOW_HEADERS,
         DEFAULT_ACCESS_CONTROL_ALLOW_METHODS);
   }
 
-  @Test
   public void shouldRejectPreflightRequestOriginExactMatchDefaultHeaders() throws Exception {
     shouldRejectPreflightRequest(ORIGIN, "flibble.com");
   }
 
-  @Test
   public void shouldAcceptPreflightRequestOriginExactMatchSpecifiedHeaders() throws Exception {
-    config.put(KsqlRestConfig.ACCESS_CONTROL_ALLOW_HEADERS, "foo-header,bar-header");
     shouldAcceptPreflightRequest(ORIGIN, ORIGIN,
         "foo-header,bar-header",
         DEFAULT_ACCESS_CONTROL_ALLOW_METHODS);
   }
 
-  @Test
   public void shouldAcceptPreflightRequestOriginExactMatchSpecifiedMethods() throws Exception {
-    config.put(KsqlRestConfig.ACCESS_CONTROL_ALLOW_METHODS, "DELETE,PATCH");
     shouldAcceptPreflightRequest(ORIGIN, ORIGIN,
         DEFAULT_ACCESS_CONTROL_ALLOW_HEADERS,
         "DELETE,PATCH");
+  }
+
+  public void shouldCallAllCorsTests(Class<?> testClass) {
+    final List<Method> testMethods = Arrays.stream(CorsTest.class.getDeclaredMethods())
+        .filter(m -> Modifier.isPublic(m.getModifiers()))
+        .filter(m -> m.getName().startsWith("should"))
+        .collect(Collectors.toList());
+    for (final Method testMethod : testMethods) {
+      try {
+        final Method method = testClass.getDeclaredMethod(testMethod.getName());
+        assertThat("Test method " + method.getName() + " does not have test annotation",
+            method.getAnnotation(Test.class),
+            not(nullValue())
+        );
+      } catch (final NoSuchMethodException e) {
+        Assert.fail("Could not find a cors test method with name " + testMethod.getName());
+      }
+    }
   }
 
   private void shouldAcceptCorsRequest(final String origin, final String allowedOrigins)
       throws Exception {
 
     // Given:
-    config.put(KsqlRestConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG, allowedOrigins);
-    init();
+    final WebClient client = clientSupplier.apply(
+        ImmutableMap.of(KsqlRestConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG, allowedOrigins));
 
     // When
-    HttpResponse<Buffer> response = sendCorsRequest(HttpMethod.POST, origin);
+    HttpResponse<Buffer> response = sendCorsRequest(client, HttpMethod.POST, origin);
 
     // Then:
-    assertThat(response.statusCode(), is(200));
+    assertThat(response.statusCode(), is(successStatus));
     assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER),
         is(origin));
     assertThat(response.getHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER), is("true"));
@@ -213,11 +222,11 @@ public class CorsTest extends BaseApiTest {
       throws Exception {
 
     // Given:
-    config.put(KsqlRestConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG, allowedOrigins);
-    init();
+    final WebClient client = clientSupplier.apply(
+        ImmutableMap.of(KsqlRestConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG, allowedOrigins));
 
     // When
-    HttpResponse<Buffer> response = sendCorsRequest(HttpMethod.POST, origin);
+    HttpResponse<Buffer> response = sendCorsRequest(client, HttpMethod.POST, origin);
 
     // Then:
     assertThat(response.statusCode(), is(403));
@@ -227,11 +236,11 @@ public class CorsTest extends BaseApiTest {
       throws Exception {
 
     // Given:
-    config.put(KsqlRestConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG, allowedOrigins);
-    init();
+    final WebClient client = clientSupplier.apply(
+        ImmutableMap.of(KsqlRestConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG, allowedOrigins));
 
     // When:
-    HttpResponse<Buffer> response = sendCorsRequest(HttpMethod.OPTIONS,
+    HttpResponse<Buffer> response = sendCorsRequest(client, HttpMethod.OPTIONS,
         MultiMap.caseInsensitiveMultiMap().add("origin", origin)
             .add(ACCESS_CONTROL_REQUEST_METHOD_HEADER, "POST"));
 
@@ -243,11 +252,16 @@ public class CorsTest extends BaseApiTest {
       final String accessControlAllowHeaders, final String accessControlAllowMethods)
       throws Exception {
 
-    config.put(KsqlRestConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG, allowedOrigins);
-    init();
+    final WebClient client = clientSupplier.apply(
+        ImmutableMap.of(
+            KsqlRestConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG, allowedOrigins,
+            KsqlRestConfig.ACCESS_CONTROL_ALLOW_HEADERS, accessControlAllowHeaders,
+            KsqlRestConfig.ACCESS_CONTROL_ALLOW_METHODS, accessControlAllowMethods
+        )
+    );
 
     // Given
-    HttpResponse<Buffer> response = sendCorsRequest(HttpMethod.OPTIONS,
+    HttpResponse<Buffer> response = sendCorsRequest(client, HttpMethod.OPTIONS,
         MultiMap.caseInsensitiveMultiMap().add("origin", origin)
             .add(ACCESS_CONTROL_REQUEST_METHOD_HEADER, "POST"));
 
@@ -267,40 +281,43 @@ public class CorsTest extends BaseApiTest {
     assertThat(set1, is(set2));
   }
 
-  private void init() {
-    config.put(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:0");
-    KsqlRestConfig serverConfig = new KsqlRestConfig(config);
-    createServer(serverConfig);
-    this.client = createClient();
+  private HttpResponse<Buffer> sendCorsRequest(
+      final WebClient client,
+      final HttpMethod httpMethod,
+      final MultiMap headers
+  ) throws Exception {
+    return sendCorsRequest(client, httpMethod, URI, headers);
   }
 
-  private HttpResponse<Buffer> sendCorsRequest(final HttpMethod httpMethod, final MultiMap headers)
-      throws Exception {
-    return sendCorsRequest(httpMethod, URI, headers);
-  }
-
-  private HttpResponse<Buffer> sendCorsRequest(final HttpMethod httpMethod, final String uri,
+  private HttpResponse<Buffer> sendCorsRequest(
+      final WebClient client,
+      final HttpMethod httpMethod,
+      final String uri,
       final MultiMap headers)
       throws Exception {
     VertxCompletableFuture<HttpResponse<Buffer>> requestFuture = new VertxCompletableFuture<>();
     client
         .request(httpMethod, uri)
         .putHeaders(headers)
-        .sendJsonObject(new JsonObject().put("sql", DEFAULT_PULL_QUERY), requestFuture);
+       .sendJsonObject(new JsonObject().put("sql", DEFAULT_PULL_QUERY), requestFuture);
     return requestFuture.get();
   }
 
-  private HttpResponse<Buffer> sendCorsRequest(final HttpMethod httpMethod,
+  private HttpResponse<Buffer> sendCorsRequest(
+      final WebClient client,
+      final HttpMethod httpMethod,
       final String origin)
       throws Exception {
-    return sendCorsRequest(httpMethod, URI, origin);
+    return sendCorsRequest(client, httpMethod, URI, origin);
   }
 
-  private HttpResponse<Buffer> sendCorsRequest(final HttpMethod httpMethod,
+  private HttpResponse<Buffer> sendCorsRequest(
+      final WebClient client,
+      final HttpMethod httpMethod,
       final String uri,
       final String origin)
       throws Exception {
-    return sendCorsRequest(httpMethod, uri,
+    return sendCorsRequest(client, httpMethod, uri,
         MultiMap.caseInsensitiveMultiMap().add("origin", origin));
   }
   

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ServerCorsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ServerCorsTest.java
@@ -1,0 +1,123 @@
+package io.confluent.ksql.api;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.rest.server.KsqlRestConfig;
+import io.confluent.ksql.rest.server.state.ServerState;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ServerCorsTest extends BaseApiTest {
+  private final CorsTest corsTest = new CorsTest(this::init);
+
+  @Before
+  public void setUp() {
+
+    vertx = Vertx.vertx();
+    vertx.exceptionHandler(t -> log.error("Unhandled exception in Vert.x", t));
+
+    testEndpoints = new TestEndpoints();
+    serverState = new ServerState();
+    serverState.setReady();
+    setDefaultRowGenerator();
+  }
+
+  @Test
+  public void shouldNotBeCorsResponseIfNoCorsConfigured() throws Exception {
+    corsTest.shouldNotBeCorsResponseIfNoCorsConfigured();
+  }
+
+  @Test
+  public void shouldExcludePath() throws Exception {
+    corsTest.shouldExcludePath(404);
+  }
+
+  @Test
+  public void shouldNotBeCorsResponseIfNotCorsRequest() throws Exception {
+    corsTest.shouldNotBeCorsResponseIfNotCorsRequest();
+  }
+
+  @Test
+  public void shouldAcceptCorsRequestOriginExactMatch() throws Exception {
+    corsTest.shouldAcceptCorsRequestOriginExactMatch();
+  }
+
+  @Test
+  public void shouldRejectCorsRequestOriginExactMatch() throws Exception {
+    corsTest.shouldRejectCorsRequestOriginExactMatch();
+  }
+
+  @Test
+  public void shouldAcceptCorsRequestOriginExactMatchOneOfList() throws Exception {
+    corsTest.shouldAcceptCorsRequestOriginExactMatchOneOfList();
+  }
+
+  @Test
+  public void shouldRejectCorsRequestOriginExactMatchOenOfList() throws Exception {
+    corsTest.shouldRejectCorsRequestOriginExactMatchOenOfList();
+  }
+
+  @Test
+  public void shouldAcceptCorsRequestAcceptAll() throws Exception {
+    corsTest.shouldAcceptCorsRequestAcceptAll();
+  }
+
+  @Test
+  public void shouldAcceptCorsRequestWildcardMatch() throws Exception {
+    corsTest.shouldAcceptCorsRequestWildcardMatch();
+  }
+
+  @Test
+  public void shouldRejectCorsRequestWildcardMatch() throws Exception {
+    corsTest.shouldRejectCorsRequestWildcardMatch();
+  }
+
+  @Test
+  public void shouldAcceptCorsRequestWilcardMatchList() throws Exception {
+    corsTest.shouldAcceptCorsRequestWilcardMatchList();
+  }
+
+  @Test
+  public void shouldRejectCorsRequestWilcardMatchList() throws Exception {
+    corsTest.shouldRejectCorsRequestWilcardMatchList();
+  }
+
+  @Test
+  public void shouldAcceptPreflightRequestOriginExactMatchDefaultHeaders() throws Exception {
+    corsTest.shouldAcceptPreflightRequestOriginExactMatchDefaultHeaders();
+  }
+
+  @Test
+  public void shouldRejectPreflightRequestOriginExactMatchDefaultHeaders() throws Exception {
+    corsTest.shouldRejectPreflightRequestOriginExactMatchDefaultHeaders();
+  }
+
+  @Test
+  public void shouldAcceptPreflightRequestOriginExactMatchSpecifiedHeaders() throws Exception {
+    corsTest.shouldAcceptPreflightRequestOriginExactMatchSpecifiedHeaders();
+  }
+
+  @Test
+  public void shouldAcceptPreflightRequestOriginExactMatchSpecifiedMethods() throws Exception {
+    corsTest.shouldAcceptPreflightRequestOriginExactMatchSpecifiedMethods();
+  }
+
+  @Test
+  public void shouldCallAllCorsTests() {
+    corsTest.shouldCallAllCorsTests(this.getClass());
+  }
+
+  private WebClient init(final Map<String, String> configs) {
+    KsqlRestConfig serverConfig = new KsqlRestConfig(
+        ImmutableMap.<String, Object>builder()
+            .putAll(configs)
+            .put(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:0").build()
+    );
+    createServer(serverConfig);
+    this.client = createClient();
+    return client;
+  }
+}
+

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PreconditionCheckerIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PreconditionCheckerIntegrationTest.java
@@ -21,17 +21,22 @@ import static org.hamcrest.Matchers.is;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.common.utils.IntegrationTest;
+import io.confluent.ksql.api.CorsTest;
 import io.confluent.ksql.rest.client.KsqlRestClient;
 import io.confluent.ksql.rest.client.RestResponse;
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.PreconditionChecker;
 import io.confluent.ksql.rest.server.state.ServerState;
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
@@ -51,27 +56,36 @@ public class PreconditionCheckerIntegrationTest {
   );
 
   private final ServerState serverState = new ServerState();
+  private final CorsTest corsTest = new CorsTest(this::init, 503);
+
+  private Vertx vertx;
+  private WebClient client;
 
   private PreconditionChecker checker;
 
   @Before
   public void setup() {
+    vertx = Vertx.vertx();
     PreconditionCheckerIntegrationTestPrecondition.ACTION.set(() -> Optional.of(new KsqlErrorMessage(123, "oops")));
-    checker = new PreconditionChecker(
-        () -> PROPERTIES,
-        serverState
-    );
-    checker.startAsync();
   }
 
   @After
   public void cleanup() {
-    checker.shutdown();
+    if (checker != null) {
+      checker.shutdown();
+    }
+    if (vertx != null) {
+      vertx.close();
+    }
+    if (client != null) {
+      client.close();
+    }
   }
 
   @Test
   public void shouldReturn503WhilePreconditionsDontPass() {
     // Given:
+    init();
     final KsqlRestClient client = buildKsqlClient();
 
     // When:
@@ -84,6 +98,7 @@ public class PreconditionCheckerIntegrationTest {
   @Test
   public void shouldExitAwaitOncePreconditionPasses() throws InterruptedException {
     // Given:
+    init();
     final Thread waiter = new Thread(() -> checker.awaitTerminated());
     waiter.start();
     PreconditionCheckerIntegrationTestPrecondition.ACTION.set(Optional::empty);
@@ -98,6 +113,7 @@ public class PreconditionCheckerIntegrationTest {
   @Test
   public void shouldExitWhenNotifiedToTerminate() throws InterruptedException {
     // Given:
+    init();
     final Thread waiter = new Thread(() -> checker.awaitTerminated());
     waiter.start();
     checker.notifyTerminated();
@@ -119,8 +135,94 @@ public class PreconditionCheckerIntegrationTest {
     shouldReturn200ForHealthcheckEndpoint("live");
   }
 
+  @Test
+  public void shouldNotBeCorsResponseIfNoCorsConfigured() throws Exception {
+    corsTest.shouldNotBeCorsResponseIfNoCorsConfigured();
+  }
+
+  @Test
+  public void shouldExcludePath() throws Exception {
+    corsTest.shouldExcludePath(503);
+  }
+
+  @Test
+  public void shouldNotBeCorsResponseIfNotCorsRequest() throws Exception {
+    corsTest.shouldNotBeCorsResponseIfNotCorsRequest();
+  }
+
+  @Test
+  public void shouldAcceptCorsRequestOriginExactMatch() throws Exception {
+    corsTest.shouldAcceptCorsRequestOriginExactMatch();
+  }
+
+  @Test
+  public void shouldRejectCorsRequestOriginExactMatch() throws Exception {
+    corsTest.shouldRejectCorsRequestOriginExactMatch();
+  }
+
+  @Test
+  public void shouldAcceptCorsRequestOriginExactMatchOneOfList() throws Exception {
+    corsTest.shouldAcceptCorsRequestOriginExactMatchOneOfList();
+  }
+
+  @Test
+  public void shouldRejectCorsRequestOriginExactMatchOenOfList() throws Exception {
+    corsTest.shouldRejectCorsRequestOriginExactMatchOenOfList();
+  }
+
+  @Test
+  public void shouldAcceptCorsRequestAcceptAll() throws Exception {
+    corsTest.shouldAcceptCorsRequestAcceptAll();
+  }
+
+  @Test
+  public void shouldAcceptCorsRequestWildcardMatch() throws Exception {
+    corsTest.shouldAcceptCorsRequestWildcardMatch();
+  }
+
+  @Test
+  public void shouldRejectCorsRequestWildcardMatch() throws Exception {
+    corsTest.shouldRejectCorsRequestWildcardMatch();
+  }
+
+  @Test
+  public void shouldAcceptCorsRequestWilcardMatchList() throws Exception {
+    corsTest.shouldAcceptCorsRequestWilcardMatchList();
+  }
+
+  @Test
+  public void shouldRejectCorsRequestWilcardMatchList() throws Exception {
+    corsTest.shouldRejectCorsRequestWilcardMatchList();
+  }
+
+  @Test
+  public void shouldAcceptPreflightRequestOriginExactMatchDefaultHeaders() throws Exception {
+    corsTest.shouldAcceptPreflightRequestOriginExactMatchDefaultHeaders();
+  }
+
+  @Test
+  public void shouldRejectPreflightRequestOriginExactMatchDefaultHeaders() throws Exception {
+    corsTest.shouldRejectPreflightRequestOriginExactMatchDefaultHeaders();
+  }
+
+  @Test
+  public void shouldAcceptPreflightRequestOriginExactMatchSpecifiedHeaders() throws Exception {
+    corsTest.shouldAcceptPreflightRequestOriginExactMatchSpecifiedHeaders();
+  }
+
+  @Test
+  public void shouldAcceptPreflightRequestOriginExactMatchSpecifiedMethods() throws Exception {
+    corsTest.shouldAcceptPreflightRequestOriginExactMatchSpecifiedMethods();
+  }
+
+  @Test
+  public void shouldCallAllCorsTests() {
+    corsTest.shouldCallAllCorsTests(this.getClass());
+  }
+
   private void shouldReturn200ForHealthcheckEndpoint(final String subPath) {
     // When:
+    init();
     HttpResponse<Buffer> resp = RestIntegrationTestUtil.rawRestRequest(
         checker.getListeners().get(0),
         HttpVersion.HTTP_1_1,
@@ -147,4 +249,31 @@ public class PreconditionCheckerIntegrationTest {
     );
   }
 
+  private void init() {
+    init(Collections.emptyMap());
+  }
+
+  private WebClient init(final Map<String, String> configs) {
+    checker = new PreconditionChecker(
+        () -> ImmutableMap.<String, String>builder()
+            .putAll(PROPERTIES)
+            .putAll(configs).build(),
+        serverState
+    );
+    checker.startAsync();
+    this.client = createClient();
+    return client;
+  }
+
+  protected WebClient createClient() {
+    return WebClient.create(vertx, createClientOptions());
+  }
+
+  protected WebClientOptions createClientOptions() {
+    return new WebClientOptions()
+        .setProtocolVersion(HttpVersion.HTTP_2).setHttp2ClearTextUpgrade(false)
+        .setDefaultHost(checker.getListeners().get(0).getHost())
+        .setDefaultPort(checker.getListeners().get(0).getPort())
+        .setReusePort(true);
+  }
 }


### PR DESCRIPTION
This patch adds cors handling for the precondition server. It also refactors the
cors test so that it can be used to test any server, and then uses the refactored
test to test the precondition server