### PR TITLE
MINOR: add static terminate cluster command and id

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandIdAssigner.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandIdAssigner.java
@@ -73,7 +73,7 @@ public class CommandIdAssigner {
           .put(DropTable.class,
               command -> getDropTableCommandId((DropTable) command))
           .put(TerminateCluster.class,
-              command -> new CommandId(Type.CLUSTER, "TerminateCluster", Action.TERMINATE))
+              command -> getTerminateClusterCommandId())
           .put(AlterSource.class, command -> getAlterSourceCommandId((AlterSource) command))
           .put(AlterSystemProperty.class, command
               -> getAlterSystemCommandId((AlterSystemProperty) command))
@@ -186,5 +186,9 @@ public class CommandIdAssigner {
 
   private static CommandId getSourceCommandId(final CommandId.Type type, final String sourceName) {
     return new CommandId(type, sourceName, CommandId.Action.CREATE);
+  }
+
+  public static CommandId getTerminateClusterCommandId() {
+    return new CommandId(Type.CLUSTER, "TerminateCluster", Action.TERMINATE);
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactory.java
@@ -118,7 +118,7 @@ public final class ValidatedCommandFactory {
   ) {
     if (statement.getUnMaskedStatementText().equals(
         TerminateCluster.TERMINATE_CLUSTER_STATEMENT_TEXT)) {
-      return Command.of(statement);
+      return createForTerminateCluster(statement);
     }
 
     if (statement.getStatement() instanceof PauseQuery) {
@@ -275,6 +275,10 @@ public final class ValidatedCommandFactory {
     }
 
     queryMetadata.close();
+    return Command.of(statement);
+  }
+
+  public static Command createForTerminateCluster(final ConfiguredStatement statement) {
     return Command.of(statement);
   }
 


### PR DESCRIPTION
### Description 
Refactor so that we have these static methods to get the command and command id objects for `TERMINATE CLUSTER`

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

