### PR TITLE
Disable shared runtimes for TerminateTransientQueryFunctionalTest

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/TerminateTransientQueryFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/TerminateTransientQueryFunctionalTest.java
@@ -65,7 +65,6 @@ public class TerminateTransientQueryFunctionalTest {
       .withStaticServiceContext(TEST_HARNESS::getServiceContext)
       .withProperty(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:8088")
       .withProperty(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "http://localhost:8088")
-      .withProperty(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED, true)
       .build();
   private static final TestKsqlRestApp REST_APP_1 = TestKsqlRestApp
       .builder(TEST_HARNESS::kafkaBootstrapServers)
@@ -73,7 +72,6 @@ public class TerminateTransientQueryFunctionalTest {
       .withProperty(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:8089")
       .withProperty(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "http://localhost:8089")
       .withProperty(StreamsConfig.STATE_DIR_CONFIG, "/tmp/Default")
-      .withProperty(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED, true)
       .build();
 
   @ClassRule


### PR DESCRIPTION
### Description 
Disable shared runtimes for TerminateTransientQueryFunctionalTest since it was making the test flaky.

### Testing done 
Ran tests many times!

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

