### PR TITLE
feat: add stop co-ordinates to NodeLocation

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/parser/NodeLocation.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/parser/NodeLocation.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 @Immutable
+@SuppressWarnings("checkstyle:CyclomaticComplexity")
 public final class NodeLocation {
 
   private final int startLine;
@@ -96,11 +97,24 @@ public final class NodeLocation {
 
     final NodeLocation that = (NodeLocation) o;
     return startLine == that.startLine
-        && startStartIndex == that.startStartIndex;
+        && startCharPositionInLine == that.startCharPositionInLine
+        && startStartIndex == that.startStartIndex
+        && startStopIndex == that.startStopIndex
+        && endLine == that.endLine
+        && stopCharPositionInLine == that.stopCharPositionInLine
+        && stopStartIndex == that.stopStartIndex
+        && stopStopIndex == that.stopStartIndex;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(startLine, startStartIndex);
+    return Objects.hash(startLine,
+        startCharPositionInLine,
+        startStartIndex,
+        startStopIndex,
+        endLine,
+        stopCharPositionInLine,
+        stopStartIndex,
+        stopStopIndex);
   }
 }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/parser/NodeLocation.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/parser/NodeLocation.java
@@ -24,65 +24,48 @@ import java.util.OptionalInt;
 @SuppressWarnings("checkstyle:CyclomaticComplexity")
 public final class NodeLocation {
 
-  private final int startLine;
-  private final int startCharPositionInLine;
-  private final OptionalInt startStartIndex;
-  private final OptionalInt startStopIndex;
-  private final OptionalInt endLine;
-  private final OptionalInt stopCharPositionInLine;
-  private final OptionalInt stopStartIndex;
-  private final OptionalInt stopStopIndex;
+  private final TokenLocation start;
+  private final TokenLocation stop;
 
-  public NodeLocation(final int startLine,
-                      final int startCharPositionInLine,
-                      final OptionalInt startStartIndex,
-                      final OptionalInt startStopIndex,
-                      final OptionalInt endLine,
-                      final OptionalInt stopCharPositionInLine,
-                      final OptionalInt stopStartIndex,
-                      final OptionalInt stopStopIndex) {
-    this.startLine = startLine;
-    this.startCharPositionInLine = startCharPositionInLine;
-    this.startStartIndex = startStartIndex;
-    this.startStopIndex = startStopIndex;
-    this.endLine = endLine;
-    this.stopCharPositionInLine = stopCharPositionInLine;
-    this.stopStartIndex = stopStartIndex;
-    this.stopStopIndex = stopStopIndex;
+  public NodeLocation(final TokenLocation start, final TokenLocation stop) {
+    this.start = start;
+    this.stop = stop;
   }
 
   public NodeLocation(final int startLine, final int startCharPositionInLine) {
-    this.startLine = startLine;
-    this.startCharPositionInLine = startCharPositionInLine;
-    this.startStartIndex = OptionalInt.empty();
-    this.startStopIndex = OptionalInt.empty();
-    this.endLine = OptionalInt.empty();
-    this.stopCharPositionInLine = OptionalInt.empty();
-    this.stopStartIndex = OptionalInt.empty();
-    this.stopStopIndex = OptionalInt.empty();
+    this.start = TokenLocation.of(startLine, startCharPositionInLine);
+    this.stop = TokenLocation.empty();
   }
 
-  public int getLineNumber() {
-    return startLine;
+  public int getStartLineNumber() {
+    return start.getLine().getAsInt();
   }
 
-  public int getColumnNumber() {
-    return startCharPositionInLine + 1;
+  public int getStartColumnNumber() {
+    return start.getCharPositionInLine().getAsInt() + 1;
   }
 
-  public OptionalInt getEndLine() {
-    return endLine;
+  public OptionalInt getStopLine() {
+    return stop.getLine();
   }
 
-  public OptionalInt getEndColumnNumber() {
-    return OptionalInt.of(stopCharPositionInLine.getAsInt()
-        + stopStopIndex.getAsInt()
-        - stopStartIndex.getAsInt()
+  public OptionalInt getStopColumnNumber() {
+    return OptionalInt.of(stop.getCharPositionInLine().getAsInt()
+        + stop.getStopIndex().getAsInt()
+        - stop.getStartIndex().getAsInt()
         + 1);
   }
 
   public OptionalInt getLength() {
-    return OptionalInt.of(stopStopIndex.getAsInt() - startStartIndex.getAsInt() + 1);
+    return OptionalInt.of(stop.getStopIndex().getAsInt() - start.getStartIndex().getAsInt() + 1);
+  }
+
+  public TokenLocation getStartTokenLocation() {
+    return start;
+  }
+
+  public TokenLocation getStopTokenLocation() {
+    return stop;
   }
 
   public String asPrefix() {
@@ -97,7 +80,9 @@ public final class NodeLocation {
 
   @Override
   public String toString() {
-    return String.format("Line: %d, Col: %d", startLine, startCharPositionInLine + 1);
+    return String.format("Line: %d, Col: %d",
+        start.getLine().getAsInt(),
+        start.getCharPositionInLine().getAsInt() + 1);
   }
 
   @Override
@@ -111,25 +96,12 @@ public final class NodeLocation {
     }
 
     final NodeLocation that = (NodeLocation) o;
-    return startLine == that.startLine
-        && startCharPositionInLine == that.startCharPositionInLine
-        && startStartIndex == that.startStartIndex
-        && startStopIndex == that.startStopIndex
-        && endLine == that.endLine
-        && stopCharPositionInLine == that.stopCharPositionInLine
-        && stopStartIndex == that.stopStartIndex
-        && stopStopIndex == that.stopStartIndex;
+    return start.equals(that.start)
+        && stop.equals(that.stop);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(startLine,
-        startCharPositionInLine,
-        startStartIndex,
-        startStopIndex,
-        endLine,
-        stopCharPositionInLine,
-        stopStartIndex,
-        stopStopIndex);
+    return Objects.hash(start, stop);
   }
 }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/parser/NodeLocation.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/parser/NodeLocation.java
@@ -20,34 +20,73 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+/**
+ * Entity that contains the location information of the start token
+ * and the stop token. The terms "Token" and "token" refer to
+ * {@link org.antlr.v4.runtime.Token}
+ */
 @Immutable
 public final class NodeLocation {
 
+  /**
+   * location information for the start {@link org.antlr.v4.runtime.Token}
+   * of the Node.
+   */
   private final TokenLocation start;
+
+  /**
+   * location information for the stop {@link org.antlr.v4.runtime.Token}
+   * of the Node.
+   */
   private final TokenLocation stop;
 
+  /**
+   * @param start {@link TokenLocation} of the start {@link org.antlr.v4.runtime.Token}
+   * @param stop {@link TokenLocation} of the stop {@link org.antlr.v4.runtime.Token}
+   */
   public NodeLocation(final TokenLocation start, final TokenLocation stop) {
     this.start = start;
     this.stop = stop;
   }
 
+  /**
+   * @param startLine line number of the start token
+   * @param startCharPositionInLine position of the first character of the start token
+   *                                within the start line
+   */
   public NodeLocation(final int startLine, final int startCharPositionInLine) {
     this.start = TokenLocation.of(startLine, startCharPositionInLine);
     this.stop = TokenLocation.empty();
   }
 
+  /**
+   * @return the line number within the statement where the {@link Node} begins.
+   *     Note: the line numbers start from 1 (and not 0).
+   */
   public int getStartLineNumber() {
     return start.getLine().getAsInt();
   }
 
+  /**
+   * @return the column number within the statement where the {@link Node} begins.
+   *     Note: the column numbers start from 1 (and not 0)
+   */
   public int getStartColumnNumber() {
     return start.getCharPositionInLine().getAsInt() + 1;
   }
 
+  /**
+   * @return the line number within the statement where the {@link Node} ends.
+   *     Note: the line numbers start from 1 (and not 0)
+   */
   public OptionalInt getStopLine() {
     return stop.getLine();
   }
 
+  /**
+   * @return the column number within the statement where the {@link Node} end.
+   *     Note: the column numbers start from 1 (and not 0)
+   */
   public OptionalInt getStopColumnNumber() {
     return OptionalInt.of(stop.getCharPositionInLine().getAsInt()
         + stop.getStopIndex().getAsInt()
@@ -55,14 +94,23 @@ public final class NodeLocation {
         + 1);
   }
 
+  /**
+   * @return the length of the statement represented by the {@link Node}
+   */
   public OptionalInt getLength() {
     return OptionalInt.of(stop.getStopIndex().getAsInt() - start.getStartIndex().getAsInt() + 1);
   }
 
+  /**
+   * @return the {@link TokenLocation} of the start {@link org.antlr.v4.runtime.Token}
+   */
   public TokenLocation getStartTokenLocation() {
     return start;
   }
 
+  /**
+   * @return the {@link TokenLocation} of the stop {@link org.antlr.v4.runtime.Token}
+   */
   public TokenLocation getStopTokenLocation() {
     return stop;
   }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/parser/NodeLocation.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/parser/NodeLocation.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 @Immutable
-@SuppressWarnings("checkstyle:CyclomaticComplexity")
 public final class NodeLocation {
 
   private final TokenLocation start;

--- a/ksqldb-common/src/main/java/io/confluent/ksql/parser/NodeLocation.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/parser/NodeLocation.java
@@ -38,7 +38,7 @@ public final class NodeLocation {
    * location information for the stop {@link org.antlr.v4.runtime.Token}
    * of the Node.
    */
-  private final TokenLocation stop;
+  private final Optional<TokenLocation> stop;
 
   /**
    * @param start {@link TokenLocation} of the start {@link org.antlr.v4.runtime.Token}
@@ -46,7 +46,7 @@ public final class NodeLocation {
    */
   public NodeLocation(final TokenLocation start, final TokenLocation stop) {
     this.start = start;
-    this.stop = stop;
+    this.stop = Optional.of(stop);
   }
 
   /**
@@ -56,7 +56,7 @@ public final class NodeLocation {
    */
   public NodeLocation(final int startLine, final int startCharPositionInLine) {
     this.start = TokenLocation.of(startLine, startCharPositionInLine);
-    this.stop = TokenLocation.empty();
+    this.stop = Optional.empty();
   }
 
   /**
@@ -64,7 +64,7 @@ public final class NodeLocation {
    *     Note: the line numbers start from 1 (and not 0).
    */
   public int getStartLineNumber() {
-    return start.getLine().getAsInt();
+    return start.getLine();
   }
 
   /**
@@ -72,33 +72,16 @@ public final class NodeLocation {
    *     Note: the column numbers start from 1 (and not 0)
    */
   public int getStartColumnNumber() {
-    return start.getCharPositionInLine().getAsInt() + 1;
-  }
-
-  /**
-   * @return the line number within the statement where the {@link Node} ends.
-   *     Note: the line numbers start from 1 (and not 0)
-   */
-  public OptionalInt getStopLine() {
-    return stop.getLine();
-  }
-
-  /**
-   * @return the column number within the statement where the {@link Node} end.
-   *     Note: the column numbers start from 1 (and not 0)
-   */
-  public OptionalInt getStopColumnNumber() {
-    return OptionalInt.of(stop.getCharPositionInLine().getAsInt()
-        + stop.getStopIndex().getAsInt()
-        - stop.getStartIndex().getAsInt()
-        + 1);
+    return start.getCharPositionInLine() + 1;
   }
 
   /**
    * @return the length of the statement represented by the {@link Node}
    */
   public OptionalInt getLength() {
-    return OptionalInt.of(stop.getStopIndex().getAsInt() - start.getStartIndex().getAsInt() + 1);
+    return stop.map(tokenLocation ->
+        OptionalInt.of(tokenLocation.getStopIndex() - start.getStartIndex() + 1))
+        .orElseGet(OptionalInt::empty);
   }
 
   /**
@@ -111,7 +94,7 @@ public final class NodeLocation {
   /**
    * @return the {@link TokenLocation} of the stop {@link org.antlr.v4.runtime.Token}
    */
-  public TokenLocation getStopTokenLocation() {
+  public Optional<TokenLocation> getStopTokenLocation() {
     return stop;
   }
 
@@ -128,8 +111,8 @@ public final class NodeLocation {
   @Override
   public String toString() {
     return String.format("Line: %d, Col: %d",
-        start.getLine().getAsInt(),
-        start.getCharPositionInLine().getAsInt() + 1);
+        start.getLine(),
+        start.getCharPositionInLine() + 1);
   }
 
   @Override

--- a/ksqldb-common/src/main/java/io/confluent/ksql/parser/NodeLocation.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/parser/NodeLocation.java
@@ -70,6 +70,21 @@ public final class NodeLocation {
     return startCharPositionInLine + 1;
   }
 
+  public OptionalInt getEndLine() {
+    return endLine;
+  }
+
+  public OptionalInt getEndColumnNumber() {
+    return OptionalInt.of(stopCharPositionInLine.getAsInt()
+        + stopStopIndex.getAsInt()
+        - stopStartIndex.getAsInt()
+        + 1);
+  }
+
+  public OptionalInt getLength() {
+    return OptionalInt.of(stopStopIndex.getAsInt() - startStartIndex.getAsInt() + 1);
+  }
+
   public String asPrefix() {
     return toString() + ": ";
   }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/parser/NodeLocation.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/parser/NodeLocation.java
@@ -18,24 +18,59 @@ package io.confluent.ksql.parser;
 import com.google.errorprone.annotations.Immutable;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 @Immutable
 public final class NodeLocation {
 
-  private final int line;
-  private final int charPositionInLine;
+  private final int startLine;
+  private final int startStartIndex;
+  private final OptionalInt startStopIndex;
+  private final OptionalInt endLine;
+  private final OptionalInt stopStartIndex;
+  private final OptionalInt stopStopIndex;
 
-  public NodeLocation(final int line, final int charPositionInLine) {
-    this.line = line;
-    this.charPositionInLine = charPositionInLine;
+  public NodeLocation(final int startLine,
+                      final int startStartIndex,
+                      final OptionalInt startStopIndex,
+                      final OptionalInt endLine,
+                      final OptionalInt stopStartIndex,
+                      final OptionalInt stopStopIndex) {
+    this.startLine = startLine;
+    this.startStartIndex = startStartIndex;
+    this.startStopIndex = startStopIndex;
+    this.endLine = endLine;
+    this.stopStartIndex = stopStartIndex;
+    this.stopStopIndex = stopStopIndex;
+  }
+
+  public NodeLocation(final int startLine, final int startStartIndex) {
+    this.startLine = startLine;
+    this.startStartIndex = startStartIndex;
+    this.startStopIndex = OptionalInt.empty();
+    this.endLine = OptionalInt.empty();
+    this.stopStartIndex = OptionalInt.empty();
+    this.stopStopIndex = OptionalInt.empty();
   }
 
   public int getLineNumber() {
-    return line;
+    return startLine;
   }
 
   public int getColumnNumber() {
-    return charPositionInLine + 1;
+    return startStartIndex + 1;
+  }
+
+  public OptionalInt getEndLineNumber() {
+    return endLine;
+  }
+
+  public OptionalInt getEndColumnNumber() {
+    return this.stopStartIndex;
+  }
+
+  public OptionalInt getStopStopIndex() {
+    return this.stopStopIndex;
   }
 
   public String asPrefix() {
@@ -50,7 +85,7 @@ public final class NodeLocation {
 
   @Override
   public String toString() {
-    return String.format("Line: %d, Col: %d", line, charPositionInLine + 1);
+    return String.format("Line: %d, Col: %d", startLine, startStartIndex + 1);
   }
 
   @Override
@@ -64,12 +99,12 @@ public final class NodeLocation {
     }
 
     final NodeLocation that = (NodeLocation) o;
-    return line == that.line
-        && charPositionInLine == that.charPositionInLine;
+    return startLine == that.startLine
+        && startStartIndex == that.startStartIndex;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(line, charPositionInLine);
+    return Objects.hash(startLine, startStartIndex);
   }
 }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/parser/NodeLocation.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/parser/NodeLocation.java
@@ -24,31 +24,39 @@ import java.util.OptionalInt;
 public final class NodeLocation {
 
   private final int startLine;
-  private final int startStartIndex;
+  private final int startCharPositionInLine;
+  private final OptionalInt startStartIndex;
   private final OptionalInt startStopIndex;
   private final OptionalInt endLine;
+  private final OptionalInt stopCharPositionInLine;
   private final OptionalInt stopStartIndex;
   private final OptionalInt stopStopIndex;
 
   public NodeLocation(final int startLine,
-                      final int startStartIndex,
+                      final int startCharPositionInLine,
+                      final OptionalInt startStartIndex,
                       final OptionalInt startStopIndex,
                       final OptionalInt endLine,
+                      final OptionalInt stopCharPositionInLine,
                       final OptionalInt stopStartIndex,
                       final OptionalInt stopStopIndex) {
     this.startLine = startLine;
+    this.startCharPositionInLine = startCharPositionInLine;
     this.startStartIndex = startStartIndex;
     this.startStopIndex = startStopIndex;
     this.endLine = endLine;
+    this.stopCharPositionInLine = stopCharPositionInLine;
     this.stopStartIndex = stopStartIndex;
     this.stopStopIndex = stopStopIndex;
   }
 
-  public NodeLocation(final int startLine, final int startStartIndex) {
+  public NodeLocation(final int startLine, final int startCharPositionInLine) {
     this.startLine = startLine;
-    this.startStartIndex = startStartIndex;
+    this.startCharPositionInLine = startCharPositionInLine;
+    this.startStartIndex = OptionalInt.empty();
     this.startStopIndex = OptionalInt.empty();
     this.endLine = OptionalInt.empty();
+    this.stopCharPositionInLine = OptionalInt.empty();
     this.stopStartIndex = OptionalInt.empty();
     this.stopStopIndex = OptionalInt.empty();
   }
@@ -58,19 +66,7 @@ public final class NodeLocation {
   }
 
   public int getColumnNumber() {
-    return startStartIndex + 1;
-  }
-
-  public OptionalInt getEndLineNumber() {
-    return endLine;
-  }
-
-  public OptionalInt getEndColumnNumber() {
-    return this.stopStartIndex;
-  }
-
-  public OptionalInt getStopStopIndex() {
-    return this.stopStopIndex;
+    return startCharPositionInLine + 1;
   }
 
   public String asPrefix() {
@@ -85,7 +81,7 @@ public final class NodeLocation {
 
   @Override
   public String toString() {
-    return String.format("Line: %d, Col: %d", startLine, startStartIndex + 1);
+    return String.format("Line: %d, Col: %d", startLine, startCharPositionInLine + 1);
   }
 
   @Override

--- a/ksqldb-common/src/main/java/io/confluent/ksql/parser/TokenLocation.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/parser/TokenLocation.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser;
+
+import java.util.Objects;
+import java.util.OptionalInt;
+
+public class TokenLocation {
+
+  private final OptionalInt line;
+  private final OptionalInt charPositionInLine;
+  private final OptionalInt startIndex;
+  private final OptionalInt stopIndex;
+
+  public static TokenLocation empty() {
+    return new TokenLocation(OptionalInt.empty(),
+        OptionalInt.empty(),
+        OptionalInt.empty(),
+        OptionalInt.empty());
+  }
+
+  public static TokenLocation of(final int line, final int charPositionInLine) {
+    return new TokenLocation(
+        OptionalInt.of(line),
+        OptionalInt.of(charPositionInLine),
+        OptionalInt.empty(),
+        OptionalInt.empty()
+    );
+  }
+
+  public TokenLocation(final OptionalInt line,
+                       final OptionalInt charPositionInLine,
+                       final OptionalInt startIndex,
+                       final OptionalInt stopIndex) {
+    this.line = line;
+    this.charPositionInLine = charPositionInLine;
+    this.startIndex = startIndex;
+    this.stopIndex = stopIndex;
+  }
+
+  public OptionalInt getLine() {
+    return line;
+  }
+
+  public OptionalInt getCharPositionInLine() {
+    return charPositionInLine;
+  }
+
+  public OptionalInt getStartIndex() {
+    return startIndex;
+  }
+
+  public OptionalInt getStopIndex() {
+    return stopIndex;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final TokenLocation that = (TokenLocation) o;
+    return line.equals(that.line)
+        && charPositionInLine.equals(that.charPositionInLine)
+        && startIndex.equals(that.startIndex)
+        && stopIndex.equals(that.stopIndex);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(line, charPositionInLine, startIndex, stopIndex);
+  }
+}

--- a/ksqldb-common/src/main/java/io/confluent/ksql/parser/TokenLocation.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/parser/TokenLocation.java
@@ -21,12 +21,12 @@ import java.util.OptionalInt;
 /**
  * Wrapper class for encapsulating the location information of the
  * antlr Token {@link org.antlr.v4.runtime.Token}
- * */
+ */
 public class TokenLocation {
 
   /**
    * line number returned by {@link org.antlr.v4.runtime.Token#getLine()}
-   * */
+   */
   private final OptionalInt line;
 
   /**
@@ -42,7 +42,7 @@ public class TokenLocation {
 
   /**
    * stop index returned by {@link org.antlr.v4.runtime.Token#getStopIndex()}
-   * */
+   */
   private final OptionalInt stopIndex;
 
   public static TokenLocation empty() {

--- a/ksqldb-common/src/main/java/io/confluent/ksql/parser/TokenLocation.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/parser/TokenLocation.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.parser;
 
 import com.google.errorprone.annotations.Immutable;
 import java.util.Objects;
-import java.util.OptionalInt;
 
 /**
  * Wrapper class for encapsulating the location information of the
@@ -29,37 +28,30 @@ public final class TokenLocation {
   /**
    * line number returned by {@link org.antlr.v4.runtime.Token#getLine()}
    */
-  private final OptionalInt line;
+  private final int line;
 
   /**
    * position of character in line returned
    * by {@link org.antlr.v4.runtime.Token#getCharPositionInLine()}
    */
-  private final OptionalInt charPositionInLine;
+  private final int charPositionInLine;
 
   /**
    * start index returned by {@link org.antlr.v4.runtime.Token#getStartIndex()}
    */
-  private final OptionalInt startIndex;
+  private final int startIndex;
 
   /**
    * stop index returned by {@link org.antlr.v4.runtime.Token#getStopIndex()}
    */
-  private final OptionalInt stopIndex;
-
-  public static TokenLocation empty() {
-    return new TokenLocation(OptionalInt.empty(),
-        OptionalInt.empty(),
-        OptionalInt.empty(),
-        OptionalInt.empty());
-  }
+  private final int stopIndex;
 
   public static TokenLocation of(final int line, final int charPositionInLine) {
     return new TokenLocation(
-        OptionalInt.of(line),
-        OptionalInt.of(charPositionInLine),
-        OptionalInt.empty(),
-        OptionalInt.empty()
+        line,
+        charPositionInLine,
+        Integer.MAX_VALUE,
+        Integer.MAX_VALUE
     );
   }
 
@@ -70,29 +62,29 @@ public final class TokenLocation {
    * @param startIndex start index returned by {@link org.antlr.v4.runtime.Token#getStartIndex()}
    * @param stopIndex stop index returned by {@link org.antlr.v4.runtime.Token#getStopIndex()}
    */
-  public TokenLocation(final OptionalInt line,
-                       final OptionalInt charPositionInLine,
-                       final OptionalInt startIndex,
-                       final OptionalInt stopIndex) {
+  public TokenLocation(final int line,
+                       final int charPositionInLine,
+                       final int startIndex,
+                       final int stopIndex) {
     this.line = line;
     this.charPositionInLine = charPositionInLine;
     this.startIndex = startIndex;
     this.stopIndex = stopIndex;
   }
 
-  public OptionalInt getLine() {
+  public int getLine() {
     return line;
   }
 
-  public OptionalInt getCharPositionInLine() {
+  public int getCharPositionInLine() {
     return charPositionInLine;
   }
 
-  public OptionalInt getStartIndex() {
+  public int getStartIndex() {
     return startIndex;
   }
 
-  public OptionalInt getStopIndex() {
+  public int getStopIndex() {
     return stopIndex;
   }
 
@@ -107,10 +99,10 @@ public final class TokenLocation {
     }
 
     final TokenLocation that = (TokenLocation) o;
-    return line.equals(that.line)
-        && charPositionInLine.equals(that.charPositionInLine)
-        && startIndex.equals(that.startIndex)
-        && stopIndex.equals(that.stopIndex);
+    return line == that.line
+        && charPositionInLine == that.charPositionInLine
+        && startIndex == that.startIndex
+        && stopIndex == that.stopIndex;
   }
 
   @Override

--- a/ksqldb-common/src/main/java/io/confluent/ksql/parser/TokenLocation.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/parser/TokenLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -18,11 +18,31 @@ package io.confluent.ksql.parser;
 import java.util.Objects;
 import java.util.OptionalInt;
 
+/**
+ * Wrapper class for encapsulating the location information of the
+ * antlr Token {@link org.antlr.v4.runtime.Token}
+ * */
 public class TokenLocation {
 
+  /**
+   * line number returned by {@link org.antlr.v4.runtime.Token#getLine()}
+   * */
   private final OptionalInt line;
+
+  /**
+   * position of character in line returned
+   * by {@link org.antlr.v4.runtime.Token#getCharPositionInLine()}
+   */
   private final OptionalInt charPositionInLine;
+
+  /**
+   * start index returned by {@link org.antlr.v4.runtime.Token#getStartIndex()}
+   */
   private final OptionalInt startIndex;
+
+  /**
+   * stop index returned by {@link org.antlr.v4.runtime.Token#getStopIndex()}
+   * */
   private final OptionalInt stopIndex;
 
   public static TokenLocation empty() {
@@ -41,6 +61,13 @@ public class TokenLocation {
     );
   }
 
+  /**
+   * @param line line number returned by {@link org.antlr.v4.runtime.Token#getLine()}
+   * @param charPositionInLine position of character in line returned
+   *                           by {@link org.antlr.v4.runtime.Token#getCharPositionInLine()}
+   * @param startIndex start index returned by {@link org.antlr.v4.runtime.Token#getStartIndex()}
+   * @param stopIndex stop index returned by {@link org.antlr.v4.runtime.Token#getStopIndex()}
+   */
   public TokenLocation(final OptionalInt line,
                        final OptionalInt charPositionInLine,
                        final OptionalInt startIndex,

--- a/ksqldb-common/src/main/java/io/confluent/ksql/parser/TokenLocation.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/parser/TokenLocation.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.parser;
 
+import com.google.errorprone.annotations.Immutable;
 import java.util.Objects;
 import java.util.OptionalInt;
 
@@ -22,7 +23,8 @@ import java.util.OptionalInt;
  * Wrapper class for encapsulating the location information of the
  * antlr Token {@link org.antlr.v4.runtime.Token}
  */
-public class TokenLocation {
+@Immutable
+public final class TokenLocation {
 
   /**
    * line number returned by {@link org.antlr.v4.runtime.Token#getLine()}

--- a/ksqldb-common/src/test/java/io/confluent/ksql/parser/TokenLocationTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/parser/TokenLocationTest.java
@@ -15,52 +15,15 @@
 
 package io.confluent.ksql.parser;
 
-import java.util.OptionalInt;
+import com.google.common.testing.EqualsTester;
 import org.junit.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-
 public class TokenLocationTest {
-
   @Test
-  public void shouldBeEqualEmptyToken() {
-    // When:
-    final TokenLocation first = TokenLocation.empty();
-    final TokenLocation second = TokenLocation.empty();
-
-    // Then:
-    assertThat(first, is(second));
+  public void shouldImplementEqualsProperly() {
+    new EqualsTester()
+        .addEqualityGroup(TokenLocation.of(1, 2))
+        .addEqualityGroup(new TokenLocation(1, 2, 3, 4), new TokenLocation(1, 2, 3, 4))
+        .testEquals();
   }
-
-  @Test
-  public void shouldBeEqualFirstTwoArgs() {
-    // When:
-    final TokenLocation first = TokenLocation.of(1, 2);
-    final TokenLocation second = TokenLocation.of(1, 2);
-
-    // Then:
-    assertThat(first, is(second));
-  }
-
-  @Test
-  public void shouldBeEqualTokens() {
-    // When:
-    final TokenLocation first = new TokenLocation(
-        OptionalInt.of(1),
-        OptionalInt.of(2),
-        OptionalInt.of(3),
-        OptionalInt.of(4)
-    );
-    final TokenLocation second = new TokenLocation(
-        OptionalInt.of(1),
-        OptionalInt.of(2),
-        OptionalInt.of(3),
-        OptionalInt.of(4)
-    );
-
-    // Then:
-    assertThat(first, is(second));
-  }
-
 }

--- a/ksqldb-common/src/test/java/io/confluent/ksql/parser/TokenLocationTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/parser/TokenLocationTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser;
+
+import java.util.OptionalInt;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class TokenLocationTest {
+
+  @Test
+  public void shouldBeEqualEmptyToken() {
+    // When:
+    final TokenLocation first = TokenLocation.empty();
+    final TokenLocation second = TokenLocation.empty();
+
+    // Then:
+    assertThat(first, is(second));
+  }
+
+  @Test
+  public void shouldBeEqualFirstTwoArgs() {
+    // When:
+    final TokenLocation first = TokenLocation.of(1, 2);
+    final TokenLocation second = TokenLocation.of(1, 2);
+
+    // Then:
+    assertThat(first, is(second));
+  }
+
+  @Test
+  public void shouldBeEqualTokens() {
+    // When:
+    final TokenLocation first = new TokenLocation(
+        OptionalInt.of(1),
+        OptionalInt.of(2),
+        OptionalInt.of(3),
+        OptionalInt.of(4)
+    );
+    final TokenLocation second = new TokenLocation(
+        OptionalInt.of(1),
+        OptionalInt.of(2),
+        OptionalInt.of(3),
+        OptionalInt.of(4)
+    );
+
+    // Then:
+    assertThat(first, is(second));
+  }
+
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/AstSanitizer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/AstSanitizer.java
@@ -122,8 +122,8 @@ public final class AstSanitizer {
         final Optional<NodeLocation> targetLocation = node.getLocation()
             .map(
                 l -> new NodeLocation(
-                    l.getLineNumber(),
-                    l.getColumnNumber() + "INSERT INTO".length()
+                    l.getStartLineNumber(),
+                    l.getStartColumnNumber() + "INSERT INTO".length()
                 )
             );
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/AstSanitizer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/AstSanitizer.java
@@ -45,6 +45,7 @@ import io.confluent.ksql.util.UnknownSourceException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
@@ -123,8 +124,11 @@ public final class AstSanitizer {
             .map(
                 l -> new NodeLocation(
                     l.getLineNumber(),
-                    l.getColumnNumber() + "INSERT INTO".length()
-                )
+                    l.getColumnNumber() + "INSERT INTO".length(),
+                    OptionalInt.empty(),
+                    OptionalInt.empty(),
+                    OptionalInt.empty(),
+                    OptionalInt.empty())
             );
 
         throw new UnknownSourceException(targetLocation, node.getTarget());

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/AstSanitizer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/AstSanitizer.java
@@ -45,7 +45,6 @@ import io.confluent.ksql.util.UnknownSourceException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
@@ -124,11 +123,8 @@ public final class AstSanitizer {
             .map(
                 l -> new NodeLocation(
                     l.getLineNumber(),
-                    l.getColumnNumber() + "INSERT INTO".length(),
-                    OptionalInt.empty(),
-                    OptionalInt.empty(),
-                    OptionalInt.empty(),
-                    OptionalInt.empty())
+                    l.getColumnNumber() + "INSERT INTO".length()
+                )
             );
 
         throw new UnknownSourceException(targetLocation, node.getTarget());

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/KsqlTestException.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/KsqlTestException.java
@@ -83,7 +83,7 @@ public class KsqlTestException extends KsqlException {
         message,
         new LocationWithinFile(
             file,
-            loc.map(NodeLocation::getLineNumber).orElse(1))
+            loc.map(NodeLocation::getStartLineNumber).orElse(1))
     );
   }
 
@@ -99,7 +99,7 @@ public class KsqlTestException extends KsqlException {
         message,
         new LocationWithinFile(
             file,
-            assertStatement.getLocation().map(NodeLocation::getLineNumber).orElse(1))
+            assertStatement.getLocation().map(NodeLocation::getStartLineNumber).orElse(1))
     );
   }
 
@@ -115,7 +115,7 @@ public class KsqlTestException extends KsqlException {
         message,
         new LocationWithinFile(
             file,
-            directive.getLocation().getLineNumber())
+            directive.getLocation().getStartLineNumber())
     );
   }
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/DirectiveParser.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/DirectiveParser.java
@@ -39,8 +39,8 @@ public final class DirectiveParser {
       throw new ParsingException(
           "Expected directive matching pattern " + DIRECTIVE_REGEX + " but got " + comment,
           null,
-          loc.getLineNumber(),
-          loc.getColumnNumber()
+          loc.getStartLineNumber(),
+          loc.getStartColumnNumber()
       );
     }
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/DirectiveParser.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/DirectiveParser.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.test.parser;
 import io.confluent.ksql.parser.NodeLocation;
 import io.confluent.ksql.parser.ParsingException;
 import io.confluent.ksql.test.parser.TestDirective.Type;
+import io.confluent.ksql.util.ParserUtil;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.antlr.v4.runtime.Token;
@@ -32,7 +33,7 @@ public final class DirectiveParser {
   }
 
   public static TestDirective parse(final Token comment) {
-    final NodeLocation loc = new NodeLocation(comment.getLine(), comment.getCharPositionInLine());
+    final NodeLocation loc = ParserUtil.getLocation(comment).get();
     final Matcher matcher = DIRECTIVE_REGEX.matcher(comment.getText().trim());
     if (!matcher.find()) {
       throw new ParsingException(

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/ParsingException.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/ParsingException.java
@@ -30,8 +30,8 @@ public class ParsingException
     this(
         message,
         null,
-        nodeLocation.map(NodeLocation::getLineNumber).orElse(1),
-        nodeLocation.map(NodeLocation::getColumnNumber).orElse(0)
+        nodeLocation.map(NodeLocation::getStartLineNumber).orElse(1),
+        nodeLocation.map(NodeLocation::getStartColumnNumber).orElse(0)
     );
   }
 

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
@@ -211,9 +211,11 @@ public final class ParserUtil {
     requireNonNull(start, "Start token is null");
     requireNonNull(stop, "Stop token is null");
     return Optional.of(new NodeLocation(start.getLine(),
-        start.getStartIndex(),
+        start.getCharPositionInLine(),
+        OptionalInt.of(start.getStartIndex()),
         OptionalInt.of(start.getStopIndex()),
         OptionalInt.of(stop.getLine()),
+        OptionalInt.of(stop.getCharPositionInLine()),
         OptionalInt.of(stop.getStartIndex()),
         OptionalInt.of(stop.getStopIndex())));
   }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
@@ -39,7 +39,6 @@ import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.parser.tree.ColumnConstraints;
 import java.math.BigDecimal;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.Set;
 import java.util.regex.Pattern;
 import org.antlr.v4.runtime.CharStreams;
@@ -213,17 +212,17 @@ public final class ParserUtil {
     requireNonNull(stop, "Stop token is null");
 
     final TokenLocation startLocation = new TokenLocation(
-        OptionalInt.of(start.getLine()),
-        OptionalInt.of(start.getCharPositionInLine()),
-        OptionalInt.of(start.getStartIndex()),
-        OptionalInt.of(start.getStopIndex())
+        start.getLine(),
+        start.getCharPositionInLine(),
+        start.getStartIndex(),
+        start.getStopIndex()
     );
 
     final TokenLocation stopLocation = new TokenLocation(
-        OptionalInt.of(stop.getLine()),
-        OptionalInt.of(stop.getCharPositionInLine()),
-        OptionalInt.of(stop.getStartIndex()),
-        OptionalInt.of(stop.getStopIndex())
+        stop.getLine(),
+        stop.getCharPositionInLine(),
+        stop.getStartIndex(),
+        stop.getStopIndex()
     );
 
     return Optional.of(new NodeLocation(startLocation, stopLocation));

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
@@ -38,6 +38,7 @@ import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.parser.tree.ColumnConstraints;
 import java.math.BigDecimal;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.regex.Pattern;
 import org.antlr.v4.runtime.CharStreams;
@@ -203,12 +204,23 @@ public final class ParserUtil {
 
   public static Optional<NodeLocation> getLocation(final ParserRuleContext parserRuleContext) {
     requireNonNull(parserRuleContext, "parserRuleContext is null");
-    return getLocation(parserRuleContext.getStart());
+    return getLocation(parserRuleContext.getStart(), parserRuleContext.getStop());
+  }
+
+  public static Optional<NodeLocation> getLocation(final Token start, final Token stop) {
+    requireNonNull(start, "Start token is null");
+    requireNonNull(stop, "Stop token is null");
+    return Optional.of(new NodeLocation(start.getLine(),
+        start.getStartIndex(),
+        OptionalInt.of(start.getStopIndex()),
+        OptionalInt.of(stop.getLine()),
+        OptionalInt.of(stop.getStartIndex()),
+        OptionalInt.of(stop.getStopIndex())));
   }
 
   public static Optional<NodeLocation> getLocation(final Token token) {
     requireNonNull(token, "token is null");
-    return Optional.of(new NodeLocation(token.getLine(), token.getCharPositionInLine()));
+    return getLocation(token, token);
   }
 
   /**

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
@@ -34,6 +34,7 @@ import io.confluent.ksql.parser.SqlBaseParser.FloatLiteralContext;
 import io.confluent.ksql.parser.SqlBaseParser.IntegerLiteralContext;
 import io.confluent.ksql.parser.SqlBaseParser.NumberContext;
 import io.confluent.ksql.parser.SqlBaseParser.SourceNameContext;
+import io.confluent.ksql.parser.TokenLocation;
 import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.parser.tree.ColumnConstraints;
 import java.math.BigDecimal;
@@ -210,14 +211,22 @@ public final class ParserUtil {
   public static Optional<NodeLocation> getLocation(final Token start, final Token stop) {
     requireNonNull(start, "Start token is null");
     requireNonNull(stop, "Stop token is null");
-    return Optional.of(new NodeLocation(start.getLine(),
-        start.getCharPositionInLine(),
+
+    final TokenLocation startLocation = new TokenLocation(
+        OptionalInt.of(start.getLine()),
+        OptionalInt.of(start.getCharPositionInLine()),
         OptionalInt.of(start.getStartIndex()),
-        OptionalInt.of(start.getStopIndex()),
+        OptionalInt.of(start.getStopIndex())
+    );
+
+    final TokenLocation stopLocation = new TokenLocation(
         OptionalInt.of(stop.getLine()),
         OptionalInt.of(stop.getCharPositionInLine()),
         OptionalInt.of(stop.getStartIndex()),
-        OptionalInt.of(stop.getStopIndex())));
+        OptionalInt.of(stop.getStopIndex())
+    );
+
+    return Optional.of(new NodeLocation(startLocation, stopLocation));
   }
 
   public static Optional<NodeLocation> getLocation(final Token token) {

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
@@ -1162,7 +1162,7 @@ public class AstBuilderTest {
         "         B.flight_id,\n" +                                                                        // 5
         "         COUNT(*)\n" +                                                                            // 6
         "  FROM bookings B\n" +                                                                            // 7
-        "  INNER JOIN customers C ON B.customer_id = C.id\n" +                                             // 8
+        "       INNER JOIN customers C ON B.customer_id = C.id\n" +                                        // 8
         "  WINDOW TUMBLING (SIZE 1 HOUR, GRACE PERIOD 2 HOURS)\n" +                                        // 9
         "  WHERE B.customer_id > 0 AND INSTR(C.EMAIL, '@') > 0\n" +                                        // 10
         "  GROUP BY C.EMAIL, B.ID, B.flight_id\n" +                                                        // 11
@@ -1190,7 +1190,7 @@ public class AstBuilderTest {
     assertThat(queryLocation.getColumnNumber(), is(3));
     assertThat(queryLocation.getEndLine(), is(OptionalInt.of(12)));
     assertThat(queryLocation.getEndColumnNumber(), is(OptionalInt.of(21)));
-    assertThat(queryLocation.getLength(), is(OptionalInt.of(305)));
+    assertThat(queryLocation.getLength(), is(OptionalInt.of(310)));
 
     final Select select = query.getSelect();
     assertTrue(select.getLocation().isPresent());
@@ -1207,8 +1207,8 @@ public class AstBuilderTest {
     assertThat(joinLocation.getLineNumber(), is(7));
     assertThat(joinLocation.getColumnNumber(), is(8));
     assertThat(joinLocation.getEndLine(), is(OptionalInt.of(8)));
-    assertThat(joinLocation.getEndColumnNumber(), is(OptionalInt.of(48)));
-    assertThat(joinLocation.getLength(), is(OptionalInt.of(59)));
+    assertThat(joinLocation.getEndColumnNumber(), is(OptionalInt.of(53)));
+    assertThat(joinLocation.getLength(), is(OptionalInt.of(64)));
 
     assertTrue(query.getWindow().isPresent());
     final WindowExpression window = query.getWindow().get();

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
@@ -1180,7 +1180,7 @@ public class AstBuilderTest {
     assertThat(createTableLocation.getLineNumber(), is(1));
     assertThat(createTableLocation.getColumnNumber(), is(1));
     assertThat(createTableLocation.getEndLine(), is(OptionalInt.of(12)));
-    assertThat(createTableLocation.getEndColumnNumber(), is(OptionalInt.of(21)));
+    assertThat(createTableLocation.getEndColumnNumber(), is(OptionalInt.of(("  HAVING COUNT(*) > 0;").length())));
     assertThat(createTableLocation.getLength(), is(OptionalInt.of(statementString.length() - 1)));
 
     final Query query = result.getQuery();
@@ -1189,8 +1189,19 @@ public class AstBuilderTest {
     assertThat(queryLocation.getLineNumber(), is(3));
     assertThat(queryLocation.getColumnNumber(), is(3));
     assertThat(queryLocation.getEndLine(), is(OptionalInt.of(12)));
-    assertThat(queryLocation.getEndColumnNumber(), is(OptionalInt.of(21)));
-    assertThat(queryLocation.getLength(), is(OptionalInt.of(310)));
+    assertThat(queryLocation.getEndColumnNumber(), is(OptionalInt.of(("  HAVING COUNT(*) > 0").length() + 1)));
+    assertThat(queryLocation.getLength(),
+        is(OptionalInt.of((
+            "SELECT C.EMAIL,\n" +
+            "         B.id,\n" +
+            "         B.flight_id,\n" +
+            "         COUNT(*)\n" +
+            "  FROM bookings B\n" +
+            "       INNER JOIN customers C ON B.customer_id = C.id\n" +
+            "  WINDOW TUMBLING (SIZE 1 HOUR, GRACE PERIOD 2 HOURS)\n" +
+            "  WHERE B.customer_id > 0 AND INSTR(C.EMAIL, '@') > 0\n" +
+            "  GROUP BY C.EMAIL, B.ID, B.flight_id\n" +
+            "  HAVING COUNT(*) > 0").length() + 1)));
 
     final Select select = query.getSelect();
     assertTrue(select.getLocation().isPresent());
@@ -1198,8 +1209,9 @@ public class AstBuilderTest {
     assertThat(selectLocation.getLineNumber(), is(3));
     assertThat(selectLocation.getColumnNumber(), is(3));
     assertThat(selectLocation.getEndLine(), is(OptionalInt.of(3)));
-    assertThat(selectLocation.getEndColumnNumber(), is(OptionalInt.of(8)));
-    assertThat(selectLocation.getLength(), is(OptionalInt.of(6)));
+    assertThat(selectLocation.getEndColumnNumber(), is(OptionalInt.of("  SELECT".length() + 1)));
+    assertThat(selectLocation.getLength(),
+        is(OptionalInt.of("SELECT".length())));
 
     final Join join = (Join) query.getFrom();
     assertTrue(join.getLocation().isPresent());
@@ -1207,8 +1219,12 @@ public class AstBuilderTest {
     assertThat(joinLocation.getLineNumber(), is(7));
     assertThat(joinLocation.getColumnNumber(), is(8));
     assertThat(joinLocation.getEndLine(), is(OptionalInt.of(8)));
-    assertThat(joinLocation.getEndColumnNumber(), is(OptionalInt.of(53)));
-    assertThat(joinLocation.getLength(), is(OptionalInt.of(64)));
+    assertThat(joinLocation.getEndColumnNumber(),
+        is(OptionalInt.of(("       INNER JOIN customers C ON B.customer_id = C.id").length() + 1)));
+    assertThat(joinLocation.getLength(),
+        is(OptionalInt.of((
+                   "bookings B\n" +
+            "       INNER JOIN customers C ON B.customer_id = C.id\n").length())));
 
     assertTrue(query.getWindow().isPresent());
     final WindowExpression window = query.getWindow().get();
@@ -1217,8 +1233,9 @@ public class AstBuilderTest {
     assertThat(windowLocation.getLineNumber(), is(9));
     assertThat(windowLocation.getColumnNumber(), is(10));
     assertThat(windowLocation.getEndLine(), is(OptionalInt.of(9)));
-    assertThat(windowLocation.getEndColumnNumber(), is(OptionalInt.of(53)));
-    assertThat(windowLocation.getLength(), is(OptionalInt.of(44)));
+    assertThat(windowLocation.getEndColumnNumber(), is(OptionalInt.of(("TUMBLING (SIZE 1 HOUR, GRACE PERIOD 2 HOURS)").length() + 1)));
+    assertThat(windowLocation.getLength(),
+        is(OptionalInt.of(("TUMBLING (SIZE 1 HOUR, GRACE PERIOD 2 HOURS)\n").length())));
 
     assertTrue(query.getWhere().isPresent());
     final LogicalBinaryExpression where = (LogicalBinaryExpression) query.getWhere().get();
@@ -1237,8 +1254,9 @@ public class AstBuilderTest {
     assertThat(groupByLocation.getLineNumber(), is(11));
     assertThat(groupByLocation.getColumnNumber(), is(12));
     assertThat(groupByLocation.getEndLine(), is(OptionalInt.of(11)));
-    assertThat(groupByLocation.getEndColumnNumber(), is(OptionalInt.of(37)));
-    assertThat(groupByLocation.getLength(), is(OptionalInt.of(26)));
+    assertThat(groupByLocation.getEndColumnNumber(), is(OptionalInt.of("C.EMAIL, B.ID, B.flight_id".length() + 1)));
+    assertThat(groupByLocation.getLength(),
+        is(OptionalInt.of("C.EMAIL, B.ID, B.flight_id\n".length())));
 
     assertTrue(query.getHaving().isPresent());
     final ComparisonExpression having = (ComparisonExpression) query.getHaving().get();

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
@@ -1162,10 +1162,10 @@ public class AstBuilderTest {
 
     // Then:
     final NodeLocation loc = result.getLocation().get();
-    assertThat(loc.getLineNumber(), is(1));
-    assertThat(loc.getColumnNumber(), is(1));
-    assertThat(loc.getEndLine(), is(OptionalInt.of(1)));
-    assertThat(loc.getEndColumnNumber(), is(OptionalInt.of(query.length() - 1)));
+    assertThat(loc.getStartLineNumber(), is(1));
+    assertThat(loc.getStartColumnNumber(), is(1));
+    assertThat(loc.getStopLine(), is(OptionalInt.of(1)));
+    assertThat(loc.getStopColumnNumber(), is(OptionalInt.of(query.length() - 1)));
     assertThat(loc.getLength(), is(OptionalInt.of(query.length() - 1)));
   }
 
@@ -1180,10 +1180,10 @@ public class AstBuilderTest {
 
     // Then:
     final NodeLocation loc = result.getLocation().get();
-    assertThat(loc.getLineNumber(), is(1));
-    assertThat(loc.getColumnNumber(), is(1));
-    assertThat(loc.getEndLine(), is(OptionalInt.of(1)));
-    assertThat(loc.getEndColumnNumber(), is(OptionalInt.of(query.length() - 1)));
+    assertThat(loc.getStartLineNumber(), is(1));
+    assertThat(loc.getStartColumnNumber(), is(1));
+    assertThat(loc.getStopLine(), is(OptionalInt.of(1)));
+    assertThat(loc.getStopColumnNumber(), is(OptionalInt.of(query.length() - 1)));
     assertThat(loc.getLength(), is(OptionalInt.of(query.length() - 1)));
   }
 
@@ -1200,10 +1200,10 @@ public class AstBuilderTest {
 
     // Then:
     final NodeLocation loc = result.getLocation().get();
-    assertThat(loc.getLineNumber(), is(1));
-    assertThat(loc.getColumnNumber(), is(1));
-    assertThat(loc.getEndLine(), is(OptionalInt.of(2)));
-    assertThat(loc.getEndColumnNumber(), is(OptionalInt.of("  SELECT * FROM TEST1".length())));
+    assertThat(loc.getStartLineNumber(), is(1));
+    assertThat(loc.getStartColumnNumber(), is(1));
+    assertThat(loc.getStopLine(), is(OptionalInt.of(2)));
+    assertThat(loc.getStopColumnNumber(), is(OptionalInt.of("  SELECT * FROM TEST1".length())));
     assertThat(loc.getLength(), is(OptionalInt.of(query.length() - 1)));
   }
 
@@ -1218,10 +1218,10 @@ public class AstBuilderTest {
 
     // Then:
     final NodeLocation loc = result.getLocation().get();
-    assertThat(loc.getLineNumber(), is(1));
-    assertThat(loc.getColumnNumber(), is(1));
-    assertThat(loc.getEndLine(), is(OptionalInt.of(1)));
-    assertThat(loc.getEndColumnNumber(), is(OptionalInt.of(query.length() - 1)));
+    assertThat(loc.getStartLineNumber(), is(1));
+    assertThat(loc.getStartColumnNumber(), is(1));
+    assertThat(loc.getStopLine(), is(OptionalInt.of(1)));
+    assertThat(loc.getStopColumnNumber(), is(OptionalInt.of(query.length() - 1)));
     assertThat(loc.getLength(), is(OptionalInt.of(query.length() - 1)));
   }
 
@@ -1236,10 +1236,10 @@ public class AstBuilderTest {
 
     // Then:
     final NodeLocation loc = result.getLocation().get();
-    assertThat(loc.getLineNumber(), is(1));
-    assertThat(loc.getColumnNumber(), is(1));
-    assertThat(loc.getEndLine(), is(OptionalInt.of(1)));
-    assertThat(loc.getEndColumnNumber(), is(OptionalInt.of(query.length() - 1)));
+    assertThat(loc.getStartLineNumber(), is(1));
+    assertThat(loc.getStartColumnNumber(), is(1));
+    assertThat(loc.getStopLine(), is(OptionalInt.of(1)));
+    assertThat(loc.getStopColumnNumber(), is(OptionalInt.of(query.length() - 1)));
     assertThat(loc.getLength(), is(OptionalInt.of(query.length() - 1)));
   }
 
@@ -1258,10 +1258,10 @@ public class AstBuilderTest {
 
     // Then:
     final NodeLocation loc = result.getLocation().get();
-    assertThat(loc.getLineNumber(), is(1));
-    assertThat(loc.getColumnNumber(), is(1));
-    assertThat(loc.getEndLine(), is(OptionalInt.of(4)));
-    assertThat(loc.getEndColumnNumber(), is(OptionalInt.of("  GROUP BY ROWKEY".length())));
+    assertThat(loc.getStartLineNumber(), is(1));
+    assertThat(loc.getStartColumnNumber(), is(1));
+    assertThat(loc.getStopLine(), is(OptionalInt.of(4)));
+    assertThat(loc.getStopColumnNumber(), is(OptionalInt.of("  GROUP BY ROWKEY".length())));
     assertThat(loc.getLength(), is(OptionalInt.of(query.length() - 1)));
   }
 
@@ -1292,19 +1292,19 @@ public class AstBuilderTest {
     assertTrue(result.getLocation().isPresent());
     final NodeLocation createTableLocation = result.getLocation().get();
 
-    assertThat(createTableLocation.getLineNumber(), is(1));
-    assertThat(createTableLocation.getColumnNumber(), is(1));
-    assertThat(createTableLocation.getEndLine(), is(OptionalInt.of(12)));
-    assertThat(createTableLocation.getEndColumnNumber(), is(OptionalInt.of(("  HAVING COUNT(*) > 0").length())));
+    assertThat(createTableLocation.getStartLineNumber(), is(1));
+    assertThat(createTableLocation.getStartColumnNumber(), is(1));
+    assertThat(createTableLocation.getStopLine(), is(OptionalInt.of(12)));
+    assertThat(createTableLocation.getStopColumnNumber(), is(OptionalInt.of(("  HAVING COUNT(*) > 0").length())));
     assertThat(createTableLocation.getLength(), is(OptionalInt.of(statementString.length() - 1)));
 
     final Query query = result.getQuery();
     assertTrue(query.getLocation().isPresent());
     final NodeLocation queryLocation = query.getLocation().get();
-    assertThat(queryLocation.getLineNumber(), is(3));
-    assertThat(queryLocation.getColumnNumber(), is(3));
-    assertThat(queryLocation.getEndLine(), is(OptionalInt.of(12)));
-    assertThat(queryLocation.getEndColumnNumber(), is(OptionalInt.of(("  HAVING COUNT(*) > 0").length())));
+    assertThat(queryLocation.getStartLineNumber(), is(3));
+    assertThat(queryLocation.getStartColumnNumber(), is(3));
+    assertThat(queryLocation.getStopLine(), is(OptionalInt.of(12)));
+    assertThat(queryLocation.getStopColumnNumber(), is(OptionalInt.of(("  HAVING COUNT(*) > 0").length())));
     assertThat(queryLocation.getLength(),
         is(OptionalInt.of((
             "SELECT C.EMAIL,\n" +
@@ -1321,10 +1321,10 @@ public class AstBuilderTest {
     final Select select = query.getSelect();
     assertTrue(select.getLocation().isPresent());
     final NodeLocation selectLocation = select.getLocation().get();
-    assertThat(selectLocation.getLineNumber(), is(3));
-    assertThat(selectLocation.getColumnNumber(), is(3));
-    assertThat(selectLocation.getEndLine(), is(OptionalInt.of(3)));
-    assertThat(selectLocation.getEndColumnNumber(),
+    assertThat(selectLocation.getStartLineNumber(), is(3));
+    assertThat(selectLocation.getStartColumnNumber(), is(3));
+    assertThat(selectLocation.getStopLine(), is(OptionalInt.of(3)));
+    assertThat(selectLocation.getStopColumnNumber(),
         is(OptionalInt.of("  SELECT".length())));
     assertThat(selectLocation.getLength(),
         is(OptionalInt.of("SELECT".length())));
@@ -1332,10 +1332,10 @@ public class AstBuilderTest {
     final Join join = (Join) query.getFrom();
     assertTrue(join.getLocation().isPresent());
     final NodeLocation joinLocation = join.getLocation().get();
-    assertThat(joinLocation.getLineNumber(), is(7));
-    assertThat(joinLocation.getColumnNumber(), is(8));
-    assertThat(joinLocation.getEndLine(), is(OptionalInt.of(8)));
-    assertThat(joinLocation.getEndColumnNumber(),
+    assertThat(joinLocation.getStartLineNumber(), is(7));
+    assertThat(joinLocation.getStartColumnNumber(), is(8));
+    assertThat(joinLocation.getStopLine(), is(OptionalInt.of(8)));
+    assertThat(joinLocation.getStopColumnNumber(),
         is(OptionalInt.of(("       INNER JOIN customers C ON B.customer_id = C.id").length())));
     assertThat(joinLocation.getLength(),
         is(OptionalInt.of((
@@ -1346,10 +1346,10 @@ public class AstBuilderTest {
     final WindowExpression window = query.getWindow().get();
     assertTrue(window.getLocation().isPresent());
     final NodeLocation windowLocation = window.getLocation().get();
-    assertThat(windowLocation.getLineNumber(), is(9));
-    assertThat(windowLocation.getColumnNumber(), is(10));
-    assertThat(windowLocation.getEndLine(), is(OptionalInt.of(9)));
-    assertThat(windowLocation.getEndColumnNumber(),
+    assertThat(windowLocation.getStartLineNumber(), is(9));
+    assertThat(windowLocation.getStartColumnNumber(), is(10));
+    assertThat(windowLocation.getStopLine(), is(OptionalInt.of(9)));
+    assertThat(windowLocation.getStopColumnNumber(),
         is(OptionalInt.of(("  WINDOW TUMBLING (SIZE 1 HOUR, GRACE PERIOD 2 HOURS)").length())));
     assertThat(windowLocation.getLength(),
         is(OptionalInt.of(("TUMBLING (SIZE 1 HOUR, GRACE PERIOD 2 HOURS)").length())));
@@ -1358,20 +1358,20 @@ public class AstBuilderTest {
     final LogicalBinaryExpression where = (LogicalBinaryExpression) query.getWhere().get();
     assertTrue(where.getLocation().isPresent());
     final NodeLocation whereLocation = where.getLocation().get();
-    assertThat(whereLocation.getLineNumber(), is(10));
-    assertThat(whereLocation.getColumnNumber(), is(27));
-    assertThat(whereLocation.getEndLine(), is(OptionalInt.of(10)));
-    assertThat(whereLocation.getEndColumnNumber(), is(OptionalInt.of(29)));
+    assertThat(whereLocation.getStartLineNumber(), is(10));
+    assertThat(whereLocation.getStartColumnNumber(), is(27));
+    assertThat(whereLocation.getStopLine(), is(OptionalInt.of(10)));
+    assertThat(whereLocation.getStopColumnNumber(), is(OptionalInt.of(29)));
     assertThat(whereLocation.getLength(), is(OptionalInt.of(3)));
 
     assertTrue(query.getGroupBy().isPresent());
     final GroupBy groupBy = query.getGroupBy().get();
     assertTrue(groupBy.getLocation().isPresent());
     final NodeLocation groupByLocation = groupBy.getLocation().get();
-    assertThat(groupByLocation.getLineNumber(), is(11));
-    assertThat(groupByLocation.getColumnNumber(), is(12));
-    assertThat(groupByLocation.getEndLine(), is(OptionalInt.of(11)));
-    assertThat(groupByLocation.getEndColumnNumber(),
+    assertThat(groupByLocation.getStartLineNumber(), is(11));
+    assertThat(groupByLocation.getStartColumnNumber(), is(12));
+    assertThat(groupByLocation.getStopLine(), is(OptionalInt.of(11)));
+    assertThat(groupByLocation.getStopColumnNumber(),
         is(OptionalInt.of("  GROUP BY C.EMAIL, B.ID, B.flight_id".length())));
     assertThat(groupByLocation.getLength(),
         is(OptionalInt.of("C.EMAIL, B.ID, B.flight_id".length())));
@@ -1380,10 +1380,10 @@ public class AstBuilderTest {
     final ComparisonExpression having = (ComparisonExpression) query.getHaving().get();
     assertTrue(having.getLocation().isPresent());
     final NodeLocation havingLocation = having.getLocation().get();
-    assertThat(havingLocation.getLineNumber(), is(12));
-    assertThat(havingLocation.getColumnNumber(), is(19));
-    assertThat(havingLocation.getEndLine(), is(OptionalInt.of(12)));
-    assertThat(havingLocation.getEndColumnNumber(), is(OptionalInt.of(19)));
+    assertThat(havingLocation.getStartLineNumber(), is(12));
+    assertThat(havingLocation.getStartColumnNumber(), is(19));
+    assertThat(havingLocation.getStopLine(), is(OptionalInt.of(12)));
+    assertThat(havingLocation.getStopColumnNumber(), is(OptionalInt.of(19)));
     assertThat(havingLocation.getLength(), is(OptionalInt.of(1)));
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
@@ -1153,18 +1153,21 @@ public class AstBuilderTest {
   @Test
   public void shouldGetCorrectLocationsComplexCtas() {
     // Given:
-    final String statementString = "CREATE TABLE customer_bookings\n" +
-        "  WITH (KAFKA_TOPIC = 'customer_bookings', KEY_FORMAT = 'JSON', VALUE_FORMAT = 'JSON') AS\n" +
-        "  SELECT C.EMAIL,\n" +
-        "         B.id,\n" +
-        "         B.flight_id,\n" +
-        "         COUNT(*)\n" +
-        "  FROM bookings B\n" +
-        "  INNER JOIN customers C ON B.customer_id = C.id\n" +
-        "  WINDOW TUMBLING (SIZE 1 HOUR, GRACE PERIOD 2 HOURS)\n" +
-        "  WHERE B.customer_id > 0 AND INSTR(C.EMAIL, '@') > 0\n" +
-        "  GROUP BY C.EMAIL, B.ID, B.flight_id\n" +
-        "  HAVING COUNT(*) > 0;";
+    final String statementString =
+    //   1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
+        "CREATE TABLE customer_bookings\n" +                                                               // 1
+        "  WITH (KAFKA_TOPIC = 'customer_bookings', KEY_FORMAT = 'JSON', VALUE_FORMAT = 'JSON') AS\n" +    // 2
+        "  SELECT C.EMAIL,\n" +                                                                            // 3
+        "         B.id,\n" +                                                                               // 4
+        "         B.flight_id,\n" +                                                                        // 5
+        "         COUNT(*)\n" +                                                                            // 6
+        "  FROM bookings B\n" +                                                                            // 7
+        "  INNER JOIN customers C ON B.customer_id = C.id\n" +                                             // 8
+        "  WINDOW TUMBLING (SIZE 1 HOUR, GRACE PERIOD 2 HOURS)\n" +                                        // 9
+        "  WHERE B.customer_id > 0 AND INSTR(C.EMAIL, '@') > 0\n" +                                        // 10
+        "  GROUP BY C.EMAIL, B.ID, B.flight_id\n" +                                                        // 11
+        "  HAVING COUNT(*) > 0;";                                                                          // 12
+    //   1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
     final SingleStatementContext stmt = givenQuery(statementString);
 
     // When:

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/DescribeConnectorTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/DescribeConnectorTest.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.parser.tree;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
 
 import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.parser.NodeLocation;

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/ListConnectorsTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/ListConnectorsTest.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.parser.tree;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
 
 import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.parser.NodeLocation;

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/PartitionByTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/PartitionByTest.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.parser.NodeLocation;
-import java.util.List;
 import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/util/ParserUtilTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/util/ParserUtilTest.java
@@ -109,9 +109,12 @@ public class ParserUtilTest {
   }
 
   private static void mockLocation(final ParserRuleContext ctx, final int line, final int col) {
-    final Token token = mock(Token.class);
-    when(token.getLine()).thenReturn(line);
-    when(token.getCharPositionInLine()).thenReturn(col);
-    when(ctx.getStart()).thenReturn(token);
+    final Token startToken = mock(Token.class);
+    when(startToken.getLine()).thenReturn(line);
+    when(startToken.getCharPositionInLine()).thenReturn(col);
+    when(ctx.getStart()).thenReturn(startToken);
+
+    final Token stopToken = mock(Token.class);
+    when(ctx.getStop()).thenReturn(stopToken);
   }
 }


### PR DESCRIPTION
### Description 
- Change constructor of `NodeLocation` to:
```java
public NodeLocation(final TokenLocation start, final TokenLocation stop) {
    this.start = start;
    this.stop = stop;
}
```
Take the example SQL:
```sql
CREATE TABLE customer_bookings
  WITH (KAFKA_TOPIC = 'customer_bookings', KEY_FORMAT = 'JSON', VALUE_FORMAT = 'JSON') AS
  SELECT C.EMAIL,
         B.id,
         B.flight_id,
         COUNT(*)
  FROM bookings B
       INNER JOIN customers C ON B.customer_id = C.id
  WINDOW TUMBLING (SIZE 1 HOUR, GRACE PERIOD 2 HOURS)
  WHERE B.customer_id > 0 AND INSTR(C.EMAIL, '@') > 0
  GROUP BY C.EMAIL, B.ID, B.flight_id
  HAVING COUNT(*) > 0;
```
These will be the arguments for the root CTAS statement:
![Screen Shot 2022-08-16 at 9 28 28 PM](https://user-images.githubusercontent.com/19577974/185035476-85c19e1d-2437-440a-90fc-71a8f91a2244.png)

Using these new parameters, 2 new public methods are introduced for `NodeLocation`:
```java
  public OptionalInt getStopLine() {
    return stop.getLine();
  }

  public OptionalInt getStopColumnNumber() {
    return OptionalInt.of(stop.getCharPositionInLine().getAsInt()
        + stop.getStopIndex().getAsInt()
        - stop.getStartIndex().getAsInt()
        + 1);
  }
```
If you were to draw some boxes with co-ords (getStartLine(), getStartColumnNumber(), getStopLine(), getStopColumnNumber()) it would looks like:
![Screen Shot 2022-08-16 at 9 41 17 PM](https://user-images.githubusercontent.com/19577974/185036938-01ae33d2-b40e-4a1f-b132-10df1842b501.png)

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

