### PR TITLE
chore: add 'keySchemaReferences' and 'valueSchemaReferences' to QTT

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/SchemaReferencesNode.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/SchemaReferencesNode.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.model;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.TextNode;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.ksql.serde.protobuf.ProtobufFormat;
+import io.confluent.ksql.test.tools.SchemaReference;
+import io.confluent.ksql.test.tools.TestJsonMapper;
+import io.confluent.ksql.test.utils.SerdeUtil;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public final class SchemaReferencesNode {
+  // Mapper used to parse schemas:
+  private static final ObjectMapper OBJECT_MAPPER = TestJsonMapper.INSTANCE.get();
+
+  private final String name;
+  private final String format;
+  private final JsonNode schema;
+
+  public SchemaReferencesNode(
+      @JsonProperty("name") final String name,
+      @JsonProperty("format") final String format,
+      @JsonProperty("schema") final JsonNode schema
+  ) {
+    this.name = name;
+    this.format = requireNonNull(format, "format");
+    this.schema = requireNonNull(schema, "schema");
+
+    // Fail early:
+    SerdeUtil.buildSchema(schema, format);
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getFormat() {
+    return format;
+  }
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public JsonNode getSchema() {
+    return schema;
+  }
+
+  public SchemaReference build() {
+    return new SchemaReference(
+        name,
+        SerdeUtil.buildSchema(schema, format).get()
+    );
+  }
+
+  public static SchemaReferencesNode from(final SchemaReference schemaReferences) {
+    return new SchemaReferencesNode(
+        schemaReferences.getName(),
+        schemaReferences.getSchema().schemaType(),
+        buildSchemaNode(schemaReferences.getSchema())
+    );
+  }
+
+  private static JsonNode buildSchemaNode(final ParsedSchema schema) {
+    final String canonical = schema.canonicalString();
+
+    try {
+      if (schema.schemaType().equals(ProtobufFormat.NAME)) {
+        return new TextNode(canonical);
+      }
+
+      return OBJECT_MAPPER.readTree(canonical);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/SchemaReference.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/SchemaReference.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.tools;
+
+import static java.util.Objects.requireNonNull;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+
+public class SchemaReference {
+  private final String name;
+  private final ParsedSchema schema;
+
+  public SchemaReference(
+      final String name,
+      final ParsedSchema schema
+  ) {
+    this.name = requireNonNull(name, "name");
+    this.schema = requireNonNull(schema, "schema");
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public ParsedSchema getSchema() {
+    return schema;
+  }
+}

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilderUtil.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilderUtil.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.test.tools;
 
 import static com.google.common.io.Files.getNameWithoutExtension;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Streams;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
@@ -155,6 +156,8 @@ public final class TestCaseBuilderUtil {
                 // Use the key/value schema built for the CREATE statement
                 keySchema,
                 valueSchema,
+                topic.getKeySchemaReferences(),
+                topic.getValueSchemaReferences(),
 
                 // Use the serde features built for the CREATE statement
                 topicFromStatement.getKeyFeatures(),
@@ -270,6 +273,8 @@ public final class TestCaseBuilderUtil {
         Optional.empty(),
         keySchema,
         valueSchema,
+        ImmutableList.of(),
+        ImmutableList.of(),
         keySerdeFeats,
         valSerdeFeats));
   }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/Topic.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/Topic.java
@@ -17,8 +17,11 @@ package io.confluent.ksql.test.tools;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.collect.ImmutableList;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.ksql.serde.SerdeFeatures;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -34,6 +37,8 @@ public class Topic {
   final Optional<Integer> valueSchemaId;
   private final Optional<ParsedSchema> keySchema;
   private final Optional<ParsedSchema> valueSchema;
+  private final List<SchemaReference> keySchemaReferences;
+  private final List<SchemaReference> valueSchemaReferences;
   private final SerdeFeatures keyFeatures;
   private final SerdeFeatures valueFeatures;
 
@@ -43,9 +48,11 @@ public class Topic {
       final Optional<ParsedSchema> valueSchema
   ) {
     this(name, DEFAULT_PARTITIONS, DEFAULT_RF, Optional.empty(), Optional.empty(),
-        keySchema, valueSchema, SerdeFeatures.of(), SerdeFeatures.of());
+        keySchema, valueSchema, ImmutableList.of(), ImmutableList.of(),
+        SerdeFeatures.of(), SerdeFeatures.of());
   }
 
+  // CHECKSTYLE_RULES.OFF: ParameterNumber
   public Topic(
       final String name,
       final int numPartitions,
@@ -54,14 +61,20 @@ public class Topic {
       final Optional<Integer> valueSchemaId,
       final Optional<ParsedSchema> keySchema,
       final Optional<ParsedSchema> valueSchema,
+      final List<SchemaReference> keySchemaReferences,
+      final List<SchemaReference> valueSchemaReferences,
       final SerdeFeatures keyFeatures,
       final SerdeFeatures valueFeatures
   ) {
+    // CHECKSTYLE_RULES.ON: ParameterNumber
+
     this.name = requireNonNull(name, "name");
     this.keySchemaId = requireNonNull(keySchemaId, "keySchemaId");
     this.valueSchemaId = requireNonNull(valueSchemaId, "valueSchemaId");
     this.keySchema = requireNonNull(keySchema, "keySchema");
     this.valueSchema = requireNonNull(valueSchema, "valueSchema");
+    this.keySchemaReferences = requireNonNull(keySchemaReferences, "keySchemaReferences");
+    this.valueSchemaReferences = requireNonNull(valueSchemaReferences, "valueSchemaReferences");
     this.numPartitions = numPartitions;
     this.replicas = (short) replicas;
     this.keyFeatures = keyFeatures;
@@ -78,6 +91,18 @@ public class Topic {
 
   public Optional<Integer> getValueSchemaId() {
     return valueSchemaId;
+  }
+
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP",
+      justification = "keySchemaReferences is ImmutableList")
+  public List<SchemaReference> getKeySchemaReferences() {
+    return keySchemaReferences;
+  }
+
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP",
+      justification = "valueSchemaReferences is ImmutableList")
+  public List<SchemaReference> getValueSchemaReferences() {
+    return valueSchemaReferences;
   }
 
   public Optional<ParsedSchema> getKeySchema() {

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/utils/SerdeUtil.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/utils/SerdeUtil.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.test.utils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.NullNode;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
@@ -50,9 +51,12 @@ import io.confluent.ksql.test.serde.none.NoneSerdeSupplier;
 import io.confluent.ksql.test.serde.protobuf.ValueSpecProtobufNoSRSerdeSupplier;
 import io.confluent.ksql.test.serde.protobuf.ValueSpecProtobufSerdeSupplier;
 import io.confluent.ksql.test.serde.string.StringSerdeSupplier;
+import io.confluent.ksql.test.tools.SchemaReference;
 import io.confluent.ksql.test.tools.exceptions.InvalidFieldException;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.kstream.SessionWindowedDeserializer;
@@ -94,33 +98,100 @@ public final class SerdeUtil {
     }
   }
 
-  public static Optional<ParsedSchema> buildSchema(final JsonNode schema, final String format) {
+  public static Optional<ParsedSchema> buildSchema(
+      final JsonNode schema,
+      final String format
+  ) {
     if (schema == null || schema instanceof NullNode) {
       return Optional.empty();
     }
 
-    try {
-      // format == null is the legacy case
-      if (format == null || format.equalsIgnoreCase(AvroFormat.NAME)) {
-        final String schemaString = OBJECT_MAPPER.writeValueAsString(schema);
-        final org.apache.avro.Schema avroSchema =
-            new org.apache.avro.Schema.Parser().parse(schemaString);
-        return Optional.of(new AvroSchema(avroSchema));
-      } else if (format.equalsIgnoreCase(JsonFormat.NAME)
-          || format.equalsIgnoreCase(JsonSchemaFormat.NAME)) {
-        final String schemaString = OBJECT_MAPPER.writeValueAsString(schema);
-        return Optional.of(new JsonSchema(schemaString));
-      } else if (format.equalsIgnoreCase(ProtobufFormat.NAME)) {
-        // since Protobuf schemas are not valid JSON, the schema JsonNode in
-        // this case is just a string.
-        final String schemaString = schema.textValue();
-        return Optional.of(new ProtobufSchema(schemaString));
-      }
-    } catch (final Exception e) {
-      throw new InvalidFieldException("schema", "failed to parse", e);
+    // format == null is the legacy case
+    final String useFormat = (format == null) ? AvroFormat.NAME : format.toUpperCase();
+    final String schemaString;
+
+    switch (useFormat) {
+      case ProtobufFormat.NAME:
+        // Protobuf schema is already a JSON string
+        schemaString = schema.textValue();
+        break;
+      case AvroFormat.NAME:
+      case JsonSchemaFormat.NAME:
+      case JsonFormat.NAME:
+        try {
+          schemaString = OBJECT_MAPPER.writeValueAsString(schema);
+        } catch (final Exception e) {
+          throw new InvalidFieldException("schema", "failed to parse", e);
+        }
+        break;
+      default:
+        throw new InvalidFieldException("schema", "not supported with format: " + format);
     }
 
-    throw new InvalidFieldException("schema", "not supported with format: " + format);
+    return Optional.of(buildSchema(schemaString, useFormat));
+  }
+
+  public static ParsedSchema buildSchema(
+      final String schemaString,
+      final String format
+  ) {
+    switch (format.toUpperCase()) {
+      case AvroFormat.NAME:
+        final org.apache.avro.Schema avroSchema =
+            new org.apache.avro.Schema.Parser().parse(schemaString);
+        return new AvroSchema(avroSchema);
+      case ProtobufFormat.NAME:
+        return new ProtobufSchema(schemaString);
+      case JsonSchemaFormat.NAME:
+      case JsonFormat.NAME:
+        return new JsonSchema(schemaString);
+      default:
+        throw new InvalidFieldException("schema", "not supported with format: " + format);
+    }
+  }
+
+  public static ParsedSchema withSchemaReferences(
+      final ParsedSchema schema,
+      final List<SchemaReference> references
+  ) {
+    if (references.isEmpty()) {
+      return schema;
+    }
+
+    /* QTT does not support subjects versions yet */
+    final int firstVersion = 1;
+
+    final Map<String, String> resolvedReferences = references.stream()
+        .collect(Collectors.toMap(
+            ref -> ref.getName(),
+            ref -> ref.getSchema().canonicalString()
+        ));
+
+    switch (schema.schemaType()) {
+      case ProtobufFormat.NAME:
+        return new ProtobufSchema(
+            schema.canonicalString(),
+            ImmutableList.of(),
+            resolvedReferences,
+            firstVersion,
+            schema.name());
+      case AvroFormat.NAME:
+        return new AvroSchema(
+            schema.canonicalString(),
+            ImmutableList.of(),
+            resolvedReferences,
+            firstVersion
+        );
+      case JsonSchemaFormat.NAME:
+        return new JsonSchema(
+            schema.canonicalString(),
+            ImmutableList.of(),
+            resolvedReferences,
+            firstVersion
+        );
+      default:
+        return schema;
+    }
   }
 
   @SuppressWarnings("unchecked")

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/StubKafkaServiceTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/StubKafkaServiceTest.java
@@ -74,6 +74,8 @@ public class StubKafkaServiceTest {
         topic.getValueSchemaId(),
         topic.getKeySchema(),
         topic.getValueSchema(),
+        topic.getKeySchemaReferences(),
+        topic.getValueSchemaReferences(),
         topic.getKeyFeatures(),
         topic.getValueFeatures()
     );

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_specify_a_protobuf_schema_with_external_references/7.4.0_1661267781763/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_specify_a_protobuf_schema_with_external_references/7.4.0_1661267781763/plan.json
@@ -1,0 +1,220 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (`event` STRUCT<`timestamp` BIGINT>) WITH (KAFKA_TOPIC='input', KEY_FORMAT='KAFKA', VALUE_FORMAT='PROTOBUF', VALUE_SCHEMA_FULL_NAME='Logistics', VALUE_SCHEMA_ID=1);",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`event` STRUCT<`timestamp` BIGINT>",
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : {
+            "fullSchemaName" : "Logistics",
+            "unwrapPrimitives" : "true",
+            "schemaId" : "1"
+          }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`event` STRUCT<`timestamp` BIGINT>",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : {
+            "fullSchemaName" : "Logistics",
+            "unwrapPrimitives" : "true"
+          }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : {
+                  "fullSchemaName" : "Logistics",
+                  "unwrapPrimitives" : "true",
+                  "schemaId" : "1"
+                }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`event` STRUCT<`timestamp` BIGINT>",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "`event` AS `event`" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : {
+              "fullSchemaName" : "Logistics",
+              "unwrapPrimitives" : "true"
+            }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.websocket.connection.max.timeout.ms" : "3600000",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "true",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.json_sr.converter.deserializer.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_specify_a_protobuf_schema_with_external_references/7.4.0_1661267781763/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_specify_a_protobuf_schema_with_external_references/7.4.0_1661267781763/spec.json
@@ -1,0 +1,129 @@
+{
+  "version" : "7.4.0",
+  "timestamp" : 1661267781763,
+  "path" : "query-validation-tests/protobuf.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`event` STRUCT<`timestamp` BIGINT>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF",
+        "properties" : {
+          "fullSchemaName" : "Logistics",
+          "unwrapPrimitives" : "true",
+          "schemaId" : "1"
+        }
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`event` STRUCT<`timestamp` BIGINT>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF",
+        "properties" : {
+          "fullSchemaName" : "Logistics",
+          "unwrapPrimitives" : "true"
+        }
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "specify a protobuf schema with external references",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "event" : {
+          "timestamp" : 1
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "event" : {
+          "timestamp" : 1
+        }
+      }
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "valueSchema" : "syntax = \"proto3\";\n\nimport \"event.proto\";\n\nmessage Logistics {\n  Event event = 1;\n}\n",
+      "valueSchemaReferences" : [ {
+        "name" : "event.proto",
+        "format" : "PROTOBUF",
+        "schema" : "syntax = \"proto3\";\n\nmessage Event {\n  int64 timestamp = 1;\n}\n"
+      } ],
+      "valueFormat" : "PROTOBUF",
+      "replicas" : 1,
+      "numPartitions" : 1
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT WITH (kafka_topic='input', value_format='PROTOBUF', value_schema_id=1);", "CREATE STREAM OUTPUT as SELECT * from INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`event` STRUCT<`timestamp` BIGINT>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`event` STRUCT<`timestamp` BIGINT>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : {
+              "fullSchemaName" : "Logistics",
+              "unwrapPrimitives" : "true",
+              "schemaId" : "1"
+            }
+          },
+          "partitions" : 1,
+          "valueSchema" : "syntax = \"proto3\";\n\nmessage Logistics {\n  Event event = 1;\n\n  message Event {\n    int64 timestamp = 1;\n  }\n}\n"
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : {
+              "fullSchemaName" : "Logistics",
+              "unwrapPrimitives" : "true"
+            }
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nmessage Logistics {\n  ConnectDefault1 event = 1;\n\n  message ConnectDefault1 {\n    int64 timestamp = 1;\n  }\n}\n"
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_specify_a_protobuf_schema_with_external_references/7.4.0_1661267781763/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_specify_a_protobuf_schema_with_external_references/7.4.0_1661267781763/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/protobuf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/protobuf.json
@@ -664,6 +664,39 @@
       ]
     },
     {
+      "name": "specify a protobuf schema with external references",
+      "statements": [
+        "CREATE STREAM INPUT WITH (kafka_topic='input', value_format='PROTOBUF', value_schema_id=1);",
+        "CREATE STREAM OUTPUT as SELECT * from INPUT;"
+      ],
+      "topics": [
+        {
+          "name": "input",
+          "valueFormat": "PROTOBUF",
+          "valueSchema": "syntax = \"proto3\";\n\nimport \"event.proto\"; \n\nmessage Logistics {\n Event event = 1;\n}",
+          "valueSchemaReferences": [
+            {
+              "name": "event.proto",
+              "format": "PROTOBUF",
+              "schema": "syntax = \"proto3\";\n\nmessage Event {\n int64 timestamp = 1;\n}"
+            }
+          ]
+        }
+      ],
+      "inputs": [
+        { "topic": "input", "value": { "event": { "timestamp": 1 } } }
+      ],
+      "outputs": [
+        { "topic": "OUTPUT", "value": { "event": { "timestamp": 1 } } }
+      ],
+      "post": {
+        "sources": [
+          {"name": "INPUT", "type": "stream", "schema": "`event` STRUCT<`timestamp` BIGINT>"},
+          {"name": "OUTPUT", "type": "stream", "schema": "`event` STRUCT<`timestamp` BIGINT>"}
+        ]
+      }
+    },
+    {
       "name": "fail if protobuf schema name is not found",
       "statements": [
         "CREATE STREAM INPUT WITH (kafka_topic='input_topic', value_format='PROTOBUF', VALUE_SCHEMA_FULL_NAME='ProtobufValue1000');"


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_
This is part of the fix for https://github.com/confluentinc/ksql/issues/9169

The above fix requires QTT to support schema references in order to verify schemas with references will work. This PR does not fix the issue yet. It only allows QTT to use schema references on Protobuf. I added a test to validate schema references can be used in QTT.

For example:
```
"statements": [
        "CREATE STREAM INPUT WITH (kafka_topic='input', value_format='PROTOBUF', value_schema_id=1);",
        "CREATE STREAM OUTPUT as SELECT * from INPUT;"
      ],

"topics": [
        {
          "name": "input",
          "valueFormat": "PROTOBUF",
          "valueSchema": "syntax = \"proto3\";\n\nimport \"event.proto\"; \n\nmessage Logistics {\n Event event = 1;\n}",
          "valueSchemaReferences": [
            {
              "name": "event.proto",
              "format": "PROTOBUF",
              "schema": "syntax = \"proto3\";\n\nmessage Event {\n int64 timestamp = 1;\n}"
            }
          ]
        }
      ],

"post": {
        "sources": [
          {"name": "INPUT", "type": "stream", "schema": "`event` STRUCT<`timestamp` BIGINT>"},
          {"name": "OUTPUT", "type": "stream", "schema": "`event` STRUCT<`timestamp` BIGINT>"}
        ]
      }
```

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

