### PR TITLE
feat: Support `Object` as the type parameter for a UDAF variadic column argument

### DIFF
--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -1110,6 +1110,28 @@ public class CliTest {
   }
 
   @Test
+  public void shouldDescribeVariadicObjectAggregateFunction() {
+    final String expectedSummary =
+            "Name        : OBJ_COL_ARG\n"
+                    + "Author      : Confluent\n"
+                    + "Overview    : Returns an array of rows where all the given columns are non-null.\n"
+                    + "Type        : AGGREGATE\n"
+                    + "Jar         : internal\n"
+                    + "Variations  : \n";
+
+    final String expectedVariant =
+            "\tVariation   : OBJ_COL_ARG(val1 INT, val2 ANY[])\n"
+                    + "\tReturns     : ARRAY<INT>\n"
+                    + "\tDescription : Testing factory";
+
+    localCli.handleLine("describe function obj_col_arg;");
+
+    final String output = terminal.getOutputString();
+    assertThat(output, containsString(expectedSummary));
+    assertThat(output, containsString(expectedVariant));
+  }
+
+  @Test
   public void shouldDescribeTableFunction() {
     final String expectedOutput =
         "Name        : EXPLODE\n"

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
@@ -105,6 +105,7 @@ public class UdfIndex<T extends FunctionSignature> {
   //               Gist: https://gist.github.com/reneesoika/2ec934940c98dad6b0f68c89769fbe42
 
   private static final Logger LOG = LoggerFactory.getLogger(UdfIndex.class);
+  private static final ParamType OBJ_VAR_ARG = ArrayType.of(ParamTypes.ANY);
 
   private final String udfName;
   private final Node root = new Node();
@@ -497,8 +498,6 @@ public class UdfIndex<T extends FunctionSignature> {
   }
 
   private final class Node {
-    private final ParamType objVarArg = ArrayType.of(ParamTypes.ANY);
-
     @VisibleForTesting
     private final Comparator<T> compareFunctions =
         Comparator.nullsFirst(
@@ -508,7 +507,7 @@ public class UdfIndex<T extends FunctionSignature> {
                 .thenComparing(fun -> -countGenerics(fun))
                 .thenComparing(fun ->
                         fun.parameters().stream().anyMatch(
-                                (param) -> param.equals(objVarArg)
+                                (param) -> param.equals(OBJ_VAR_ARG)
                         )
                         ? 0 : 1
                 ).thenComparing(this::indexOfVariadic)
@@ -555,7 +554,7 @@ public class UdfIndex<T extends FunctionSignature> {
     private int countGenerics(final T function) {
       return function.parameters().stream()
           .filter((param) -> GenericsUtil.hasGenerics(param)
-                  || param.equals(objVarArg))
+                  || param.equals(OBJ_VAR_ARG))
           .mapToInt(p -> 1)
           .sum();
     }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/types/AnyType.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/types/AnyType.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.types;
+
+public final class AnyType extends ObjectType {
+  public static final AnyType INSTANCE = new AnyType();
+
+  @Override
+  public int hashCode() {
+    return 11;
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    return obj instanceof AnyType;
+  }
+
+  @Override
+  public String toString() {
+    return "ANY";
+  }
+}

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/types/ParamTypes.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/types/ParamTypes.java
@@ -45,6 +45,7 @@ public final class ParamTypes {
   public static final TimestampType TIMESTAMP = TimestampType.INSTANCE;
   public static final IntervalUnitType INTERVALUNIT = IntervalUnitType.INSTANCE;
   public static final BytesType BYTES = BytesType.INSTANCE;
+  public static final AnyType ANY = AnyType.INSTANCE;
 
   public static boolean areCompatible(final SqlArgument actual, final ParamType declared) {
     return areCompatible(actual, declared, false);
@@ -59,6 +60,10 @@ public final class ParamTypes {
   ) {
     // CHECKSTYLE_RULES.ON: CyclomaticComplexity
     // CHECKSTYLE_RULES.ON: NPathComplexity
+    if (declared instanceof AnyType) {
+      return true;
+    }
+
     final Optional<SqlLambda> sqlLambdaOptional = argument.getSqlLambda();
 
     if (sqlLambdaOptional.isPresent() && declared instanceof LambdaType) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafTypes.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafTypes.java
@@ -145,7 +145,7 @@ class UdafTypes {
     final int indexOfFirstObj = indexOfType(inputTypes, Object.class);
     final boolean objArgIsNotVariadic = indexOfFirstObj >= 0 && indexOfFirstObj != variadicColIndex;
     if (hasMultipleObjectArgs || objArgIsNotVariadic) {
-      throw new KsqlException("The Object type can only be used in a variadic column argument");
+      throw new KsqlException("The Object type can only be used as a variadic column argument");
     }
 
     this.aggregateType = type.getActualTypeArguments()[1];

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafTypes.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafTypes.java
@@ -123,7 +123,7 @@ class UdafTypes {
       throw new KsqlException("A UDAF and its factory can have at most one variadic argument");
     }
 
-    variadicColIndex = indexOfVariadic(inputTypes);
+    variadicColIndex = indexOfType(inputTypes, VARIADIC_TYPE);
     if (method.isVarArgs()) {
       this.isVariadic = true;
     } else if (isMultipleArgs && variadicColIndex > -1) {
@@ -140,15 +140,23 @@ class UdafTypes {
       this.isVariadic = false;
     }
 
+    // Disallow an object type outside a variadic column
+    final boolean hasMultipleObjectArgs = countTypes(inputTypes, Object.class) > 1;
+    final int indexOfFirstObj = indexOfType(inputTypes, Object.class);
+    final boolean objArgIsNotVariadic = indexOfFirstObj >= 0 && indexOfFirstObj != variadicColIndex;
+    if (hasMultipleObjectArgs || objArgIsNotVariadic) {
+      throw new KsqlException("The Object type can only be used in a variadic column argument");
+    }
+
     this.aggregateType = type.getActualTypeArguments()[1];
     this.outputType = type.getActualTypeArguments()[2];
 
     this.literalParams = FunctionLoaderUtils
         .createParameters(method, functionName.text(), sqlTypeParser);
 
-    validateTypes(inputTypes);
-    validateType(aggregateType);
-    validateType(outputType);
+    validateTypes(inputTypes, variadicColIndex);
+    validateType(aggregateType, false);
+    validateType(outputType, false);
   }
 
   List<ParameterInfo> getInputSchema(final String[] inSchemas) {
@@ -161,9 +169,11 @@ class UdafTypes {
 
       validateStructAnnotation(inputType, schema, "paramSchema");
 
-      ParamType paramType = getSchemaFromType(inputType, schema);
+      final ParamType paramType;
       if (paramIndex == variadicColIndex) {
-        paramType = ArrayType.of(paramType);
+        paramType = ArrayType.of(getSchemaFromType(inputType, schema, true));
+      } else {
+        paramType = getSchemaFromType(inputType, schema, false);
       }
 
       paramTypes.add(paramType);
@@ -189,12 +199,12 @@ class UdafTypes {
 
   ParamType getAggregateSchema(final String aggSchema) {
     validateStructAnnotation(aggregateType, aggSchema, "aggregateSchema");
-    return getSchemaFromType(aggregateType, aggSchema);
+    return getSchemaFromType(aggregateType, aggSchema, false);
   }
 
   ParamType getOutputSchema(final String outSchema) {
     validateStructAnnotation(outputType, outSchema, "returnSchema");
-    return getSchemaFromType(outputType, outSchema);
+    return getSchemaFromType(outputType, outSchema, false);
   }
 
   boolean isVariadic() {
@@ -205,20 +215,22 @@ class UdafTypes {
     return ImmutableList.copyOf(literalParams);
   }
 
-  private void validateType(final Type t) {
-    if (!(t instanceof TypeVariable) && isUnsupportedType((Class<?>) getRawType(t))) {
+  private void validateType(final Type t, final boolean isVariadic) {
+    if (!(t instanceof TypeVariable)
+            && isUnsupportedType((Class<?>) getRawType(t), isVariadic)) {
+
       throw new KsqlException(String.format(invalidClassErrorMsg, t));
     }
   }
 
-  private void validateTypes(final Type[] types) {
-    for (Type type : types) {
-      validateType(type);
+  private void validateTypes(final Type[] types, final int variadicColIndex) {
+    for (int index = 0; index < types.length; index++) {
+      validateType(types[index], index == variadicColIndex);
     }
   }
 
   private static long countVariadic(final Type[] types, final Method factory) {
-    long count = Arrays.stream(types).filter((type) -> getRawType(type) == VARIADIC_TYPE).count();
+    long count = countTypes(types, VARIADIC_TYPE);
 
     /* If there is a variadic initial argument, include it in the total number of variadic
     arguments. We need to include this because there can only be one variadic argument in
@@ -230,9 +242,13 @@ class UdafTypes {
     return count;
   }
 
-  private static int indexOfVariadic(final Type[] types) {
+  private static long countTypes(final Type[] types, final Type matchType) {
+    return Arrays.stream(types).filter((type) -> getRawType(type).equals(matchType)).count();
+  }
+
+  private static int indexOfType(final Type[] types, final Type matchType) {
     return IntStream.range(0, types.length)
-            .filter((index) -> getRawType(types[index]) == VARIADIC_TYPE)
+            .filter((index) -> getRawType(types[index]).equals(matchType))
             .findFirst()
             .orElse(-1);
   }
@@ -248,11 +264,15 @@ class UdafTypes {
     }
   }
 
-  private ParamType getSchemaFromType(final Type type, final String schema) {
-    return schema.isEmpty()
-        ? UdfUtil.getSchemaFromType(type)
-        : SchemaConverters.sqlToFunctionConverter().toFunctionType(
-            sqlTypeParser.parse(schema).getSqlType());
+  private ParamType getSchemaFromType(final Type type, final String schema,
+                                      final boolean isVariadic) {
+    if (schema.isEmpty()) {
+      return isVariadic ? UdfUtil.getVarArgsSchemaFromType(type) : UdfUtil.getSchemaFromType(type);
+    }
+
+    return SchemaConverters.sqlToFunctionConverter().toFunctionType(
+            sqlTypeParser.parse(schema).getSqlType()
+    );
   }
 
   private static Type getRawType(final Type type) {
@@ -262,14 +282,16 @@ class UdafTypes {
     return type;
   }
 
-  static boolean isUnsupportedType(final Class<?> type) {
+  @SuppressWarnings("checkstyle:BooleanExpressionComplexity")
+  private static boolean isUnsupportedType(final Class<?> type, final boolean allowObject) {
     return !SUPPORTED_TYPES.contains(type)
         && (!type.isArray() || !SUPPORTED_TYPES.contains(type.getComponentType()))
-        && SUPPORTED_TYPES.stream().noneMatch(supported -> supported.isAssignableFrom(type));
+        && SUPPORTED_TYPES.stream().noneMatch(supported -> supported.isAssignableFrom(type))
+        && (!allowObject || !type.equals(Object.class));
   }
 
   static void checkSupportedType(final Method method, final Class<?> type) {
-    if (UdafTypes.isUnsupportedType(type)) {
+    if (UdafTypes.isUnsupportedType(type, false)) {
       throw new KsqlException(
           String.format(
               "Type %s is not supported by UDF methods. "

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdafTypesTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdafTypesTest.java
@@ -141,6 +141,13 @@ public class UdafTypesTest {
   }
 
   @Test
+  public void shouldNotThrowWhenColArgIsObjVariadic() {
+    UdafTypes udafTypes = createTypes("udafWithObjVarArg", int.class);
+    assertTrue(udafTypes.isVariadic());
+    assertTrue(udafTypes.literalParams().stream().noneMatch(ParameterInfo::isVariadic));
+  }
+
+  @Test
   public void shouldNotThrowWhenOnlyInitArgIsVariadic() {
     UdafTypes udafTypes = createTypes("udafWithVariadicInitArg", int[].class);
     assertTrue(udafTypes.isVariadic());
@@ -174,6 +181,60 @@ public class UdafTypesTest {
     assertThat(e.getMessage(), is("Variadic column arguments are only allowed inside tuples"));
   }
 
+  @Test
+  public void shouldThrowWhenColArgAndInitArgAreObjVariadic() {
+    final Exception e = assertThrows(
+            KsqlException.class,
+            () -> createTypes("udafWithVariadicColAndInitArgs", int[].class)
+    );
+
+    assertThat(e.getMessage(), is("A UDAF and its factory can have at most one variadic argument"));
+  }
+
+  @Test
+  public void shouldThrowWhenNonVariadicObjArgBeforeVariadicArg() {
+    final Exception e = assertThrows(
+            KsqlException.class,
+            () -> createTypes("udafWithObjArgBeforeVariadicArg")
+    );
+
+    assertThat(e.getMessage(),
+            is("The Object type can only be used in a variadic column argument"));
+  }
+
+  @Test
+  public void shouldThrowWhenNonVariadicObjArgAfterVariadicArg() {
+    final Exception e = assertThrows(
+            KsqlException.class,
+            () -> createTypes("udafWithObjArgAfterVariadicArg")
+    );
+
+    assertThat(e.getMessage(),
+            is("The Object type can only be used in a variadic column argument"));
+  }
+
+  @Test
+  public void shouldThrowWhenNonVariadicObjArgBeforeObjVariadicArg() {
+    final Exception e = assertThrows(
+            KsqlException.class,
+            () -> createTypes("udafWithObjArgBeforeObjVarArg")
+    );
+
+    assertThat(e.getMessage(),
+            is("The Object type can only be used in a variadic column argument"));
+  }
+
+  @Test
+  public void shouldThrowWhenNonVariadicObjArgAfterObjVariadicArg() {
+    final Exception e = assertThrows(
+            KsqlException.class,
+            () -> createTypes("udafWithObjArgAfterObjVarArg")
+    );
+
+    assertThat(e.getMessage(),
+            is("The Object type can only be used in a variadic column argument"));
+  }
+
   @SuppressWarnings({"unused", "MethodMayBeStatic"})
   private Udaf<Pair<Integer, Double>, Long, Double> udafWithMultipleParams(String initParam) {
     return null;
@@ -192,6 +253,39 @@ public class UdafTypesTest {
   @SuppressWarnings({"unused", "MethodMayBeStatic"})
   private Udaf<Pair<Integer, VariadicArgs<Double>>, Long, Double> udafWithVariadicColAndInitArgs(
           int... args) {
+    return null;
+  }
+
+  @SuppressWarnings({"unused", "MethodMayBeStatic"})
+  private Udaf<Pair<Integer, VariadicArgs<Double>>, Long, Double> udafWithVariadicObjColAndInitArgs(
+          Object... args) {
+    return null;
+  }
+
+  @SuppressWarnings({"unused", "MethodMayBeStatic"})
+  private Udaf<Pair<Object, VariadicArgs<Double>>, Long, Double> udafWithObjArgBeforeVariadicArg() {
+    return null;
+  }
+
+  @SuppressWarnings({"unused", "MethodMayBeStatic"})
+  private Udaf<Pair<VariadicArgs<Double>, Object>, Long, Double> udafWithObjArgAfterVariadicArg() {
+    return null;
+  }
+
+  @SuppressWarnings({"unused", "MethodMayBeStatic"})
+  private Udaf<Pair<Object, VariadicArgs<Object>>, Long, Double> udafWithObjArgBeforeObjVarArg() {
+    return null;
+  }
+
+  @SuppressWarnings({"unused", "MethodMayBeStatic"})
+  private Udaf<Pair<VariadicArgs<Object>, Object>, Long, Double> udafWithObjArgAfterObjVarArg() {
+    return null;
+  }
+
+  @SuppressWarnings({"unused", "MethodMayBeStatic"})
+  private Udaf<Pair<VariadicArgs<Object>, Integer>, Long, Double> udafWithObjVarArg(
+          final int param
+  ) {
     return null;
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdafTypesTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdafTypesTest.java
@@ -199,7 +199,7 @@ public class UdafTypesTest {
     );
 
     assertThat(e.getMessage(),
-            is("The Object type can only be used in a variadic column argument"));
+            is("The Object type can only be used as a variadic column argument"));
   }
 
   @Test
@@ -210,7 +210,7 @@ public class UdafTypesTest {
     );
 
     assertThat(e.getMessage(),
-            is("The Object type can only be used in a variadic column argument"));
+            is("The Object type can only be used as a variadic column argument"));
   }
 
   @Test
@@ -221,7 +221,7 @@ public class UdafTypesTest {
     );
 
     assertThat(e.getMessage(),
-            is("The Object type can only be used in a variadic column argument"));
+            is("The Object type can only be used as a variadic column argument"));
   }
 
   @Test
@@ -232,7 +232,7 @@ public class UdafTypesTest {
     );
 
     assertThat(e.getMessage(),
-            is("The Object type can only be used in a variadic column argument"));
+            is("The Object type can only be used as a variadic column argument"));
   }
 
   @SuppressWarnings({"unused", "MethodMayBeStatic"})

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/ObjVarColArgUdaf.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/ObjVarColArgUdaf.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udaf;
+
+import io.confluent.ksql.schema.ksql.SqlArgument;
+import io.confluent.ksql.schema.ksql.types.SqlArray;
+import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.util.KsqlConstants;
+import io.confluent.ksql.util.Pair;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+@UdafDescription(
+        name = "OBJ_COL_ARG",
+        description = "Returns an array of rows where all the given columns are non-null.",
+        author = KsqlConstants.CONFLUENT_AUTHOR
+)
+public class ObjVarColArgUdaf
+        implements Udaf<Pair<Integer, VariadicArgs<Object>>, List<Integer>, List<Integer>> {
+
+  @UdafFactory(description = "Testing factory")
+  public static Udaf<Pair<Integer, VariadicArgs<Object>>, List<Integer>, List<Integer>>
+      createObjVarArgUdaf() {
+    return new ObjVarColArgUdaf();
+  }
+
+  private SqlType firstType;
+
+  @Override
+  public List<Integer> initialize() {
+    return new ArrayList<>();
+  }
+
+  @Override
+  public List<Integer> aggregate(Pair<Integer, VariadicArgs<Object>> current,
+                                 List<Integer> aggregate) {
+    final boolean isLeftNonNull = current.getLeft() != null;
+    final boolean isRightNonNull = current.getRight().stream().allMatch(Objects::nonNull);
+
+    if (isLeftNonNull && isRightNonNull) {
+      aggregate.add(current.getLeft());
+    }
+
+    return aggregate;
+  }
+
+  @Override
+  public List<Integer> merge(List<Integer> aggOne, List<Integer> aggTwo) {
+    aggOne.addAll(aggTwo);
+    return aggOne;
+  }
+
+  @Override
+  public List<Integer> map(List<Integer> agg) {
+    return agg;
+  }
+
+  @Override
+  public void initializeTypeArguments(List<SqlArgument> argTypeList) {
+    firstType = argTypeList.get(0).getSqlTypeOrThrow();
+  }
+
+  @Override
+  public Optional<SqlType> getAggregateSqlType() {
+    return Optional.of(SqlArray.of(firstType));
+  }
+
+  @Override
+  public Optional<SqlType> getReturnSqlType() {
+    return Optional.of(SqlArray.of(firstType));
+  }
+}

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/function/UdfUtilTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/function/UdfUtilTest.java
@@ -211,6 +211,11 @@ public class UdfUtilTest {
     UdfUtil.getSchemaFromType(System.class);
   }
 
+  @Test(expected = KsqlException.class)
+  public void shouldThrowExceptionForObjClass() {
+    UdfUtil.getSchemaFromType(Object.class);
+  }
+
   @Test
   public void shouldGetGenericSchemaFromType() throws NoSuchMethodException {
     // Given:
@@ -344,6 +349,279 @@ public class UdfUtilTest {
 
     // When:
     final ParamType returnType = UdfUtil.getSchemaFromType(genericType);
+
+    // Then:
+    assertThat(returnType, is(LambdaType.of(ImmutableList.of(GenericType.of("T"), GenericType.of("U"), GenericType.of("V")), GenericType.of("W"))));
+  }
+
+  @Test
+  public void shouldGetObjectSchemaForObjectClassVariadic() {
+    assertThat(
+            UdfUtil.getVarArgsSchemaFromType(Object.class),
+            equalTo(ParamTypes.ANY)
+    );
+  }
+
+  @Test
+  public void shouldGetBooleanSchemaForBooleanClassVariadic() {
+    assertThat(
+            UdfUtil.getVarArgsSchemaFromType(Boolean.class),
+            equalTo(ParamTypes.BOOLEAN)
+    );
+  }
+
+  @Test
+  public void shouldGetBooleanSchemaForBooleanPrimitiveClassVariadic() {
+    assertThat(
+            UdfUtil.getVarArgsSchemaFromType(boolean.class),
+            equalTo(ParamTypes.BOOLEAN)
+    );
+  }
+
+  @Test
+  public void shouldGetIntSchemaForIntegerClassVariadic() {
+    assertThat(
+            UdfUtil.getVarArgsSchemaFromType(Integer.class),
+            equalTo(ParamTypes.INTEGER)
+    );
+  }
+
+  @Test
+  public void shouldGetIntegerSchemaForIntPrimitiveClassVariadic() {
+    assertThat(
+            UdfUtil.getVarArgsSchemaFromType(int.class),
+            equalTo(ParamTypes.INTEGER)
+    );
+  }
+
+  @Test
+  public void shouldGetLongSchemaForLongClassVariadic() {
+    assertThat(
+            UdfUtil.getVarArgsSchemaFromType(Long.class),
+            equalTo(ParamTypes.LONG)
+    );
+  }
+
+  @Test
+  public void shouldGetLongSchemaForLongPrimitiveClassVariadic() {
+    assertThat(
+            UdfUtil.getVarArgsSchemaFromType(long.class),
+            equalTo(ParamTypes.LONG)
+    );
+  }
+
+  @Test
+  public void shouldGetFloatSchemaForDoubleClassVariadic() {
+    assertThat(
+            UdfUtil.getVarArgsSchemaFromType(Double.class),
+            equalTo(ParamTypes.DOUBLE)
+    );
+  }
+
+  @Test
+  public void shouldGetFloatSchemaForDoublePrimitiveClassVariadic() {
+    assertThat(
+            UdfUtil.getVarArgsSchemaFromType(double.class),
+            equalTo(ParamTypes.DOUBLE)
+    );
+  }
+
+  @Test
+  public void shouldGetDecimalSchemaForBigDecimalClassVariadic() {
+    assertThat(
+            UdfUtil.getVarArgsSchemaFromType(BigDecimal.class),
+            is(ParamTypes.DECIMAL)
+    );
+  }
+
+  @Test
+  public void shouldGetTimestampSchemaForTimestampClassVariadic() {
+    assertThat(
+            UdfUtil.getVarArgsSchemaFromType(Timestamp.class),
+            is(ParamTypes.TIMESTAMP)
+    );
+  }
+
+  @Test
+  public void shouldGetIntervalUnitTypeForTimeUnitClassVariadic() {
+    assertThat(
+            UdfUtil.getVarArgsSchemaFromType(TimeUnit.class),
+            is(ParamTypes.INTERVALUNIT)
+    );
+  }
+
+  @Test
+  public void shouldGetMapSchemaFromMapClassVariadic() throws NoSuchMethodException {
+    final Type type = getClass().getDeclaredMethod("mapType", Map.class)
+            .getGenericParameterTypes()[0];
+    final ParamType schema = UdfUtil.getVarArgsSchemaFromType(type);
+    assertThat(schema, instanceOf(MapType.class));
+    assertThat(((MapType) schema).value(), equalTo(ParamTypes.INTEGER));
+  }
+
+  @Test
+  public void shouldGetArraySchemaFromListClassVariadic() throws NoSuchMethodException {
+    final Type type = getClass().getDeclaredMethod("listType", List.class)
+            .getGenericParameterTypes()[0];
+    final ParamType schema = UdfUtil.getVarArgsSchemaFromType(type);
+    assertThat(schema, instanceOf(ArrayType.class));
+    assertThat(((ArrayType) schema).element(), equalTo(ParamTypes.DOUBLE));
+  }
+
+  @Test
+  public void shouldGetStringSchemaFromStringClassVariadic() {
+    assertThat(
+            UdfUtil.getVarArgsSchemaFromType(String.class),
+            equalTo(ParamTypes.STRING)
+    );
+  }
+
+  @Test
+  public void shouldGetStringSchemaFromStructClassVariadic() {
+    assertThat(
+            UdfUtil.getVarArgsSchemaFromType(Struct.class),
+            equalTo(StructType.ANY_STRUCT)
+    );
+  }
+
+  @Test(expected = KsqlException.class)
+  public void shouldThrowExceptionIfClassDoesntMapToSchemaVariadic() {
+    UdfUtil.getVarArgsSchemaFromType(System.class);
+  }
+
+  @Test
+  public void shouldGetGenericSchemaFromTypeVariadic() throws NoSuchMethodException {
+    // Given:
+    final Type genericType = getClass().getMethod("genericType").getGenericReturnType();
+
+    // When:
+    final ParamType returnType = UdfUtil.getVarArgsSchemaFromType(genericType);
+
+    // Then:
+    MatcherAssert.assertThat(returnType, CoreMatchers.is(GenericType.of("T")));
+  }
+
+  @Test
+  public void shouldGetGenericSchemaFromParameterizedTypeVariadic() throws NoSuchMethodException {
+    // Given:
+    final Type genericType = getClass().getMethod("genericMapType").getGenericReturnType();
+
+    // When:
+    final ParamType returnType = UdfUtil.getVarArgsSchemaFromType(genericType);
+
+    // Then:
+    assertThat(returnType, is(MapType.of(GenericType.of("K"), GenericType.of("V"))));
+  }
+
+  @Test
+  public void shouldGetGenericSchemaFromPartialParameterizedTypeVariadic() throws NoSuchMethodException {
+    // Given:
+    final Type genericType = getClass().getMethod("partialGenericMapType").getGenericReturnType();
+
+    // When:
+    final ParamType returnType = UdfUtil.getVarArgsSchemaFromType(genericType);
+
+    // Then:
+    assertThat(returnType, is(MapType.of(ParamTypes.LONG, GenericType.of("V"))));
+  }
+
+  @Test
+  public void shouldGetFunctionVariadic() throws NoSuchMethodException {
+    final Type type = getClass().getDeclaredMethod("functionType", Function.class)
+            .getGenericParameterTypes()[0];
+    final ParamType schema = UdfUtil.getVarArgsSchemaFromType(type);
+    assertThat(schema, instanceOf(LambdaType.class));
+    assertThat(((LambdaType) schema).inputTypes(), equalTo(ImmutableList.of(ParamTypes.LONG)));
+    assertThat(((LambdaType) schema).returnType(), equalTo(ParamTypes.INTEGER));
+  }
+
+  @Test
+  public void shouldGetPartialGenericFunctionVariadic() throws NoSuchMethodException {
+    // Given:
+    final Type genericType = getClass().getMethod("partialGenericFunctionType").getGenericReturnType();
+
+    // When:
+    final ParamType returnType = UdfUtil.getVarArgsSchemaFromType(genericType);
+
+    // Then:
+    assertThat(returnType, is(LambdaType.of(ImmutableList.of(ParamTypes.LONG), GenericType.of("U"))));
+  }
+
+  @Test
+  public void shouldGetGenericFunctionVariadic() throws NoSuchMethodException {
+    // Given:
+    final Type genericType = getClass().getMethod("genericFunctionType").getGenericReturnType();
+
+    // When:
+    final ParamType returnType = UdfUtil.getVarArgsSchemaFromType(genericType);
+
+    // Then:
+    assertThat(returnType, is(LambdaType.of(ImmutableList.of(GenericType.of("T")), GenericType.of("U"))));
+  }
+
+  @Test
+  public void shouldGetBiFunctionVariadic() throws NoSuchMethodException {
+    final Type type = getClass().getDeclaredMethod("biFunctionType", BiFunction.class)
+            .getGenericParameterTypes()[0];
+    final ParamType schema = UdfUtil.getVarArgsSchemaFromType(type);
+    assertThat(schema, instanceOf(LambdaType.class));
+    assertThat(((LambdaType) schema).inputTypes(), equalTo(ImmutableList.of(ParamTypes.LONG, ParamTypes.INTEGER)));
+    assertThat(((LambdaType) schema).returnType(), equalTo(ParamTypes.BOOLEAN));
+  }
+
+  @Test
+  public void shouldGetPartialGenericBiFunctionVariadic() throws NoSuchMethodException {
+    // Given:
+    final Type genericType = getClass().getMethod("partialGenericBiFunctionType").getGenericReturnType();
+
+    // When:
+    final ParamType returnType = UdfUtil.getVarArgsSchemaFromType(genericType);
+
+    // Then:
+    assertThat(returnType, is(LambdaType.of(ImmutableList.of(GenericType.of("T"), ParamTypes.BOOLEAN), GenericType.of("U"))));
+  }
+
+  @Test
+  public void shouldGetGenericBiFunctionVariadic() throws NoSuchMethodException {
+    // Given:
+    final Type genericType = getClass().getMethod("partialGenericBiFunctionType").getGenericReturnType();
+
+    // When:
+    final ParamType returnType = UdfUtil.getVarArgsSchemaFromType(genericType);
+
+    // Then:
+    assertThat(returnType, is(LambdaType.of(ImmutableList.of(GenericType.of("T"), ParamTypes.BOOLEAN), GenericType.of("U"))));
+  }
+
+  @Test
+  public void shouldGetTriFunctionVariadic() throws NoSuchMethodException {
+    final Type type = getClass().getDeclaredMethod("triFunctionType", TriFunction.class)
+            .getGenericParameterTypes()[0];
+    final ParamType schema = UdfUtil.getVarArgsSchemaFromType(type);
+    assertThat(schema, instanceOf(LambdaType.class));
+    assertThat(((LambdaType) schema).inputTypes(), equalTo(ImmutableList.of(ParamTypes.LONG, ParamTypes.INTEGER, ParamTypes.BOOLEAN)));
+    assertThat(((LambdaType) schema).returnType(), equalTo(ParamTypes.BOOLEAN));
+  }
+
+  @Test
+  public void shouldGetPartialGenericTriFunctionVariadic() throws NoSuchMethodException {
+    // Given:
+    final Type genericType = getClass().getMethod("partialGenericTriFunctionType").getGenericReturnType();
+
+    // When:
+    final ParamType returnType = UdfUtil.getVarArgsSchemaFromType(genericType);
+
+    // Then:
+    assertThat(returnType, is(LambdaType.of(ImmutableList.of(GenericType.of("T"), ParamTypes.BOOLEAN, GenericType.of("U")), ParamTypes.INTEGER)));
+  }
+
+  @Test
+  public void shouldGetGenericTriFunctionVariadic() throws NoSuchMethodException {
+    // Given:
+    final Type genericType = getClass().getMethod("genericTriFunctionType").getGenericReturnType();
+
+    // When:
+    final ParamType returnType = UdfUtil.getVarArgsSchemaFromType(genericType);
 
     // Then:
     assertThat(returnType, is(LambdaType.of(ImmutableList.of(GenericType.of("T"), GenericType.of("U"), GenericType.of("V")), GenericType.of("W"))));

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_different_decimals_in_var_arg/7.4.0_1661206992270/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_different_decimals_in_var_arg/7.4.0_1661206992270/plan.json
@@ -1,0 +1,258 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, FIRST INTEGER, SECOND BIGINT, THIRD BOOLEAN, FOURTH DECIMAL(5, 1), FIFTH INTEGER, SIXTH DECIMAL(4, 3)) WITH (KAFKA_TOPIC='input_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DECIMAL(5, 1), `FIFTH` INTEGER, `SIXTH` DECIMAL(4, 3)",
+      "timestampColumn" : null,
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  OBJ_COL_ARG(INPUT.FIRST, INPUT.SECOND, INPUT.THIRD, INPUT.FOURTH, INPUT.FIFTH, INPUT.SIXTH) RESULT\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `RESULT` ARRAY<INTEGER>",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "input_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    }
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` BIGINT KEY, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DECIMAL(5, 1), `FIFTH` INTEGER, `SIXTH` DECIMAL(4, 3)",
+                  "pseudoColumnVersion" : 1
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectedKeys" : null,
+                "selectExpressions" : [ "ID AS ID", "FIRST AS FIRST", "SECOND AS SECOND", "THIRD AS THIRD", "FOURTH AS FOURTH", "FIFTH AS FIFTH", "SIXTH AS SIXTH" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "JSON",
+                  "properties" : { }
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "FIRST", "SECOND", "THIRD", "FOURTH", "FIFTH", "SIXTH" ],
+            "aggregationFunctions" : [ "OBJ_COL_ARG(FIRST, SECOND, THIRD, FOURTH, FIFTH, SIXTH)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS RESULT" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA",
+              "properties" : { }
+            },
+            "valueFormat" : {
+              "format" : "JSON",
+              "properties" : { }
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.websocket.connection.max.timeout.ms" : "3600000",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "true",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.json_sr.converter.deserializer.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_different_decimals_in_var_arg/7.4.0_1661206992270/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_different_decimals_in_var_arg/7.4.0_1661206992270/spec.json
@@ -1,0 +1,308 @@
+{
+  "version" : "7.4.0",
+  "timestamp" : 1661206992270,
+  "path" : "query-validation-tests/obj-var-col-arg-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `RESULT` ARRAY<INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DECIMAL(5, 1), `FIFTH` INTEGER, `SIXTH` DECIMAL(4, 3)",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DECIMAL(5, 1), `FIFTH` INTEGER, `SIXTH` DECIMAL(4, 3)",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DECIMAL(5, 1), `FIFTH` INTEGER, `SIXTH` DECIMAL(4, 3), `KSQL_AGG_VARIABLE_0` ARRAY<INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `RESULT` ARRAY<INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "different decimals in var arg",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 6,
+        "SECOND" : 5,
+        "THIRD" : true,
+        "FOURTH" : 3.2,
+        "FIFTH" : 7,
+        "SIXTH" : 1.23
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 2,
+        "SECOND" : 1,
+        "THIRD" : false,
+        "FOURTH" : 1.4,
+        "FIFTH" : 8,
+        "SIXTH" : 1.567
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : null,
+        "SECOND" : 5,
+        "THIRD" : true,
+        "FOURTH" : 12.3,
+        "FIFTH" : 1,
+        "SIXTH" : 8.76
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 5,
+        "SECOND" : 3,
+        "THIRD" : null,
+        "FOURTH" : 0.9,
+        "FIFTH" : 2,
+        "SIXTH" : 5.34
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 5,
+        "SECOND" : null,
+        "THIRD" : true,
+        "FOURTH" : 1.2,
+        "FIFTH" : 6,
+        "SIXTH" : 0.912
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 3,
+        "SECOND" : 7,
+        "THIRD" : false,
+        "FOURTH" : null,
+        "FIFTH" : 8,
+        "SIXTH" : 5.823
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 2,
+        "SECOND" : 2,
+        "THIRD" : true,
+        "FOURTH" : 9.8,
+        "FIFTH" : null,
+        "SIXTH" : 3.42
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 21,
+        "SECOND" : 10,
+        "THIRD" : null,
+        "FOURTH" : 5.0,
+        "FIFTH" : 2,
+        "SIXTH" : 7.31
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : null,
+        "SECOND" : 20,
+        "THIRD" : true,
+        "FOURTH" : null,
+        "FIFTH" : 3,
+        "SIXTH" : 0.418
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 3,
+        "SECOND" : 2,
+        "THIRD" : false,
+        "FOURTH" : 4.3,
+        "FIFTH" : 4,
+        "SIXTH" : 9.352
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 6,
+        "SECOND" : 1,
+        "THIRD" : false,
+        "FOURTH" : 4.9,
+        "FIFTH" : 10,
+        "SIXTH" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : [ 6 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : [ 6 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : [ 6 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : [ 6 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2, 3 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2, 3 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, FIRST integer, SECOND bigint, THIRD boolean, FOURTH decimal(5, 1), FIFTH integer, SIXTH decimal(4, 3)) WITH (kafka_topic='input_topic', value_format='JSON');", "CREATE TABLE OUTPUT as SELECT id, OBJ_COL_ARG(FIRST, SECOND, THIRD, FOURTH, FIFTH, SIXTH) as RESULT FROM INPUT group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DECIMAL(5, 1), `FIFTH` INTEGER, `SIXTH` DECIMAL(4, 3)",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `RESULT` ARRAY<INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_different_decimals_in_var_arg/7.4.0_1661206992270/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_different_decimals_in_var_arg/7.4.0_1661206992270/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_list_in_var_arg/7.4.0_1661206996380/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_list_in_var_arg/7.4.0_1661206996380/plan.json
@@ -1,0 +1,258 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, FIRST INTEGER, SECOND BIGINT, THIRD BOOLEAN, FOURTH DOUBLE, FIFTH INTEGER, SIXTH ARRAY<INTEGER>) WITH (KAFKA_TOPIC='input_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` ARRAY<INTEGER>",
+      "timestampColumn" : null,
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  OBJ_COL_ARG(INPUT.FIRST, INPUT.SECOND, INPUT.THIRD, INPUT.FOURTH, INPUT.FIFTH, INPUT.SIXTH) RESULT\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `RESULT` ARRAY<INTEGER>",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "input_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    }
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` BIGINT KEY, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` ARRAY<INTEGER>",
+                  "pseudoColumnVersion" : 1
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectedKeys" : null,
+                "selectExpressions" : [ "ID AS ID", "FIRST AS FIRST", "SECOND AS SECOND", "THIRD AS THIRD", "FOURTH AS FOURTH", "FIFTH AS FIFTH", "SIXTH AS SIXTH" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "JSON",
+                  "properties" : { }
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "FIRST", "SECOND", "THIRD", "FOURTH", "FIFTH", "SIXTH" ],
+            "aggregationFunctions" : [ "OBJ_COL_ARG(FIRST, SECOND, THIRD, FOURTH, FIFTH, SIXTH)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS RESULT" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA",
+              "properties" : { }
+            },
+            "valueFormat" : {
+              "format" : "JSON",
+              "properties" : { }
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.websocket.connection.max.timeout.ms" : "3600000",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "true",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.json_sr.converter.deserializer.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_list_in_var_arg/7.4.0_1661206996380/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_list_in_var_arg/7.4.0_1661206996380/spec.json
@@ -1,0 +1,308 @@
+{
+  "version" : "7.4.0",
+  "timestamp" : 1661206996380,
+  "path" : "query-validation-tests/obj-var-col-arg-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `RESULT` ARRAY<INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` ARRAY<INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` ARRAY<INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` ARRAY<INTEGER>, `KSQL_AGG_VARIABLE_0` ARRAY<INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `RESULT` ARRAY<INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "list in var arg",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 6,
+        "SECOND" : 5,
+        "THIRD" : true,
+        "FOURTH" : 3.2,
+        "FIFTH" : 7,
+        "SIXTH" : [ 3, 5 ]
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 2,
+        "SECOND" : 1,
+        "THIRD" : false,
+        "FOURTH" : 1.44,
+        "FIFTH" : 8,
+        "SIXTH" : [ 8, 1 ]
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : null,
+        "SECOND" : 5,
+        "THIRD" : true,
+        "FOURTH" : 12.34,
+        "FIFTH" : 1,
+        "SIXTH" : [ 7, 0, 2 ]
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 5,
+        "SECOND" : 3,
+        "THIRD" : null,
+        "FOURTH" : 0.9,
+        "FIFTH" : 2,
+        "SIXTH" : [ 1 ]
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 5,
+        "SECOND" : null,
+        "THIRD" : true,
+        "FOURTH" : 1.2,
+        "FIFTH" : 6,
+        "SIXTH" : [ 5, 13 ]
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 3,
+        "SECOND" : 7,
+        "THIRD" : false,
+        "FOURTH" : null,
+        "FIFTH" : 8,
+        "SIXTH" : [ 10, null ]
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 2,
+        "SECOND" : 2,
+        "THIRD" : true,
+        "FOURTH" : 9.8,
+        "FIFTH" : null,
+        "SIXTH" : [ 8, 1, 19 ]
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 21,
+        "SECOND" : 10,
+        "THIRD" : null,
+        "FOURTH" : 5.0,
+        "FIFTH" : 2,
+        "SIXTH" : [ 11, 20 ]
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : null,
+        "SECOND" : 20,
+        "THIRD" : true,
+        "FOURTH" : null,
+        "FIFTH" : 3,
+        "SIXTH" : [ 2 ]
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 3,
+        "SECOND" : 2,
+        "THIRD" : false,
+        "FOURTH" : 4.3,
+        "FIFTH" : 4,
+        "SIXTH" : [ 0, 0 ]
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 6,
+        "SECOND" : 1,
+        "THIRD" : false,
+        "FOURTH" : 4.9,
+        "FIFTH" : 10,
+        "SIXTH" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : [ 6 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : [ 6 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : [ 6 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : [ 6 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2, 3 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2, 3 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, FIRST integer, SECOND bigint, THIRD boolean, FOURTH double, FIFTH integer, SIXTH array<int>) WITH (kafka_topic='input_topic', value_format='JSON');", "CREATE TABLE OUTPUT as SELECT id, OBJ_COL_ARG(FIRST, SECOND, THIRD, FOURTH, FIFTH, SIXTH) as RESULT FROM INPUT group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` ARRAY<INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `RESULT` ARRAY<INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_list_in_var_arg/7.4.0_1661206996380/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_list_in_var_arg/7.4.0_1661206996380/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_map_in_var_arg/7.4.0_1661206995011/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_map_in_var_arg/7.4.0_1661206995011/plan.json
@@ -1,0 +1,258 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, FIRST INTEGER, SECOND BIGINT, THIRD BOOLEAN, FOURTH DOUBLE, FIFTH INTEGER, SIXTH MAP<STRING, INTEGER>) WITH (KAFKA_TOPIC='input_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` MAP<STRING, INTEGER>",
+      "timestampColumn" : null,
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  OBJ_COL_ARG(INPUT.FIRST, INPUT.SECOND, INPUT.THIRD, INPUT.FOURTH, INPUT.FIFTH, INPUT.SIXTH) RESULT\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `RESULT` ARRAY<INTEGER>",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "input_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    }
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` BIGINT KEY, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` MAP<STRING, INTEGER>",
+                  "pseudoColumnVersion" : 1
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectedKeys" : null,
+                "selectExpressions" : [ "ID AS ID", "FIRST AS FIRST", "SECOND AS SECOND", "THIRD AS THIRD", "FOURTH AS FOURTH", "FIFTH AS FIFTH", "SIXTH AS SIXTH" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "JSON",
+                  "properties" : { }
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "FIRST", "SECOND", "THIRD", "FOURTH", "FIFTH", "SIXTH" ],
+            "aggregationFunctions" : [ "OBJ_COL_ARG(FIRST, SECOND, THIRD, FOURTH, FIFTH, SIXTH)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS RESULT" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA",
+              "properties" : { }
+            },
+            "valueFormat" : {
+              "format" : "JSON",
+              "properties" : { }
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.websocket.connection.max.timeout.ms" : "3600000",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "true",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.json_sr.converter.deserializer.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_map_in_var_arg/7.4.0_1661206995011/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_map_in_var_arg/7.4.0_1661206995011/spec.json
@@ -1,0 +1,328 @@
+{
+  "version" : "7.4.0",
+  "timestamp" : 1661206995011,
+  "path" : "query-validation-tests/obj-var-col-arg-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `RESULT` ARRAY<INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` MAP<STRING, INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` MAP<STRING, INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` MAP<STRING, INTEGER>, `KSQL_AGG_VARIABLE_0` ARRAY<INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `RESULT` ARRAY<INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "map in var arg",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 6,
+        "SECOND" : 5,
+        "THIRD" : true,
+        "FOURTH" : 3.2,
+        "FIFTH" : 7,
+        "SIXTH" : {
+          "hello" : 3
+        }
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 2,
+        "SECOND" : 1,
+        "THIRD" : false,
+        "FOURTH" : 1.44,
+        "FIFTH" : 8,
+        "SIXTH" : {
+          "world" : 8
+        }
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : null,
+        "SECOND" : 5,
+        "THIRD" : true,
+        "FOURTH" : 12.34,
+        "FIFTH" : 1,
+        "SIXTH" : {
+          "test" : 7
+        }
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 5,
+        "SECOND" : 3,
+        "THIRD" : null,
+        "FOURTH" : 0.9,
+        "FIFTH" : 2,
+        "SIXTH" : {
+          "udaf" : 1
+        }
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 5,
+        "SECOND" : null,
+        "THIRD" : true,
+        "FOURTH" : 1.2,
+        "FIFTH" : 6,
+        "SIXTH" : {
+          "aggregate" : 5
+        }
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 3,
+        "SECOND" : 7,
+        "THIRD" : false,
+        "FOURTH" : null,
+        "FIFTH" : 8,
+        "SIXTH" : {
+          "function" : 10
+        }
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 2,
+        "SECOND" : 2,
+        "THIRD" : true,
+        "FOURTH" : 9.8,
+        "FIFTH" : null,
+        "SIXTH" : {
+          "ksql" : 8
+        }
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 21,
+        "SECOND" : 10,
+        "THIRD" : null,
+        "FOURTH" : 5.0,
+        "FIFTH" : 2,
+        "SIXTH" : {
+          "qtt" : 11
+        }
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : null,
+        "SECOND" : 20,
+        "THIRD" : true,
+        "FOURTH" : null,
+        "FIFTH" : 3,
+        "SIXTH" : {
+          "variadic" : 2
+        }
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 3,
+        "SECOND" : 2,
+        "THIRD" : false,
+        "FOURTH" : 4.3,
+        "FIFTH" : 4,
+        "SIXTH" : {
+          "object" : 0
+        }
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 6,
+        "SECOND" : 1,
+        "THIRD" : false,
+        "FOURTH" : 4.9,
+        "FIFTH" : 10,
+        "SIXTH" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : [ 6 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : [ 6 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : [ 6 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : [ 6 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2, 3 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2, 3 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, FIRST integer, SECOND bigint, THIRD boolean, FOURTH double, FIFTH integer, SIXTH map<varchar, int>) WITH (kafka_topic='input_topic', value_format='JSON');", "CREATE TABLE OUTPUT as SELECT id, OBJ_COL_ARG(FIRST, SECOND, THIRD, FOURTH, FIFTH, SIXTH) as RESULT FROM INPUT group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` MAP<STRING, INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `RESULT` ARRAY<INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_map_in_var_arg/7.4.0_1661206995011/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_map_in_var_arg/7.4.0_1661206995011/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_no_variadic_args/7.4.0_1661206997735/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_no_variadic_args/7.4.0_1661206997735/plan.json
@@ -1,0 +1,258 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, FIRST INTEGER, SECOND BIGINT, THIRD BOOLEAN, FOURTH DOUBLE, FIFTH INTEGER, SIXTH STRING) WITH (KAFKA_TOPIC='input_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` STRING",
+      "timestampColumn" : null,
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  OBJ_COL_ARG(INPUT.FIRST) RESULT\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `RESULT` ARRAY<INTEGER>",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "input_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    }
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` BIGINT KEY, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` STRING",
+                  "pseudoColumnVersion" : 1
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectedKeys" : null,
+                "selectExpressions" : [ "ID AS ID", "FIRST AS FIRST" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "JSON",
+                  "properties" : { }
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "FIRST" ],
+            "aggregationFunctions" : [ "OBJ_COL_ARG(FIRST)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS RESULT" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA",
+              "properties" : { }
+            },
+            "valueFormat" : {
+              "format" : "JSON",
+              "properties" : { }
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.websocket.connection.max.timeout.ms" : "3600000",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "true",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.json_sr.converter.deserializer.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_no_variadic_args/7.4.0_1661206997735/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_no_variadic_args/7.4.0_1661206997735/spec.json
@@ -1,0 +1,308 @@
+{
+  "version" : "7.4.0",
+  "timestamp" : 1661206997735,
+  "path" : "query-validation-tests/obj-var-col-arg-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `RESULT` ARRAY<INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `FIRST` INTEGER",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `FIRST` INTEGER, `KSQL_AGG_VARIABLE_0` ARRAY<INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `RESULT` ARRAY<INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "no variadic args",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 6,
+        "SECOND" : 5,
+        "THIRD" : true,
+        "FOURTH" : 3.2,
+        "FIFTH" : 7,
+        "SIXTH" : "hello"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 2,
+        "SECOND" : 1,
+        "THIRD" : false,
+        "FOURTH" : 1.44,
+        "FIFTH" : 8,
+        "SIXTH" : "world"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : null,
+        "SECOND" : 5,
+        "THIRD" : true,
+        "FOURTH" : 12.34,
+        "FIFTH" : 1,
+        "SIXTH" : "test"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 5,
+        "SECOND" : 3,
+        "THIRD" : null,
+        "FOURTH" : 0.9,
+        "FIFTH" : 2,
+        "SIXTH" : "udaf"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 5,
+        "SECOND" : null,
+        "THIRD" : true,
+        "FOURTH" : 1.2,
+        "FIFTH" : 6,
+        "SIXTH" : "aggregate"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 3,
+        "SECOND" : 7,
+        "THIRD" : false,
+        "FOURTH" : null,
+        "FIFTH" : 8,
+        "SIXTH" : "function"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 2,
+        "SECOND" : 2,
+        "THIRD" : true,
+        "FOURTH" : 9.8,
+        "FIFTH" : null,
+        "SIXTH" : "ksql"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 21,
+        "SECOND" : 10,
+        "THIRD" : null,
+        "FOURTH" : 5.0,
+        "FIFTH" : 2,
+        "SIXTH" : "qtt"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : null,
+        "SECOND" : 20,
+        "THIRD" : true,
+        "FOURTH" : null,
+        "FIFTH" : 3,
+        "SIXTH" : "variadic"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 3,
+        "SECOND" : 2,
+        "THIRD" : false,
+        "FOURTH" : 4.3,
+        "FIFTH" : 4,
+        "SIXTH" : "object"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 6,
+        "SECOND" : 1,
+        "THIRD" : false,
+        "FOURTH" : 4.9,
+        "FIFTH" : 10,
+        "SIXTH" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : [ 6 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : [ 6 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2, 5 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : [ 6, 5 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2, 5, 3 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2, 5, 3, 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : [ 6, 5, 21 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2, 5, 3, 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2, 5, 3, 2, 3 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2, 5, 3, 2, 3, 6 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, FIRST integer, SECOND bigint, THIRD boolean, FOURTH double, FIFTH integer, SIXTH string) WITH (kafka_topic='input_topic', value_format='JSON');", "CREATE TABLE OUTPUT as SELECT id, OBJ_COL_ARG(FIRST) as RESULT FROM INPUT group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `RESULT` ARRAY<INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_no_variadic_args/7.4.0_1661206997735/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_no_variadic_args/7.4.0_1661206997735/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_only_primitives_in_var_arg/7.4.0_1661206990896/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_only_primitives_in_var_arg/7.4.0_1661206990896/plan.json
@@ -1,0 +1,258 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, FIRST INTEGER, SECOND BIGINT, THIRD BOOLEAN, FOURTH DOUBLE, FIFTH INTEGER, SIXTH STRING) WITH (KAFKA_TOPIC='input_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` STRING",
+      "timestampColumn" : null,
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  OBJ_COL_ARG(INPUT.FIRST, INPUT.SECOND, INPUT.THIRD, INPUT.FOURTH, INPUT.FIFTH, INPUT.SIXTH) RESULT\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `RESULT` ARRAY<INTEGER>",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "input_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    }
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` BIGINT KEY, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` STRING",
+                  "pseudoColumnVersion" : 1
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectedKeys" : null,
+                "selectExpressions" : [ "ID AS ID", "FIRST AS FIRST", "SECOND AS SECOND", "THIRD AS THIRD", "FOURTH AS FOURTH", "FIFTH AS FIFTH", "SIXTH AS SIXTH" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "JSON",
+                  "properties" : { }
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "FIRST", "SECOND", "THIRD", "FOURTH", "FIFTH", "SIXTH" ],
+            "aggregationFunctions" : [ "OBJ_COL_ARG(FIRST, SECOND, THIRD, FOURTH, FIFTH, SIXTH)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS RESULT" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA",
+              "properties" : { }
+            },
+            "valueFormat" : {
+              "format" : "JSON",
+              "properties" : { }
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.websocket.connection.max.timeout.ms" : "3600000",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "true",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.json_sr.converter.deserializer.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_only_primitives_in_var_arg/7.4.0_1661206990896/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_only_primitives_in_var_arg/7.4.0_1661206990896/spec.json
@@ -1,0 +1,308 @@
+{
+  "version" : "7.4.0",
+  "timestamp" : 1661206990896,
+  "path" : "query-validation-tests/obj-var-col-arg-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `RESULT` ARRAY<INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` STRING, `KSQL_AGG_VARIABLE_0` ARRAY<INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `RESULT` ARRAY<INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "only primitives in var arg",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 6,
+        "SECOND" : 5,
+        "THIRD" : true,
+        "FOURTH" : 3.2,
+        "FIFTH" : 7,
+        "SIXTH" : "hello"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 2,
+        "SECOND" : 1,
+        "THIRD" : false,
+        "FOURTH" : 1.44,
+        "FIFTH" : 8,
+        "SIXTH" : "world"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : null,
+        "SECOND" : 5,
+        "THIRD" : true,
+        "FOURTH" : 12.34,
+        "FIFTH" : 1,
+        "SIXTH" : "test"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 5,
+        "SECOND" : 3,
+        "THIRD" : null,
+        "FOURTH" : 0.9,
+        "FIFTH" : 2,
+        "SIXTH" : "udaf"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 5,
+        "SECOND" : null,
+        "THIRD" : true,
+        "FOURTH" : 1.2,
+        "FIFTH" : 6,
+        "SIXTH" : "aggregate"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 3,
+        "SECOND" : 7,
+        "THIRD" : false,
+        "FOURTH" : null,
+        "FIFTH" : 8,
+        "SIXTH" : "function"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 2,
+        "SECOND" : 2,
+        "THIRD" : true,
+        "FOURTH" : 9.8,
+        "FIFTH" : null,
+        "SIXTH" : "ksql"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 21,
+        "SECOND" : 10,
+        "THIRD" : null,
+        "FOURTH" : 5.0,
+        "FIFTH" : 2,
+        "SIXTH" : "qtt"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : null,
+        "SECOND" : 20,
+        "THIRD" : true,
+        "FOURTH" : null,
+        "FIFTH" : 3,
+        "SIXTH" : "variadic"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 3,
+        "SECOND" : 2,
+        "THIRD" : false,
+        "FOURTH" : 4.3,
+        "FIFTH" : 4,
+        "SIXTH" : "object"
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 6,
+        "SECOND" : 1,
+        "THIRD" : false,
+        "FOURTH" : 4.9,
+        "FIFTH" : 10,
+        "SIXTH" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : [ 6 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : [ 6 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : [ 6 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : [ 6 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2, 3 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2, 3 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, FIRST integer, SECOND bigint, THIRD boolean, FOURTH double, FIFTH integer, SIXTH string) WITH (kafka_topic='input_topic', value_format='JSON');", "CREATE TABLE OUTPUT as SELECT id, OBJ_COL_ARG(FIRST, SECOND, THIRD, FOURTH, FIFTH, SIXTH) as RESULT FROM INPUT group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `RESULT` ARRAY<INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_only_primitives_in_var_arg/7.4.0_1661206990896/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_only_primitives_in_var_arg/7.4.0_1661206990896/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_struct_in_var_arg/7.4.0_1661206993687/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_struct_in_var_arg/7.4.0_1661206993687/plan.json
@@ -1,0 +1,258 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, FIRST INTEGER, SECOND BIGINT, THIRD BOOLEAN, FOURTH DOUBLE, FIFTH INTEGER, SIXTH STRUCT<A INTEGER, B STRING>) WITH (KAFKA_TOPIC='input_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` STRUCT<`A` INTEGER, `B` STRING>",
+      "timestampColumn" : null,
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  OBJ_COL_ARG(INPUT.FIRST, INPUT.SECOND, INPUT.THIRD, INPUT.FOURTH, INPUT.FIFTH, INPUT.SIXTH) RESULT\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `RESULT` ARRAY<INTEGER>",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "input_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON",
+                      "properties" : { }
+                    }
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` BIGINT KEY, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` STRUCT<`A` INTEGER, `B` STRING>",
+                  "pseudoColumnVersion" : 1
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectedKeys" : null,
+                "selectExpressions" : [ "ID AS ID", "FIRST AS FIRST", "SECOND AS SECOND", "THIRD AS THIRD", "FOURTH AS FOURTH", "FIFTH AS FIFTH", "SIXTH AS SIXTH" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "JSON",
+                  "properties" : { }
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "FIRST", "SECOND", "THIRD", "FOURTH", "FIFTH", "SIXTH" ],
+            "aggregationFunctions" : [ "OBJ_COL_ARG(FIRST, SECOND, THIRD, FOURTH, FIFTH, SIXTH)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS RESULT" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA",
+              "properties" : { }
+            },
+            "valueFormat" : {
+              "format" : "JSON",
+              "properties" : { }
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.websocket.connection.max.timeout.ms" : "3600000",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "true",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.json_sr.converter.deserializer.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_struct_in_var_arg/7.4.0_1661206993687/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_struct_in_var_arg/7.4.0_1661206993687/spec.json
@@ -1,0 +1,338 @@
+{
+  "version" : "7.4.0",
+  "timestamp" : 1661206993687,
+  "path" : "query-validation-tests/obj-var-col-arg-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `RESULT` ARRAY<INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` STRUCT<`A` INTEGER, `B` STRING>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` STRUCT<`A` INTEGER, `B` STRING>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` STRUCT<`A` INTEGER, `B` STRING>, `KSQL_AGG_VARIABLE_0` ARRAY<INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `RESULT` ARRAY<INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "struct in var arg",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 6,
+        "SECOND" : 5,
+        "THIRD" : true,
+        "FOURTH" : 3.2,
+        "FIFTH" : 7,
+        "SIXTH" : {
+          "a" : 3,
+          "b" : "hello"
+        }
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 2,
+        "SECOND" : 1,
+        "THIRD" : false,
+        "FOURTH" : 1.44,
+        "FIFTH" : 8,
+        "SIXTH" : {
+          "a" : 8,
+          "b" : "world"
+        }
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : null,
+        "SECOND" : 5,
+        "THIRD" : true,
+        "FOURTH" : 12.34,
+        "FIFTH" : 1,
+        "SIXTH" : {
+          "a" : 7,
+          "b" : "test"
+        }
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 5,
+        "SECOND" : 3,
+        "THIRD" : null,
+        "FOURTH" : 0.9,
+        "FIFTH" : 2,
+        "SIXTH" : {
+          "a" : 1,
+          "b" : null
+        }
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 5,
+        "SECOND" : null,
+        "THIRD" : true,
+        "FOURTH" : 1.2,
+        "FIFTH" : 6,
+        "SIXTH" : {
+          "a" : 5,
+          "b" : "aggregate"
+        }
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 3,
+        "SECOND" : 7,
+        "THIRD" : false,
+        "FOURTH" : null,
+        "FIFTH" : 8,
+        "SIXTH" : {
+          "a" : 10,
+          "b" : "function"
+        }
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 2,
+        "SECOND" : 2,
+        "THIRD" : true,
+        "FOURTH" : 9.8,
+        "FIFTH" : null,
+        "SIXTH" : {
+          "a" : 8,
+          "b" : "ksql"
+        }
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 0,
+      "value" : {
+        "FIRST" : 21,
+        "SECOND" : 10,
+        "THIRD" : null,
+        "FOURTH" : 5.0,
+        "FIFTH" : 2,
+        "SIXTH" : {
+          "a" : null,
+          "b" : "qtt"
+        }
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : null,
+        "SECOND" : 20,
+        "THIRD" : true,
+        "FOURTH" : null,
+        "FIFTH" : 3,
+        "SIXTH" : {
+          "a" : 2,
+          "b" : "variadic"
+        }
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 3,
+        "SECOND" : 2,
+        "THIRD" : false,
+        "FOURTH" : 4.3,
+        "FIFTH" : 4,
+        "SIXTH" : {
+          "a" : 0,
+          "b" : "object"
+        }
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 100,
+      "value" : {
+        "FIRST" : 6,
+        "SECOND" : 1,
+        "THIRD" : false,
+        "FOURTH" : 4.9,
+        "FIFTH" : 10,
+        "SIXTH" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : [ 6 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : [ 6 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : [ 6 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "RESULT" : [ 6 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2, 3 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 100,
+      "value" : {
+        "RESULT" : [ 2, 3 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, FIRST integer, SECOND bigint, THIRD boolean, FOURTH double, FIFTH integer, SIXTH struct<a int, b varchar>) WITH (kafka_topic='input_topic', value_format='JSON');", "CREATE TABLE OUTPUT as SELECT id, OBJ_COL_ARG(FIRST, SECOND, THIRD, FOURTH, FIFTH, SIXTH) as RESULT FROM INPUT group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `FIRST` INTEGER, `SECOND` BIGINT, `THIRD` BOOLEAN, `FOURTH` DOUBLE, `FIFTH` INTEGER, `SIXTH` STRUCT<`A` INTEGER, `B` STRING>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `RESULT` ARRAY<INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_struct_in_var_arg/7.4.0_1661206993687/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/obj-var-col-arg-udaf_-_struct_in_var_arg/7.4.0_1661206993687/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/obj-var-col-arg-udaf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/obj-var-col-arg-udaf.json
@@ -1,0 +1,210 @@
+{
+  "comments": [
+    "You can specify multiple statements per test case, i.e., to set up the various streams needed",
+    "for joins etc, but currently only the final topology will be verified. This should be enough",
+    "for most tests as we can simulate the outputs from previous stages into the final stage. If we",
+    "take a modular approach to testing we can still verify that it all works correctly, i.e, if we",
+    "verify the output of a select or aggregate is correct, we can use simulated output to feed into",
+    "a join or another aggregate."
+  ],
+  "tests": [
+    {
+      "name": "only primitives in var arg",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, FIRST integer, SECOND bigint, THIRD boolean, FOURTH double, FIFTH integer, SIXTH string) WITH (kafka_topic='input_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT id, OBJ_COL_ARG(FIRST, SECOND, THIRD, FOURTH, FIFTH, SIXTH) as RESULT FROM INPUT group by id;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 6, "SECOND": 5, "THIRD": true, "FOURTH": 3.2, "FIFTH": 7, "SIXTH": "hello"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 2, "SECOND": 1, "THIRD": false, "FOURTH": 1.44, "FIFTH": 8, "SIXTH": "world"}},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": null, "SECOND": 5, "THIRD": true, "FOURTH": 12.34, "FIFTH": 1, "SIXTH": "test"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 5, "SECOND": 3, "THIRD": null, "FOURTH": 0.9, "FIFTH": 2, "SIXTH": "udaf"}},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 5, "SECOND": null, "THIRD": true, "FOURTH": 1.2, "FIFTH": 6, "SIXTH": "aggregate"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 3, "SECOND": 7, "THIRD": false, "FOURTH": null, "FIFTH": 8, "SIXTH": "function"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 2, "SECOND": 2, "THIRD": true, "FOURTH": 9.8, "FIFTH": null, "SIXTH": "ksql"}},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 21, "SECOND": 10, "THIRD": null, "FOURTH": 5.0, "FIFTH": 2, "SIXTH": "qtt"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": null, "SECOND": 20, "THIRD": true, "FOURTH": null, "FIFTH": 3, "SIXTH": "variadic"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 3, "SECOND": 2, "THIRD": false, "FOURTH": 4.3, "FIFTH": 4, "SIXTH": "object"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 6, "SECOND": 1, "THIRD": false, "FOURTH": 4.9, "FIFTH": 10, "SIXTH": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": [6]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": [6]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": [6]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": [6]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2, 3]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2, 3]}}
+      ]
+    },
+    {
+      "name": "different decimals in var arg",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, FIRST integer, SECOND bigint, THIRD boolean, FOURTH decimal(5, 1), FIFTH integer, SIXTH decimal(4, 3)) WITH (kafka_topic='input_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT id, OBJ_COL_ARG(FIRST, SECOND, THIRD, FOURTH, FIFTH, SIXTH) as RESULT FROM INPUT group by id;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 6, "SECOND": 5, "THIRD": true, "FOURTH": 3.2, "FIFTH": 7, "SIXTH": 1.23}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 2, "SECOND": 1, "THIRD": false, "FOURTH": 1.4, "FIFTH": 8, "SIXTH": 1.567}},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": null, "SECOND": 5, "THIRD": true, "FOURTH": 12.3, "FIFTH": 1, "SIXTH": 8.76}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 5, "SECOND": 3, "THIRD": null, "FOURTH": 0.9, "FIFTH": 2, "SIXTH": 5.34}},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 5, "SECOND": null, "THIRD": true, "FOURTH": 1.2, "FIFTH": 6, "SIXTH": 0.912}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 3, "SECOND": 7, "THIRD": false, "FOURTH": null, "FIFTH": 8, "SIXTH": 5.823}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 2, "SECOND": 2, "THIRD": true, "FOURTH": 9.8, "FIFTH": null, "SIXTH": 3.42}},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 21, "SECOND": 10, "THIRD": null, "FOURTH": 5.0, "FIFTH": 2, "SIXTH": 7.31}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": null, "SECOND": 20, "THIRD": true, "FOURTH": null, "FIFTH": 3, "SIXTH": 0.418}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 3, "SECOND": 2, "THIRD": false, "FOURTH": 4.3, "FIFTH": 4, "SIXTH": 9.352}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 6, "SECOND": 1, "THIRD": false, "FOURTH": 4.9, "FIFTH": 10, "SIXTH": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": [6]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": [6]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": [6]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": [6]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2, 3]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2, 3]}}
+      ]
+    },
+    {
+      "name": "struct in var arg",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, FIRST integer, SECOND bigint, THIRD boolean, FOURTH double, FIFTH integer, SIXTH struct<a int, b varchar>) WITH (kafka_topic='input_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT id, OBJ_COL_ARG(FIRST, SECOND, THIRD, FOURTH, FIFTH, SIXTH) as RESULT FROM INPUT group by id;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 6, "SECOND": 5, "THIRD": true, "FOURTH": 3.2, "FIFTH": 7, "SIXTH": { "a": 3, "b": "hello" }}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 2, "SECOND": 1, "THIRD": false, "FOURTH": 1.44, "FIFTH": 8, "SIXTH": { "a": 8, "b": "world" }}},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": null, "SECOND": 5, "THIRD": true, "FOURTH": 12.34, "FIFTH": 1, "SIXTH": { "a": 7, "b": "test" }}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 5, "SECOND": 3, "THIRD": null, "FOURTH": 0.9, "FIFTH": 2, "SIXTH": { "a": 1, "b": null }}},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 5, "SECOND": null, "THIRD": true, "FOURTH": 1.2, "FIFTH": 6, "SIXTH": { "a": 5, "b": "aggregate" }}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 3, "SECOND": 7, "THIRD": false, "FOURTH": null, "FIFTH": 8, "SIXTH": { "a": 10, "b": "function" }}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 2, "SECOND": 2, "THIRD": true, "FOURTH": 9.8, "FIFTH": null, "SIXTH": { "a": 8, "b": "ksql" }}},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 21, "SECOND": 10, "THIRD": null, "FOURTH": 5.0, "FIFTH": 2, "SIXTH": { "a": null, "b": "qtt" }}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": null, "SECOND": 20, "THIRD": true, "FOURTH": null, "FIFTH": 3, "SIXTH": { "a": 2, "b": "variadic" }}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 3, "SECOND": 2, "THIRD": false, "FOURTH": 4.3, "FIFTH": 4, "SIXTH": { "a": 0, "b": "object" }}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 6, "SECOND": 1, "THIRD": false, "FOURTH": 4.9, "FIFTH": 10, "SIXTH": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": [6]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": [6]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": [6]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": [6]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2, 3]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2, 3]}}
+      ]
+    },
+    {
+      "name": "map in var arg",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, FIRST integer, SECOND bigint, THIRD boolean, FOURTH double, FIFTH integer, SIXTH map<varchar, int>) WITH (kafka_topic='input_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT id, OBJ_COL_ARG(FIRST, SECOND, THIRD, FOURTH, FIFTH, SIXTH) as RESULT FROM INPUT group by id;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 6, "SECOND": 5, "THIRD": true, "FOURTH": 3.2, "FIFTH": 7, "SIXTH": { "hello": 3 }}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 2, "SECOND": 1, "THIRD": false, "FOURTH": 1.44, "FIFTH": 8, "SIXTH": { "world": 8 }}},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": null, "SECOND": 5, "THIRD": true, "FOURTH": 12.34, "FIFTH": 1, "SIXTH": { "test": 7 }}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 5, "SECOND": 3, "THIRD": null, "FOURTH": 0.9, "FIFTH": 2, "SIXTH": { "udaf": 1 }}},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 5, "SECOND": null, "THIRD": true, "FOURTH": 1.2, "FIFTH": 6, "SIXTH": { "aggregate": 5 }}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 3, "SECOND": 7, "THIRD": false, "FOURTH": null, "FIFTH": 8, "SIXTH": { "function": 10 }}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 2, "SECOND": 2, "THIRD": true, "FOURTH": 9.8, "FIFTH": null, "SIXTH": { "ksql": 8 }}},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 21, "SECOND": 10, "THIRD": null, "FOURTH": 5.0, "FIFTH": 2, "SIXTH": { "qtt": 11 }}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": null, "SECOND": 20, "THIRD": true, "FOURTH": null, "FIFTH": 3, "SIXTH": { "variadic": 2 }}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 3, "SECOND": 2, "THIRD": false, "FOURTH": 4.3, "FIFTH": 4, "SIXTH": { "object": 0 }}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 6, "SECOND": 1, "THIRD": false, "FOURTH": 4.9, "FIFTH": 10, "SIXTH": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": [6]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": [6]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": [6]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": [6]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2, 3]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2, 3]}}
+      ]
+    },
+    {
+      "name": "list in var arg",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, FIRST integer, SECOND bigint, THIRD boolean, FOURTH double, FIFTH integer, SIXTH array<int>) WITH (kafka_topic='input_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT id, OBJ_COL_ARG(FIRST, SECOND, THIRD, FOURTH, FIFTH, SIXTH) as RESULT FROM INPUT group by id;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 6, "SECOND": 5, "THIRD": true, "FOURTH": 3.2, "FIFTH": 7, "SIXTH": [3, 5] }},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 2, "SECOND": 1, "THIRD": false, "FOURTH": 1.44, "FIFTH": 8, "SIXTH": [8, 1] }},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": null, "SECOND": 5, "THIRD": true, "FOURTH": 12.34, "FIFTH": 1, "SIXTH": [7, 0, 2] }},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 5, "SECOND": 3, "THIRD": null, "FOURTH": 0.9, "FIFTH": 2, "SIXTH": [1] }},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 5, "SECOND": null, "THIRD": true, "FOURTH": 1.2, "FIFTH": 6, "SIXTH": [5, 13] }},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 3, "SECOND": 7, "THIRD": false, "FOURTH": null, "FIFTH": 8, "SIXTH": [10, null] }},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 2, "SECOND": 2, "THIRD": true, "FOURTH": 9.8, "FIFTH": null, "SIXTH": [8, 1, 19] }},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 21, "SECOND": 10, "THIRD": null, "FOURTH": 5.0, "FIFTH": 2, "SIXTH": [11, 20] }},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": null, "SECOND": 20, "THIRD": true, "FOURTH": null, "FIFTH": 3, "SIXTH": [2] }},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 3, "SECOND": 2, "THIRD": false, "FOURTH": 4.3, "FIFTH": 4, "SIXTH": [0, 0] }},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 6, "SECOND": 1, "THIRD": false, "FOURTH": 4.9, "FIFTH": 10, "SIXTH": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": [6]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": [6]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": [6]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": [6]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2, 3]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2, 3]}}
+      ]
+    },
+    {
+      "name": "no variadic args",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, FIRST integer, SECOND bigint, THIRD boolean, FOURTH double, FIFTH integer, SIXTH string) WITH (kafka_topic='input_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT id, OBJ_COL_ARG(FIRST) as RESULT FROM INPUT group by id;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 6, "SECOND": 5, "THIRD": true, "FOURTH": 3.2, "FIFTH": 7, "SIXTH": "hello"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 2, "SECOND": 1, "THIRD": false, "FOURTH": 1.44, "FIFTH": 8, "SIXTH": "world"}},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": null, "SECOND": 5, "THIRD": true, "FOURTH": 12.34, "FIFTH": 1, "SIXTH": "test"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 5, "SECOND": 3, "THIRD": null, "FOURTH": 0.9, "FIFTH": 2, "SIXTH": "udaf"}},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 5, "SECOND": null, "THIRD": true, "FOURTH": 1.2, "FIFTH": 6, "SIXTH": "aggregate"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 3, "SECOND": 7, "THIRD": false, "FOURTH": null, "FIFTH": 8, "SIXTH": "function"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 2, "SECOND": 2, "THIRD": true, "FOURTH": 9.8, "FIFTH": null, "SIXTH": "ksql"}},
+        {"topic": "input_topic", "key": 0, "value": {"FIRST": 21, "SECOND": 10, "THIRD": null, "FOURTH": 5.0, "FIFTH": 2, "SIXTH": "qtt"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": null, "SECOND": 20, "THIRD": true, "FOURTH": null, "FIFTH": 3, "SIXTH": "variadic"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 3, "SECOND": 2, "THIRD": false, "FOURTH": 4.3, "FIFTH": 4, "SIXTH": "object"}},
+        {"topic": "input_topic", "key": 100, "value": {"FIRST": 6, "SECOND": 1, "THIRD": false, "FOURTH": 4.9, "FIFTH": 10, "SIXTH": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": [6]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": [6]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2, 5]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": [6, 5]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2, 5, 3]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2, 5, 3, 2]}},
+        {"topic": "OUTPUT", "key": 0, "value": {"RESULT": [6, 5, 21]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2, 5, 3, 2]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2, 5, 3, 2, 3]}},
+        {"topic": "OUTPUT", "key": 100, "value": {"RESULT": [2, 5, 3, 2, 3, 6]}}
+      ]
+    }
+  ]
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutorTest.java
@@ -145,6 +145,32 @@ public class DescribeFunctionExecutorTest {
   }
 
   @Test
+  public void shouldDescribeUDAFWithObjVarArgs() {
+    // When:
+    final FunctionDescriptionList functionList = (FunctionDescriptionList)
+            CustomExecutors.DESCRIBE_FUNCTION.execute(
+                    engine.configure("DESCRIBE FUNCTION OBJ_COL_ARG;"),
+                    mock(SessionProperties.class),
+                    engine.getEngine(),
+                    engine.getServiceContext()
+            ).getEntity().orElseThrow(IllegalStateException::new);
+
+    // Then:
+    assertThat(functionList, new TypeSafeMatcher<FunctionDescriptionList>() {
+      @Override
+      protected boolean matchesSafely(final FunctionDescriptionList item) {
+        return functionList.getName().equals("OBJ_COL_ARG")
+                && functionList.getType().equals(FunctionType.AGGREGATE);
+      }
+
+      @Override
+      public void describeTo(final Description description) {
+        description.appendText(functionList.getName());
+      }
+    });
+  }
+
+  @Test
   public void shouldDescribeUDTF() {
     // When:
     final FunctionDescriptionList functionList = (FunctionDescriptionList)


### PR DESCRIPTION
### Description 
Follow-up to #9361. This PR adds support for heterogeneous variadics in a UDAF variadic column argument by using `Object` as the type parameter to `VariadicArgs`. UDAF implementations must do the type checking manually if the aggregate type or output type depends on the input types. See `Udaf#getAggregateSqlType()` and `Udaf#getReturnSqlType()`.

A new `ParamType`, `AnyType`, has been added. It accepts any argument, but it can only be used by having `VariadicArgs<Object>` in the input type of a UDAF signature. Attempting to use `Object` anywhere else will prevent the UDAF or UDF from loading, as we do not intend to support that with this PR. This means having `Object...` as a UDAF initial argument is not supported.

User documentation for this will be added with the rest of the new docs for recent UDAF work.

This PR is necessary to add support for variadic TopK because we do not know the types of the additional columns ahead of time.

Issue #3414 is related. I was originally going to close this, but since `Object` isn't supported for all variadics, I am leaving it open for now. I don't think `Object` support needs to be added to regular column arguments since we already have generics, and you can add as many generic parameters as needed.

### Testing done 
Added unit tests and QTT tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

