### PR TITLE
feat: expose cleanup policy in create statements

### DIFF
--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -75,6 +75,7 @@ import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.integration.IntegrationTestHarness;
 import io.confluent.ksql.integration.Retry;
 import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.properties.with.CommonCreateConfigs;
 import io.confluent.ksql.rest.ApiJsonMapper;
 import io.confluent.ksql.rest.entity.ConnectorList;
 import io.confluent.ksql.rest.entity.KsqlEntity;
@@ -972,7 +973,7 @@ public class ClientIntegrationTest {
             hasProperty("queryType", is(QueryType.PERSISTENT)),
             hasProperty("id", startsWith("CTAS_" + AGG_TABLE)),
             hasProperty("sql", is(
-                    "CREATE TABLE " + AGG_TABLE + " WITH (KAFKA_TOPIC='" + AGG_TABLE + "', PARTITIONS=1, REPLICAS=1, RETENTION_MS=-1) AS SELECT\n"
+                    "CREATE TABLE " + AGG_TABLE + " WITH (CLEANUP_POLICY='compact', KAFKA_TOPIC='" + AGG_TABLE + "', PARTITIONS=1, REPLICAS=1, RETENTION_MS=-1) AS SELECT\n"
                             + "  " + TEST_STREAM + ".K K,\n"
                             + "  LATEST_BY_OFFSET(" + TEST_STREAM + ".LONG) LONG\n"
                             + "FROM " + TEST_STREAM + " " + TEST_STREAM + "\n"
@@ -1005,7 +1006,7 @@ public class ClientIntegrationTest {
     assertThat(description.readQueries().get(0).getQueryType(), is(QueryType.PERSISTENT));
     assertThat(description.readQueries().get(0).getId(), startsWith("CTAS_" + AGG_TABLE));
     assertThat(description.readQueries().get(0).getSql(), is(
-        "CREATE TABLE " + AGG_TABLE + " WITH (KAFKA_TOPIC='" + AGG_TABLE + "', PARTITIONS=1, REPLICAS=1, RETENTION_MS=-1) AS SELECT\n"
+        "CREATE TABLE " + AGG_TABLE + " WITH (CLEANUP_POLICY='compact', KAFKA_TOPIC='" + AGG_TABLE + "', PARTITIONS=1, REPLICAS=1, RETENTION_MS=-1) AS SELECT\n"
             + "  " + TEST_STREAM + ".K K,\n"
             + "  LATEST_BY_OFFSET(" + TEST_STREAM + ".LONG) LONG\n"
             + "FROM " + TEST_STREAM + " " + TEST_STREAM + "\n"
@@ -1023,7 +1024,7 @@ public class ClientIntegrationTest {
             + "ARRAY_ARRAY ARRAY<ARRAY<STRING>>, ARRAY_STRUCT ARRAY<STRUCT<F1 STRING>>, "
             + "ARRAY_MAP ARRAY<MAP<STRING, INTEGER>>, MAP_ARRAY MAP<STRING, ARRAY<STRING>>, "
             + "MAP_MAP MAP<STRING, MAP<STRING, INTEGER>>, MAP_STRUCT MAP<STRING, STRUCT<F1 STRING>>>, TIMESTAMP TIMESTAMP, DATE DATE, TIME TIME, HEAD BYTES HEADER('h0')) "
-            + "WITH (KAFKA_TOPIC='STRUCTURED_TYPES_TOPIC', KEY_FORMAT='JSON', VALUE_FORMAT='JSON');"));
+            + "WITH (CLEANUP_POLICY='delete', KAFKA_TOPIC='STRUCTURED_TYPES_TOPIC', KEY_FORMAT='JSON', VALUE_FORMAT='JSON');"));
   }
 
   @Test

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CommonCreateConfigs.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CommonCreateConfigs.java
@@ -204,7 +204,7 @@ public final class CommonCreateConfigs {
             SOURCE_TOPIC_CLEANUP_POLICY,
             ConfigDef.Type.STRING,
             null,
-            Importance.HIGH,
+            Importance.LOW,
             "This config designates the retention policy to use on log segments. "
                 + "The \"delete\" policy (which is the default) will discard old segments "
                 + "when their retention time or size limit has been reached. The \"compact\" "

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CommonCreateConfigs.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CommonCreateConfigs.java
@@ -55,6 +55,7 @@ public final class CommonCreateConfigs {
   public static final String KEY_SCHEMA_ID = "KEY_SCHEMA_ID";
   public static final String VALUE_SCHEMA_ID = "VALUE_SCHEMA_ID";
 
+  @SuppressWarnings("checkstyle:MethodLength")
   public static void addToConfigDef(
       final ConfigDef configDef,
       final boolean topicNameRequired
@@ -204,7 +205,14 @@ public final class CommonCreateConfigs {
             ConfigDef.Type.STRING,
             null,
             Importance.HIGH,
-            "Undocumented feature");
+            "This config designates the retention policy to use on log segments. "
+                + "The \"delete\" policy (which is the default) will discard old segments "
+                + "when their retention time or size limit has been reached. The \"compact\" "
+                + "policy will enable <a href=\"#compaction\">log compaction</a>, which retains "
+                + "the latest value for each key. It is also possible to specify both policies "
+                + "in a comma-separated list (e.g. \"delete,compact\"). In this case, old segments "
+                + "will be discarded per the retention time and size configuration, while retained "
+                + "segments will be compacted.");
   }
 
   public static void validateKeyValueFormats(final Map<String, Object> configs) {

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CommonCreateConfigs.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CommonCreateConfigs.java
@@ -33,6 +33,7 @@ public final class CommonCreateConfigs {
   public static final String SOURCE_NUMBER_OF_PARTITIONS = "PARTITIONS";
   public static final String SOURCE_NUMBER_OF_REPLICAS = "REPLICAS";
   public static final String SOURCE_TOPIC_RETENTION_IN_MS = "RETENTION_MS";
+  public static final String SOURCE_TOPIC_CLEANUP_POLICY = "CLEANUP_POLICY";
 
   // Timestamp Props:
   public static final String TIMESTAMP_NAME_PROPERTY = "TIMESTAMP";
@@ -197,6 +198,12 @@ public final class CommonCreateConfigs {
             ConfigDef.Type.INT,
             null,
             Importance.LOW,
+            "Undocumented feature"
+        ).define(
+            SOURCE_TOPIC_CLEANUP_POLICY,
+            ConfigDef.Type.STRING,
+            null,
+            Importance.HIGH,
             "Undocumented feature");
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/topic/TopicCreateInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/topic/TopicCreateInjector.java
@@ -54,7 +54,12 @@ public class TopicCreateInjector implements Injector {
 
   private static final String CLEANUP_POLICY_PRESENT_EXCEPTION =
       String.format(
-          "Invalid config variable in the WITH clause: %s",
+          "Invalid config variable in the WITH clause: %s.\n"
+              + "The %s config is automatically inferred based "
+              + "on the type of source (STREAM or TABLE).\n"
+              + "Users can't set the %s config manually.",
+          CommonCreateConfigs.SOURCE_TOPIC_CLEANUP_POLICY,
+          CommonCreateConfigs.SOURCE_TOPIC_CLEANUP_POLICY,
           CommonCreateConfigs.SOURCE_TOPIC_CLEANUP_POLICY);
 
   private final KafkaTopicClient topicClient;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/topic/TopicCreateInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/topic/TopicCreateInjector.java
@@ -52,8 +52,10 @@ import org.apache.kafka.common.config.TopicConfig;
  */
 public class TopicCreateInjector implements Injector {
 
-  private static final String CLEANUP_POLICY_PRESENT_EXCEPTION = String.format(
-      "Invalid config variable in the WITH clause: %s", CommonCreateConfigs.SOURCE_TOPIC_CLEANUP_POLICY);
+  private static final String CLEANUP_POLICY_PRESENT_EXCEPTION =
+      String.format(
+          "Invalid config variable in the WITH clause: %s",
+          CommonCreateConfigs.SOURCE_TOPIC_CLEANUP_POLICY);
 
   private final KafkaTopicClient topicClient;
   private final MetaStore metaStore;
@@ -107,7 +109,9 @@ public class TopicCreateInjector implements Injector {
     final CreateSource createSource = statement.getStatement();
     final CreateSourceProperties properties = createSource.getProperties();
 
-    if (properties.getCleanupPolicy().isPresent()) throw new KsqlException(CLEANUP_POLICY_PRESENT_EXCEPTION);
+    if (properties.getCleanupPolicy().isPresent()) {
+      throw new KsqlException(CLEANUP_POLICY_PRESENT_EXCEPTION);
+    }
 
     final String topicCleanUpPolicy = createSource instanceof CreateTable
         ? TopicConfig.CLEANUP_POLICY_COMPACT : TopicConfig.CLEANUP_POLICY_DELETE;
@@ -157,7 +161,9 @@ public class TopicCreateInjector implements Injector {
     final T createAsSelect = statement.getStatement();
     final CreateSourceAsProperties properties = createAsSelect.getProperties();
 
-    if (properties.getCleanupPolicy().isPresent()) throw new KsqlException(CLEANUP_POLICY_PRESENT_EXCEPTION);
+    if (properties.getCleanupPolicy().isPresent()) {
+      throw new KsqlException(CLEANUP_POLICY_PRESENT_EXCEPTION);
+    }
 
     final SourceTopicsExtractor extractor = new SourceTopicsExtractor(metaStore);
     extractor.process(statement.getStatement().getQuery(), null);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/topic/TopicCreateInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/topic/TopicCreateInjector.java
@@ -300,6 +300,10 @@ public class TopicCreateInjector implements Injector {
   private static <T extends Statement> KsqlParser.PreparedStatement<T> buildPreparedStatement(
       final T stmt
   ) {
-    return KsqlParser.PreparedStatement.of(SqlFormatter.formatSql(stmt), stmt);
+    String formattedSql = SqlFormatter.formatSql(stmt);
+    if (!formattedSql.endsWith(";")) {
+      formattedSql = formattedSql + ";";
+    }
+    return KsqlParser.PreparedStatement.of(formattedSql, stmt);
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/topic/TopicCreateInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/topic/TopicCreateInjector.java
@@ -54,9 +54,9 @@ public class TopicCreateInjector implements Injector {
 
   private static final String CLEANUP_POLICY_PRESENT_EXCEPTION =
       String.format(
-          "Invalid config variable in the WITH clause: %s.\n"
+          "Invalid config variable in the WITH clause: %s.%n"
               + "The %s config is automatically inferred based "
-              + "on the type of source (STREAM or TABLE).\n"
+              + "on the type of source (STREAM or TABLE).%n"
               + "Users can't set the %s config manually.",
           CommonCreateConfigs.SOURCE_TOPIC_CLEANUP_POLICY,
           CommonCreateConfigs.SOURCE_TOPIC_CLEANUP_POLICY,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
@@ -598,7 +598,9 @@ public class TopicCreateInjectorTest {
     // Then:
     assertThat(
         e.getMessage(),
-        containsString("Invalid config variable in the WITH clause: CLEANUP_POLICY"));
+        containsString("Invalid config variable in the WITH clause: CLEANUP_POLICY.\n"
+            + "The CLEANUP_POLICY config is automatically inferred based on the type of source (STREAM or TABLE).\n"
+            + "Users can't set the CLEANUP_POLICY config manually."));
   }
 
   @Test
@@ -615,7 +617,9 @@ public class TopicCreateInjectorTest {
     // Then:
     assertThat(
         e.getMessage(),
-        containsString("Invalid config variable in the WITH clause: CLEANUP_POLICY"));
+        containsString("Invalid config variable in the WITH clause: CLEANUP_POLICY.\n"
+            + "The CLEANUP_POLICY config is automatically inferred based on the type of source (STREAM or TABLE).\n"
+            + "Users can't set the CLEANUP_POLICY config manually."));
   }
 
   @Test
@@ -632,7 +636,9 @@ public class TopicCreateInjectorTest {
     // Then:
     assertThat(
         e.getMessage(),
-        containsString("Invalid config variable in the WITH clause: CLEANUP_POLICY"));
+        containsString("Invalid config variable in the WITH clause: CLEANUP_POLICY.\n"
+            + "The CLEANUP_POLICY config is automatically inferred based on the type of source (STREAM or TABLE).\n"
+            + "Users can't set the CLEANUP_POLICY config manually."));
   }
 
   @Test
@@ -649,7 +655,9 @@ public class TopicCreateInjectorTest {
     // Then:
     assertThat(
         e.getMessage(),
-        containsString("Invalid config variable in the WITH clause: CLEANUP_POLICY"));
+        containsString("Invalid config variable in the WITH clause: CLEANUP_POLICY.\n"
+            + "The CLEANUP_POLICY config is automatically inferred based on the type of source (STREAM or TABLE).\n"
+            + "Users can't set the CLEANUP_POLICY config manually."));
   }
 
   private ConfiguredStatement<?> givenStatement(final String sql) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
@@ -334,7 +334,7 @@ public class TopicCreateInjectorTest {
         equalTo(
             "CREATE STREAM X WITH (CLEANUP_POLICY='delete', KAFKA_TOPIC='name', PARTITIONS=1, REPLICAS=1, RETENTION_MS=100) AS SELECT *"
                 + "\nFROM SOURCE SOURCE\n"
-                + "EMIT CHANGES"));
+                + "EMIT CHANGES;"));
   }
 
   @Test

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/AssertExecutorMetaTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/AssertExecutorMetaTest.java
@@ -23,9 +23,10 @@ public class AssertExecutorMetaTest {
    * These are excluded from coverage
    */
   private final Set<String> excluded = ImmutableSet.of(
-      CommonCreateConfigs.SOURCE_NUMBER_OF_PARTITIONS, // testing tool does not support partitions
-      CommonCreateConfigs.SOURCE_NUMBER_OF_REPLICAS,   // testing tool does not support replicas
-      CommonCreateConfigs.SOURCE_TOPIC_RETENTION_IN_MS // testing tool does not support retention_ms
+      CommonCreateConfigs.SOURCE_NUMBER_OF_PARTITIONS,  // testing tool does not support partitions
+      CommonCreateConfigs.SOURCE_NUMBER_OF_REPLICAS,    // testing tool does not support replicas
+      CommonCreateConfigs.SOURCE_TOPIC_RETENTION_IN_MS, // testing tool does not support retention_ms
+      CommonCreateConfigs.SOURCE_TOPIC_CLEANUP_POLICY   // testing tool does not support cleanup_policy
   );
 
   @Test

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceAsProperties.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceAsProperties.java
@@ -93,6 +93,10 @@ public final class CreateSourceAsProperties {
     return Optional.ofNullable(props.getLong(CommonCreateConfigs.SOURCE_TOPIC_RETENTION_IN_MS));
   }
 
+  public Optional<String> getCleanupPolicy() {
+    return Optional.ofNullable(props.getString(CommonCreateConfigs.SOURCE_TOPIC_CLEANUP_POLICY));
+  }
+
   public Optional<ColumnName> getTimestampColumnName() {
     return Optional.ofNullable(props.getString(CommonCreateConfigs.TIMESTAMP_NAME_PROPERTY))
         .map(ColumnReferenceParser::parse);
@@ -223,6 +227,15 @@ public final class CreateSourceAsProperties {
       final boolean unwrapProtobufPrimitives
   ) {
     return new CreateSourceAsProperties(props.copyOfOriginalLiterals(), unwrapProtobufPrimitives);
+  }
+
+  public CreateSourceAsProperties withCleanupPolicy(final String cleanupPolicy) {
+    final Map<String, Literal> originals = props.copyOfOriginalLiterals();
+    originals.put(
+        CommonCreateConfigs.SOURCE_TOPIC_CLEANUP_POLICY,
+        new StringLiteral(cleanupPolicy));
+
+    return new CreateSourceAsProperties(originals, unwrapProtobufPrimitives);
   }
 
   @Override

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
@@ -103,6 +103,10 @@ public final class CreateSourceProperties {
     return Optional.ofNullable(props.getLong(CommonCreateConfigs.SOURCE_TOPIC_RETENTION_IN_MS));
   }
 
+  public Optional<String> getCleanupPolicy() {
+    return Optional.ofNullable(props.getString(CommonCreateConfigs.SOURCE_TOPIC_CLEANUP_POLICY));
+  }
+
   public Optional<WindowType> getWindowType() {
     try {
       return Optional.ofNullable(props.getString(CreateConfigs.WINDOW_TYPE_PROPERTY))
@@ -279,6 +283,15 @@ public final class CreateSourceProperties {
         durationParser,
         unwrapProtobufPrimitives
     );
+  }
+
+  public CreateSourceProperties withCleanupPolicy(final String cleanupPolicy) {
+    final Map<String, Literal> originals = props.copyOfOriginalLiterals();
+    originals.put(
+        CommonCreateConfigs.SOURCE_TOPIC_CLEANUP_POLICY,
+        new StringLiteral(cleanupPolicy));
+
+    return new CreateSourceProperties(originals, durationParser, unwrapProtobufPrimitives);
   }
 
   public Map<String, Literal> copyOfOriginalLiterals() {


### PR DESCRIPTION
### Description 
Injects `CLEANUP_POLICY` to `CreateSourceProperties` and `CreateSourceAsProperties`.

The cleanup policy is exposed visa the `getCleanupPolicy()` method in the respective property classes. 
### Testing done 
- unit testing
- manual testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

