### PR TITLE
feat: Support variadic arguments in the middle of a function signature

### DIFF
--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -1088,6 +1088,28 @@ public class CliTest {
   }
 
   @Test
+  public void shouldDescribeVariadicAggregateFunction() {
+    final String expectedSummary =
+            "Name        : MID_VAR_ARG\n"
+                    + "Author      : Confluent\n"
+                    + "Overview    : Returns the sum of the provided longs, lengths of strings, and initial arguments.\n"
+                    + "Type        : AGGREGATE\n"
+                    + "Jar         : internal\n"
+                    + "Variations  : \n";
+
+    final String expectedVariant =
+            "\tVariation   : MID_VAR_ARG(val1 BIGINT, val2 VARCHAR[], first INT, second INT)\n"
+                    + "\tReturns     : BIGINT\n"
+                    + "\tDescription : Testing factory";
+
+    localCli.handleLine("describe function mid_var_arg;");
+
+    final String output = terminal.getOutputString();
+    assertThat(output, containsString(expectedSummary));
+    assertThat(output, containsString(expectedVariant));
+  }
+
+  @Test
   public void shouldDescribeTableFunction() {
     final String expectedOutput =
         "Name        : EXPLODE\n"

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/KsqlFunction.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/KsqlFunction.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.function;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import com.google.errorprone.annotations.Immutable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.function.types.ArrayType;
@@ -70,9 +69,16 @@ public class KsqlFunction implements FunctionSignature {
         throw new IllegalArgumentException(
             "KSQL variadic functions must have at least one parameter");
       }
-      if (!(Iterables.getLast(parameters).type() instanceof ArrayType)) {
+      if (parameterInfo().stream().noneMatch(
+              (info) -> info.type() instanceof ArrayType && info.isVariadic()
+      )) {
         throw new IllegalArgumentException(
-            "KSQL variadic functions must have ARRAY type as their last parameter");
+            "KSQL variadic functions must have ARRAY type as their variadic parameter");
+      }
+      if (parameterInfo().stream().filter(ParameterInfo::isVariadic).count() != 1) {
+        throw new IllegalArgumentException(
+                "KSQL variadic functions must have exactly one variadic argument"
+        );
       }
     }
   }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
@@ -47,10 +47,10 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Resolving a method signature takes the following precedence rules:
  * <ul>
- *   <li>If only one exact method exists, return it</li>
+ *   <li>If only one exact method exists, return it.</li>
  *   <li>If a method exists such that all non-null {@code Schema} in the
- *       parameters match, and all other parameters are optional, return
- *       that method</li>
+ *       parameters match, and all of the method's other parameters are null,
+ *       return that method.</li>
  *   <li>If two methods exist that match given the above rules, and one
  *       does not have variable arguments (e.g. {@code String...}, return
  *       that one.</li>

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
@@ -60,7 +60,7 @@ import org.slf4j.LoggerFactory;
  *   <li>If two methods exist that match given the above rules, return the
  *       method with fewer generic arguments.</li>
  *   <li>If two methods exist that match given the above rules, return the
- *       method the variadic argument in the later position.</li>
+ *       method with the variadic argument in the later position.</li>
  *   <li>If two methods exist that match given the above rules, the function
  *       call is ambiguous and an exception is thrown.</li>
  * </ul>

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
@@ -113,7 +113,7 @@ public class UdfIndex<T extends FunctionSignature> {
           "Can't add function " + function.name()
               + " with parameters " + function.parameters()
               + " as a function with the same name and parameter types already exists "
-              + allFunctions.get(parameters)
+              + allFunctions.get(function.parameters())
       );
     }
 
@@ -310,7 +310,7 @@ public class UdfIndex<T extends FunctionSignature> {
     return Pair.of(parentOfVariadic, variadicOffset);
   }
 
-  private int indexAfterCenter(int size) {
+  private int indexAfterCenter(final int size) {
     return (size + 1) / 2;
   }
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
@@ -184,7 +184,13 @@ public class UdfIndex<T extends FunctionSignature> {
       iterates through the already-created branch for the case where there is one variadic
       parameter. This is necessary because the variadic loop was not added when that branch
       was built, but it needs to be added if there are no non-variadic parameters (i.e.
-      paramsWithoutVariadic.size() == 0 and maxAddedVariadics == 1). */
+      paramsWithoutVariadic.size() == 0 and maxAddedVariadics == 1).
+
+      The number of nodes added here is quadratic with respect to paramsWithoutVariadic.size().
+      However, this tree is only built on ksql startup, and this tree structure allows resolving
+      functions with variadic arguments in the middle in linear time. The number of edges generated
+      as a function of paramsWithoutVariadic.size() is roughly 0.25x^2 + 1.5x + 3, which is not
+      excessive for reasonable numbers of arguments. */
       while (fromIndex >= 0 && toIndex <= combinedAllParams.size()) {
         buildTree(
                 variadicParent,

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
@@ -450,7 +450,6 @@ public class UdfIndex<T extends FunctionSignature> {
   }
 
   private static <T extends FunctionSignature> String formatAvailableSignatures(final T function) {
-    final boolean variadicFunction = function.isVariadic();
     final List<ParameterInfo> parameters = function.parameterInfo();
 
     final StringBuilder result = new StringBuilder();
@@ -458,8 +457,7 @@ public class UdfIndex<T extends FunctionSignature> {
 
     for (int i = 0; i < parameters.size(); i++) {
       final ParameterInfo param = parameters.get(i);
-      final boolean variadicParam = variadicFunction && i == (parameters.size() - 1);
-      final String type = variadicParam
+      final String type = param.isVariadic()
           ? ((ArrayType) param.type()).element().toString() + "..."
           : param.type().toString();
 

--- a/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
@@ -1378,6 +1378,26 @@ public class UdfIndexTest {
   }
 
   @Test
+  public void shouldChooseLaterVariadicWhenTwoVariadicsMatchDiffBranches() {
+    // Given:
+    givenFunctions(
+            function(OTHER, 1, GenericType.of("A"), INT_VARARGS, STRING, DOUBLE),
+            function(EXPECTED, 2, GenericType.of("B"), INT, STRING_VARARGS, DOUBLE)
+    );
+
+    // When:
+    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(
+            SqlArgument.of(SqlTypes.BIGINT),
+            SqlArgument.of(SqlTypes.INTEGER),
+            SqlArgument.of(SqlTypes.STRING),
+            SqlArgument.of(SqlTypes.DOUBLE))
+    );
+
+    // Then:
+    assertThat(fun.name(), equalTo(EXPECTED));
+  }
+
+  @Test
   public void shouldChooseLaterVariadicWhenTwoVariadicsMatchReversedInsertionOrder() {
     // Given:
     givenFunctions(

--- a/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
@@ -143,9 +143,9 @@ public class UdfIndexTest {
   public void shouldFindPreferredOneArgWithCast() {
     // Given:
     final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
-        function(EXPECTED, -1, LONG),
+        function(OTHER, -1, LONG),
         function(EXPECTED, -1, INT),
-        function(EXPECTED, -1, DOUBLE)
+        function(OTHER, -1, DOUBLE)
     };
     Arrays.stream(functions).forEach(udfIndex::addFunction);
 
@@ -191,7 +191,7 @@ public class UdfIndexTest {
     // Given:
     givenFunctions(
         function(EXPECTED, -1, STRING),
-        function(EXPECTED, -1, INT)
+        function(OTHER, -1, INT)
     );
 
     // When:
@@ -206,7 +206,7 @@ public class UdfIndexTest {
     // Given:
     givenFunctions(
         function(EXPECTED, -1, STRING, STRING),
-        function(EXPECTED, -1, STRING, INT)
+        function(OTHER, -1, STRING, INT)
     );
 
     // When:
@@ -220,7 +220,7 @@ public class UdfIndexTest {
   public void shouldChooseCorrectStruct() {
     // Given:
     givenFunctions(
-        function(EXPECTED, -1, STRUCT2),
+        function(OTHER, -1, STRUCT2),
         function(EXPECTED, -1, STRUCT1)
     );
 
@@ -235,7 +235,7 @@ public class UdfIndexTest {
   public void shouldChooseCorrectMap() {
     // Given:
     givenFunctions(
-        function(EXPECTED, -1, MAP2),
+        function(OTHER, -1, MAP2),
         function(EXPECTED, -1, MAP1)
     );
 

--- a/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
@@ -112,6 +112,20 @@ public class UdfIndexTest {
   }
 
   @Test
+  public void shouldFindNoArgsVariadic() {
+    // Given:
+    givenFunctions(
+            function(EXPECTED, 0, STRING_VARARGS)
+    );
+
+    // When:
+    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of());
+
+    // Then:
+    assertThat(fun.name(), equalTo(EXPECTED));
+  }
+
+  @Test
   public void shouldFindOneArg() {
     // Given:
     givenFunctions(

--- a/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
@@ -2,8 +2,8 @@ package io.confluent.ksql.function;
 
 import static io.confluent.ksql.function.KsqlScalarFunction.INTERNAL_PATH;
 import static io.confluent.ksql.function.types.ArrayType.of;
-import static io.confluent.ksql.schema.ksql.types.SqlTypes.INTEGER;
 import static io.confluent.ksql.schema.ksql.types.SqlTypes.BIGINT;
+import static io.confluent.ksql.schema.ksql.types.SqlTypes.INTEGER;
 import static java.lang.System.lineSeparator;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -82,13 +83,13 @@ public class UdfIndexTest {
   public void shouldThrowOnAddIfFunctionWithSameNameAndParamsExists() {
     // Given:
     givenFunctions(
-        function(EXPECTED, false, DOUBLE)
+        function(EXPECTED, -1, DOUBLE)
     );
 
     // When:
     final Exception e = assertThrows(
         KsqlFunctionException.class,
-        () -> udfIndex.addFunction(function(EXPECTED, false, DOUBLE))
+        () -> udfIndex.addFunction(function(EXPECTED, -1, DOUBLE))
     );
 
     // Then:
@@ -100,7 +101,7 @@ public class UdfIndexTest {
   public void shouldFindNoArgs() {
     // Given:
     givenFunctions(
-        function(EXPECTED, false)
+        function(EXPECTED, -1)
     );
 
     // When:
@@ -114,7 +115,7 @@ public class UdfIndexTest {
   public void shouldFindOneArg() {
     // Given:
     givenFunctions(
-        function(EXPECTED, false, STRING)
+        function(EXPECTED, -1, STRING)
     );
 
     // When:
@@ -128,7 +129,7 @@ public class UdfIndexTest {
   public void shouldFindOneArgWithCast() {
     // Given:
     final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
-        function(EXPECTED, false, LONG)};
+        function(EXPECTED, -1, LONG)};
     Arrays.stream(functions).forEach(udfIndex::addFunction);
 
     // When:
@@ -142,9 +143,9 @@ public class UdfIndexTest {
   public void shouldFindPreferredOneArgWithCast() {
     // Given:
     final KsqlScalarFunction[] functions = new KsqlScalarFunction[]{
-        function(OTHER, false, LONG),
-        function(EXPECTED, false, INT),
-        function(OTHER, false, DOUBLE)
+        function(EXPECTED, -1, LONG),
+        function(EXPECTED, -1, INT),
+        function(EXPECTED, -1, DOUBLE)
     };
     Arrays.stream(functions).forEach(udfIndex::addFunction);
 
@@ -159,7 +160,7 @@ public class UdfIndexTest {
   public void shouldFindTwoDifferentArgs() {
     // Given:
     givenFunctions(
-        function(EXPECTED, false, STRING, INT)
+        function(EXPECTED, -1, STRING, INT)
     );
 
     // When:
@@ -174,7 +175,7 @@ public class UdfIndexTest {
   public void shouldFindTwoSameArgs() {
     // Given:
     givenFunctions(
-        function(EXPECTED, false, STRING, STRING)
+        function(EXPECTED, -1, STRING, STRING)
     );
 
     // When:
@@ -189,8 +190,8 @@ public class UdfIndexTest {
   public void shouldFindOneArgConflict() {
     // Given:
     givenFunctions(
-        function(EXPECTED, false, STRING),
-        function(OTHER, false, INT)
+        function(EXPECTED, -1, STRING),
+        function(EXPECTED, -1, INT)
     );
 
     // When:
@@ -204,8 +205,8 @@ public class UdfIndexTest {
   public void shouldFindTwoArgSameFirstConflict() {
     // Given:
     givenFunctions(
-        function(EXPECTED, false, STRING, STRING),
-        function(OTHER, false, STRING, INT)
+        function(EXPECTED, -1, STRING, STRING),
+        function(EXPECTED, -1, STRING, INT)
     );
 
     // When:
@@ -219,8 +220,8 @@ public class UdfIndexTest {
   public void shouldChooseCorrectStruct() {
     // Given:
     givenFunctions(
-        function(OTHER, false, STRUCT2),
-        function(EXPECTED, false, STRUCT1)
+        function(EXPECTED, -1, STRUCT2),
+        function(EXPECTED, -1, STRUCT1)
     );
 
     // When:
@@ -234,8 +235,8 @@ public class UdfIndexTest {
   public void shouldChooseCorrectMap() {
     // Given:
     givenFunctions(
-        function(OTHER, false, MAP2),
-        function(EXPECTED, false, MAP1)
+        function(EXPECTED, -1, MAP2),
+        function(EXPECTED, -1, MAP1)
     );
 
     // When:
@@ -249,7 +250,7 @@ public class UdfIndexTest {
   public void shouldChooseIntervalUnit() {
     // Given:
     givenFunctions(
-        function(EXPECTED, false, INTERVALUNIT)
+        function(EXPECTED, -1, INTERVALUNIT)
     );
 
     // When:
@@ -264,10 +265,10 @@ public class UdfIndexTest {
   public void shouldChooseCorrectLambdaFunction() {
     // Given:
     givenFunctions(
-        function(FIRST_FUNC, false, GENERIC_MAP, LAMBDA_KEY_FUNCTION)
+        function(FIRST_FUNC, -1, GENERIC_MAP, LAMBDA_KEY_FUNCTION)
     );
     givenFunctions(
-        function(SECOND_FUNC, false, GENERIC_MAP, LAMBDA_VALUE_FUNCTION)
+        function(SECOND_FUNC, -1, GENERIC_MAP, LAMBDA_VALUE_FUNCTION)
     );
 
     // When:
@@ -296,7 +297,7 @@ public class UdfIndexTest {
   public void shouldChooseCorrectLambdaBiFunction() {
     // Given:
     givenFunctions(
-        function(EXPECTED, false, GENERIC_MAP, LAMBDA_BI_FUNCTION)
+        function(EXPECTED, -1, GENERIC_MAP, LAMBDA_BI_FUNCTION)
     );
 
     // When:
@@ -316,7 +317,7 @@ public class UdfIndexTest {
   public void shouldChooseCorrectLambdaForTypeSpecificCollections() {
     // Given:
     givenFunctions(
-        function(EXPECTED, false, MAP1, LAMBDA_BI_FUNCTION_STRING)
+        function(EXPECTED, -1, MAP1, LAMBDA_BI_FUNCTION_STRING)
     );
 
     // When:
@@ -361,7 +362,7 @@ public class UdfIndexTest {
   public void shouldThrowOnInvalidLambdaMapping() {
     // Given:
     givenFunctions(
-        function(OTHER, false, GENERIC_MAP, LAMBDA_BI_FUNCTION)
+        function(OTHER, -1, GENERIC_MAP, LAMBDA_BI_FUNCTION)
     );
 
     // When:
@@ -406,7 +407,7 @@ public class UdfIndexTest {
   public void shouldAllowAnyDecimal() {
     // Given:
     givenFunctions(
-        function(EXPECTED, false, DECIMAL)
+        function(EXPECTED, -1, DECIMAL)
     );
 
     // When:
@@ -420,7 +421,7 @@ public class UdfIndexTest {
   public void shouldFindVarargsEmpty() {
     // Given:
     givenFunctions(
-        function(EXPECTED, true, STRING_VARARGS)
+        function(EXPECTED, 0, STRING_VARARGS)
     );
 
     // When:
@@ -434,7 +435,7 @@ public class UdfIndexTest {
   public void shouldFindVarargsOne() {
     // Given:
     givenFunctions(
-        function(EXPECTED, true, STRING_VARARGS)
+        function(EXPECTED, 0, STRING_VARARGS)
     );
 
     // When:
@@ -448,7 +449,7 @@ public class UdfIndexTest {
   public void shouldFindVarargsTwo() {
     // Given:
     givenFunctions(
-        function(EXPECTED, true, STRING_VARARGS)
+        function(EXPECTED, 0, STRING_VARARGS)
     );
 
     // When:
@@ -463,7 +464,7 @@ public class UdfIndexTest {
   public void shouldFindVarargWithStruct() {
     // Given:
     givenFunctions(
-        function(EXPECTED, true, ArrayType.of(STRUCT1))
+        function(EXPECTED, 0, ArrayType.of(STRUCT1))
     );
 
     // When:
@@ -477,7 +478,7 @@ public class UdfIndexTest {
   public void shouldFindVarargWithList() {
     // Given:
     givenFunctions(
-        function(EXPECTED, true, STRING_VARARGS)
+        function(EXPECTED, 0, STRING_VARARGS)
     );
 
     // When:
@@ -492,8 +493,8 @@ public class UdfIndexTest {
   public void shouldChooseSpecificOverVarArgs() {
     // Given:
     givenFunctions(
-        function(EXPECTED, false, STRING),
-        function(OTHER, true, STRING_VARARGS)
+        function(EXPECTED, -1, STRING),
+        function(OTHER, 0, STRING_VARARGS)
     );
 
     // When:
@@ -507,9 +508,9 @@ public class UdfIndexTest {
   public void shouldChooseSpecificOverMultipleVarArgs() {
     // Given:
     givenFunctions(
-        function(EXPECTED, false, STRING),
-        function(OTHER, true, STRING_VARARGS),
-        function("two", true, STRING, STRING_VARARGS)
+        function(EXPECTED, -1, STRING),
+        function(OTHER, 0, STRING_VARARGS),
+        function("two", 1, STRING, STRING_VARARGS)
     );
 
     // When:
@@ -523,8 +524,8 @@ public class UdfIndexTest {
   public void shouldChooseVarArgsIfSpecificDoesntMatch() {
     // Given:
     givenFunctions(
-        function(OTHER, false, STRING),
-        function(EXPECTED, true, STRING_VARARGS)
+        function(EXPECTED, -1, STRING),
+        function(EXPECTED, 0, STRING_VARARGS)
     );
 
     // When:
@@ -539,7 +540,7 @@ public class UdfIndexTest {
   public void shouldFindNonVarargWithNullValues() {
     // Given:
     givenFunctions(
-        function(EXPECTED, false, STRING)
+        function(EXPECTED, -1, STRING)
     );
 
     // When:
@@ -553,7 +554,7 @@ public class UdfIndexTest {
   public void shouldFindNonVarargWithPartialNullValues() {
     // Given:
     givenFunctions(
-        function(EXPECTED, false, STRING, STRING)
+        function(EXPECTED, -1, STRING, STRING)
     );
 
     // When:
@@ -567,7 +568,7 @@ public class UdfIndexTest {
   public void shouldFindVarargWithSomeNullValues() {
     // Given:
     givenFunctions(
-        function(EXPECTED, true, STRING_VARARGS)
+        function(EXPECTED, 0, STRING_VARARGS)
     );
 
     // When:
@@ -581,8 +582,8 @@ public class UdfIndexTest {
   public void shouldChooseNonVarargWithNullValues() {
     // Given:
     givenFunctions(
-        function(EXPECTED, false, STRING),
-        function(OTHER, true, STRING_VARARGS)
+        function(EXPECTED, -1, STRING),
+        function(OTHER, 0, STRING_VARARGS)
     );
 
     // When:
@@ -596,8 +597,8 @@ public class UdfIndexTest {
   public void shouldChooseNonVarargWithNullValuesOfDifferingSchemas() {
     // Given:
     givenFunctions(
-        function(EXPECTED, false, STRING, INT),
-        function(OTHER, true, STRING_VARARGS)
+        function(EXPECTED, -1, STRING, INT),
+        function(OTHER, 0, STRING_VARARGS)
     );
 
     // When:
@@ -611,8 +612,8 @@ public class UdfIndexTest {
   public void shouldChooseNonVarargWithNullValuesOfSameSchemas() {
     // Given:
     givenFunctions(
-        function(EXPECTED, false, STRING, STRING),
-        function(OTHER, true, STRING_VARARGS)
+        function(EXPECTED, -1, STRING, STRING),
+        function(OTHER, 0, STRING_VARARGS)
     );
 
     // When:
@@ -626,8 +627,8 @@ public class UdfIndexTest {
   public void shouldChooseNonVarargWithNullValuesOfPartialNulls() {
     // Given:
     givenFunctions(
-        function(EXPECTED, false, STRING, INT),
-        function(OTHER, true, STRING_VARARGS)
+        function(EXPECTED, -1, STRING, INT),
+        function(OTHER, 0, STRING_VARARGS)
     );
 
     // When:
@@ -641,11 +642,11 @@ public class UdfIndexTest {
   public void shouldChooseCorrectlyInComplicatedTopology() {
     // Given:
     givenFunctions(
-        function(EXPECTED, false, STRING, INT, STRING, INT), function(OTHER, true, STRING_VARARGS),
-        function("two", true, STRING, STRING_VARARGS),
-        function("three", true, STRING, INT, STRING_VARARGS),
-        function("four", true, STRING, INT, STRING, INT, STRING_VARARGS),
-        function("five", true, INT, INT, STRING, INT, STRING_VARARGS)
+        function(EXPECTED, -1, STRING, INT, STRING, INT), function(OTHER, 0, STRING_VARARGS),
+        function("two", 1, STRING, STRING_VARARGS),
+        function("three", 2, STRING, INT, STRING_VARARGS),
+        function("four", 4, STRING, INT, STRING, INT, STRING_VARARGS),
+        function("five", 4, INT, INT, STRING, INT, STRING_VARARGS)
     );
 
     // When:
@@ -659,7 +660,7 @@ public class UdfIndexTest {
   public void shouldFindGenericMethodWithIntParam() {
     // Given:
     givenFunctions(
-        function(EXPECTED, false, GENERIC_LIST)
+        function(EXPECTED, -1, GENERIC_LIST)
     );
 
     // When:
@@ -673,7 +674,7 @@ public class UdfIndexTest {
   public void shouldFindGenericMethodWithStringParam() {
     // Given:
     givenFunctions(
-        function(EXPECTED, false, GENERIC_LIST)
+        function(EXPECTED, -1, GENERIC_LIST)
     );
 
     // When:
@@ -688,7 +689,7 @@ public class UdfIndexTest {
     // Given:
     final GenericType generic = GenericType.of("A");
     givenFunctions(
-        function(EXPECTED, false, generic, generic)
+        function(EXPECTED, -1, generic, generic)
     );
 
     // When:
@@ -704,7 +705,7 @@ public class UdfIndexTest {
     final GenericType genericA = GenericType.of("A");
     final GenericType genericB = GenericType.of("B");
     givenFunctions(
-        function(EXPECTED, false, genericA, genericB)
+        function(EXPECTED, -1, genericA, genericB)
     );
 
     // When:
@@ -719,7 +720,7 @@ public class UdfIndexTest {
     // Given:
     final ArrayType generic = ArrayType.of(GenericType.of("A"));
     givenFunctions(
-        function(EXPECTED, false, generic, generic)
+        function(EXPECTED, -1, generic, generic)
     );
 
     // When:
@@ -733,7 +734,7 @@ public class UdfIndexTest {
   public void shouldNotMatchIfParamLengthDiffers() {
     // Given:
     givenFunctions(
-        function(OTHER, false, STRING)
+        function(EXPECTED, -1, STRING)
     );
 
     // When:
@@ -751,7 +752,7 @@ public class UdfIndexTest {
   public void shouldNotMatchIfNoneFound() {
     // Given:
     givenFunctions(
-        function(OTHER, false, STRING)
+        function(EXPECTED, -1, STRING)
     );
 
     // When:
@@ -769,7 +770,7 @@ public class UdfIndexTest {
   public void shouldNotMatchIfNoneFoundWithNull() {
     // Given:
     givenFunctions(
-        function(OTHER, false, STRING, INT)
+        function(EXPECTED, -1, STRING, INT)
     );
 
     // When:
@@ -787,8 +788,8 @@ public class UdfIndexTest {
   public void shouldNotChooseSpecificWhenTrickyVarArgLoop() {
     // Given:
     givenFunctions(
-        function(OTHER, false, STRING, INT),
-        function("two", true, STRING_VARARGS)
+        function(EXPECTED, -1, STRING, INT),
+        function("two", 0, STRING_VARARGS)
     );
 
     // When:
@@ -806,7 +807,7 @@ public class UdfIndexTest {
   public void shouldNotMatchWhenNullTypeInArgsIfParamLengthDiffers() {
     // Given:
     givenFunctions(
-        function(OTHER, false, STRING)
+        function(EXPECTED, -1, STRING)
     );
 
     // When:
@@ -824,7 +825,7 @@ public class UdfIndexTest {
   public void shouldNotMatchVarargDifferentStructs() {
     // Given:
     givenFunctions(
-        function(OTHER, true, ArrayType.of(STRUCT1))
+        function(OTHER, 0, ArrayType.of(STRUCT1))
     );
 
     // When:
@@ -843,7 +844,7 @@ public class UdfIndexTest {
     // Given:
     final GenericType generic = GenericType.of("A");
     givenFunctions(
-        function(EXPECTED, false, generic, generic)
+        function(EXPECTED, -1, generic, generic)
     );
 
     // When:
@@ -862,7 +863,7 @@ public class UdfIndexTest {
     // Given:
     final ArrayType generic = ArrayType.of(GenericType.of("A"));
     givenFunctions(
-        function(EXPECTED, false, generic, generic)
+        function(EXPECTED, -1, generic, generic)
     );
 
     // When:
@@ -882,9 +883,9 @@ public class UdfIndexTest {
     // Given:
     final ArrayType generic = of(GenericType.of("A"));
     givenFunctions(
-        function(OTHER, true, false, STRING, INT),
-        function(OTHER, true, STRING_VARARGS),
-        function(OTHER, false, generic)
+        function(OTHER, true, -1, STRING, INT),
+        function(OTHER, 0, STRING_VARARGS),
+        function(OTHER, -1, generic)
     );
 
     // When:
@@ -907,7 +908,7 @@ public class UdfIndexTest {
   public void shouldSupportMatchAndImplicitCastEnabled() {
     // Given:
     givenFunctions(
-            function(EXPECTED, false, DOUBLE)
+            function(EXPECTED, -1, DOUBLE)
     );
 
     // When:
@@ -922,7 +923,7 @@ public class UdfIndexTest {
     // Given:
     udfIndex = new UdfIndex<>("name", false);
     givenFunctions(
-            function(OTHER, false, DOUBLE)
+            function(EXPECTED, -1, DOUBLE)
     );
 
     // When:
@@ -940,8 +941,8 @@ public class UdfIndexTest {
   public void shouldThrowOnAmbiguousImplicitCastWithoutGenerics() {
     // Given:
     givenFunctions(
-        function(FIRST_FUNC, false, LONG, LONG),
-        function(SECOND_FUNC, false, DOUBLE, DOUBLE)
+        function(FIRST_FUNC, -1, LONG, LONG),
+        function(SECOND_FUNC, -1, DOUBLE, DOUBLE)
     );
 
     // When:
@@ -959,8 +960,8 @@ public class UdfIndexTest {
   public void shouldFindFewerGenerics() {
     // Given:
     givenFunctions(
-        function(EXPECTED, false, INT, GenericType.of("A"), INT),
-        function(OTHER, false, INT, GenericType.of("A"), GenericType.of("B"))
+        function(EXPECTED, -1, INT, GenericType.of("A"), INT),
+        function(EXPECTED, -1, INT, GenericType.of("A"), GenericType.of("B"))
     );
 
     // When:
@@ -975,8 +976,8 @@ public class UdfIndexTest {
   public void shouldThrowOnAmbiguousImplicitCastWithGenerics() {
     // Given:
     givenFunctions(
-        function(FIRST_FUNC, false, LONG, GenericType.of("A"), GenericType.of("B")),
-        function(SECOND_FUNC, false, DOUBLE, GenericType.of("A"), GenericType.of("B"))
+        function(FIRST_FUNC, -1, LONG, GenericType.of("A"), GenericType.of("B")),
+        function(SECOND_FUNC, -1, DOUBLE, GenericType.of("A"), GenericType.of("B"))
     );
 
     // When:
@@ -997,24 +998,24 @@ public class UdfIndexTest {
 
   private static KsqlScalarFunction function(
       final String name,
-      final boolean isVarArgs,
+      final int variadicIndex,
       final ParamType... args
   ) {
-    return function(FunctionName.of(name), isVarArgs, args);
+    return function(FunctionName.of(name), variadicIndex, args);
   }
 
   private static KsqlScalarFunction function(
       final FunctionName name,
-      final boolean isVarArgs,
+      final int variadicIndex,
       final ParamType... args
   ) {
-    return function(name, false, isVarArgs, args);
+    return function(name, false, variadicIndex, args);
   }
 
   private static KsqlScalarFunction function(
       final FunctionName name,
       final boolean namedParams,
-      final boolean isVarArgs,
+      final int variadicIndex,
       final ParamType... args
   ) {
     final Function<KsqlConfig, Kudf> udfFactory = ksqlConfig -> {
@@ -1026,9 +1027,13 @@ public class UdfIndexTest {
       }
     };
 
-    final List<ParameterInfo> paramInfos = Arrays.stream(args)
-        .map(type -> new ParameterInfo(namedParams ? "paramName" : "", type, "", false))
-        .collect(Collectors.toList());
+    final List<ParameterInfo> paramInfos = IntStream.range(0, args.length)
+            .mapToObj(index -> new ParameterInfo(
+                    namedParams ? "paramName" : "", 
+                    args[index], 
+                    "", 
+                    index == variadicIndex
+            )).collect(Collectors.toList());
 
     return KsqlScalarFunction.create(
         (params, arguments) -> SqlTypes.STRING,
@@ -1039,7 +1044,7 @@ public class UdfIndexTest {
         udfFactory,
         "",
         INTERNAL_PATH,
-        isVarArgs);
+        variadicIndex >= 0);
   }
 
   private static final class MyUdf implements Kudf {

--- a/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
@@ -98,6 +98,25 @@ public class UdfIndexTest {
   }
 
   @Test
+  public void shouldThrowOnAddFunctionSameParamsExceptOneVariadic() {
+    // Given:
+    givenFunctions(
+            function(EXPECTED, -1, STRING_VARARGS)
+    );
+
+    // When:
+    final Exception e = assertThrows(
+            KsqlFunctionException.class,
+            () -> udfIndex.addFunction(function(EXPECTED, 0, STRING_VARARGS))
+    );
+
+    // Then:
+    assertThat(e.getMessage(), startsWith("Can't add function `expected` with parameters"
+            + " [ARRAY<VARCHAR>] as a function with the same name and parameter types already"
+            + " exists"));
+  }
+
+  @Test
   public void shouldFindNoArgs() {
     // Given:
     givenFunctions(
@@ -549,6 +568,21 @@ public class UdfIndexTest {
     // When:
     final KsqlScalarFunction fun = udfIndex
         .getFunction(ImmutableList.of(SqlArgument.of(SqlArray.of(SqlTypes.STRING))));
+
+    // Then:
+    assertThat(fun.name(), equalTo(EXPECTED));
+  }
+
+  @Test
+  public void shouldFindNonVarargWithList() {
+    // Given:
+    givenFunctions(
+            function(EXPECTED, -1, STRING_VARARGS)
+    );
+
+    // When:
+    final KsqlScalarFunction fun = udfIndex
+            .getFunction(ImmutableList.of(SqlArgument.of(SqlArray.of(SqlTypes.STRING))));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));

--- a/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
@@ -461,6 +461,57 @@ public class UdfIndexTest {
   }
 
   @Test
+  public void shouldFindVarargsManyEven() {
+    // Given:
+    givenFunctions(
+            function(EXPECTED, 2, INT, INT, STRING_VARARGS, STRING, INT)
+    );
+
+    // When:
+    final KsqlScalarFunction fun = udfIndex
+            .getFunction(ImmutableList.of(
+                    SqlArgument.of(SqlTypes.INTEGER), SqlArgument.of(SqlTypes.INTEGER),
+                    SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.STRING),
+                    SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.STRING),
+                    SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.STRING),
+                    SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.STRING),
+                    SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.STRING),
+                    SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.STRING),
+                    SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.STRING),
+                    SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.INTEGER)
+            ));
+
+    // Then:
+    assertThat(fun.name(), equalTo(EXPECTED));
+  }
+
+  @Test
+  public void shouldFindVarargsManyOdd() {
+    // Given:
+    givenFunctions(
+            function(EXPECTED, 2, INT, INT, STRING_VARARGS, STRING, INT)
+    );
+
+    // When:
+    final KsqlScalarFunction fun = udfIndex
+            .getFunction(ImmutableList.of(
+                    SqlArgument.of(SqlTypes.INTEGER), SqlArgument.of(SqlTypes.INTEGER),
+                    SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.STRING),
+                    SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.STRING),
+                    SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.STRING),
+                    SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.STRING),
+                    SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.STRING),
+                    SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.STRING),
+                    SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.STRING),
+                    SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.STRING),
+                    SqlArgument.of(SqlTypes.INTEGER)
+            ));
+
+    // Then:
+    assertThat(fun.name(), equalTo(EXPECTED));
+  }
+
+  @Test
   public void shouldFindVarargWithStruct() {
     // Given:
     givenFunctions(
@@ -490,7 +541,7 @@ public class UdfIndexTest {
   }
 
   @Test
-  public void shouldChooseSpecificOverVarArgs() {
+  public void shouldChooseSpecificOverOnlyVarArgs() {
     // Given:
     givenFunctions(
         function(EXPECTED, -1, STRING),
@@ -499,6 +550,44 @@ public class UdfIndexTest {
 
     // When:
     final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlArgument.of(SqlTypes.STRING)));
+
+    // Then:
+    assertThat(fun.name(), equalTo(EXPECTED));
+  }
+
+  @Test
+  public void shouldChooseSpecificOverVarArgsAtEnd() {
+    // Given:
+    givenFunctions(
+            function(EXPECTED, -1, INT, INT, STRING),
+            function(OTHER, 2, INT, INT, STRING_VARARGS)
+    );
+
+    // When:
+    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(
+            SqlArgument.of(SqlTypes.INTEGER), SqlArgument.of(SqlTypes.INTEGER),
+            SqlArgument.of(SqlTypes.STRING)
+    ));
+
+    // Then:
+    assertThat(fun.name(), equalTo(EXPECTED));
+  }
+
+  @Test
+  public void shouldChooseSpecificOverVarArgsInMiddle() {
+    // Given:
+    givenFunctions(
+            function(EXPECTED, -1, INT, INT, STRING, STRING, STRING, STRING, INT),
+            function(OTHER, 2, INT, INT, STRING_VARARGS, STRING, STRING, STRING, INT)
+    );
+
+    // When:
+    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(
+            SqlArgument.of(SqlTypes.INTEGER), SqlArgument.of(SqlTypes.INTEGER),
+            SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.STRING),
+            SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.STRING),
+            SqlArgument.of(SqlTypes.INTEGER)
+    ));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));

--- a/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
@@ -551,7 +551,7 @@ public class UdfIndexTest {
     final Exception e = assertThrows(
             KsqlException.class,
             () -> udfIndex.getFunction(ImmutableList.of(
-                    SqlArgument.of(SqlArray.of(SqlTypes.INTEGER))
+                    SqlArgument.of(SqlTypes.INTEGER)
             ))
     );
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafTypes.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafTypes.java
@@ -131,11 +131,6 @@ class UdafTypes {
       this.inputTypes[variadicColIndex] = ((ParameterizedType) inputTypes[variadicColIndex])
               .getActualTypeArguments()[0];
 
-      // TEMPORARY: Disallow initial args when col arg is variadic
-      if (method.getParameterCount() > 0) {
-        throw new KsqlException("Methods with variadic column args cannot have factory args");
-      }
-
     } else if (variadicColIndex > -1) {
 
       // Prevent zero column arguments
@@ -236,12 +231,10 @@ class UdafTypes {
   }
 
   private static int indexOfVariadic(final Type[] types) {
-    final int lastTypeIndex = types.length - 1;
-    if (types.length > 0 && getRawType(types[lastTypeIndex]) == VARIADIC_TYPE) {
-      return lastTypeIndex;
-    }
-
-    return -1;
+    return IntStream.range(0, types.length)
+            .filter((index) -> getRawType(types[index]) == VARIADIC_TYPE)
+            .findFirst()
+            .orElse(-1);
   }
 
   private static void validateStructAnnotation(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdafTypesTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdafTypesTest.java
@@ -133,15 +133,11 @@ public class UdafTypesTest {
     assertThat(e.getMessage(), is("A UDAF and its factory can have at most one variadic argument"));
   }
 
-  // TEMPORARY: until variadic args in the middle are added
   @Test
-  public void shouldThrowWhenOnlyColArgIsVariadic() {
-    final Exception e = assertThrows(
-            KsqlException.class,
-            () -> createTypes("udafWithInitArgAndVariadicColArg", int.class)
-    );
-
-    assertThat(e.getMessage(), is("Methods with variadic column args cannot have factory args"));
+  public void shouldNotThrowWhenOnlyColArgIsVariadic() {
+    UdafTypes udafTypes = createTypes("udafWithInitArgAndVariadicColArg", int.class);
+    assertTrue(udafTypes.isVariadic());
+    assertTrue(udafTypes.literalParams().stream().noneMatch(ParameterInfo::isVariadic));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/MiddleVarArgUdaf.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/MiddleVarArgUdaf.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udaf;
+
+import io.confluent.ksql.util.KsqlConstants;
+import io.confluent.ksql.util.Pair;
+import java.util.Objects;
+
+@UdafDescription(
+        name = "MID_VAR_ARG",
+        description = "Returns the sum of the provided longs, lengths of strings, "
+                + "and initial arguments.",
+        author = KsqlConstants.CONFLUENT_AUTHOR
+)
+@SuppressWarnings("unused")
+public class MiddleVarArgUdaf implements Udaf<Pair<Long, VariadicArgs<String>>, Long, Long> {
+
+  @UdafFactory(description = "Testing factory")
+  public static Udaf<Pair<Long, VariadicArgs<String>>, Long, Long> createVarArgUdaf(int first,
+                                                                                    int second) {
+    return new MiddleVarArgUdaf(first, second);
+  }
+
+  private final int constant;
+
+  public MiddleVarArgUdaf(int first, int second) {
+    constant = first + second;
+  }
+
+  @Override
+  public Long initialize() {
+    return 0L;
+  }
+
+  @Override
+  public Long aggregate(final Pair<Long, VariadicArgs<String>> currentValue,
+                        final Long aggregateValue) {
+    final long firstVal = currentValue.getLeft() == null ? 0 : currentValue.getLeft();
+    final int secondVal = currentValue.getRight() == null ? 0 : currentValue.getRight().stream()
+            .filter(Objects::nonNull)
+            .map(String::length)
+            .reduce(0, Integer::sum);
+
+    return aggregateValue + firstVal + secondVal;
+  }
+
+  @Override
+  public Long merge(final Long aggOne, final Long aggTwo) {
+    return aggOne + aggTwo;
+  }
+
+  @Override
+  public Long map(final Long agg) {
+    return agg + constant;
+  }
+}

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
@@ -539,6 +539,7 @@ public class SqlToJavaVisitor {
         final SqlType sqlType =
             argumentInfos.get(i).getSqlArgument().getSqlType().orElse(null);
 
+        // Since scalar UDFs are being handled here, varargs cannot be in the middle.
         final ParamType paramType;
         if (i >= function.parameters().size() - 1 && function.isVariadic()) {
           paramType = ((ArrayType) Iterables.getLast(function.parameters())).element();

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/TermCompiler.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/TermCompiler.java
@@ -394,6 +394,7 @@ public class TermCompiler implements ExpressionVisitor<Term, Context> {
       // lambda arguments and null values are considered to have null type
       final SqlType sqlType = argumentInfos.get(i).getSqlArgument().getSqlType().orElse(null);;
 
+      // Since scalar UDFs are being handled here, varargs cannot be in the middle.
       final ParamType paramType;
       if (i >= function.parameters().size() - 1 && function.isVariadic()) {
         paramType = ((ArrayType) Iterables.getLast(function.parameters())).element();

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/middle-variadic-udaf_-_all_arguments/7.3.0_1660161097805/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/middle-variadic-udaf_-_all_arguments/7.3.0_1660161097805/plan.json
@@ -1,0 +1,258 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, FIRST BIGINT, SECOND STRING, THIRD STRING, FOURTH STRING) WITH (KAFKA_TOPIC='input_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `FIRST` BIGINT, `SECOND` STRING, `THIRD` STRING, `FOURTH` STRING",
+      "timestampColumn" : null,
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  MID_VAR_ARG(INPUT.FIRST, INPUT.SECOND, INPUT.THIRD, INPUT.FOURTH, 7, 3) RESULT\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `RESULT` BIGINT",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "input_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    }
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` BIGINT KEY, `FIRST` BIGINT, `SECOND` STRING, `THIRD` STRING, `FOURTH` STRING",
+                  "pseudoColumnVersion" : 1
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectedKeys" : null,
+                "selectExpressions" : [ "ID AS ID", "FIRST AS FIRST", "SECOND AS SECOND", "THIRD AS THIRD", "FOURTH AS FOURTH", "7 AS KSQL_INTERNAL_COL_5", "3 AS KSQL_INTERNAL_COL_6" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "JSON",
+                  "properties" : { }
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "FIRST", "SECOND", "THIRD", "FOURTH" ],
+            "aggregationFunctions" : [ "MID_VAR_ARG(FIRST, SECOND, THIRD, FOURTH, 7, 3)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS RESULT" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA",
+              "properties" : { }
+            },
+            "valueFormat" : {
+              "format" : "JSON",
+              "properties" : { }
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.websocket.connection.max.timeout.ms" : "0",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "true",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.json_sr.converter.deserializer.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/middle-variadic-udaf_-_all_arguments/7.3.0_1660161097805/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/middle-variadic-udaf_-_all_arguments/7.3.0_1660161097805/spec.json
@@ -1,0 +1,286 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1660161097805,
+  "path" : "query-validation-tests/middle-variadic-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `RESULT` BIGINT",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `FIRST` BIGINT, `SECOND` STRING, `THIRD` STRING, `FOURTH` STRING, `KSQL_INTERNAL_COL_5` INTEGER, `KSQL_INTERNAL_COL_6` INTEGER",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `FIRST` BIGINT, `SECOND` STRING, `THIRD` STRING, `FOURTH` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `FIRST` BIGINT, `SECOND` STRING, `THIRD` STRING, `FOURTH` STRING, `KSQL_AGG_VARIABLE_0` BIGINT",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `RESULT` BIGINT",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "all arguments",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 6,
+        "SECOND" : "hi",
+        "THIRD" : "hello",
+        "FOURTH" : "world"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 2,
+        "SECOND" : "a",
+        "THIRD" : "hello",
+        "FOURTH" : "world"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : null,
+        "SECOND" : "hello",
+        "THIRD" : "hello",
+        "FOURTH" : "world"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 5,
+        "SECOND" : "world",
+        "THIRD" : "hello",
+        "FOURTH" : "world"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 5,
+        "SECOND" : null,
+        "THIRD" : "hello",
+        "FOURTH" : "world"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 3,
+        "SECOND" : "test",
+        "THIRD" : "hello",
+        "FOURTH" : "world"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 2,
+        "SECOND" : "testing",
+        "THIRD" : "hello",
+        "FOURTH" : "world"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 21,
+        "SECOND" : "aggregate",
+        "THIRD" : "hello",
+        "FOURTH" : "world"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : null,
+        "SECOND" : "function",
+        "THIRD" : "hello",
+        "FOURTH" : "world"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 3,
+        "SECOND" : "ksql",
+        "THIRD" : "hello",
+        "FOURTH" : "world"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 6,
+        "SECOND" : "test",
+        "THIRD" : "hello",
+        "FOURTH" : "world"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : 28
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : 23
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : 43
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : 43
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : 58
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : 60
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : 79
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : 98
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : 97
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : 114
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : 134
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, FIRST bigint, SECOND string, THIRD string, FOURTH string) WITH (kafka_topic='input_topic', value_format='JSON');", "CREATE TABLE OUTPUT as SELECT id, MID_VAR_ARG(FIRST, SECOND, THIRD, FOURTH, 7, 3) as RESULT FROM INPUT group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `FIRST` BIGINT, `SECOND` STRING, `THIRD` STRING, `FOURTH` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `RESULT` BIGINT",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/middle-variadic-udaf_-_all_arguments/7.3.0_1660161097805/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/middle-variadic-udaf_-_all_arguments/7.3.0_1660161097805/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/middle-variadic-udaf_-_no_variadic_args/7.3.0_1660161100790/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/middle-variadic-udaf_-_no_variadic_args/7.3.0_1660161100790/plan.json
@@ -1,0 +1,258 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, FIRST BIGINT, SECOND STRING) WITH (KAFKA_TOPIC='input_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `FIRST` BIGINT, `SECOND` STRING",
+      "timestampColumn" : null,
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  MID_VAR_ARG(INPUT.FIRST, 7, 3) RESULT\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `RESULT` BIGINT",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "input_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    }
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` BIGINT KEY, `FIRST` BIGINT, `SECOND` STRING",
+                  "pseudoColumnVersion" : 1
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectedKeys" : null,
+                "selectExpressions" : [ "ID AS ID", "FIRST AS FIRST", "7 AS KSQL_INTERNAL_COL_2", "3 AS KSQL_INTERNAL_COL_3" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "JSON",
+                  "properties" : { }
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "FIRST" ],
+            "aggregationFunctions" : [ "MID_VAR_ARG(FIRST, 7, 3)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS RESULT" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA",
+              "properties" : { }
+            },
+            "valueFormat" : {
+              "format" : "JSON",
+              "properties" : { }
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.websocket.connection.max.timeout.ms" : "0",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "true",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.json_sr.converter.deserializer.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/middle-variadic-udaf_-_no_variadic_args/7.3.0_1660161100790/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/middle-variadic-udaf_-_no_variadic_args/7.3.0_1660161100790/spec.json
@@ -1,0 +1,264 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1660161100790,
+  "path" : "query-validation-tests/middle-variadic-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `RESULT` BIGINT",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `FIRST` BIGINT, `KSQL_INTERNAL_COL_2` INTEGER, `KSQL_INTERNAL_COL_3` INTEGER",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `FIRST` BIGINT, `SECOND` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `FIRST` BIGINT, `KSQL_AGG_VARIABLE_0` BIGINT",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `RESULT` BIGINT",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "no variadic args",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 6,
+        "SECOND" : "hi"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 2,
+        "SECOND" : "a"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : null,
+        "SECOND" : "hello"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 5,
+        "SECOND" : "world"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 5,
+        "SECOND" : null
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 3,
+        "SECOND" : "test"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 2,
+        "SECOND" : "testing"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 21,
+        "SECOND" : "aggregate"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : null,
+        "SECOND" : "function"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 3,
+        "SECOND" : "ksql"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 6,
+        "SECOND" : "test"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : 16
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : 12
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : 16
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : 17
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : 21
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : 20
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : 22
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : 42
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : 22
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : 25
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : 31
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, FIRST bigint, SECOND string) WITH (kafka_topic='input_topic', value_format='JSON');", "CREATE TABLE OUTPUT as SELECT id, MID_VAR_ARG(FIRST, 7, 3) as RESULT FROM INPUT group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `FIRST` BIGINT, `SECOND` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `RESULT` BIGINT",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/middle-variadic-udaf_-_no_variadic_args/7.3.0_1660161100790/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/middle-variadic-udaf_-_no_variadic_args/7.3.0_1660161100790/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/middle-variadic-udaf_-_regular_arg_literal/7.3.0_1660161099405/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/middle-variadic-udaf_-_regular_arg_literal/7.3.0_1660161099405/plan.json
@@ -1,0 +1,258 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, FIRST BIGINT, SECOND STRING) WITH (KAFKA_TOPIC='input_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `FIRST` BIGINT, `SECOND` STRING",
+      "timestampColumn" : null,
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  MID_VAR_ARG(INPUT.FIRST, 'hello', '10', '20', INPUT.SECOND, '3', 7, 3) RESULT\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `RESULT` BIGINT",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "input_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    }
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` BIGINT KEY, `FIRST` BIGINT, `SECOND` STRING",
+                  "pseudoColumnVersion" : 1
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectedKeys" : null,
+                "selectExpressions" : [ "ID AS ID", "FIRST AS FIRST", "SECOND AS SECOND", "'hello' AS KSQL_INTERNAL_COL_3", "'10' AS KSQL_INTERNAL_COL_4", "'20' AS KSQL_INTERNAL_COL_5", "'3' AS KSQL_INTERNAL_COL_6", "7 AS KSQL_INTERNAL_COL_7", "3 AS KSQL_INTERNAL_COL_8" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "JSON",
+                  "properties" : { }
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "FIRST", "SECOND" ],
+            "aggregationFunctions" : [ "MID_VAR_ARG(FIRST, KSQL_INTERNAL_COL_3, KSQL_INTERNAL_COL_4, KSQL_INTERNAL_COL_5, SECOND, KSQL_INTERNAL_COL_6, 7, 3)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS RESULT" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA",
+              "properties" : { }
+            },
+            "valueFormat" : {
+              "format" : "JSON",
+              "properties" : { }
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.websocket.connection.max.timeout.ms" : "0",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "true",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.json_sr.converter.deserializer.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/middle-variadic-udaf_-_regular_arg_literal/7.3.0_1660161099405/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/middle-variadic-udaf_-_regular_arg_literal/7.3.0_1660161099405/spec.json
@@ -1,0 +1,264 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1660161099405,
+  "path" : "query-validation-tests/middle-variadic-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `RESULT` BIGINT",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `FIRST` BIGINT, `SECOND` STRING, `KSQL_INTERNAL_COL_3` STRING, `KSQL_INTERNAL_COL_4` STRING, `KSQL_INTERNAL_COL_5` STRING, `KSQL_INTERNAL_COL_6` STRING, `KSQL_INTERNAL_COL_7` INTEGER, `KSQL_INTERNAL_COL_8` INTEGER",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `FIRST` BIGINT, `SECOND` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `FIRST` BIGINT, `SECOND` STRING, `KSQL_AGG_VARIABLE_0` BIGINT",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `RESULT` BIGINT",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "regular arg literal",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 6,
+        "SECOND" : "hi"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 2,
+        "SECOND" : "a"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : null,
+        "SECOND" : "hello"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 5,
+        "SECOND" : "world"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 5,
+        "SECOND" : null
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 3,
+        "SECOND" : "test"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 2,
+        "SECOND" : "testing"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 21,
+        "SECOND" : "aggregate"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : null,
+        "SECOND" : "function"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 3,
+        "SECOND" : "ksql"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 6,
+        "SECOND" : "test"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : 28
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : 23
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : 43
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : 43
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : 58
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : 60
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : 79
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : 98
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : 97
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : 114
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : 134
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, FIRST bigint, SECOND string) WITH (kafka_topic='input_topic', value_format='JSON');", "CREATE TABLE OUTPUT as SELECT id, MID_VAR_ARG(FIRST, 'hello', '10', '20', SECOND, '3', 7, 3) as RESULT FROM INPUT group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `FIRST` BIGINT, `SECOND` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `RESULT` BIGINT",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/middle-variadic-udaf_-_regular_arg_literal/7.3.0_1660161099405/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/middle-variadic-udaf_-_regular_arg_literal/7.3.0_1660161099405/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/middle-variadic-udaf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/middle-variadic-udaf.json
@@ -1,0 +1,144 @@
+{
+  "comments": [
+    "You can specify multiple statements per test case, i.e., to set up the various streams needed",
+    "for joins etc, but currently only the final topology will be verified. This should be enough",
+    "for most tests as we can simulate the outputs from previous stages into the final stage. If we",
+    "take a modular approach to testing we can still verify that it all works correctly, i.e, if we",
+    "verify the output of a select or aggregate is correct, we can use simulated output to feed into",
+    "a join or another aggregate."
+  ],
+  "tests": [
+    {
+      "name": "missing first argument",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, FIRST bigint, SECOND string, THIRD string) WITH (kafka_topic='input_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT id, MID_VAR_ARG(SECOND, THIRD, 2, 3) as RESULT FROM INPUT group by id;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Function 'MID_VAR_ARG' does not accept parameters (STRING, STRING, INTEGER, INTEGER)."
+      }
+    },
+    {
+      "name": "missing initial argument",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, FIRST bigint, SECOND string, THIRD string) WITH (kafka_topic='input_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT id, MID_VAR_ARG(FIRST, SECOND, THIRD, 3) as RESULT FROM INPUT group by id;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Function 'MID_VAR_ARG' does not accept parameters (BIGINT, STRING, STRING, INTEGER)."
+      }
+    },
+    {
+      "name": "var args type mismatch",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, FIRST bigint, SECOND integer) WITH (kafka_topic='input_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT id, MID_VAR_ARG(FIRST, SECOND, 3, 2) as RESULT FROM INPUT group by id;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Function 'MID_VAR_ARG' does not accept parameters (BIGINT, INTEGER, INTEGER, INTEGER)."
+      }
+    },
+    {
+      "name": "all arguments",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, FIRST bigint, SECOND string, THIRD string, FOURTH string) WITH (kafka_topic='input_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT id, MID_VAR_ARG(FIRST, SECOND, THIRD, FOURTH, 7, 3) as RESULT FROM INPUT group by id;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 6, "SECOND": "hi", "THIRD": "hello", "FOURTH": "world"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 2, "SECOND": "a", "THIRD": "hello", "FOURTH": "world"}},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": null, "SECOND": "hello", "THIRD": "hello", "FOURTH": "world"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 5, "SECOND": "world", "THIRD": "hello", "FOURTH": "world"}},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 5, "SECOND": null, "THIRD": "hello", "FOURTH": "world"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 3, "SECOND": "test", "THIRD": "hello", "FOURTH": "world"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 2, "SECOND": "testing", "THIRD": "hello", "FOURTH": "world"}},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 21, "SECOND": "aggregate", "THIRD": "hello", "FOURTH": "world"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": null, "SECOND": "function", "THIRD": "hello", "FOURTH": "world"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 3, "SECOND": "ksql", "THIRD": "hello", "FOURTH": "world"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 6, "SECOND": "test", "THIRD": "hello", "FOURTH": "world"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": 28}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": 23}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": 43}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": 43}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": 58}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": 60}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": 79}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": 98}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": 97}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": 114}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": 134}}
+      ]
+    },
+    {
+      "name": "regular arg literal",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, FIRST bigint, SECOND string) WITH (kafka_topic='input_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT id, MID_VAR_ARG(FIRST, 'hello', '10', '20', SECOND, '3', 7, 3) as RESULT FROM INPUT group by id;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 6, "SECOND": "hi"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 2, "SECOND": "a"}},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": null, "SECOND": "hello"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 5, "SECOND": "world"}},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 5, "SECOND": null}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 3, "SECOND": "test"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 2, "SECOND": "testing"}},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 21, "SECOND": "aggregate"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": null, "SECOND": "function"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 3, "SECOND": "ksql"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 6, "SECOND": "test"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": 28}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": 23}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": 43}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": 43}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": 58}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": 60}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": 79}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": 98}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": 97}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": 114}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": 134}}
+      ]
+    },
+    {
+      "name": "no variadic args",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, FIRST bigint, SECOND string) WITH (kafka_topic='input_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT id, MID_VAR_ARG(FIRST, 7, 3) as RESULT FROM INPUT group by id;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 6, "SECOND": "hi"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 2, "SECOND": "a"}},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": null, "SECOND": "hello"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 5, "SECOND": "world"}},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 5, "SECOND": null}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 3, "SECOND": "test"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 2, "SECOND": "testing"}},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 21, "SECOND": "aggregate"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": null, "SECOND": "function"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 3, "SECOND": "ksql"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 6, "SECOND": "test"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": 16}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": 12}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": 16}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": 17}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": 21}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": 20}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": 22}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": 42}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": 22}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": 25}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": 31}}
+      ]
+    }
+  ]
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutor.java
@@ -86,7 +86,7 @@ public final class DescribeFunctionExecutor {
 
     aggregateFactory.eachFunction((func, description) -> listBuilder.add(
         getFunctionInfo(
-            func.parameterInfo(), func.declaredReturnType(), description, false)));
+            func.parameterInfo(), func.declaredReturnType(), description)));
 
     return createFunctionDescriptionList(
         statementText, aggregateFactory.getMetadata(), listBuilder.build(), FunctionType.AGGREGATE);
@@ -106,8 +106,7 @@ public final class DescribeFunctionExecutor {
         getFunctionInfo(
             func.parameterInfo(),
             func.declaredReturnType(),
-            func.getDescription(),
-            func.isVariadic()
+            func.getDescription()
         )));
 
     return createFunctionDescriptionList(
@@ -131,8 +130,7 @@ public final class DescribeFunctionExecutor {
         getFunctionInfo(
             func.parameterInfo(),
             func.declaredReturnType(),
-            func.getDescription(),
-            func.isVariadic()
+            func.getDescription()
         )));
 
     return createFunctionDescriptionList(
@@ -146,17 +144,14 @@ public final class DescribeFunctionExecutor {
   private static FunctionInfo getFunctionInfo(
       final List<ParameterInfo> argTypes,
       final ParamType returnTypeSchema,
-      final String description,
-      final boolean variadic
+      final String description
   ) {
     final List<ArgumentInfo> args = new ArrayList<>();
-    for (int i = 0; i < argTypes.size(); i++) {
-      final ParameterInfo param = argTypes.get(i);
-      final boolean isVariadic = variadic && i == (argTypes.size() - 1);
-      final String type = isVariadic
-          ? ((ArrayType) param.type()).element().toString()
-          : param.type().toString();
-      args.add(new ArgumentInfo(param.name(), type, param.description(), isVariadic));
+    for (final ParameterInfo param : argTypes) {
+      final String type = param.isVariadic()
+              ? ((ArrayType) param.type()).element().toString()
+              : param.type().toString();
+      args.add(new ArgumentInfo(param.name(), type, param.description(), param.isVariadic()));
     }
 
     return new FunctionInfo(args, returnTypeSchema.toString(), description);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutorTest.java
@@ -119,6 +119,32 @@ public class DescribeFunctionExecutorTest {
   }
 
   @Test
+  public void shouldDescribeUDAFWithVarArgsInMiddle() {
+    // When:
+    final FunctionDescriptionList functionList = (FunctionDescriptionList)
+            CustomExecutors.DESCRIBE_FUNCTION.execute(
+                    engine.configure("DESCRIBE FUNCTION MID_VAR_ARG;"),
+                    mock(SessionProperties.class),
+                    engine.getEngine(),
+                    engine.getServiceContext()
+            ).getEntity().orElseThrow(IllegalStateException::new);
+
+    // Then:
+    assertThat(functionList, new TypeSafeMatcher<FunctionDescriptionList>() {
+      @Override
+      protected boolean matchesSafely(final FunctionDescriptionList item) {
+        return functionList.getName().equals("MID_VAR_ARG")
+                && functionList.getType().equals(FunctionType.AGGREGATE);
+      }
+
+      @Override
+      public void describeTo(final Description description) {
+        description.appendText(functionList.getName());
+      }
+    });
+  }
+
+  @Test
   public void shouldDescribeUDTF() {
     // When:
     final FunctionDescriptionList functionList = (FunctionDescriptionList)


### PR DESCRIPTION
### Description 
Follow-up to #9361. This PR adds support for a variadic argument anywhere in the function signature. There can still be only one variadic argument in the function signature.

This change is being made because we currently cannot support variadic UDAFs with initial arguments. Allowing a variadic argument in the middle removes this restriction.

The main changes to enable this feature are in `UdfIndex`. The tree of parameter types is now based on pairs of parameters, with one parameter from the left half of the parameter list and one parameter from the right half. This structure ensures the loop for variadic arguments is always at the bottom of the tree, eliminating most edge cases. There is also a new rule to determine function precedence:

> If two methods exist that match given the above rules, return the method with the variadic argument in the later position.

The number of nodes generated is quadratic with respect to the number of parameters in the function (only for variadic functions), but we only generate the tree once at startup. The number of nodes generated is not excessive unless there is a grossly absurd number of arguments ([see graph](https://www.desmos.com/calculator/fbnikgl7ow)). Currently, the only way to have a function with this many arguments is to have many initial arguments, as Java supports up to 255 arguments for a method. Resolving a function still takes linear time.

How `UdfIndex` now works is documented more thoroughly in comments. Other changes are removing exceptions thrown for var args in the middle or tests.

### Testing done 
Added unit tests and QTTs for var args in the middle.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

