### PR TITLE
fix: use resolved configs in precondition checker

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/PreconditionChecker.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/PreconditionChecker.java
@@ -224,12 +224,12 @@ public class PreconditionChecker implements Executable {
         new VertxOptions()
             .setMaxWorkerExecuteTimeUnit(TimeUnit.MILLISECONDS)
             .setMaxWorkerExecuteTime(Long.MAX_VALUE));
+    final KsqlConfig ksqlConfig = new KsqlConfig(properties);
     final KsqlClient sharedClient = InternalKsqlClientFactory.createInternalClient(
-        properties,
+        ksqlConfig.originalsStrings(),
         SocketAddress::inetSocketAddress,
         vertx
     );
-    final KsqlConfig ksqlConfig = new KsqlConfig(properties);
     final Supplier<SchemaRegistryClient> schemaRegistryClientFactory =
         new KsqlSchemaRegistryClientFactory(ksqlConfig, Collections.emptyMap())::get;
     final ConnectClientFactory connectClientFactory = new DefaultConnectClientFactory(ksqlConfig);


### PR DESCRIPTION
### Description 
The precondition checker was using raw configs to create an http client, so if a user uses  [secrets protection](https://docs.confluent.io/platform/current/security/secrets.html), then the client created would use passwords like `${securepass...}` instead of the actual password that gets resolved in `AbstractConfig`

### Testing done 
Manually tested

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

