### PR TITLE
fix: track lag by queryId rather than applicationId (#9420)

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -1023,12 +1023,12 @@ public final class KsqlRestApplication implements Executable {
       final KsqlConfig configWithApplicationServer,
       final Optional<HeartbeatAgent> heartbeatAgent,
       final Optional<LagReportingAgent> lagReportingAgent) {
-    return (routingOptions, hosts, active, applicationQueryId, storeName, partition) -> {
+    return (routingOptions, hosts, active, queryId, storeName, partition) -> {
       final ImmutableList.Builder<RoutingFilter> filterBuilder = ImmutableList.builder();
 
       // If the lookup is for a forwarded request, apply only MaxLagFilter for localhost
       if (routingOptions.getIsSkipForwardRequest()) {
-        MaximumLagFilter.create(lagReportingAgent, routingOptions, hosts, applicationQueryId,
+        MaximumLagFilter.create(lagReportingAgent, routingOptions, hosts, queryId,
                                 storeName, partition)
             .map(filterBuilder::add);
       } else {
@@ -1037,7 +1037,7 @@ public final class KsqlRestApplication implements Executable {
           filterBuilder.add(new ActiveHostFilter(active));
         }
         filterBuilder.add(new LivenessFilter(heartbeatAgent));
-        MaximumLagFilter.create(lagReportingAgent, routingOptions, hosts, applicationQueryId,
+        MaximumLagFilter.create(lagReportingAgent, routingOptions, hosts, queryId,
                                 storeName, partition)
             .map(filterBuilder::add);
       }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/LagReportingAgent.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/LagReportingAgent.java
@@ -223,7 +223,7 @@ public final class LagReportingAgent implements HostStatusListener {
           .map(qm -> Pair.of(qm, qm.getAllLocalStorePartitionLags()))
           .map(pair -> pair.getRight().entrySet().stream()
               .collect(Collectors.toMap(
-                  e -> QueryStateStoreId.of(pair.getLeft().getQueryApplicationId(), e.getKey()),
+                  e -> QueryStateStoreId.of(pair.getLeft().getQueryId().toString(), e.getKey()),
                   Entry::getValue)))
           .flatMap(map -> map.entrySet().stream())
           .collect(Collectors.toMap(Entry::getKey, Entry::getValue));

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/MaximumLagFilter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/MaximumLagFilter.java
@@ -91,7 +91,7 @@ public final class MaximumLagFilter implements RoutingFilter {
    * @param lagReportingAgent The optional lag reporting agent.
    * @param routingOptions The routing options
    * @param hosts The set of all hosts that have the store, including actives and standbys
-   * @param applicationQueryId The query id of the persistent query that materialized the table
+   * @param queryId The query id of the persistent query that materialized the table
    * @param storeName The state store name of the materialized table
    * @param partition The partition of the topic
    * @return a new FreshnessFilter, unless lag reporting is disabled.
@@ -100,14 +100,14 @@ public final class MaximumLagFilter implements RoutingFilter {
       final Optional<LagReportingAgent> lagReportingAgent,
       final RoutingOptions routingOptions,
       final List<KsqlHostInfo> hosts,
-      final String applicationQueryId,
+      final String queryId,
       final String storeName,
       final int partition
   ) {
     if (!lagReportingAgent.isPresent()) {
       return Optional.empty();
     }
-    final QueryStateStoreId queryStateStoreId = QueryStateStoreId.of(applicationQueryId, storeName);
+    final QueryStateStoreId queryStateStoreId = QueryStateStoreId.of(queryId, storeName);
     final ImmutableMap<KsqlHostInfo, Optional<LagInfoEntity>> lagByHost = hosts.stream()
         .collect(ImmutableMap.toImmutableMap(
             Function.identity(),

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/LagReportingAgentFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/LagReportingAgentFunctionalTest.java
@@ -58,10 +58,10 @@ public class LagReportingAgentFunctionalTest {
   private static final int NUM_ROWS = PAGE_VIEWS_PROVIDER.data().size();
 
   private static final QueryStateStoreId STORE_0 = QueryStateStoreId.of(
-      "_confluent-ksql-default_query_CTAS_USER_VIEWS_3",
+      "CTAS_USER_VIEWS_3",
       "Aggregate-Aggregate-Materialize");
   private static final QueryStateStoreId STORE_1 = QueryStateStoreId.of(
-      "_confluent-ksql-default_query_CTAS_USER_LATEST_VIEWTIME_5",
+      "CTAS_USER_LATEST_VIEWTIME_5",
       "Aggregate-Aggregate-Materialize");
 
   private static final KsqlHostInfoEntity HOST0 = new KsqlHostInfoEntity("localhost", 8188);
@@ -84,6 +84,7 @@ public class LagReportingAgentFunctionalTest {
       // Lag Reporting
       .withProperty(KsqlRestConfig.KSQL_LAG_REPORTING_ENABLE_CONFIG, true)
       .withProperty(KsqlRestConfig.KSQL_LAG_REPORTING_SEND_INTERVAL_MS_CONFIG, 3000)
+      .withProperty("ksql.runtime.feature.shared.enabled", true)
       .build();
   private static final TestKsqlRestApp REST_APP_1 = TestKsqlRestApp
       .builder(TEST_HARNESS::kafkaBootstrapServers)
@@ -102,6 +103,8 @@ public class LagReportingAgentFunctionalTest {
       // Lag Reporting
       .withProperty(KsqlRestConfig.KSQL_LAG_REPORTING_ENABLE_CONFIG, true)
       .withProperty(KsqlRestConfig.KSQL_LAG_REPORTING_SEND_INTERVAL_MS_CONFIG, 3000)
+      .withProperty(StreamsConfig.STATE_DIR_CONFIG, "/tmp/Default")
+      .withProperty("ksql.runtime.feature.shared.enabled", true)
       .build();
 
   @ClassRule
@@ -148,7 +151,7 @@ public class LagReportingAgentFunctionalTest {
     // Then:
     // Read the raw Kafka data from the topic to verify the reported lags
     final List<ConsumerRecord<byte[], byte[]>> records =
-        TEST_HARNESS.verifyAvailableRecords("_confluent-ksql-default_query_CTAS_USER_VIEWS_3-"
+        TEST_HARNESS.verifyAvailableRecords("_confluent-ksql-default_query-CTAS_USER_VIEWS_3-"
             + "Aggregate-Aggregate-Materialize-changelog", NUM_ROWS);
     Map<Integer, Optional<ConsumerRecord<byte[], byte[]>>> partitionToMaxOffset =
         records.stream()

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/TerminateTransientQueryFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/TerminateTransientQueryFunctionalTest.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.rest.integration;
 
+import org.apache.kafka.streams.StreamsConfig;
+
 import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -26,6 +28,7 @@ import io.confluent.ksql.rest.entity.Queries;
 import io.confluent.ksql.rest.entity.RunningQuery;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PageViewDataProvider;
 import java.util.List;
 import java.util.Optional;
@@ -62,12 +65,15 @@ public class TerminateTransientQueryFunctionalTest {
       .withStaticServiceContext(TEST_HARNESS::getServiceContext)
       .withProperty(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:8088")
       .withProperty(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "http://localhost:8088")
+      .withProperty(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED, true)
       .build();
   private static final TestKsqlRestApp REST_APP_1 = TestKsqlRestApp
       .builder(TEST_HARNESS::kafkaBootstrapServers)
       .withStaticServiceContext(TEST_HARNESS::getServiceContext)
       .withProperty(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:8089")
       .withProperty(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "http://localhost:8089")
+      .withProperty(StreamsConfig.STATE_DIR_CONFIG, "/tmp/Default")
+      .withProperty(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED, true)
       .build();
 
   @ClassRule

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/LagReportingAgentTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/LagReportingAgentTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.engine.KsqlEngine;
+import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.entity.HostStoreLags;
 import io.confluent.ksql.rest.entity.KsqlHostInfoEntity;
 import io.confluent.ksql.rest.entity.LagInfoEntity;
@@ -263,9 +264,9 @@ public class LagReportingAgentTest {
 
     when(ksqlEngine.getPersistentQueries()).thenReturn(ImmutableList.of(query0, query1));
     when(query0.getAllLocalStorePartitionLags()).thenReturn(query0Lag);
-    when(query0.getQueryApplicationId()).thenReturn(QUERY_ID0);
+    when(query0.getQueryId()).thenReturn(new QueryId(QUERY_ID0));
     when(query1.getAllLocalStorePartitionLags()).thenReturn(query1Lag);
-    when(query1.getQueryApplicationId()).thenReturn(QUERY_ID1);
+    when(query1.getQueryId()).thenReturn(new QueryId(QUERY_ID1));
   }
 
   @Test

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryStateStoreId.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryStateStoreId.java
@@ -31,19 +31,19 @@ import java.util.Objects;
 public final class QueryStateStoreId {
   private static final String SEPARATOR = "#";
 
-  private final String queryApplicationId;
+  private final String queryId;
   private final String stateStoreName;
 
-  public static QueryStateStoreId of(final String queryApplicationId, final String stateStoreName) {
-    return new QueryStateStoreId(queryApplicationId, stateStoreName);
+  public static QueryStateStoreId of(final String queryId, final String stateStoreName) {
+    return new QueryStateStoreId(queryId, stateStoreName);
   }
 
   public static QueryStateStoreId of(final String serializedKey) {
     return new QueryStateStoreId(serializedKey);
   }
 
-  private QueryStateStoreId(final String queryApplicationId, final String stateStoreName) {
-    this.queryApplicationId = queryApplicationId;
+  private QueryStateStoreId(final String queryId, final String stateStoreName) {
+    this.queryId = queryId;
     this.stateStoreName = stateStoreName;
   }
 
@@ -51,12 +51,12 @@ public final class QueryStateStoreId {
   public QueryStateStoreId(final String serializedPair) {
     final String [] parts = serializedPair.split("\\" + SEPARATOR);
     Preconditions.checkArgument(parts.length == 2);
-    this.queryApplicationId = Objects.requireNonNull(parts[0]);
+    this.queryId = Objects.requireNonNull(parts[0]);
     this.stateStoreName = Objects.requireNonNull(parts[1]);
   }
 
-  public String getQueryApplicationId() {
-    return queryApplicationId;
+  public String getQueryId() {
+    return queryId;
   }
 
   public String getStateStoreName() {
@@ -74,18 +74,18 @@ public final class QueryStateStoreId {
     }
 
     final QueryStateStoreId that = (QueryStateStoreId) o;
-    return Objects.equals(queryApplicationId, that.queryApplicationId)
+    return Objects.equals(queryId, that.queryId)
         && Objects.equals(stateStoreName, that.stateStoreName);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(queryApplicationId, stateStoreName);
+    return Objects.hash(queryId, stateStoreName);
   }
 
   @JsonValue
   @Override
   public String toString() {
-    return queryApplicationId + SEPARATOR + stateStoreName;
+    return queryId + SEPARATOR + stateStoreName;
   }
 }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
@@ -77,7 +77,6 @@ public final class KsLocator implements Locator {
   private final Topology topology;
   private final Serializer<GenericKey> keySerializer;
   private final URL localHost;
-  private final String applicationId;
   private final boolean sharedRuntimesEnabled;
   private final String queryId;
 
@@ -87,7 +86,6 @@ public final class KsLocator implements Locator {
       final Topology topology,
       final Serializer<GenericKey> keySerializer,
       final URL localHost,
-      final String applicationId,
       final boolean sharedRuntimesEnabled,
       final String queryId
   ) {
@@ -96,7 +94,6 @@ public final class KsLocator implements Locator {
     this.keySerializer = requireNonNull(keySerializer, "keySerializer");
     this.storeName = requireNonNull(stateStoreName, "stateStoreName");
     this.localHost = requireNonNull(localHost, "localHost");
-    this.applicationId = requireNonNull(applicationId, "applicationId");
     this.sharedRuntimesEnabled = sharedRuntimesEnabled;
     this.queryId = requireNonNull(queryId, "queryId");
   }
@@ -369,7 +366,7 @@ public final class KsLocator implements Locator {
         routingOptions,
         allHosts,
         activeHost,
-        applicationId,
+        queryId,
         storeName,
         partition
     );

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializationFactory.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializationFactory.java
@@ -95,7 +95,6 @@ public final class KsMaterializationFactory {
         topology,
         keySerializer,
         localHost,
-        applicationId,
         ksqlConfig.getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED),
         queryId
     );
@@ -138,7 +137,6 @@ public final class KsMaterializationFactory {
         Topology topology,
         Serializer<GenericKey> keySerializer,
         URL localHost,
-        String applicationId,
         boolean sharedRuntimesEnabled,
         String queryId
     );

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocatorTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocatorTest.java
@@ -171,7 +171,6 @@ public class KsLocatorTest {
         topology,
         keySerializer,
         LOCAL_HOST_URL,
-        APPLICATION_ID,
         false,
         "queryId"
     );
@@ -303,7 +302,7 @@ public class KsLocatorTest {
   public void shouldUseNamedTopologyWhenSharedRuntimeIsEnabledForStreamsMetadataForStore() {
     // Given:
     final KsLocator locator = new KsLocator(STORE_NAME, kafkaStreamsNamedTopologyWrapper, topology,
-        keySerializer, LOCAL_HOST_URL, APPLICATION_ID, true, "queryId");
+        keySerializer, LOCAL_HOST_URL, true, "queryId");
 
     // When:
     locator.getStreamsMetadata();
@@ -316,7 +315,7 @@ public class KsLocatorTest {
   public void shouldUseNamedTopologyWhenSharedRuntimeIsEnabledForQueryMetadataForKey() {
     // Given:
     final KsLocator locator = new KsLocator(STORE_NAME, kafkaStreamsNamedTopologyWrapper, topology,
-        keySerializer, LOCAL_HOST_URL, APPLICATION_ID, true, "queryId");
+        keySerializer, LOCAL_HOST_URL, true, "queryId");
 
     // When:
     locator.getKeyQueryMetadata(KEY);

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializationFactoryTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializationFactoryTest.java
@@ -94,7 +94,7 @@ public class KsMaterializationFactoryTest {
         materializationFactory
     );
 
-    when(locatorFactory.create(any(), any(), any(), any(), any(), any(),
+    when(locatorFactory.create(any(), any(), any(), any(), any(),
         anyBoolean(), anyString())).thenReturn(locator);
     when(storeFactory.create(any(), any(), any(), any(), any())).thenReturn(stateStore);
     when(materializationFactory.create(any(), any(), any())).thenReturn(materialization);
@@ -139,7 +139,6 @@ public class KsMaterializationFactoryTest {
         topology,
         keySerializer,
         DEFAULT_APP_SERVER,
-        APPLICATION_ID,
         false,
         "queryId"
     );


### PR DESCRIPTION
Hotfix: https://github.com/confluentinc/ksql/pull/9420