### PR TITLE
refactor: add 'keySchemaId' and 'valueSchemaId'  on QTT/topics sections

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/PostConditionsNode.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/PostConditionsNode.java
@@ -177,6 +177,8 @@ public final class PostConditionsNode {
     private final KeyFormat keyFormat;
     private final ValueFormat valueFormat;
     private final OptionalInt partitions;
+    final Optional<Integer> keySchemaId;
+    final Optional<Integer> valueSchemaId;
     private final JsonNode keySchema;
     private final JsonNode valueSchema;
 
@@ -185,6 +187,8 @@ public final class PostConditionsNode {
         @JsonProperty(value = "keyFormat", required = true) final KeyFormat keyFormat,
         @JsonProperty(value = "valueFormat", required = true) final ValueFormat valueFormat,
         @JsonProperty(value = "partitions") final OptionalInt partitions,
+        @JsonProperty(value = "keySchemaId") final Optional<Integer> keySchemaId,
+        @JsonProperty(value = "valueSchemaId") final Optional<Integer> valueSchemaId,
         @JsonProperty(value = "keySchema") final JsonNode keySchema,
         @JsonProperty(value = "valueSchema") final JsonNode valueSchema
     ) {
@@ -192,6 +196,8 @@ public final class PostConditionsNode {
       this.keyFormat = requireNonNull(keyFormat, "KeyFormat");
       this.valueFormat = requireNonNull(valueFormat, "valueFormat");
       this.partitions = requireNonNull(partitions, "partitions");
+      this.keySchemaId = requireNonNull(keySchemaId, "keySchemaId");
+      this.valueSchemaId = requireNonNull(valueSchemaId, "valueSchemaId");
       this.keySchema = keySchema;
       this.valueSchema = valueSchema;
 
@@ -230,6 +236,8 @@ public final class PostConditionsNode {
               && Objects.equals(keyFormat, that.keyFormat)
               && Objects.equals(valueFormat, that.valueFormat)
               && (!partitions.isPresent() || partitions.equals(that.partitions))
+              && Objects.equals(keySchemaId, that.keySchemaId)
+              && Objects.equals(valueSchemaId, that.valueSchemaId)
               && (keySchema == null || keySchema instanceof NullNode
               || keySchema.equals(that.keySchema))
               && (valueSchema == null || valueSchema instanceof NullNode
@@ -256,6 +264,14 @@ public final class PostConditionsNode {
       return partitions;
     }
 
+    public Optional<Integer> getKeySchemaId() {
+      return keySchemaId;
+    }
+
+    public Optional<Integer> getValueSchemaId() {
+      return valueSchemaId;
+    }
+
     @JsonInclude(Include.NON_NULL)
     public JsonNode getKeySchema() {
       return keySchema instanceof NullNode ? null : keySchema;
@@ -266,8 +282,11 @@ public final class PostConditionsNode {
       return valueSchema instanceof NullNode ? null : valueSchema;
     }
 
+    // CHECKSTYLE_RULES.OFF: CyclomaticComplexity
     @Override
     public boolean equals(final Object o) {
+      // CHECKSTYLE_RULES.ON: CyclomaticComplexity
+
       if (this == o) {
         return true;
       }
@@ -279,13 +298,16 @@ public final class PostConditionsNode {
           && Objects.equals(keyFormat, that.keyFormat)
           && Objects.equals(valueFormat, that.valueFormat)
           && Objects.equals(partitions, that.partitions)
+          && Objects.equals(keySchemaId, that.keySchemaId)
+          && Objects.equals(valueSchemaId, that.valueSchemaId)
           && Objects.equals(keySchema, that.keySchema)
           && Objects.equals(valueSchema, that.valueSchema);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(name, keyFormat, valueFormat, partitions, keySchema, valueSchema);
+      return Objects.hash(name, keyFormat, valueFormat, partitions,
+          keySchemaId, valueSchemaId, keySchema, valueSchema);
     }
 
     @Override

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/TopicNode.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/TopicNode.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.test.tools.TestJsonMapper;
 import io.confluent.ksql.test.tools.Topic;
 import io.confluent.ksql.test.tools.exceptions.InvalidFieldException;
 import io.confluent.ksql.test.utils.SerdeUtil;
+import java.util.Optional;
 
 @JsonInclude(Include.NON_EMPTY)
 public final class TopicNode {
@@ -37,6 +38,8 @@ public final class TopicNode {
   private static final ObjectMapper OBJECT_MAPPER = TestJsonMapper.INSTANCE.get();
 
   private final String name;
+  private final Optional<Integer> keySchemaId;
+  private final Optional<Integer> valueSchemaId;
   private final JsonNode keySchema;
   private final JsonNode valueSchema;
   private final int numPartitions;
@@ -46,8 +49,11 @@ public final class TopicNode {
   private final SerdeFeatures keySerdeFeatures;
   private final SerdeFeatures valueSerdeFeatures;
 
+  // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
   public TopicNode(
       @JsonProperty("name") final String name,
+      @JsonProperty("keySchemaId") final Optional<Integer> keySchemaId,
+      @JsonProperty("valueSchemaId") final Optional<Integer> valueSchemaId,
       @JsonProperty("keySchema") final JsonNode keySchema,
       @JsonProperty("valueSchema") final JsonNode valueSchema,
       @JsonProperty("keyFormat") final String keyFormat,
@@ -57,8 +63,11 @@ public final class TopicNode {
       @JsonProperty("keySerdeFeatures") final SerdeFeatures keySerdeFeatures,
       @JsonProperty("valueSerdeFeatures") final SerdeFeatures valueSerdeFeatures
   ) {
+    // CHECKSTYLE_RULES.ON: ParameterNumberCheck
 
     this.name = name == null ? "" : name;
+    this.keySchemaId = keySchemaId;
+    this.valueSchemaId = valueSchemaId;
     this.keySchema = keySchema;
     this.valueSchema = valueSchema;
     this.keyFormat = keyFormat;
@@ -79,6 +88,14 @@ public final class TopicNode {
 
   public String getName() {
     return name;
+  }
+
+  public Optional<Integer> getKeySchemaId() {
+    return keySchemaId;
+  }
+
+  public Optional<Integer> getValueSchemaId() {
+    return valueSchemaId;
   }
 
   @JsonInclude(Include.NON_NULL)
@@ -120,6 +137,8 @@ public final class TopicNode {
         name,
         numPartitions,
         replicas,
+        keySchemaId,
+        valueSchemaId,
         SerdeUtil.buildSchema(keySchema, keyFormat),
         SerdeUtil.buildSchema(valueSchema, valueFormat),
         keySerdeFeatures,
@@ -137,6 +156,8 @@ public final class TopicNode {
 
     return new TopicNode(
         topic.getName(),
+        topic.getKeySchemaId(),
+        topic.getValueSchemaId(),
         topic.getKeySchema()
             .map(schema -> buildSchemaNode(schema, keyFormat))
             .orElseGet(NullNode::getInstance),

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilderUtil.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilderUtil.java
@@ -147,6 +147,11 @@ public final class TestCaseBuilderUtil {
                 topic.getNumPartitions(),
                 topic.getReplicas(),
 
+                // key/value schema ID (if not empty) should be related to the key/value schema
+                // already found in the 'Topic', not in the 'topicFromStatement'
+                topic.getKeySchemaId(),
+                topic.getValueSchemaId(),
+
                 // Use the key/value schema built for the CREATE statement
                 keySchema,
                 valueSchema,
@@ -256,8 +261,17 @@ public final class TestCaseBuilderUtil {
     final short rf = props.getReplicas()
         .orElse(Topic.DEFAULT_RF);
 
-    return Optional.of(new Topic(props.getKafkaTopic(), partitions, rf, keySchema, valueSchema,
-        keySerdeFeats, valSerdeFeats));
+    return Optional.of(new Topic(
+        props.getKafkaTopic(),
+        partitions,
+        rf,
+        // key/value schemas IDs do not exist if schema is found on the statement
+        Optional.empty(),
+        Optional.empty(),
+        keySchema,
+        valueSchema,
+        keySerdeFeats,
+        valSerdeFeats));
   }
 
   private static Optional<ParsedSchema> buildSchema(

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/Topic.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/Topic.java
@@ -30,6 +30,8 @@ public class Topic {
   private final String name;
   private final int numPartitions;
   private final short replicas;
+  final Optional<Integer> keySchemaId;
+  final Optional<Integer> valueSchemaId;
   private final Optional<ParsedSchema> keySchema;
   private final Optional<ParsedSchema> valueSchema;
   private final SerdeFeatures keyFeatures;
@@ -40,20 +42,24 @@ public class Topic {
       final Optional<ParsedSchema> keySchema,
       final Optional<ParsedSchema> valueSchema
   ) {
-    this(name, DEFAULT_PARTITIONS, DEFAULT_RF, keySchema, valueSchema,
-        SerdeFeatures.of(), SerdeFeatures.of());
+    this(name, DEFAULT_PARTITIONS, DEFAULT_RF, Optional.empty(), Optional.empty(),
+        keySchema, valueSchema, SerdeFeatures.of(), SerdeFeatures.of());
   }
 
   public Topic(
       final String name,
       final int numPartitions,
       final int replicas,
+      final Optional<Integer> keySchemaId,
+      final Optional<Integer> valueSchemaId,
       final Optional<ParsedSchema> keySchema,
       final Optional<ParsedSchema> valueSchema,
       final SerdeFeatures keyFeatures,
       final SerdeFeatures valueFeatures
   ) {
     this.name = requireNonNull(name, "name");
+    this.keySchemaId = requireNonNull(keySchemaId, "keySchemaId");
+    this.valueSchemaId = requireNonNull(valueSchemaId, "valueSchemaId");
     this.keySchema = requireNonNull(keySchema, "keySchema");
     this.valueSchema = requireNonNull(valueSchema, "valueSchema");
     this.numPartitions = numPartitions;
@@ -64,6 +70,14 @@ public class Topic {
 
   public String getName() {
     return name;
+  }
+
+  public Optional<Integer> getKeySchemaId() {
+    return keySchemaId;
+  }
+
+  public Optional<Integer> getValueSchemaId() {
+    return valueSchemaId;
   }
 
   public Optional<ParsedSchema> getKeySchema() {
@@ -103,12 +117,15 @@ public class Topic {
     return numPartitions == topic.numPartitions
         && replicas == topic.replicas
         && Objects.equals(name, topic.name)
+        && Objects.equals(keySchemaId, topic.keySchemaId)
+        && Objects.equals(valueSchemaId, topic.valueSchemaId)
         && Objects.equals(keySchema, topic.keySchema)
         && Objects.equals(valueSchema, topic.valueSchema);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, numPartitions, replicas, keySchema, valueSchema);
+    return Objects.hash(name, numPartitions, replicas, keySchemaId,
+        valueSchemaId, keySchema, valueSchema);
   }
 }

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/model/PostConditionsNodeTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/model/PostConditionsNodeTest.java
@@ -44,7 +44,9 @@ public class PostConditionsNodeTest {
     final PostTopicsNode topics = new PostTopicsNode(
         Optional.of(".*repartition"),
         Optional.of(ImmutableList.of(
-            new PostTopicNode("t1", KEY_FORMAT, VALUE_FORMAT, PARTITION_COUNT, JsonNodeFactory.instance.textNode("a"), JsonNodeFactory.instance.textNode("b"))
+            new PostTopicNode("t1", KEY_FORMAT, VALUE_FORMAT, PARTITION_COUNT,
+                Optional.of(1), Optional.of(2),
+                JsonNodeFactory.instance.textNode("a"), JsonNodeFactory.instance.textNode("b"))
         ))
     );
 

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/StubKafkaServiceTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/StubKafkaServiceTest.java
@@ -70,6 +70,8 @@ public class StubKafkaServiceTest {
         topic.getName(),
         topic.getNumPartitions() + 1,
         topic.getReplicas() + 1,
+        topic.getKeySchemaId(),
+        topic.getValueSchemaId(),
         topic.getKeySchema(),
         topic.getValueSchema(),
         topic.getKeyFeatures(),

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
@@ -498,6 +498,8 @@ public class TestExecutorTest {
                 KeyFormat.nonWindowed(FormatInfo.of("Kafka"), SerdeFeatures.of()),
                 ValueFormat.of(FormatInfo.of("Json"), SerdeFeatures.of()),
                 OptionalInt.empty(),
+                Optional.empty(),
+                Optional.empty(),
                 NullNode.getInstance(),
                 NullNode.getInstance()
             )


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_
This is part of supporting schema references on QTT. First part is to add `keySchemaId` and `valueSchemaId` to the `topics` section in QTT tests. 

For example:

```
"statements": [
        "CREATE STREAM INPUT WITH (kafka_topic='input', value_format='PROTOBUF', value_schema_id=5);",
        "CREATE STREAM OUTPUT as SELECT * from INPUT;"
      ]
"topics": [
        {
          "name": "input",
          "valueSchemaId": 5,
          "valueFormat": "PROTOBUF",
          "valueSchema": "syntax = \"proto3\";\n\nmessage Event {\n int64 timestamp = 1;\n}"
        }
      ]
```

Currently, the ID specified in the CREATE statement is confusing 'cause the subjects ID do not exist yet. Seems we need to start with `1` and `2` if one key and key value schema are part of the `topics` section. You cannot set any other ID. This PR lets you register a schema from the `topic` section using an ID specified in the `keySchemaId` or `valueSchemaId` so they can be used in the CREATE statement.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

