### PR TITLE
fix: roll back pinned nanoversions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ common {
     downStreamRepos = ["confluent-security-plugins", "confluent-cloud-plugins", "cc-docker-ksql"]
     downStreamValidate = false
     nanoVersion = true
-    pinnedNanoVersions = true
+    pinnedNanoVersions = false
     maxBuildsToKeep = 99
     maxDaysToKeep = 90
     extraBuildArgs = "-Dmaven.gitcommitid.nativegit=true"

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,7 @@
         <scala.version>2.13.2</scala.version>
         <apache.io.version>2.7</apache.io.version>
         <io.confluent.ksql.version>0.29.0-rc1</io.confluent.ksql.version>
+        <io.confluent.schema-registry.version>7.4.0-cc-docker-ksql.124-215-rc1</io.confluent.schema-registry.version>
         <netty-tcnative-version>2.0.53.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`
@@ -291,25 +292,25 @@
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-avro-converter</artifactId>
-                <version>7.4.0-209</version>
+                <version>${io.confluent.schema-registry.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-json-serializer</artifactId>
-                <version>7.4.0-209</version>
+                <version>${io.confluent.schema-registry.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-avro-serializer</artifactId>
-                <version>7.4.0-209</version>
+                <version>${io.confluent.schema-registry.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-schema-registry-client</artifactId>
-                <version>7.4.0-209</version>
+                <version>${io.confluent.schema-registry.version}</version>
             </dependency>
 
             <dependency>
@@ -333,25 +334,25 @@
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-json-schema-provider</artifactId>
-                <version>7.4.0-209</version>
+                <version>${io.confluent.schema-registry.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-protobuf-provider</artifactId>
-                <version>7.4.0-209</version>
+                <version>${io.confluent.schema-registry.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-json-schema-converter</artifactId>
-                <version>7.4.0-209</version>
+                <version>${io.confluent.schema-registry.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-protobuf-converter</artifactId>
-                <version>7.4.0-209</version>
+                <version>${io.confluent.schema-registry.version}</version>
             </dependency>
 
             <!-- End Confluent dependencies -->


### PR DESCRIPTION
Pinned nanoversions aren't completely implemented for the release stabilization tool, so cutting this release resulted in a mixed dependency set. This PR manually fixes up the dependencies and disables pinned nanoversions.

For future reference, there are two commits we need to undo for releases to function:

    https://github.com/confluentinc/ksql/commit/577029425c4ae4288fa527488acf1ef4820aade2
    https://github.com/confluentinc/ksql/commit/d3545b9d8873465f967b6e951a45260fb775c948

See also the 0.28 rollback:  https://github.com/confluentinc/ksql/pull/9374