### PR TITLE
remove cc-docker-ksql from downstream builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ common {
     dockerPush = false
     dockerScan = false
     dockerImageClean = false
-    downStreamRepos = ["confluent-security-plugins", "confluent-cloud-plugins", "cc-docker-ksql"]
+    downStreamRepos = ["confluent-security-plugins", "confluent-cloud-plugins"]
     downStreamValidate = false
     nanoVersion = true
     maxBuildsToKeep = 99


### PR DESCRIPTION
remove cc-docker-ksql from downstream builds for 7.3.x as we
don't cut cp release branches for cc-docker-ksql.
