### PR TITLE
test: change default partitions in tests to 1

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/Topic.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/Topic.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 
 public class Topic {
 
-  public static final int DEFAULT_PARTITIONS = 4;
+  public static final int DEFAULT_PARTITIONS = 1;
   public static final short DEFAULT_RF = 1;
 
   private final String name;


### PR DESCRIPTION
### Description 
Changing it to 1 because some of the RQTTs have been failing due to results coming out of order.

```
Expected: is "ID: 1\nFILTERED_TRANSFORMED {\n  key: \"C\"\n  value: -1\n}\nFILTERED_TRANSFORMED {\n  key: \"T\"\n  value: 3\n}\n"
     but: was "FILTERED_TRANSFORMED {\n  key: \"A\"\n  value: 4\n}\nFILTERED_TRANSFORMED {\n  key: \"B\"\n  value: -1\n}\n"
failed test: pull-queries-protobuf - transform a map with array values
in file: file:///home/jenkins/workspace/confluentinc_ksql_master/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-protobuf.json:7
```

### Testing done 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

