### PR TITLE
feat: add source connector property to CREATE SOURCE statements

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CreateConfigs.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CreateConfigs.java
@@ -32,6 +32,7 @@ public final class CreateConfigs {
   public static final String WINDOW_TYPE_PROPERTY = "WINDOW_TYPE";
   public static final String WINDOW_SIZE_PROPERTY = "WINDOW_SIZE";
   public static final String SOURCE_CONNECTOR = "SOURCE_CONNECTOR";
+  public static final String SOURCE_CONNECTOR_PROPERTY = "SOURCED_BY_CONNECTOR";
 
   private static final ConfigDef CONFIG_DEF = new ConfigDef()
       .define(
@@ -61,6 +62,12 @@ public final class CreateConfigs {
           "Indicates that this source was created by a connector with the given name. This "
               + "is useful for understanding which sources map to which connectors and will "
               + "be automatically populated for connectors."
+      ).define(
+          SOURCE_CONNECTOR_PROPERTY,
+          Type.STRING,
+          null,
+          Importance.LOW,
+          "write something useful"
       );
 
   static {

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CreateConfigs.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CreateConfigs.java
@@ -32,7 +32,7 @@ public final class CreateConfigs {
   public static final String WINDOW_TYPE_PROPERTY = "WINDOW_TYPE";
   public static final String WINDOW_SIZE_PROPERTY = "WINDOW_SIZE";
   public static final String SOURCE_CONNECTOR = "SOURCE_CONNECTOR";
-  public static final String SOURCE_CONNECTOR_PROPERTY = "SOURCED_BY_CONNECTOR";
+  public static final String SOURCED_BY_CONNECTOR_PROPERTY = "SOURCED_BY_CONNECTOR";
 
   private static final ConfigDef CONFIG_DEF = new ConfigDef()
       .define(
@@ -63,11 +63,11 @@ public final class CreateConfigs {
               + "is useful for understanding which sources map to which connectors and will "
               + "be automatically populated for connectors."
       ).define(
-          SOURCE_CONNECTOR_PROPERTY,
+          SOURCED_BY_CONNECTOR_PROPERTY,
           Type.STRING,
           null,
           Importance.LOW,
-          "write something useful"
+          "Expresses the dataflow between connectors and the topics they source."
       );
 
   static {

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
@@ -208,7 +208,7 @@ public final class CreateSourceProperties {
   }
 
   public Optional<String> getSourceConnector() {
-    return Optional.ofNullable(props.getString(CreateConfigs.SOURCE_CONNECTOR_PROPERTY));
+    return Optional.ofNullable(props.getString(CreateConfigs.SOURCED_BY_CONNECTOR_PROPERTY));
   }
 
   public Map<String, String> getValueFormatProperties(final String valueFormat) {

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
@@ -207,6 +207,10 @@ public final class CreateSourceProperties {
         .map(format -> FormatInfo.of(format, getValueFormatProperties(valueFormat)));
   }
 
+  public Optional<String> getSourceConnector() {
+    return Optional.ofNullable(props.getString(CreateConfigs.SOURCE_CONNECTOR_PROPERTY));
+  }
+
   public Map<String, String> getValueFormatProperties(final String valueFormat) {
     final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
 

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -31,7 +31,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression;
@@ -55,7 +54,6 @@ import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.SqlBaseParser.SingleStatementContext;
 import io.confluent.ksql.parser.exception.ParseFailedException;
-import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
 import io.confluent.ksql.parser.tree.AliasedRelation;
 import io.confluent.ksql.parser.tree.AllColumns;
 import io.confluent.ksql.parser.tree.StructAll;

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -31,6 +31,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression;
 import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression.Sign;
@@ -605,21 +607,25 @@ public class KsqlParserTest {
 
   @Test
   public void shouldFailIfSourcedByConnectorProvidedCXAS() {
-    // Given:
-    final String cxasQuery = "CREATE STREAM bigorders_json WITH (value_format = 'json', "
-        + "kafka_topic='bigorders_topic', sourced_by_connector='jdbc') AS SELECT * FROM orders;";
+    for (final String source: ImmutableSet.of("STREAM", "TABLE")) {
+      // Given:
+      final String cxasQuery =
+          "CREATE " + source
+          + " bigorders_json WITH (value_format = 'json', "
+          + "kafka_topic='bigorders_topic', sourced_by_connector='jdbc') AS SELECT * FROM orders;";
 
-    // When:
-    final Exception e = assertThrows(
-        KsqlException.class,
-        () -> KsqlParserTestUtil.<CreateStreamAsSelect>buildSingleAst(
-            cxasQuery,
-            metaStore)
-    );
+      // When:
+      final Exception e = assertThrows(
+          KsqlException.class,
+          () -> KsqlParserTestUtil.<CreateStreamAsSelect>buildSingleAst(
+              cxasQuery,
+              metaStore)
+      );
 
-    // Then:
-    assertThat(e.getMessage(), containsString("Failed to prepare statement: " +
-        "Invalid config variable(s) in the WITH clause: SOURCED_BY_CONNECTOR"));
+      // Then:
+      assertThat(e.getMessage(), containsString("Failed to prepare statement: " +
+          "Invalid config variable(s) in the WITH clause: SOURCED_BY_CONNECTOR"));
+    }
   }
 
   @Test

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
@@ -43,6 +43,7 @@ import io.confluent.ksql.execution.expression.tree.Literal;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
+import io.confluent.ksql.properties.with.CreateConfigs;
 import io.confluent.ksql.serde.SerdeFeature;
 import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.serde.avro.AvroFormat;
@@ -460,5 +461,20 @@ public class CreateSourceAsPropertiesTest {
     // When / Then:
     assertThat(props.getValueFormatProperties("PROTOBUF"),
         not(hasKey(ProtobufProperties.UNWRAP_PRIMITIVES)));
+  }
+
+  @Test
+  public void shouldThrowIfSourceConnectorPropertyProvided() {
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> CreateSourceAsProperties.from(
+            ImmutableMap.<String, Literal>builder()
+                .put(CreateConfigs.SOURCE_CONNECTOR_PROPERTY, new StringLiteral("whatever"))
+                .build())
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString("Invalid config variable(s) in the WITH clause: SOURCED_BY_CONNECTOR"));
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
@@ -470,7 +470,7 @@ public class CreateSourceAsPropertiesTest {
         KsqlException.class,
         () -> CreateSourceAsProperties.from(
             ImmutableMap.<String, Literal>builder()
-                .put(CreateConfigs.SOURCE_CONNECTOR_PROPERTY, new StringLiteral("whatever"))
+                .put(CreateConfigs.SOURCED_BY_CONNECTOR_PROPERTY, new StringLiteral("whatever"))
                 .build())
     );
 

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourcePropertiesTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourcePropertiesTest.java
@@ -56,18 +56,15 @@ import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.serde.connect.ConnectProperties;
 import io.confluent.ksql.serde.protobuf.ProtobufProperties;
 import io.confluent.ksql.util.KsqlException;
-import java.lang.reflect.Constructor;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.reflections.Reflections;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CreateSourcePropertiesTest {
@@ -175,7 +172,7 @@ public class CreateSourcePropertiesTest {
         ImmutableMap.<String, Literal>builder()
             .putAll(MINIMUM_VALID_PROPS)
             .put(
-                CreateConfigs.SOURCE_CONNECTOR_PROPERTY,
+                CreateConfigs.SOURCED_BY_CONNECTOR_PROPERTY,
                 new StringLiteral("source_connector")
             )
             .build());
@@ -189,7 +186,7 @@ public class CreateSourcePropertiesTest {
     // Given:
     final Map<String, Literal> props = ImmutableMap.<String, Literal>builder()
         .putAll(MINIMUM_VALID_PROPS)
-        .put(CreateConfigs.SOURCE_CONNECTOR_PROPERTY, new IntegerLiteral(1))
+        .put(CreateConfigs.SOURCED_BY_CONNECTOR_PROPERTY, new IntegerLiteral(1))
         .build();
 
     // When:


### PR DESCRIPTION
### Description 
Add a Stream/Table property `sourced_by_connector` to indicate which source connector is writing to it. This helps express the dataflow between connectors and the topics they source.

For example: 
```
CREATE SOURCE CONNECTOR `jdbc-connector` WITH(
    "connector.class"='io.confluent.connect.jdbc.JdbcSourceConnector',
    "connection.url"='jdbc:postgresql://localhost:5432/my.db',
    "mode"='bulk',
    "topic.prefix"='jdbc-',
    "table.whitelist"='users',
    "key"='username');

CREATE STREAM users (
    page_id BIGINT KEY
) WITH (
    KAFKA_TOPIC = 'jdbc-users',
    VALUE_FORMAT = 'JSON_SR'
    SOURCED_BY_CONNECTOR = 'jdbc-connector'
);
```
Please note that there is no validation logic for ensuring that the source connector exists. This is a cosmetic change.

### Testing done 
- unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

