### PR TITLE
feat: add a customer log4j MetricAppender to track log level stats

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/metrics/MetricAppender.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/metrics/MetricAppender.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.metrics;
+
+import com.google.common.collect.ImmutableList;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.common.metrics.JmxReporter;
+import org.apache.kafka.common.metrics.KafkaMetricsContext;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Rate;
+import org.apache.kafka.common.utils.SystemTime;
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.Level;
+import org.apache.log4j.spi.LoggingEvent;
+
+/**
+ * {@code MetricAppender} publishes JMX metrics around the number of messages that
+ * are sent to any logger configured to use this appender.
+ */
+public class MetricAppender extends AppenderSkeleton {
+
+  private static final String KSQL_LOGGING_JMX_PREFIX = "io.confluent.ksql.metrics.logging";
+  private static final String KSQL_LOGGING_METRIC_GROUP = "ksql-logging";
+
+  private final Metrics metrics;
+  private final Sensor errors;
+  private final Sensor warns;
+  private final Sensor infos;
+
+  public MetricAppender() {
+    metrics = new Metrics(
+        new MetricConfig().samples(100).timeWindow(1, TimeUnit.SECONDS),
+        ImmutableList.of(new JmxReporter()),
+        new SystemTime(),
+        new KafkaMetricsContext(KSQL_LOGGING_JMX_PREFIX)
+    );
+
+    errors = metrics.sensor(KSQL_LOGGING_METRIC_GROUP + "-error-rate");
+    errors.add(
+        metrics.metricName("errors", KSQL_LOGGING_METRIC_GROUP, "number of error logs"),
+        new Rate()
+    );
+
+    warns = metrics.sensor(KSQL_LOGGING_METRIC_GROUP + "-warn-rate");
+    warns.add(
+        metrics.metricName("warns", KSQL_LOGGING_METRIC_GROUP, "number of warn logs"),
+        new Rate()
+    );
+
+    infos = metrics.sensor(KSQL_LOGGING_METRIC_GROUP + "-info-rate");
+    infos.add(
+        metrics.metricName("infos", KSQL_LOGGING_METRIC_GROUP, "number of info logs"),
+        new Rate()
+    );
+  }
+
+  @Override
+  protected void append(final LoggingEvent event) {
+    if (event.getLevel() == Level.INFO) {
+      infos.record();
+    }  else if (event.getLevel() == Level.WARN) {
+      warns.record();
+    } else if (event.getLevel() == Level.ERROR) {
+      errors.record();
+    }
+  }
+
+  @Override
+  public void close() {
+    metrics.close();
+  }
+
+  @Override
+  public boolean requiresLayout() {
+    return false;
+  }
+
+}

--- a/ksqldb-common/src/main/java/io/confluent/ksql/metrics/MetricAppender.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/metrics/MetricAppender.java
@@ -52,19 +52,19 @@ public class MetricAppender extends AppenderSkeleton {
 
     errors = metrics.sensor(KSQL_LOGGING_METRIC_GROUP + "-error-rate");
     errors.add(
-        metrics.metricName("errors", KSQL_LOGGING_METRIC_GROUP, "number of error logs"),
+        metrics.metricName("errors", KSQL_LOGGING_METRIC_GROUP, "number of error logs per second"),
         new Rate()
     );
 
     warns = metrics.sensor(KSQL_LOGGING_METRIC_GROUP + "-warn-rate");
     warns.add(
-        metrics.metricName("warns", KSQL_LOGGING_METRIC_GROUP, "number of warn logs"),
+        metrics.metricName("warns", KSQL_LOGGING_METRIC_GROUP, "number of warn logs per second"),
         new Rate()
     );
 
     infos = metrics.sensor(KSQL_LOGGING_METRIC_GROUP + "-info-rate");
     infos.add(
-        metrics.metricName("infos", KSQL_LOGGING_METRIC_GROUP, "number of info logs"),
+        metrics.metricName("infos", KSQL_LOGGING_METRIC_GROUP, "number of info logs per second"),
         new Rate()
     );
   }


### PR DESCRIPTION
### Description 

Introduce `MetricAppender`, which can be added to the root logger to track the number of ERROR/WARN/INFO messages that are being logged for a host.

I spent quite a long time on the internet scouring to see if there's an already built implementation of this, but it looks like it's dependent on the metric system that you use (e.g. Prometheus and Dropwizard each have their own instrumenting adapter, but Kafka metrics systems do not). In the future, it may make sense to contribute this back to Kafka or some common Confluent repository.

### Testing done 

I enabled it in the log4j configuration:
```
log4j.appender.metrics=io.confluent.ksql.metrics.MetricAppender
log4j.rootLogger=INFO, stdout, metrics
```

And then used `jconsole` to confirm the JMX beans were reported properly.

![image](https://user-images.githubusercontent.com/3172405/187001096-0394445d-8758-4d50-9449-0e7ad41b1006.png)


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

