### PR TITLE
fix: only use the internal topic id for the shared runtimes without a… (#9470)

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -575,16 +575,12 @@ final class QueryBuilder {
         ThroughputMetricsReporter.class.getName()
     );
 
-    final String type = queryId.isPresent() && queryId.get().toString().contains("transient")
-        ? queryId.get().toString()
-        : QueryApplicationId.PERSISTENT_QUERY_INDICATOR;
-
-    if (config.getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)
-        && type.equals(QueryApplicationId.PERSISTENT_QUERY_INDICATOR)) {
+    if (!queryId.isPresent()) {
+      //QueryId is empty for shared runtimes when building the runtime
       newStreamsProperties.put(StreamsConfig.InternalConfig.TOPIC_PREFIX_ALTERNATIVE,
           ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX
               + config.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)
-              + type);
+              + QueryApplicationId.PERSISTENT_QUERY_INDICATOR);
     }
 
     // Passing shared state into managed components

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -77,6 +78,7 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.processor.internals.namedtopology.AddNamedTopologyResult;
@@ -321,6 +323,11 @@ public class QueryBuilderTest {
     assertThat(queryMetadata.getProcessingLogger(), equalTo(uncaughtProcessingLogger));
     assertThat(queryMetadata.getPersistentQueryType(),
         equalTo(KsqlConstants.PersistentQueryType.CREATE_AS));
+    // queries in dedicated runtimes must not include alternative topic prefix
+    assertThat(
+        queryMetadata.getStreamsProperties().get(InternalConfig.TOPIC_PREFIX_ALTERNATIVE),
+        is(nullValue())
+    );
   }
 
   @Test


### PR DESCRIPTION
* fix: only use the internal topic id for the shared runtimes without a query id

* add case for prefix alt for old runtime

* remove type

Co-authored-by: Rohan <desai.p.rohan@gmail.com>