### PR TITLE
test: verify change log is named correctly

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
@@ -95,7 +95,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class QueryBuilderTest {
 
   private static final String STATEMENT_TEXT = "KSQL STATEMENT";
@@ -361,7 +361,6 @@ public class QueryBuilderTest {
     assertThat(queryMetadata.getDataSourceType().get(), equalTo(DataSourceType.KSTREAM));
     assertThat(queryMetadata.getExecutionPlan(), equalTo(SUMMARY));
     assertThat(queryMetadata.getTopology(), is(namedTopology));
-    assertThat(queryMetadata.getStreamsProperties(), equalTo(capturedStreamsProperties()));
     assertThat(queryMetadata.getOverriddenProperties(), equalTo(OVERRIDES));
     assertThat(queryMetadata.getProcessingLogger(), equalTo(uncaughtProcessingLogger));
     assertThat(queryMetadata.getPersistentQueryType(),

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
@@ -287,6 +287,7 @@ public class QueryBuilderTest {
     assertThat(queryMetadata.getOverriddenProperties(), equalTo(OVERRIDES));
     verify(kafkaStreamsBuilder).build(any(), propertyCaptor.capture());
     assertThat(queryMetadata.getStreamsProperties(), equalTo(propertyCaptor.getValue()));
+    assertThat(queryMetadata.getStreamsProperties().get(InternalConfig.TOPIC_PREFIX_ALTERNATIVE), nullValue());
   }
 
   @Test
@@ -363,6 +364,7 @@ public class QueryBuilderTest {
     assertThat(queryMetadata.getProcessingLogger(), equalTo(uncaughtProcessingLogger));
     assertThat(queryMetadata.getPersistentQueryType(),
         equalTo(KsqlConstants.PersistentQueryType.INSERT));
+    assertThat(queryMetadata.getStreamsProperties().get(InternalConfig.TOPIC_PREFIX_ALTERNATIVE), nullValue());
   }
 
   @Test
@@ -403,6 +405,8 @@ public class QueryBuilderTest {
 
     // Then:
     assertThat(result.get(), is(materialization));
+    assertThat(queryMetadata.getStreamsProperties().get(InternalConfig.TOPIC_PREFIX_ALTERNATIVE),
+        is("_confluent-ksql-service-query"));
   }
 
   @Test


### PR DESCRIPTION

### Testing done 
Make sure the change log is named correctly in Gen1, Gen2 and with Gen1 queries running in Gen2  env.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

