### PR TITLE
test: Enhance integration test coverage for ksql/connect integration

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/ConnectIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/ConnectIntegrationTest.java
@@ -363,17 +363,13 @@ public class ConnectIntegrationTest {
 
   @Test
   public void shouldListConnectorPlugins() {
-    // Given:
-    create("mock-connector", ImmutableMap.of(
-        "connector.class", "org.apache.kafka.connect.tools.MockSourceConnector"));
-
     // When:
     final RestResponse<KsqlEntityList> response = ksqlRestClient.makeKsqlRequest("LIST CONNECTOR PLUGINS;");
 
     // Then:
     assertThat(response.isSuccessful(), is(true));
     assertThat(response.getResponse().get(0), instanceOf(ConnectorPluginsList.class));
-    // Since no plugin is added to the connector, the size of plugins list is 0.
+    // Since no plugins have been added, the size of plugins list is 0.
     assertThat(((ConnectorPluginsList)response.getResponse().get(0)).getConnectorsPlugins().size(), is(0));
   }
 


### PR DESCRIPTION
### Description 
KSE-1001
The ksqlConnectIntegrationTest lacked a successful `CREATE CONNECTOR` response and `LIST CONNECTOR PLUGINS` which are added in this fix.

### Testing done 
integration test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")



[KSE-1001]: https://confluentinc.atlassian.net/browse/KSE-1001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ