### PR TITLE
test: ignore order of protobuf responses in rqtt

### DIFF
--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -69,6 +70,7 @@ import java.net.URL;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -83,6 +85,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import joptsimple.internal.Strings;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -1084,7 +1087,16 @@ public class RestTestExecutor implements Closeable {
       assertThat("Expected query response", expectedType, is("queryProto"));
       assertThat("Query response should be an array", expectedPayload, is(instanceOf(List.class)));
 
-      final List<?> expectedRows = (List<?>) expectedPayload;
+      final List<Map<String, Object>> expectedRows = ((List<?>) expectedPayload).stream()
+          .map(row -> {
+            assertThat(
+                "Each row should be JSON object",
+                row,
+                is(instanceOf(Map.class))
+            );
+            return (Map<String, Object>) row;
+          })
+          .collect(Collectors.toList());
 
       assertThat(
               "row count mismatch."
@@ -1102,50 +1114,85 @@ public class RestTestExecutor implements Closeable {
               rows,
               hasSize(expectedRows.size())
       );
-
-      ProtobufSchema schema = null;
       ProtobufNoSRConverter.Deserializer deserializer = new ProtobufNoSRConverter.Deserializer();
+
+      final List<Map<String, Object>> actualRows = rows.stream()
+          .map(row -> asJson(row, PAYLOAD_TYPE))
+          .collect(Collectors.toList());
+      final ProtobufSchema schema = verifyHeaderAndFinalMessageAndGetSchema(actualRows, expectedRows, verifyOrder);
+
       final JsonMapper mapper = new JsonMapper();
+
+      final List<String> actualRowsDeserialized = actualRows.stream()
+          .filter(actual -> !actual.containsKey(HEADER_PROTOBUF) && !actual.containsKey("finalMessage"))
+          .map(actual -> {
+            JSONObject row = new JSONObject(actual);
+            byte[] bytes;
+            try {
+              bytes = mapper.readTree(row.toString()).get("row").get("protobufBytes").binaryValue();
+            } catch (IOException e) {
+              throw new RuntimeException("Failed to deserialize the ProtoBuf bytes from the " +
+                  "RQTT JSON response row: " + row);
+            }
+            return deserializer.deserialize(bytes, schema).toString();
+          }).collect(Collectors.toList());
+      final List<String> expectedRowsDeserialized = expectedRows.stream()
+          .filter(expected -> !expected.containsKey(HEADER_PROTOBUF) && !expected.containsKey("finalMessage"))
+          .map(expected -> expected.get("row").toString())
+          .collect(Collectors.toList());
+
+      if (!verifyOrder) {
+        Collections.sort(actualRowsDeserialized);
+        Collections.sort(expectedRowsDeserialized);
+      }
+      assertEquals("Response mismatch. Got:\n"
+          + Strings.join(actualRowsDeserialized, "")
+          + "Expected: \n" + Strings.join(expectedRowsDeserialized, ""),
+          actualRowsDeserialized,
+          expectedRowsDeserialized
+      );
+    }
+
+    private ProtobufSchema verifyHeaderAndFinalMessageAndGetSchema(
+        List<Map<String, Object>> actualRows,
+        List<Map<String, Object>> expectedRows,
+        final boolean verifyOrder
+    ) {
+      ProtobufSchema schema = null;
       for (int i = 0; i != rows.size(); ++i) {
-        assertThat(
-                "Each row should be JSON object",
-                expectedRows.get(i),
-                is(instanceOf(Map.class))
-        );
-
-        final Map<String, Object> actual = asJson(rows.get(i), PAYLOAD_TYPE);
-        final Map<String, Object> expected = (Map<String, Object>) expectedRows.get(i);
-
+        final Map<String, Object> actual = actualRows.get(i);
         if (actual.containsKey(HEADER_PROTOBUF)
-                && ((HashMap<String, Object>) actual.get(HEADER_PROTOBUF)).containsKey(SCHEMA)) {
-
-          assertThat(i, is(0));
+            && ((HashMap<String, Object>) actual.get(HEADER_PROTOBUF)).containsKey(SCHEMA)) {
 
           schema = new ProtobufSchema((String) ((Map<?, ?>)actual.get(HEADER_PROTOBUF)).get(SCHEMA));
           final String actualSchema = (String) ((Map<?, ?>)actual.get(HEADER_PROTOBUF)).get(SCHEMA);
-          final String expectedSchema = (String) ((Map<?, ?>)expected.get(HEADER_PROTOBUF)).get(SCHEMA);
+          final Map<String, Object> expected;
 
+          if (verifyOrder) {
+            expected = expectedRows.get(i);
+          } else {
+            assertThat(i, is(0));
+            expected = expectedRows.stream()
+                .filter(row -> row.containsKey(HEADER_PROTOBUF))
+                .findFirst()
+                .get();
+          }
+          final String expectedSchema = (String) ((Map<?, ?>)expected.get(HEADER_PROTOBUF)).get(SCHEMA);
           assertThat(actualSchema, is(expectedSchema));
         } else if (actual.containsKey("finalMessage")) {
-          assertThat(actual, is(expected));
-        } else {
-          JSONObject row = new JSONObject(actual);
+          if (verifyOrder) {
+            assertThat(actual, is(expectedRows.get(i)));
+          } else {
+            final Optional<Map<String, Object>> expected = expectedRows.stream()
+                .filter(row -> row.containsKey("finalMessage"))
+                .findFirst();
 
-          byte[] bytes;
-          try {
-            bytes = mapper.readTree(row.toString()).get("row").get("protobufBytes").binaryValue();
-          } catch (IOException e) {
-            throw new RuntimeException("Failed to deserialize the ProtoBuf bytes from the " +
-                    "RQTT JSON response row: " + row);
+            assertThat("No final message present", expected.isPresent());
+            assertThat(actual, is(expected.get()));
           }
-
-          final Object message = deserializer.deserialize(bytes, schema);
-          final String actualMessage = message.toString();
-          final String expectedMessage = expected.get("row").toString();
-
-          assertThat(actualMessage, is(expectedMessage));
         }
       }
+      return schema;
     }
   }
 


### PR DESCRIPTION
### Description 
The RQTT proto response validator was checking the order of responses even if `verifyOrder` is set to true. As a result, sometimes RQTT protobuf tests fail due to incorrect ordering.

 ### Testing done 
Passes RQTTs locally, added unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

