### PR TITLE
chore: skip migration command in command topic backup

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicBackupImpl.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicBackupImpl.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.rest.server;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.confluent.ksql.rest.server.computation.InternalTopicSerdes;
 import io.confluent.ksql.rest.server.resources.CommandTopicCorruptionException;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlConfig;
@@ -144,7 +145,17 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
       LOG.warn(String.format("Can't backup a command topic record with a null key/value:"
               + " key=%s, value=%s, partition=%d, offset=%d",
           record.key(), record.value(), record.partition(), record.offset()));
+      corruptionDetected = true;
+      return;
+    }
 
+    if (Arrays.equals(record.key(), InternalTopicSerdes.serializer().serialize(
+        "",
+        CommandTopicMigrationUtil.MIGRATION_COMMAND_ID)
+    )) {
+      LOG.warn(String.format("Can't backup migration command topic record offset=%d",
+          record.offset()));
+      corruptionDetected = true;
       return;
     }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicBackupImpl.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicBackupImpl.java
@@ -145,8 +145,6 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
       LOG.warn(String.format("Can't backup a command topic record with a null key/value:"
               + " key=%s, value=%s, partition=%d, offset=%d",
           record.key(), record.value(), record.partition(), record.offset()));
-      corruptionDetected = true;
-      return;
     }
 
     if (Arrays.equals(record.key(), InternalTopicSerdes.serializer().serialize(

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicMigrationUtil.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicMigrationUtil.java
@@ -40,6 +40,8 @@ import org.slf4j.LoggerFactory;
 public final class CommandTopicMigrationUtil {
 
   private static final Logger log = LoggerFactory.getLogger(CommandTopicMigrationUtil.class);
+  public static final CommandId MIGRATION_COMMAND_ID =
+      new CommandId(CommandId.Type.CLUSTER, "migration", CommandId.Action.ALTER);
 
   private CommandTopicMigrationUtil() {
 
@@ -59,12 +61,10 @@ public final class CommandTopicMigrationUtil {
         InternalTopicSerdes.serializer(),
         InternalTopicSerdes.serializer()
     );
-    final CommandId migrationCommandId =
-        new CommandId(CommandId.Type.CLUSTER, "migration", CommandId.Action.ALTER);
     final ProducerRecord<CommandId, Command> degradedCommand = new ProducerRecord<>(
         commandTopic,
         topicPartition.partition(),
-        migrationCommandId,
+        MIGRATION_COMMAND_ID,
         new Command(
             "",
             Collections.emptyMap(),
@@ -98,7 +98,7 @@ public final class CommandTopicMigrationUtil {
     final List<QueuedCommand> commandsToMigrate = new ArrayList<>();
     for (QueuedCommand command : commands) {
       final CommandId currentCommandId = command.getAndDeserializeCommandId();
-      if (currentCommandId.equals(migrationCommandId)) {
+      if (currentCommandId.equals(MIGRATION_COMMAND_ID)) {
         log.info("skipping migration command sent to old command "
             + "topic when migrating to new one");
       } else {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicBackupImplTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicBackupImplTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.confluent.ksql.rest.server.computation.InternalTopicSerdes;
 import io.confluent.ksql.rest.server.resources.CommandTopicCorruptionException;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.test.util.KsqlTestFolder;
@@ -192,6 +193,22 @@ public class CommandTopicBackupImplTest {
     final ConsumerRecord<byte[], byte[]> record = mock(ConsumerRecord.class);
     when(record.key()).thenReturn(new byte[]{});
     when(record.value()).thenReturn(null);
+
+    // When
+    commandTopicBackup.writeRecord(record);
+
+    // Then
+    final List<Pair<byte[], byte[]>> commands = commandTopicBackup.getReplayFile().readRecords();
+    assertThat(commands.size(), is(0));
+  }
+
+  @Test
+  public void shouldNotWriteMigrationCommandToBackup() throws IOException {
+    // Given
+    commandTopicBackup.initialize();
+    final ConsumerRecord<byte[], byte[]> record = mock(ConsumerRecord.class);
+    when(record.key()).thenReturn(InternalTopicSerdes.serializer().serialize("", CommandTopicMigrationUtil.MIGRATION_COMMAND_ID));
+    when(record.value()).thenReturn(new byte[]{});
 
     // When
     commandTopicBackup.writeRecord(record);


### PR DESCRIPTION
### Description 
When migrating the command topic, we fence off the old command topic with a migration command from other running servers that haven't migrated yet. We shouldn't back this command into the backup file since it's not a valid command

### Testing done 
unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

