### PR TITLE
fix: handle windowed queries in YATT

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/TestDriverPipeline.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/TestDriverPipeline.java
@@ -65,12 +65,12 @@ public class TestDriverPipeline {
 
   public static final class TopicInfo {
     final String name;
-    final Serde<GenericKey> keySerde;
+    final Serde<?> keySerde;
     final Serde<GenericRow> valueSerde;
 
     public TopicInfo(
         final String name,
-        final Serde<GenericKey> keySerde,
+        final Serde<?> keySerde,
         final Serde<GenericRow> valueSerde
     ) {
       this.name = name;

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
@@ -395,21 +395,34 @@ public class KsqlTesterTest {
     }
   }
 
-  private Serde<GenericKey> keySerde(final DataSource sinkSource) {
+  private Serde<?> keySerde(final DataSource sinkSource) {
     final PersistenceSchema schema = PersistenceSchema.from(
         sinkSource.getSchema().key(),
         sinkSource.getKsqlTopic().getKeyFormat().getFeatures()
     );
 
-    return new GenericKeySerDe().create(
-        sinkSource.getKsqlTopic().getKeyFormat().getFormatInfo(),
-        schema,
-        config,
-        serviceContext.getSchemaRegistryClientFactory(),
-        "",
-        NoopProcessingLogContext.INSTANCE,
-        Optional.empty()
-    );
+    if (sinkSource.getKsqlTopic().getKeyFormat().getWindowInfo().isPresent()) {
+      return new GenericKeySerDe().create(
+          sinkSource.getKsqlTopic().getKeyFormat().getFormatInfo(),
+          sinkSource.getKsqlTopic().getKeyFormat().getWindowInfo().get(),
+          schema,
+          config,
+          serviceContext.getSchemaRegistryClientFactory(),
+          "",
+          NoopProcessingLogContext.INSTANCE,
+          Optional.empty()
+      );
+    } else {
+      return new GenericKeySerDe().create(
+          sinkSource.getKsqlTopic().getKeyFormat().getFormatInfo(),
+          schema,
+          config,
+          serviceContext.getSchemaRegistryClientFactory(),
+          "",
+          NoopProcessingLogContext.INSTANCE,
+          Optional.empty()
+      );
+    }
   }
 
   private Serde<GenericRow> valueSerde(final DataSource sinkSource) {

--- a/ksqldb-functional-tests/src/test/resources/sql-tests/query-upgrades/session-windows.sql
+++ b/ksqldb-functional-tests/src/test/resources/sql-tests/query-upgrades/session-windows.sql
@@ -1,0 +1,65 @@
+-- Tests around session windows
+
+----------------------------------------------------------------------------------------------------
+--@test: out of order - no grace period
+----------------------------------------------------------------------------------------------------
+CREATE STREAM TEST (ID BIGINT KEY, VALUE bigint) WITH (kafka_topic='test_topic', value_format='DELIMITED');
+CREATE TABLE S2 as SELECT ID, max(value) as max, windowstart as ws, windowend as we FROM test WINDOW SESSION (30 SECONDS) group by id;
+
+INSERT INTO TEST (id, value, rowtime) VALUES (0, 0, 0);
+INSERT INTO TEST (id, value, rowtime) VALUES (0, 1, 70010);
+INSERT INTO TEST (id, value, rowtime) VALUES (0, 5, 10009);
+INSERT INTO TEST (id, value, rowtime) VALUES (0, 6, 10010);
+INSERT INTO TEST (id, value, rowtime) VALUES (1, 100, 10009);
+INSERT INTO TEST (id, value, rowtime) VALUES (1, 101, 10010);
+INSERT INTO TEST (id, value, rowtime) VALUES (1, 200, 86412022);
+INSERT INTO TEST (id, value, rowtime) VALUES (1, 200, 60000);
+
+ASSERT VALUES S2 (id, max, ws, we) VALUES (0, 0, 0, 0);
+ASSERT VALUES S2 (id, max, ws, we) VALUES (0, 1, 70010, 70010);
+ASSERT NULL VALUES S2 (id) KEY (0);
+ASSERT VALUES S2 (id, max, ws, we) VALUES (0, 5, 0, 10009);
+ASSERT NULL VALUES S2 (id) KEY (0);
+ASSERT VALUES S2 (id, max, ws, we) VALUES (0, 6, 0, 10010);
+ASSERT VALUES S2 (id, max, ws, we) VALUES (1, 100, 10009, 10009);
+ASSERT NULL VALUES S2 (id) KEY (1);
+ASSERT VALUES S2 (id, max, ws, we) VALUES (1, 101, 10009, 10010);
+ASSERT VALUES S2 (id, max, ws, we) VALUES (1, 200, 86412022, 86412022);
+ASSERT VALUES S2 (id, max, ws, we) VALUES (1, 200, 60000, 60000);
+
+----------------------------------------------------------------------------------------------------
+--@test: out of order - explicit grace period
+----------------------------------------------------------------------------------------------------
+CREATE STREAM TEST (ID BIGINT KEY, VALUE bigint) WITH (kafka_topic='test_topic', value_format='DELIMITED');
+CREATE TABLE S2 as SELECT ID, max(value) as max, windowstart as ws, windowend as we FROM test WINDOW SESSION (30 SECONDS, GRACE PERIOD 1 MINUTE) group by id;
+
+INSERT INTO TEST (id, value, rowtime) VALUES (0, 0, 0);
+INSERT INTO TEST (id, value, rowtime) VALUES (0, 1, 100010);
+INSERT INTO TEST (id, value, rowtime) VALUES (0, 5, 10009);
+INSERT INTO TEST (id, value, rowtime) VALUES (0, 6, 10010);
+INSERT INTO TEST (id, value, rowtime) VALUES (1, 100, 10009);
+INSERT INTO TEST (id, value, rowtime) VALUES (1, 101, 10010);
+INSERT INTO TEST (id, value, rowtime) VALUES (1, 200, 86412022);
+INSERT INTO TEST (id, value, rowtime) VALUES (1, 200, 60000);
+
+ASSERT VALUES S2 (id, max, ws, we) VALUES (0, 0, 0, 0);
+ASSERT VALUES S2 (id, max, ws, we) VALUES (0, 1, 100010, 100010);
+ASSERT NULL VALUES S2 (id) KEY (0);
+ASSERT VALUES S2 (id, max, ws, we) VALUES (0, 6, 0, 10010);
+ASSERT VALUES S2 (id, max, ws, we) VALUES (1, 101, 10010, 10010);
+ASSERT VALUES S2 (id, max, ws, we) VALUES (1, 200, 86412022, 86412022);
+
+----------------------------------------------------------------------------------------------------
+--@test: non-KAFKA key format
+----------------------------------------------------------------------------------------------------
+CREATE STREAM INPUT (A DECIMAL(4,2)) WITH (kafka_topic='INPUT', format='JSON');
+CREATE TABLE OUTPUT AS SELECT A, COUNT() AS COUNT, windowstart as ws, windowend as we FROM INPUT WINDOW SESSION (30 SECONDS) group by A;
+
+INSERT INTO INPUT (A, rowtime) VALUES (12.3, 10);
+INSERT INTO INPUT (A, rowtime) VALUES (12.3, 11);
+INSERT INTO INPUT (A, rowtime) VALUES (1, 12);
+
+ASSERT VALUES OUTPUT (A, count, ws, we) VALUES (12.3, 1, 10, 10);
+ASSERT NULL VALUES OUTPUT (A) KEY (12.3);
+ASSERT VALUES OUTPUT (A, count, ws, we) VALUES (12.3, 2, 10, 11);
+ASSERT VALUES OUTPUT (A, count, ws, we) VALUES (1, 1, 12, 12);


### PR DESCRIPTION
### Description 
Previously YATT would throw serialization errors when trying to test windowed queries.

DDL over windowed sources is still not supported yet. We also can't directly assert windowstart/windowend yet without selecting them in the query.

### Testing done 
Converted some of the tests from [session-windows.json](https://github.com/confluentinc/ksql/blob/master/ksqldb-functional-tests/src/test/resources/query-validation-tests/session-windows.json) to YATT tests. 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

