### PR TITLE
docs: restore docs for EMIT FINAL syntax (DOCS-15926)

### DIFF
--- a/docs/concepts/time-and-windows-in-ksqldb-queries.md
+++ b/docs/concepts/time-and-windows-in-ksqldb-queries.md
@@ -614,3 +614,27 @@ CREATE TABLE pageviews_per_region AS
 Note that the specified retention period should be larger than the sum of window size and any grace
 period.
 
+### Window final results
+
+In ksqlDB, windowed aggregations update their results continuously. As new data
+arrives for a window, freshly computed results are emitted downstream. For many
+applications, this is ideal, since fresh results are always available, and
+ksqlDB is designed to make programming continuous computations seamless.
+
+However, some applications need to take action only on the final result of a
+windowed computation. Common examples include sending alerts or delivering
+results to a system that doesn't support updates.
+
+Suppose that you have an hourly windowed count of events per user. If you want
+to send an alert when a user has less than three events in an hour, you have a
+real challenge. All users would match this condition at first, until they
+accrue enough events, so you can’t simply send an alert when someone matches
+the condition; you have to wait until you know you won’t see any more events
+for a particular window, and then send the alert.
+
+ksqlDB offers a clean way to define this logic: after defining your windowed
+aggregation, you can suppress the intermediate results, emitting the final
+count for each user when the window is closed.
+
+Specify EMIT FINAL in your SELECT statement to suppress intermediate results.
+

--- a/docs/developer-guide/ksqldb-reference/create-table-as-select.md
+++ b/docs/developer-guide/ksqldb-reference/create-table-as-select.md
@@ -18,7 +18,7 @@ CREATE [OR REPLACE] TABLE table_name
   [ WHERE condition ]
   [ GROUP BY grouping_expression ]
   [ HAVING having_expression ]
-  [ EMIT CHANGES ];
+  [ EMIT output_refinement ];
 ```
 
 ## Description

--- a/docs/developer-guide/ksqldb-reference/quick-reference.md
+++ b/docs/developer-guide/ksqldb-reference/quick-reference.md
@@ -324,6 +324,20 @@ CREATE STREAM stream_name
   EMIT CHANGES;
 ```
 
+## EMIT FINAL
+Specify a push query with a suppressed output refinement in a SELECT statement
+on a windowed aggregation. For more information, see
+[Push Queries](/concepts/queries#push).
+
+```sql
+CREATE TABLE table_name
+  AS SELECT  select_expr_with_aggregation [, ...]
+  FROM from_stream
+  [ WINDOW window_expression ]
+  [ GROUP BY grouping_expression ]
+  EMIT FINAL;
+```
+
 ## EXPLAIN
 Show the execution plan for a SQL expression or running query. For more
 information, see [EXPLAIN](../../ksqldb-reference/explain).

--- a/docs/developer-guide/ksqldb-reference/select-push-query.md
+++ b/docs/developer-guide/ksqldb-reference/select-push-query.md
@@ -65,15 +65,26 @@ For more information, see
 
 ### EMIT
 
-The EMIT clause lets you control the output refinement of your push query. The output refinement is
-how you would like to *emit* your results. 
+The EMIT clause lets you control the output refinement of your push query. The
+output refinement is how you would like to *emit* your results. 
 
 ksqlDB supports the following output refinement types.
 
-### CHANGES
+#### CHANGES
 
-This is the standard output refinement for push queries, for when we would like to see all changes 
-happening.
+This is the standard output refinement for push queries, for when you would
+like to see all changes happening.
+
+#### FINAL
+
+Use the EMIT FINAL output refinement when you want to emit only the final
+result of a windowed aggregation and suppress the intermediate results until
+the window closes. This output refinement is supported only for windowed
+aggregations.
+
+!!! note
+    EMIT `output_refinement` defaults to CHANGES unless explicitly set to FINAL on
+    a windowed aggregation.
 
 
 ## Examples

--- a/docs/reference/server-configuration.md
+++ b/docs/reference/server-configuration.md
@@ -871,6 +871,13 @@ Sets the maximum number of concurrent pull queries. This limit is enforced per h
 After hitting the limit, the host will fail pull query requests until it determines that it's no longer
 at the limit.
 
+## `ksql.suppress.enabled`
+
+**Per query:** yes
+
+Enable the EMIT FINAL output refinement in a SELECT statement to suppress
+intermediate results on a windowed aggregation. The default is `true`.
+
 ## `ksql.idle.connection.timeout.seconds`
 
 **Per query:** no

--- a/docs/reference/sql/appendix.md
+++ b/docs/reference/sql/appendix.md
@@ -46,6 +46,7 @@ The following table shows all keywords in the language.
 | `EXPLAIN`      | show execution plan                                            | `EXPLAIN <query-name>;` or `EXPLAIN <expression>;`                    |
 | `EXTENDED`     | list details for object(s)                                     | `DESCRIBE <stream-name> EXTENDED;`                                    |
 | `FALSE`        | Boolean value of false                                         |                                                                       |
+| `FINAL`        | suppress intermediate results on a windowed aggregation        | `SELECT * FROM users EMIT FINAL;`
 | `FROM`         | specify record source for queries                              | `SELECT * FROM users;`                                                |
 | `FULL`         | specify `FULL JOIN`                                            | `CREATE TABLE t AS SELECT * FROM l FULL OUTER JOIN r ON l.ID = r.ID;` |
 | `FUNCTION`     | list details for a function                                    | `DESCRIBE FUNCTION <function-name>;`                                  |


### PR DESCRIPTION
Restored and updated from https://github.com/confluentinc/ksql/pull/6528/.