### PR TITLE
docs: cherry-pick: document specific limits for CC COLLECT_SET (DOCS-16838)

### DIFF
--- a/docs/developer-guide/ksqldb-reference/aggregate-functions.md
+++ b/docs/developer-guide/ksqldb-reference/aggregate-functions.md
@@ -37,6 +37,11 @@ The size of the result ARRAY can be limited to a maximum of
 `ksql.functions.collect_list.limit` entries, and any values beyond this
 limit are ignored silently.
 
+!!! note
+
+    In {{ site.ccloud }}, the `ksql.functions.collect_list.limit` config is set
+    to 1000 and can't be changed.
+
 When used with `SESSION` window, sometimes two session windows are merged
 together into one, when a out-of-order record with a timestamp between
 the two windows is processed. In this case, the record limit is calculated by
@@ -61,6 +66,11 @@ each input row (for the specified grouping and time window, if any).
 The size of the result ARRAY can be limited to a maximum of
 `ksql.functions.collect_set.limit` entries, and any values beyond this
 limit are ignored silently.
+
+!!! note
+
+    In {{ site.ccloud }}, the `ksql.functions.collect_set.limit` config is set
+    to 1000 and can't be changed.
 
 When used with a `SESSION` window, sometimes two session windows are merged
 together into one, when a out-of-order record with a timestamp between

--- a/docs/reference/server-configuration.md
+++ b/docs/reference/server-configuration.md
@@ -177,6 +177,11 @@ any further values are silently ignored, by setting this configuration to N.
 For more information, see
 [aggregate-functions](/developer-guide/ksqldb-reference/aggregate-functions/#collect_list).
 
+!!! note
+
+    In {{ site.ccloud }}, the `ksql.functions.collect_list.limit` config is set
+    to 1000 and can't be changed.
+
 ## `ksql.functions.collect_set.limit`
 
 **Per query:** no
@@ -186,6 +191,11 @@ any further values are silently ignored, by setting this configuration to N.
 
 For more information, see
 [aggregate-functions](/developer-guide/ksqldb-reference/aggregate-functions/#collect_set).
+
+!!! note
+
+    In {{ site.ccloud }}, the `ksql.functions.collect_set.limit` config is set
+    to 1000 and can't be changed.
 
 ## `ksql.endpoint.logging.log.queries`
 


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/9486.