### PR TITLE
fix: enhance error messages when source has extra/lacks double quotes

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/DropSourceFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/DropSourceFactory.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.parser.tree.DropStream;
 import io.confluent.ksql.parser.tree.DropTable;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Objects;
+import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 
 public final class DropSourceFactory {
@@ -59,7 +60,7 @@ public final class DropSourceFactory {
     final DataSource dataSource = metaStore.getSource(sourceName);
     if (dataSource == null) {
       if (!ifExists) {
-        final String hint = metaStore.checkAlternatives(sourceName);
+        final String hint = metaStore.checkAlternatives(sourceName, Optional.of(dataSourceType));
         throw new KsqlException(StringUtils.capitalize(dataSourceType.getKsqlType().toLowerCase())
             + " " + sourceName.text() + " does not exist." + hint);
       }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/DropSourceFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/DropSourceFactory.java
@@ -59,8 +59,9 @@ public final class DropSourceFactory {
     final DataSource dataSource = metaStore.getSource(sourceName);
     if (dataSource == null) {
       if (!ifExists) {
+        final String hint = metaStore.checkAlternatives(sourceName);
         throw new KsqlException(StringUtils.capitalize(dataSourceType.getKsqlType().toLowerCase())
-            + " " + sourceName.text() + " does not exist.");
+            + " " + sourceName.text() + " does not exist." + hint);
       }
     } else if (dataSource.getDataSourceType() != dataSourceType) {
       throw new KsqlException(String.format(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/DataSourceExtractor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/DataSourceExtractor.java
@@ -35,6 +35,7 @@ import io.confluent.ksql.util.KsqlException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -112,7 +113,7 @@ public class DataSourceExtractor {
       final SourceName fromName = ((Table) relation.getRelation()).getName();
       final DataSource source = metaStore.getSource(fromName);
       if (source == null) {
-        final String hint = metaStore.checkAlternatives(fromName);
+        final String hint = metaStore.checkAlternatives(fromName, Optional.empty());
         throw new KsqlException(fromName.text() + " does not exist." + hint);
       }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -746,6 +746,64 @@ public class KsqlEngineTest {
     assertThat(e, statementText(is("drop table bar;")));
   }
 
+  @Test
+  public void shouldNotShowHintWhenFailingToDropNonExistingTable() {
+    // Given:
+    KsqlEngineTestUtil.execute(
+        serviceContext,
+        ksqlEngine,
+        "create stream \"bar\" as select * from test1;",
+        ksqlConfig,
+        Collections.emptyMap()
+    );
+
+    // When:
+    final KsqlStatementException e = assertThrows(
+        KsqlStatementException.class,
+        () -> KsqlEngineTestUtil.execute(
+            serviceContext,
+            ksqlEngine,
+            "drop table bar;",
+            ksqlConfig,
+            Collections.emptyMap()
+        )
+    );
+
+    // Then:
+    assertThat(e, rawMessage(is(
+        "Table BAR does not exist.")));
+    assertThat(e, statementText(is("drop table bar;")));
+  }
+
+  @Test
+  public void shouldNotShowHintWhenFailingToDropNonExistingStream() {
+    // Given:
+    KsqlEngineTestUtil.execute(
+        serviceContext,
+        ksqlEngine,
+        "create table \"bar\" as select * from test2;",
+        ksqlConfig,
+        Collections.emptyMap()
+    );
+
+    // When:
+    final KsqlStatementException e = assertThrows(
+        KsqlStatementException.class,
+        () -> KsqlEngineTestUtil.execute(
+            serviceContext,
+            ksqlEngine,
+            "drop stream bar;",
+            ksqlConfig,
+            Collections.emptyMap()
+        )
+    );
+
+    // Then:
+    assertThat(e, rawMessage(is(
+        "Stream BAR does not exist.")));
+    assertThat(e, statementText(is("drop stream bar;")));
+  }
+
   @Test(expected = ParseFailedException.class)
   public void shouldFailWhenSyntaxIsInvalid() {
     KsqlEngineTestUtil.execute(

--- a/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MetaStore.java
+++ b/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MetaStore.java
@@ -17,8 +17,10 @@ package io.confluent.ksql.metastore;
 
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.model.DataSource;
+import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.name.SourceName;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 public interface MetaStore extends FunctionRegistry, TypeRegistry {
@@ -29,7 +31,7 @@ public interface MetaStore extends FunctionRegistry, TypeRegistry {
 
   Set<SourceName> getSourceConstraints(SourceName sourceName);
 
-  String checkAlternatives(SourceName sourceName);
+  String checkAlternatives(SourceName sourceName, Optional<DataSourceType> sourceType);
 
   MetaStore copy();
 }

--- a/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
+++ b/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
@@ -22,6 +22,7 @@ import io.confluent.ksql.function.KsqlTableFunction;
 import io.confluent.ksql.function.TableFunctionFactory;
 import io.confluent.ksql.function.UdfFactory;
 import io.confluent.ksql.metastore.model.DataSource;
+import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.SqlArgument;
@@ -203,13 +204,17 @@ public final class MetaStoreImpl implements MutableMetaStore {
     }
   }
 
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   @Override
-  public String checkAlternatives(final SourceName sourceName) {
+  public String checkAlternatives(
+      final SourceName sourceName, Optional<DataSourceType> sourceType) {
     final StringBuilder hint = new StringBuilder();
     final List<String> matchedSources = new ArrayList<>();
 
     for (SourceName name:getAllDataSources().keySet()) {
-      if (name.text().equalsIgnoreCase(sourceName.text())) {
+      if (name.text().equalsIgnoreCase(sourceName.text())
+          && (!sourceType.isPresent() || sourceType.get().equals(
+              Objects.requireNonNull(getSource(name)).getDataSourceType()))) {
         matchedSources.add(name.text());
       }
     }

--- a/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
+++ b/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
@@ -250,7 +250,7 @@ public final class MetaStoreImpl implements MutableMetaStore {
       } else {
         // contains at least one small letter
         final String sourceNameText = matchedSources.get(0).getName().text();
-        if (matchedSources.get(0).getName().text().chars().anyMatch(Character::isLowerCase)) {
+        if (sourceNameText.chars().anyMatch(Character::isLowerCase)) {
           hint.append(
               String.format("\"%s\"? Hint: wrap the source name in double quotes "
                   + "to make it case-sensitive.", sourceNameText));

--- a/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
+++ b/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
@@ -207,7 +207,7 @@ public final class MetaStoreImpl implements MutableMetaStore {
   @SuppressWarnings("checkstyle:CyclomaticComplexity")
   @Override
   public String checkAlternatives(
-      final SourceName sourceName, Optional<DataSourceType> sourceType) {
+      final SourceName sourceName, final Optional<DataSourceType> sourceType) {
     final StringBuilder hint = new StringBuilder();
     final List<String> matchedSources = new ArrayList<>();
 

--- a/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
+++ b/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
@@ -30,7 +30,6 @@ import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlReferentialIntegrityException;
 import io.vertx.core.impl.ConcurrentHashSet;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -204,29 +203,33 @@ public final class MetaStoreImpl implements MutableMetaStore {
     }
   }
 
-  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   @Override
   public String checkAlternatives(
       final SourceName sourceName, final Optional<DataSourceType> sourceType) {
     final StringBuilder hint = new StringBuilder();
-    final List<String> matchedSources = new ArrayList<>();
+    final List<DataSource> matchedSources = getAllDataSources()
+        .values()
+        .stream()
+        .filter(dataSource -> {
+          final boolean nameMatches = dataSource
+              .getName()
+              .text()
+              .equalsIgnoreCase(sourceName.text());
+          final boolean sourceTypeMatches = sourceType
+              .map(st -> st.equals(dataSource.getDataSourceType()))
+              .orElse(true);
+          return nameMatches && sourceTypeMatches;
+        })
+        .sorted(Comparator.comparing(x -> x.getName().text()))
+        .collect(Collectors.toList());
 
-    for (SourceName name:getAllDataSources().keySet()) {
-      if (name.text().equalsIgnoreCase(sourceName.text())
-          && (!sourceType.isPresent() || sourceType.get().equals(
-              Objects.requireNonNull(getSource(name)).getDataSourceType()))) {
-        matchedSources.add(name.text());
-      }
-    }
-    matchedSources.sort(Comparator.naturalOrder());
     if (matchedSources.size() > 0) {
       hint.append("\nDid you mean ");
       if (matchedSources.size() > 1) {
         final int n = matchedSources.size();
         for (int i = 0; i < n; i++) {
-          final String dataSourceType = Objects.requireNonNull(
-              getSource(SourceName.of(matchedSources.get(i)))
-          ).getDataSourceType().getKsqlType();
+          final String dataSourceType = matchedSources.get(i).getDataSourceType().getKsqlType();
+          final String sourceNameText = matchedSources.get(i).getName().text();
           final String punctuation;
           if (i < n - 2) {
             punctuation = ", ";
@@ -240,21 +243,21 @@ public final class MetaStoreImpl implements MutableMetaStore {
             punctuation = "? ";
           }
           hint.append(
-              String.format("\"%s\" (%s)%s", matchedSources.get(i), dataSourceType, punctuation)
+              String.format("\"%s\" (%s)%s", sourceNameText, dataSourceType, punctuation)
           );
         }
         hint.append("Hint: wrap the source name in double quotes to make it case-sensitive.");
       } else {
         // contains at least one small letter
-        if (matchedSources.get(0).chars().anyMatch(Character::isLowerCase)) {
+        final String sourceNameText = matchedSources.get(0).getName().text();
+        if (matchedSources.get(0).getName().text().chars().anyMatch(Character::isLowerCase)) {
           hint.append(
               String.format("\"%s\"? Hint: wrap the source name in double quotes "
-                  + "to make it case-sensitive.", matchedSources.get(0)
-              ));
+                  + "to make it case-sensitive.", sourceNameText));
         } else { // contains only capital letters
           hint.append(
               String.format("%s? Hint: try removing double quotes from the source name.",
-                  matchedSources.get(0))
+                  sourceNameText)
           );
         }
       }


### PR DESCRIPTION
Generalises the solution for [issue#9243](https://github.com/confluentinc/ksql/issues/9243)

### Description 
When performing `DROP` on a source name with a very special case of typo (typing source name mistakenly with/without double quotes), the error message is the same as when the source is not existing at all. This fix adds a Hint to the error message to make it more informative.



### Testing done 
Unit test
manual testing
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

