### PR TITLE
test: Ups timeout for queries to be running in ShowQueriesMultiNode* tests

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ShowQueriesMultiNodeFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ShowQueriesMultiNodeFunctionalTest.java
@@ -93,8 +93,8 @@ public class ShowQueriesMultiNodeFunctionalTest {
     final Supplier<String> app1Response = () -> getShowQueriesResult(REST_APP_1);
 
     // Then:
-    assertThatEventually("App0", app0Response, is("RUNNING:2"));
-    assertThatEventually("App1", app1Response, is("RUNNING:2"));
+    assertThatEventually("App0", app0Response, is("RUNNING:2"), 60, TimeUnit.SECONDS);
+    assertThatEventually("App1", app1Response, is("RUNNING:2"), 60, TimeUnit.SECONDS);
   }
 
   private static String getShowQueriesResult(final TestKsqlRestApp restApp) {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ShowQueriesMultiNodeWithTlsFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ShowQueriesMultiNodeWithTlsFunctionalTest.java
@@ -96,8 +96,8 @@ public class ShowQueriesMultiNodeWithTlsFunctionalTest {
     final Supplier<String> app1Response = () -> getShowQueriesResult(REST_APP_1);
 
     // Then:
-    assertThatEventually("App0", app0Response, is("RUNNING:2"));
-    assertThatEventually("App1", app1Response, is("RUNNING:2"));
+    assertThatEventually("App0", app0Response, is("RUNNING:2"), 60, TimeUnit.SECONDS);
+    assertThatEventually("App1", app1Response, is("RUNNING:2"), 60, TimeUnit.SECONDS);
   }
 
   private static String getShowQueriesResult(final TestKsqlRestApp restApp) {


### PR DESCRIPTION
### Description 
Currently, the tests given 30 seconds for a statement to be running across a two node cluster.  This is somewhat small for our CI environment, so this ups it to 60 seconds.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

