### PR TITLE
docs: cherry-pick: adding newline to allow correct script execution (DOCS-17112)

### DIFF
--- a/docs/operate-and-deploy/installation/install-ksqldb-with-docker.md
+++ b/docs/operate-and-deploy/installation/install-ksqldb-with-docker.md
@@ -521,7 +521,7 @@ ksql-cli:
         sleep 5
       done
       echo -e "\n\n-> Running SQL commands\n"
-      cat /data/scripts/my-ksql-script.sql <(echo 'EXIT')| ksql http://<ksql-server-ip>:8088
+      cat /data/scripts/my-ksql-script.sql <(echo -e '\nEXIT')| ksql http://<ksql-server-ip>:8088
       echo -e "\n\n-> Sleeping…\n"
       sleep infinity
 ```


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/9458.

Adding a newline to avoid the need to remember to leave an empty line at the end of a KSQL script to allow for EXIT to be correctly appended to the script.

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

