### PR TITLE
docs: cherry-pick: fix typo in server config section on schemas (DOCS-17150)

### DIFF
--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -203,7 +203,7 @@ REST endpoint and interactive use.
 ### Schema resolution
 
 When you run a ksqlDB application that uses Avro or Protobuf, ksqlDB infers 
-chemas from {{ site.sr }} automatically, but the behavior after restarting
+schemas from {{ site.sr }} automatically, but the behavior after restarting
 ksqlDB Server differs between interactive and non-interactive mode.
 
 - **Interactive mode:** after ksqlDB Server restarts, it doesn't contact


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/9548.