### PR TITLE
fix: allow assert values command to check partial columns

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/AssertExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/AssertExecutor.java
@@ -167,7 +167,7 @@ public final class AssertExecutor {
       final boolean isTombstone
   ) {
     final DataSource dataSource = engine.getMetaStore().getSource(values.getTarget());
-    KsqlGenericRecord expected = new GenericRecordFactory(
+    final KsqlGenericRecord expected = new GenericRecordFactory(
         config, engine.getMetaStore(), System::currentTimeMillis
     ).build(
         values.getColumns(),

--- a/ksqldb-functional-tests/src/test/resources/sql-tests/test.sql
+++ b/ksqldb-functional-tests/src/test/resources/sql-tests/test.sql
@@ -257,3 +257,18 @@ INSERT INTO foo (rowtime, id, col1) VALUES (1, 3, 1);
 ASSERT VALUES foo (rowtime, id, col1) VALUES (1, 2, 1);
 ASSERT VALUES foo (rowtime, id, col1) VALUES (1, 1, 1);
 ASSERT VALUES foo (rowtime, id, col1) VALUES (1, 3, 1);
+
+----------------------------------------------------------------------------------------------------
+--@test: assert a subset of columns
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT, col2 STRING) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar AS SELECT * FROM foo;
+
+INSERT INTO foo (rowtime, id, col1, col2) VALUES (1, 2, 3, 'ABC');
+ASSERT VALUES bar (col1) VALUES (3);
+INSERT INTO foo (rowtime, id, col1, col2) VALUES (1, 2, 3, 'ABC');
+ASSERT VALUES bar (col2, col1) VALUES ('ABC', 3);
+INSERT INTO foo (rowtime, id, col1, col2) VALUES (1, 2, 3, 'ABC');
+ASSERT VALUES bar (col2, rowtime, id) VALUES ('ABC', 1, 2);
+INSERT INTO foo (rowtime, id, col1, col2) VALUES (1, 2, 3, 'ABC');
+ASSERT VALUES bar (col1, id) VALUES (3, 2);

--- a/ksqldb-functional-tests/src/test/resources/sql-tests/test.sql
+++ b/ksqldb-functional-tests/src/test/resources/sql-tests/test.sql
@@ -272,3 +272,17 @@ INSERT INTO foo (rowtime, id, col1, col2) VALUES (1, 2, 3, 'ABC');
 ASSERT VALUES bar (col2, rowtime, id) VALUES ('ABC', 1, 2);
 INSERT INTO foo (rowtime, id, col1, col2) VALUES (1, 2, 3, 'ABC');
 ASSERT VALUES bar (col1, id) VALUES (3, 2);
+
+----------------------------------------------------------------------------------------------------
+--@test: assert tombstones
+--@expected.error: java.lang.AssertionError
+--@expected.message: Expected record does not match actual
+----------------------------------------------------------------------------------------------------
+CREATE TABLE a (id INT PRIMARY KEY, col1 INT) WITH (kafka_topic='a', value_format='JSON');
+CREATE TABLE b AS SELECT * FROM a WHERE col1 > 0;
+
+INSERT INTO a (id, col1) VALUES (1, 0);
+INSERT INTO a (id, col1) VALUES (2, 2);
+
+ASSERT NULL VALUES b (id) KEY (1);
+ASSERT NULL VALUES b (id) KEY (2);


### PR DESCRIPTION
### Description 
Make the assert executor only check the values of the columns specified in the assert command instead of the entire record.
Fixes #6056

### Testing done 
Added a YATT test.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

