### PR TITLE
Fix avro optional fields

### DIFF
--- a/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_VALUE_SCHEMA_ID_with_compound_types/7.4.0_1666063444063/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_VALUE_SCHEMA_ID_with_compound_types/7.4.0_1666063444063/plan.json
@@ -1,0 +1,295 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TXS (`id` STRING, `transaction` STRING) WITH (KAFKA_TOPIC='transaction', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TXS",
+      "schema" : "`id` STRING, `transaction` STRING",
+      "timestampColumn" : null,
+      "topicName" : "transaction",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TXS_REKEY WITH (KAFKA_TOPIC='transaction-rekey', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON') AS SELECT\n  TXS.`id` `id`,\n  TXS.`transaction` `transaction`\nFROM TXS TXS\nPARTITION BY TXS.`id`\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TXS_REKEY",
+      "schema" : "`id` STRING KEY, `transaction` STRING",
+      "timestampColumn" : null,
+      "topicName" : "transaction-rekey",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TXS" ],
+      "sink" : "TXS_REKEY",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "TXS_REKEY"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSelectKeyV2",
+            "properties" : {
+              "queryContext" : "PartitionBy"
+            },
+            "source" : {
+              "@type" : "streamSourceV1",
+              "properties" : {
+                "queryContext" : "KsqlTopic/Source"
+              },
+              "topicName" : "transaction",
+              "formats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "JSON",
+                  "properties" : { }
+                }
+              },
+              "timestampColumn" : null,
+              "sourceSchema" : "`id` STRING, `transaction` STRING",
+              "pseudoColumnVersion" : 1
+            },
+            "keyExpression" : [ "`id`" ]
+          },
+          "keyColumnNames" : [ "id" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "`transaction` AS `transaction`" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "transaction-rekey",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_TXS_REKEY_0",
+      "runtimeId" : null
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM MODEL_TXS_EVENT WITH (KAFKA_TOPIC='model-transaction', KEY_FORMAT='KAFKA', VALUE_FORMAT='AVRO', VALUE_SCHEMA_FULL_NAME='com.acme.namespace.Transaction', VALUE_SCHEMA_ID=102) AS SELECT\n  TXS.`id` `id`,\n  AS_VALUE(TXS.`id`) `eventID`,\n  STRUCT(`num_shares`:=CAST(EXTRACTJSONFIELD(TXS.`transaction`, '$.num_shares') AS INTEGER), `amount`:=CAST(EXTRACTJSONFIELD(TXS.`transaction`, '$.amount') AS INTEGER), `customer`:=STRUCT(`first_name`:=EXTRACTJSONFIELD(TXS.`transaction`, '$.customer.first_name'), `last_name`:=EXTRACTJSONFIELD(TXS.`transaction`, '$.customer.last_name'), `email`:=EXTRACTJSONFIELD(TXS.`transaction`, '$.customer.email'))) `transaction`\nFROM TXS_REKEY TXS\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "MODEL_TXS_EVENT",
+      "schema" : "`id` STRING KEY, `eventID` STRING, `transaction` STRUCT<`num_shares` INTEGER, `amount` INTEGER, `customer` STRUCT<`first_name` STRING, `last_name` STRING, `email` STRING>>",
+      "timestampColumn" : null,
+      "topicName" : "model-transaction",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : {
+            "fullSchemaName" : "com.acme.namespace.Transaction",
+            "schemaId" : "102"
+          }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TXS_REKEY" ],
+      "sink" : "MODEL_TXS_EVENT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "MODEL_TXS_EVENT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "transaction-rekey",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`id` STRING KEY, `transaction` STRING",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "id" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "AS_VALUE(`id`) AS `eventID`", "STRUCT(`num_shares`:=CAST(EXTRACTJSONFIELD(`transaction`, '$.num_shares') AS INTEGER), `amount`:=CAST(EXTRACTJSONFIELD(`transaction`, '$.amount') AS INTEGER), `customer`:=STRUCT(`first_name`:=EXTRACTJSONFIELD(`transaction`, '$.customer.first_name'), `last_name`:=EXTRACTJSONFIELD(`transaction`, '$.customer.last_name'), `email`:=EXTRACTJSONFIELD(`transaction`, '$.customer.email'))) AS `transaction`" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : {
+              "fullSchemaName" : "com.acme.namespace.Transaction",
+              "schemaId" : "102"
+            }
+          }
+        },
+        "topicName" : "model-transaction",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_MODEL_TXS_EVENT_1",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.websocket.connection.max.timeout.ms" : "3600000",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "true",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.json_sr.converter.deserializer.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_VALUE_SCHEMA_ID_with_compound_types/7.4.0_1666063444063/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_VALUE_SCHEMA_ID_with_compound_types/7.4.0_1666063444063/spec.json
@@ -1,0 +1,344 @@
+{
+  "version" : "7.4.0",
+  "timestamp" : 1666063444063,
+  "path" : "query-validation-tests/avro.json",
+  "schemas" : {
+    "CSAS_MODEL_TXS_EVENT_1.KsqlTopic.Source" : {
+      "schema" : "`id` STRING KEY, `transaction` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_MODEL_TXS_EVENT_1.MODEL_TXS_EVENT" : {
+      "schema" : "`id` STRING KEY, `eventID` STRING, `transaction` STRUCT<`num_shares` INTEGER, `amount` INTEGER, `customer` STRUCT<`first_name` STRING, `last_name` STRING, `email` STRING>>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO",
+        "properties" : {
+          "fullSchemaName" : "com.acme.namespace.Transaction",
+          "schemaId" : "102"
+        }
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "VALUE_SCHEMA_ID with compound types",
+    "inputs" : [ {
+      "topic" : "transaction",
+      "key" : null,
+      "value" : {
+        "id" : "1",
+        "transaction" : {
+          "num_shares" : 50000,
+          "amount" : 50044568,
+          "txn_ts" : "2020-11-18 02:31:43",
+          "customer" : {
+            "first_name" : "Jill",
+            "last_name" : "Smith",
+            "id" : 1234567,
+            "email" : "jsmith@foo.com"
+          },
+          "company" : {
+            "name" : "ACME Corp",
+            "ticker" : "ACMC",
+            "id" : "ACME837275222752952",
+            "address" : "Anytown USA, 333333"
+          }
+        }
+      }
+    }, {
+      "topic" : "transaction",
+      "key" : null,
+      "value" : {
+        "id" : "2",
+        "transaction" : {
+          "num_shares" : 30000,
+          "amount" : 5004,
+          "txn_ts" : "2020-11-18 02:35:43",
+          "customer" : {
+            "first_name" : "Art",
+            "last_name" : "Vandeley",
+            "id" : 8976612,
+            "email" : "avendleay@foo.com"
+          },
+          "company" : {
+            "name" : "Imports Corp",
+            "ticker" : "IMPC",
+            "id" : "IMPC88875222752952",
+            "address" : "Anytown USA, 333333"
+          }
+        }
+      }
+    }, {
+      "topic" : "transaction",
+      "key" : null,
+      "value" : {
+        "id" : "3",
+        "transaction" : {
+          "num_shares" : 3000000,
+          "amount" : 50045,
+          "txn_ts" : "2020-11-18 02:36:43",
+          "customer" : {
+            "first_name" : "John",
+            "last_name" : "England",
+            "id" : 456321,
+            "email" : "je@foo.com"
+          },
+          "company" : {
+            "name" : "Hechinger",
+            "ticker" : "HECH",
+            "id" : "HECH8333785222752952",
+            "address" : "Anytown USA, 333333"
+          }
+        }
+      }
+    }, {
+      "topic" : "transaction",
+      "key" : null,
+      "value" : {
+        "id" : "4",
+        "transaction" : {
+          "num_shares" : 10000,
+          "amount" : 80044,
+          "txn_ts" : "2020-11-18 02:37:43",
+          "customer" : {
+            "first_name" : "Fred",
+            "last_name" : "Pym",
+            "id" : 333567,
+            "email" : "fjone@foo.com"
+          },
+          "company" : {
+            "name" : "PymTech",
+            "ticker" : "PYMT",
+            "id" : "PYME837275222714197419202020",
+            "address" : "Anytown USA, 333333"
+          }
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "model-transaction",
+      "key" : "1",
+      "value" : {
+        "eventID" : "1",
+        "transaction" : {
+          "amount" : 50044568,
+          "num_shares" : 50000,
+          "customer" : {
+            "last_name" : "Smith",
+            "first_name" : "Jill",
+            "email" : "jsmith@foo.com"
+          }
+        }
+      }
+    }, {
+      "topic" : "model-transaction",
+      "key" : "2",
+      "value" : {
+        "eventID" : "2",
+        "transaction" : {
+          "amount" : 5004,
+          "num_shares" : 30000,
+          "customer" : {
+            "last_name" : "Vandeley",
+            "first_name" : "Art",
+            "email" : "avendleay@foo.com"
+          }
+        }
+      }
+    }, {
+      "topic" : "model-transaction",
+      "key" : "3",
+      "value" : {
+        "eventID" : "3",
+        "transaction" : {
+          "amount" : 50045,
+          "num_shares" : 3000000,
+          "customer" : {
+            "last_name" : "England",
+            "first_name" : "John",
+            "email" : "je@foo.com"
+          }
+        }
+      }
+    }, {
+      "topic" : "model-transaction",
+      "key" : "4",
+      "value" : {
+        "eventID" : "4",
+        "transaction" : {
+          "amount" : 80044,
+          "num_shares" : 10000,
+          "customer" : {
+            "last_name" : "Pym",
+            "first_name" : "Fred",
+            "email" : "fjone@foo.com"
+          }
+        }
+      }
+    } ],
+    "topics" : [ {
+      "name" : "model-transaction",
+      "valueSchemaId" : 102,
+      "valueSchema" : {
+        "type" : "record",
+        "name" : "Transaction",
+        "namespace" : "com.acme.namespace",
+        "fields" : [ {
+          "name" : "eventID",
+          "type" : "string"
+        }, {
+          "name" : "transaction",
+          "type" : {
+            "type" : "record",
+            "name" : "transaction",
+            "fields" : [ {
+              "name" : "num_shares",
+              "type" : "int"
+            }, {
+              "name" : "amount",
+              "type" : "int"
+            }, {
+              "name" : "customer",
+              "type" : {
+                "type" : "record",
+                "name" : "customer",
+                "fields" : [ {
+                  "name" : "first_name",
+                  "type" : "string"
+                }, {
+                  "name" : "last_name",
+                  "type" : "string"
+                }, {
+                  "name" : "email",
+                  "type" : "string"
+                } ]
+              }
+            } ]
+          }
+        } ]
+      },
+      "valueFormat" : "AVRO",
+      "replicas" : 1,
+      "numPartitions" : 1
+    }, {
+      "name" : "transaction",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TXS (`id` VARCHAR, `transaction` VARCHAR) WITH (KAFKA_TOPIC='transaction', VALUE_FORMAT='JSON', KEY_FORMAT='KAFKA');", "CREATE STREAM TXS_REKEY WITH (KAFKA_TOPIC='transaction-rekey', VALUE_FORMAT='JSON', KEY_FORMAT='KAFKA') AS SELECT `id`, `transaction` FROM TXS PARTITION BY `id`;", "CREATE STREAM MODEL_TXS_EVENT WITH  (KAFKA_TOPIC='model-transaction', KEY_FORMAT='KAFKA', VALUE_FORMAT='AVRO', VALUE_SCHEMA_ID=102) AS SELECT `id`, as_value(txs.`id`) AS `eventID`, STRUCT(`num_shares` := CAST(EXTRACTJSONFIELD(txs.`transaction`, '$.num_shares') AS INT), `amount` := CAST(EXTRACTJSONFIELD(txs.`transaction`, '$.amount') AS INT), `customer` := STRUCT(`first_name`:= EXTRACTJSONFIELD(txs.`transaction`, '$.customer.first_name'), `last_name`:= EXTRACTJSONFIELD(txs.`transaction`, '$.customer.last_name'), `email`:= EXTRACTJSONFIELD(txs.`transaction`, '$.customer.email'))) AS `transaction` FROM TXS_REKEY txs;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "MODEL_TXS_EVENT",
+        "type" : "STREAM",
+        "schema" : "`id` STRING KEY, `eventID` STRING, `transaction` STRUCT<`num_shares` INTEGER, `amount` INTEGER, `customer` STRUCT<`first_name` STRING, `last_name` STRING, `email` STRING>>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "AVRO",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TXS",
+        "type" : "STREAM",
+        "schema" : "`id` STRING, `transaction` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TXS_REKEY",
+        "type" : "STREAM",
+        "schema" : "`id` STRING KEY, `transaction` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "transaction-rekey",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "model-transaction",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : {
+              "fullSchemaName" : "com.acme.namespace.Transaction",
+              "schemaId" : "102"
+            }
+          },
+          "partitions" : 4,
+          "valueSchema" : {
+            "type" : "record",
+            "name" : "Transaction",
+            "namespace" : "com.acme.namespace",
+            "fields" : [ {
+              "name" : "eventID",
+              "type" : "string"
+            }, {
+              "name" : "transaction",
+              "type" : {
+                "type" : "record",
+                "name" : "transaction",
+                "fields" : [ {
+                  "name" : "num_shares",
+                  "type" : "int"
+                }, {
+                  "name" : "amount",
+                  "type" : "int"
+                }, {
+                  "name" : "customer",
+                  "type" : {
+                    "type" : "record",
+                    "name" : "customer",
+                    "fields" : [ {
+                      "name" : "first_name",
+                      "type" : "string"
+                    }, {
+                      "name" : "last_name",
+                      "type" : "string"
+                    }, {
+                      "name" : "email",
+                      "type" : "string"
+                    } ]
+                  }
+                } ]
+              }
+            } ]
+          }
+        }, {
+          "name" : "transaction",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_VALUE_SCHEMA_ID_with_compound_types/7.4.0_1666063444063/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_VALUE_SCHEMA_ID_with_compound_types/7.4.0_1666063444063/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [transaction-rekey])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: model-transaction)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_VALUE_SCHEMA_ID_with_compound_types_and_default_value/7.4.0_1666063444283/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_VALUE_SCHEMA_ID_with_compound_types_and_default_value/7.4.0_1666063444283/plan.json
@@ -1,0 +1,295 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TXS (`id` STRING, `transaction` STRING) WITH (KAFKA_TOPIC='transaction', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TXS",
+      "schema" : "`id` STRING, `transaction` STRING",
+      "timestampColumn" : null,
+      "topicName" : "transaction",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TXS_REKEY WITH (KAFKA_TOPIC='transaction-rekey', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON') AS SELECT\n  TXS.`id` `id`,\n  TXS.`transaction` `transaction`\nFROM TXS TXS\nPARTITION BY TXS.`id`\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TXS_REKEY",
+      "schema" : "`id` STRING KEY, `transaction` STRING",
+      "timestampColumn" : null,
+      "topicName" : "transaction-rekey",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TXS" ],
+      "sink" : "TXS_REKEY",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "TXS_REKEY"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSelectKeyV2",
+            "properties" : {
+              "queryContext" : "PartitionBy"
+            },
+            "source" : {
+              "@type" : "streamSourceV1",
+              "properties" : {
+                "queryContext" : "KsqlTopic/Source"
+              },
+              "topicName" : "transaction",
+              "formats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "JSON",
+                  "properties" : { }
+                }
+              },
+              "timestampColumn" : null,
+              "sourceSchema" : "`id` STRING, `transaction` STRING",
+              "pseudoColumnVersion" : 1
+            },
+            "keyExpression" : [ "`id`" ]
+          },
+          "keyColumnNames" : [ "id" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "`transaction` AS `transaction`" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "transaction-rekey",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_TXS_REKEY_0",
+      "runtimeId" : null
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM MODEL_TXS_EVENT WITH (KAFKA_TOPIC='model-transaction', KEY_FORMAT='KAFKA', VALUE_FORMAT='AVRO', VALUE_SCHEMA_FULL_NAME='com.acme.namespace.Transaction', VALUE_SCHEMA_ID=102) AS SELECT\n  TXS.`id` `id`,\n  AS_VALUE(TXS.`id`) `eventID`,\n  STRUCT(`num_shares`:=CAST(EXTRACTJSONFIELD(TXS.`transaction`, '$.num_shares') AS INTEGER), `amount`:=CAST(EXTRACTJSONFIELD(TXS.`transaction`, '$.amount') AS INTEGER), `customer`:=STRUCT(`first_name`:=EXTRACTJSONFIELD(TXS.`transaction`, '$.customer.first_name'), `last_name`:=EXTRACTJSONFIELD(TXS.`transaction`, '$.customer.last_name'), `email`:=EXTRACTJSONFIELD(TXS.`transaction`, '$.customer.email'))) `transaction`\nFROM TXS_REKEY TXS\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "MODEL_TXS_EVENT",
+      "schema" : "`id` STRING KEY, `eventID` STRING, `transaction` STRUCT<`num_shares` INTEGER, `amount` INTEGER, `customer` STRUCT<`first_name` STRING, `last_name` STRING, `email` STRING>>",
+      "timestampColumn" : null,
+      "topicName" : "model-transaction",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : {
+            "fullSchemaName" : "com.acme.namespace.Transaction",
+            "schemaId" : "102"
+          }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TXS_REKEY" ],
+      "sink" : "MODEL_TXS_EVENT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "MODEL_TXS_EVENT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "transaction-rekey",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`id` STRING KEY, `transaction` STRING",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "id" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "AS_VALUE(`id`) AS `eventID`", "STRUCT(`num_shares`:=CAST(EXTRACTJSONFIELD(`transaction`, '$.num_shares') AS INTEGER), `amount`:=CAST(EXTRACTJSONFIELD(`transaction`, '$.amount') AS INTEGER), `customer`:=STRUCT(`first_name`:=EXTRACTJSONFIELD(`transaction`, '$.customer.first_name'), `last_name`:=EXTRACTJSONFIELD(`transaction`, '$.customer.last_name'), `email`:=EXTRACTJSONFIELD(`transaction`, '$.customer.email'))) AS `transaction`" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : {
+              "fullSchemaName" : "com.acme.namespace.Transaction",
+              "schemaId" : "102"
+            }
+          }
+        },
+        "topicName" : "model-transaction",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_MODEL_TXS_EVENT_1",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.websocket.connection.max.timeout.ms" : "3600000",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "true",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.json_sr.converter.deserializer.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_VALUE_SCHEMA_ID_with_compound_types_and_default_value/7.4.0_1666063444283/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_VALUE_SCHEMA_ID_with_compound_types_and_default_value/7.4.0_1666063444283/spec.json
@@ -1,0 +1,340 @@
+{
+  "version" : "7.4.0",
+  "timestamp" : 1666063444283,
+  "path" : "query-validation-tests/avro.json",
+  "schemas" : {
+    "CSAS_MODEL_TXS_EVENT_1.KsqlTopic.Source" : {
+      "schema" : "`id` STRING KEY, `transaction` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_MODEL_TXS_EVENT_1.MODEL_TXS_EVENT" : {
+      "schema" : "`id` STRING KEY, `eventID` STRING, `transaction` STRUCT<`num_shares` INTEGER, `amount` INTEGER, `customer` STRUCT<`first_name` STRING, `last_name` STRING, `email` STRING>>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO",
+        "properties" : {
+          "fullSchemaName" : "com.acme.namespace.Transaction",
+          "schemaId" : "102"
+        }
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "VALUE_SCHEMA_ID with compound types and default value",
+    "inputs" : [ {
+      "topic" : "transaction",
+      "key" : null,
+      "value" : {
+        "id" : "1",
+        "transaction" : {
+          "txn_ts" : "2020-11-18 02:31:43",
+          "customer" : {
+            "first_name" : "Jill",
+            "last_name" : "Smith",
+            "id" : 1234567,
+            "email" : "jsmith@foo.com"
+          },
+          "company" : {
+            "name" : "ACME Corp",
+            "ticker" : "ACMC",
+            "id" : "ACME837275222752952",
+            "address" : "Anytown USA, 333333"
+          }
+        }
+      }
+    }, {
+      "topic" : "transaction",
+      "key" : null,
+      "value" : {
+        "id" : "2",
+        "transaction" : {
+          "txn_ts" : "2020-11-18 02:35:43",
+          "customer" : {
+            "first_name" : "Art",
+            "last_name" : "Vandeley",
+            "id" : 8976612,
+            "email" : "avendleay@foo.com"
+          },
+          "company" : {
+            "name" : "Imports Corp",
+            "ticker" : "IMPC",
+            "id" : "IMPC88875222752952",
+            "address" : "Anytown USA, 333333"
+          }
+        }
+      }
+    }, {
+      "topic" : "transaction",
+      "key" : null,
+      "value" : {
+        "id" : "3",
+        "transaction" : {
+          "txn_ts" : "2020-11-18 02:36:43",
+          "customer" : {
+            "first_name" : "John",
+            "last_name" : "England",
+            "id" : 456321,
+            "email" : "je@foo.com"
+          },
+          "company" : {
+            "name" : "Hechinger",
+            "ticker" : "HECH",
+            "id" : "HECH8333785222752952",
+            "address" : "Anytown USA, 333333"
+          }
+        }
+      }
+    }, {
+      "topic" : "transaction",
+      "key" : null,
+      "value" : {
+        "id" : "4",
+        "transaction" : {
+          "txn_ts" : "2020-11-18 02:37:43",
+          "customer" : {
+            "first_name" : "Fred",
+            "last_name" : "Pym",
+            "id" : 333567,
+            "email" : "fjone@foo.com"
+          },
+          "company" : {
+            "name" : "PymTech",
+            "ticker" : "PYMT",
+            "id" : "PYME837275222714197419202020",
+            "address" : "Anytown USA, 333333"
+          }
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "model-transaction",
+      "key" : "1",
+      "value" : {
+        "eventID" : "1",
+        "transaction" : {
+          "amount" : 0,
+          "num_shares" : 0,
+          "customer" : {
+            "last_name" : "Smith",
+            "first_name" : "Jill",
+            "email" : "jsmith@foo.com"
+          }
+        }
+      }
+    }, {
+      "topic" : "model-transaction",
+      "key" : "2",
+      "value" : {
+        "eventID" : "2",
+        "transaction" : {
+          "amount" : 0,
+          "num_shares" : 0,
+          "customer" : {
+            "last_name" : "Vandeley",
+            "first_name" : "Art",
+            "email" : "avendleay@foo.com"
+          }
+        }
+      }
+    }, {
+      "topic" : "model-transaction",
+      "key" : "3",
+      "value" : {
+        "eventID" : "3",
+        "transaction" : {
+          "amount" : 0,
+          "num_shares" : 0,
+          "customer" : {
+            "last_name" : "England",
+            "first_name" : "John",
+            "email" : "je@foo.com"
+          }
+        }
+      }
+    }, {
+      "topic" : "model-transaction",
+      "key" : "4",
+      "value" : {
+        "eventID" : "4",
+        "transaction" : {
+          "amount" : 0,
+          "num_shares" : 0,
+          "customer" : {
+            "last_name" : "Pym",
+            "first_name" : "Fred",
+            "email" : "fjone@foo.com"
+          }
+        }
+      }
+    } ],
+    "topics" : [ {
+      "name" : "model-transaction",
+      "valueSchemaId" : 102,
+      "valueSchema" : {
+        "type" : "record",
+        "name" : "Transaction",
+        "namespace" : "com.acme.namespace",
+        "fields" : [ {
+          "name" : "eventID",
+          "type" : "string"
+        }, {
+          "name" : "transaction",
+          "type" : {
+            "type" : "record",
+            "name" : "transaction",
+            "fields" : [ {
+              "name" : "num_shares",
+              "type" : "int",
+              "default" : 0
+            }, {
+              "name" : "amount",
+              "type" : "int",
+              "default" : 0
+            }, {
+              "name" : "customer",
+              "type" : {
+                "type" : "record",
+                "name" : "customer",
+                "fields" : [ {
+                  "name" : "first_name",
+                  "type" : "string"
+                }, {
+                  "name" : "last_name",
+                  "type" : "string"
+                }, {
+                  "name" : "email",
+                  "type" : "string"
+                } ]
+              }
+            } ]
+          }
+        } ]
+      },
+      "valueFormat" : "AVRO",
+      "replicas" : 1,
+      "numPartitions" : 1
+    }, {
+      "name" : "transaction",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TXS (`id` VARCHAR, `transaction` VARCHAR) WITH (KAFKA_TOPIC='transaction', VALUE_FORMAT='JSON', KEY_FORMAT='KAFKA');", "CREATE STREAM TXS_REKEY WITH (KAFKA_TOPIC='transaction-rekey', VALUE_FORMAT='JSON', KEY_FORMAT='KAFKA') AS SELECT `id`, `transaction` FROM TXS PARTITION BY `id`;", "CREATE STREAM MODEL_TXS_EVENT WITH  (KAFKA_TOPIC='model-transaction', KEY_FORMAT='KAFKA', VALUE_FORMAT='AVRO', VALUE_SCHEMA_ID=102) AS SELECT `id`, as_value(txs.`id`) AS `eventID`, STRUCT(`num_shares` := CAST(EXTRACTJSONFIELD(txs.`transaction`, '$.num_shares') AS INT), `amount` := CAST(EXTRACTJSONFIELD(txs.`transaction`, '$.amount') AS INT), `customer` := STRUCT(`first_name`:= EXTRACTJSONFIELD(txs.`transaction`, '$.customer.first_name'), `last_name`:= EXTRACTJSONFIELD(txs.`transaction`, '$.customer.last_name'), `email`:= EXTRACTJSONFIELD(txs.`transaction`, '$.customer.email'))) AS `transaction` FROM TXS_REKEY txs;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "MODEL_TXS_EVENT",
+        "type" : "STREAM",
+        "schema" : "`id` STRING KEY, `eventID` STRING, `transaction` STRUCT<`num_shares` INTEGER, `amount` INTEGER, `customer` STRUCT<`first_name` STRING, `last_name` STRING, `email` STRING>>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "AVRO",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TXS",
+        "type" : "STREAM",
+        "schema" : "`id` STRING, `transaction` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TXS_REKEY",
+        "type" : "STREAM",
+        "schema" : "`id` STRING KEY, `transaction` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "transaction-rekey",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "model-transaction",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : {
+              "fullSchemaName" : "com.acme.namespace.Transaction",
+              "schemaId" : "102"
+            }
+          },
+          "partitions" : 4,
+          "valueSchema" : {
+            "type" : "record",
+            "name" : "Transaction",
+            "namespace" : "com.acme.namespace",
+            "fields" : [ {
+              "name" : "eventID",
+              "type" : "string"
+            }, {
+              "name" : "transaction",
+              "type" : {
+                "type" : "record",
+                "name" : "transaction",
+                "fields" : [ {
+                  "name" : "num_shares",
+                  "type" : "int",
+                  "default" : 0
+                }, {
+                  "name" : "amount",
+                  "type" : "int",
+                  "default" : 0
+                }, {
+                  "name" : "customer",
+                  "type" : {
+                    "type" : "record",
+                    "name" : "customer",
+                    "fields" : [ {
+                      "name" : "first_name",
+                      "type" : "string"
+                    }, {
+                      "name" : "last_name",
+                      "type" : "string"
+                    }, {
+                      "name" : "email",
+                      "type" : "string"
+                    } ]
+                  }
+                } ]
+              }
+            } ]
+          }
+        }, {
+          "name" : "transaction",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_VALUE_SCHEMA_ID_with_compound_types_and_default_value/7.4.0_1666063444283/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_VALUE_SCHEMA_ID_with_compound_types_and_default_value/7.4.0_1666063444283/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [transaction-rekey])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: model-transaction)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_VALUE_SCHEMA_ID_with_compound_types_and_default_value_in_the_end_of_schema/7.4.0_1666063444659/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_VALUE_SCHEMA_ID_with_compound_types_and_default_value_in_the_end_of_schema/7.4.0_1666063444659/plan.json
@@ -1,0 +1,295 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TXS (`id` STRING, `transaction` STRING) WITH (KAFKA_TOPIC='transaction', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TXS",
+      "schema" : "`id` STRING, `transaction` STRING",
+      "timestampColumn" : null,
+      "topicName" : "transaction",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TXS_REKEY WITH (KAFKA_TOPIC='transaction-rekey', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON') AS SELECT\n  TXS.`id` `id`,\n  TXS.`transaction` `transaction`\nFROM TXS TXS\nPARTITION BY TXS.`id`\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TXS_REKEY",
+      "schema" : "`id` STRING KEY, `transaction` STRING",
+      "timestampColumn" : null,
+      "topicName" : "transaction-rekey",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TXS" ],
+      "sink" : "TXS_REKEY",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "TXS_REKEY"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSelectKeyV2",
+            "properties" : {
+              "queryContext" : "PartitionBy"
+            },
+            "source" : {
+              "@type" : "streamSourceV1",
+              "properties" : {
+                "queryContext" : "KsqlTopic/Source"
+              },
+              "topicName" : "transaction",
+              "formats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "JSON",
+                  "properties" : { }
+                }
+              },
+              "timestampColumn" : null,
+              "sourceSchema" : "`id` STRING, `transaction` STRING",
+              "pseudoColumnVersion" : 1
+            },
+            "keyExpression" : [ "`id`" ]
+          },
+          "keyColumnNames" : [ "id" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "`transaction` AS `transaction`" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "transaction-rekey",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_TXS_REKEY_0",
+      "runtimeId" : null
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM MODEL_TXS_EVENT WITH (KAFKA_TOPIC='model-transaction', KEY_FORMAT='KAFKA', VALUE_FORMAT='AVRO', VALUE_SCHEMA_FULL_NAME='com.acme.namespace.Transaction', VALUE_SCHEMA_ID=102) AS SELECT\n  TXS.`id` `id`,\n  AS_VALUE(TXS.`id`) `eventID`,\n  STRUCT(`num_shares`:=CAST(EXTRACTJSONFIELD(TXS.`transaction`, '$.num_shares') AS INTEGER), `amount`:=CAST(EXTRACTJSONFIELD(TXS.`transaction`, '$.amount') AS INTEGER), `customer`:=STRUCT(`first_name`:=EXTRACTJSONFIELD(TXS.`transaction`, '$.customer.first_name'), `last_name`:=EXTRACTJSONFIELD(TXS.`transaction`, '$.customer.last_name'), `email`:=EXTRACTJSONFIELD(TXS.`transaction`, '$.customer.email'))) `transaction`\nFROM TXS_REKEY TXS\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "MODEL_TXS_EVENT",
+      "schema" : "`id` STRING KEY, `eventID` STRING, `transaction` STRUCT<`num_shares` INTEGER, `amount` INTEGER, `customer` STRUCT<`first_name` STRING, `last_name` STRING, `email` STRING>>",
+      "timestampColumn" : null,
+      "topicName" : "model-transaction",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : {
+            "fullSchemaName" : "com.acme.namespace.Transaction",
+            "schemaId" : "102"
+          }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TXS_REKEY" ],
+      "sink" : "MODEL_TXS_EVENT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "MODEL_TXS_EVENT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "transaction-rekey",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`id` STRING KEY, `transaction` STRING",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "id" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "AS_VALUE(`id`) AS `eventID`", "STRUCT(`num_shares`:=CAST(EXTRACTJSONFIELD(`transaction`, '$.num_shares') AS INTEGER), `amount`:=CAST(EXTRACTJSONFIELD(`transaction`, '$.amount') AS INTEGER), `customer`:=STRUCT(`first_name`:=EXTRACTJSONFIELD(`transaction`, '$.customer.first_name'), `last_name`:=EXTRACTJSONFIELD(`transaction`, '$.customer.last_name'), `email`:=EXTRACTJSONFIELD(`transaction`, '$.customer.email'))) AS `transaction`" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : {
+              "fullSchemaName" : "com.acme.namespace.Transaction",
+              "schemaId" : "102"
+            }
+          }
+        },
+        "topicName" : "model-transaction",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_MODEL_TXS_EVENT_1",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.websocket.connection.max.timeout.ms" : "3600000",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "true",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.json_sr.converter.deserializer.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_VALUE_SCHEMA_ID_with_compound_types_and_default_value_in_the_end_of_schema/7.4.0_1666063444659/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_VALUE_SCHEMA_ID_with_compound_types_and_default_value_in_the_end_of_schema/7.4.0_1666063444659/spec.json
@@ -1,0 +1,348 @@
+{
+  "version" : "7.4.0",
+  "timestamp" : 1666063444659,
+  "path" : "query-validation-tests/avro.json",
+  "schemas" : {
+    "CSAS_MODEL_TXS_EVENT_1.KsqlTopic.Source" : {
+      "schema" : "`id` STRING KEY, `transaction` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_MODEL_TXS_EVENT_1.MODEL_TXS_EVENT" : {
+      "schema" : "`id` STRING KEY, `eventID` STRING, `transaction` STRUCT<`num_shares` INTEGER, `amount` INTEGER, `customer` STRUCT<`first_name` STRING, `last_name` STRING, `email` STRING>>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO",
+        "properties" : {
+          "fullSchemaName" : "com.acme.namespace.Transaction",
+          "schemaId" : "102"
+        }
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "VALUE_SCHEMA_ID with compound types and default value in the end of schema",
+    "inputs" : [ {
+      "topic" : "transaction",
+      "key" : null,
+      "value" : {
+        "id" : "1",
+        "transaction" : {
+          "txn_ts" : "2020-11-18 02:31:43",
+          "customer" : {
+            "first_name" : "Jill",
+            "last_name" : "Smith",
+            "id" : 1234567,
+            "email" : "jsmith@foo.com"
+          },
+          "company" : {
+            "name" : "ACME Corp",
+            "ticker" : "ACMC",
+            "id" : "ACME837275222752952",
+            "address" : "Anytown USA, 333333"
+          }
+        }
+      }
+    }, {
+      "topic" : "transaction",
+      "key" : null,
+      "value" : {
+        "id" : "2",
+        "transaction" : {
+          "txn_ts" : "2020-11-18 02:35:43",
+          "customer" : {
+            "first_name" : "Art",
+            "last_name" : "Vandeley",
+            "id" : 8976612,
+            "email" : "avendleay@foo.com"
+          },
+          "company" : {
+            "name" : "Imports Corp",
+            "ticker" : "IMPC",
+            "id" : "IMPC88875222752952",
+            "address" : "Anytown USA, 333333"
+          }
+        }
+      }
+    }, {
+      "topic" : "transaction",
+      "key" : null,
+      "value" : {
+        "id" : "3",
+        "transaction" : {
+          "txn_ts" : "2020-11-18 02:36:43",
+          "customer" : {
+            "first_name" : "John",
+            "last_name" : "England",
+            "id" : 456321,
+            "email" : "je@foo.com"
+          },
+          "company" : {
+            "name" : "Hechinger",
+            "ticker" : "HECH",
+            "id" : "HECH8333785222752952",
+            "address" : "Anytown USA, 333333"
+          }
+        }
+      }
+    }, {
+      "topic" : "transaction",
+      "key" : null,
+      "value" : {
+        "id" : "4",
+        "transaction" : {
+          "txn_ts" : "2020-11-18 02:37:43",
+          "customer" : {
+            "first_name" : "Fred",
+            "last_name" : "Pym",
+            "id" : 333567,
+            "email" : "fjone@foo.com"
+          },
+          "company" : {
+            "name" : "PymTech",
+            "ticker" : "PYMT",
+            "id" : "PYME837275222714197419202020",
+            "address" : "Anytown USA, 333333"
+          }
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "model-transaction",
+      "key" : "1",
+      "value" : {
+        "optField" : "foo",
+        "eventID" : "1",
+        "transaction" : {
+          "amount" : null,
+          "num_shares" : null,
+          "customer" : {
+            "last_name" : "Smith",
+            "first_name" : "Jill",
+            "email" : "jsmith@foo.com"
+          }
+        }
+      }
+    }, {
+      "topic" : "model-transaction",
+      "key" : "2",
+      "value" : {
+        "optField" : "foo",
+        "eventID" : "2",
+        "transaction" : {
+          "amount" : null,
+          "num_shares" : null,
+          "customer" : {
+            "last_name" : "Vandeley",
+            "first_name" : "Art",
+            "email" : "avendleay@foo.com"
+          }
+        }
+      }
+    }, {
+      "topic" : "model-transaction",
+      "key" : "3",
+      "value" : {
+        "optField" : "foo",
+        "eventID" : "3",
+        "transaction" : {
+          "amount" : null,
+          "num_shares" : null,
+          "customer" : {
+            "last_name" : "England",
+            "first_name" : "John",
+            "email" : "je@foo.com"
+          }
+        }
+      }
+    }, {
+      "topic" : "model-transaction",
+      "key" : "4",
+      "value" : {
+        "optField" : "foo",
+        "eventID" : "4",
+        "transaction" : {
+          "amount" : null,
+          "num_shares" : null,
+          "customer" : {
+            "last_name" : "Pym",
+            "first_name" : "Fred",
+            "email" : "fjone@foo.com"
+          }
+        }
+      }
+    } ],
+    "topics" : [ {
+      "name" : "model-transaction",
+      "valueSchemaId" : 102,
+      "valueSchema" : {
+        "type" : "record",
+        "name" : "Transaction",
+        "namespace" : "com.acme.namespace",
+        "fields" : [ {
+          "name" : "eventID",
+          "type" : "string"
+        }, {
+          "name" : "transaction",
+          "type" : {
+            "type" : "record",
+            "name" : "transaction",
+            "fields" : [ {
+              "name" : "num_shares",
+              "type" : [ "null", "int" ]
+            }, {
+              "name" : "amount",
+              "type" : [ "null", "int" ]
+            }, {
+              "name" : "customer",
+              "type" : {
+                "type" : "record",
+                "name" : "customer",
+                "fields" : [ {
+                  "name" : "first_name",
+                  "type" : "string"
+                }, {
+                  "name" : "last_name",
+                  "type" : "string"
+                }, {
+                  "name" : "email",
+                  "type" : "string"
+                } ]
+              }
+            } ]
+          }
+        }, {
+          "name" : "optField",
+          "type" : "string",
+          "default" : "foo"
+        } ]
+      },
+      "valueFormat" : "AVRO",
+      "replicas" : 1,
+      "numPartitions" : 1
+    }, {
+      "name" : "transaction",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TXS (`id` VARCHAR, `transaction` VARCHAR) WITH (KAFKA_TOPIC='transaction', VALUE_FORMAT='JSON', KEY_FORMAT='KAFKA');", "CREATE STREAM TXS_REKEY WITH (KAFKA_TOPIC='transaction-rekey', VALUE_FORMAT='JSON', KEY_FORMAT='KAFKA') AS SELECT `id`, `transaction` FROM TXS PARTITION BY `id`;", "CREATE STREAM MODEL_TXS_EVENT WITH  (KAFKA_TOPIC='model-transaction', KEY_FORMAT='KAFKA', VALUE_FORMAT='AVRO', VALUE_SCHEMA_ID=102) AS SELECT `id`, as_value(txs.`id`) AS `eventID`, STRUCT(`num_shares` := CAST(EXTRACTJSONFIELD(txs.`transaction`, '$.num_shares') AS INT), `amount` := CAST(EXTRACTJSONFIELD(txs.`transaction`, '$.amount') AS INT), `customer` := STRUCT(`first_name`:= EXTRACTJSONFIELD(txs.`transaction`, '$.customer.first_name'), `last_name`:= EXTRACTJSONFIELD(txs.`transaction`, '$.customer.last_name'), `email`:= EXTRACTJSONFIELD(txs.`transaction`, '$.customer.email'))) AS `transaction` FROM TXS_REKEY txs;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "MODEL_TXS_EVENT",
+        "type" : "STREAM",
+        "schema" : "`id` STRING KEY, `eventID` STRING, `transaction` STRUCT<`num_shares` INTEGER, `amount` INTEGER, `customer` STRUCT<`first_name` STRING, `last_name` STRING, `email` STRING>>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "AVRO",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TXS",
+        "type" : "STREAM",
+        "schema" : "`id` STRING, `transaction` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TXS_REKEY",
+        "type" : "STREAM",
+        "schema" : "`id` STRING KEY, `transaction` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "transaction-rekey",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "model-transaction",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : {
+              "fullSchemaName" : "com.acme.namespace.Transaction",
+              "schemaId" : "102"
+            }
+          },
+          "partitions" : 4,
+          "valueSchema" : {
+            "type" : "record",
+            "name" : "Transaction",
+            "namespace" : "com.acme.namespace",
+            "fields" : [ {
+              "name" : "eventID",
+              "type" : "string"
+            }, {
+              "name" : "transaction",
+              "type" : {
+                "type" : "record",
+                "name" : "transaction",
+                "fields" : [ {
+                  "name" : "num_shares",
+                  "type" : [ "null", "int" ]
+                }, {
+                  "name" : "amount",
+                  "type" : [ "null", "int" ]
+                }, {
+                  "name" : "customer",
+                  "type" : {
+                    "type" : "record",
+                    "name" : "customer",
+                    "fields" : [ {
+                      "name" : "first_name",
+                      "type" : "string"
+                    }, {
+                      "name" : "last_name",
+                      "type" : "string"
+                    }, {
+                      "name" : "email",
+                      "type" : "string"
+                    } ]
+                  }
+                } ]
+              }
+            }, {
+              "name" : "optField",
+              "type" : "string",
+              "default" : "foo"
+            } ]
+          }
+        }, {
+          "name" : "transaction",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_VALUE_SCHEMA_ID_with_compound_types_and_default_value_in_the_end_of_schema/7.4.0_1666063444659/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_VALUE_SCHEMA_ID_with_compound_types_and_default_value_in_the_end_of_schema/7.4.0_1666063444659/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [transaction-rekey])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: model-transaction)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_VALUE_SCHEMA_ID_with_compound_types_and_optional_value/7.4.0_1666063444480/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_VALUE_SCHEMA_ID_with_compound_types_and_optional_value/7.4.0_1666063444480/plan.json
@@ -1,0 +1,295 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TXS (`id` STRING, `transaction` STRING) WITH (KAFKA_TOPIC='transaction', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TXS",
+      "schema" : "`id` STRING, `transaction` STRING",
+      "timestampColumn" : null,
+      "topicName" : "transaction",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TXS_REKEY WITH (KAFKA_TOPIC='transaction-rekey', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON') AS SELECT\n  TXS.`id` `id`,\n  TXS.`transaction` `transaction`\nFROM TXS TXS\nPARTITION BY TXS.`id`\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TXS_REKEY",
+      "schema" : "`id` STRING KEY, `transaction` STRING",
+      "timestampColumn" : null,
+      "topicName" : "transaction-rekey",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TXS" ],
+      "sink" : "TXS_REKEY",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "TXS_REKEY"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSelectKeyV2",
+            "properties" : {
+              "queryContext" : "PartitionBy"
+            },
+            "source" : {
+              "@type" : "streamSourceV1",
+              "properties" : {
+                "queryContext" : "KsqlTopic/Source"
+              },
+              "topicName" : "transaction",
+              "formats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "JSON",
+                  "properties" : { }
+                }
+              },
+              "timestampColumn" : null,
+              "sourceSchema" : "`id` STRING, `transaction` STRING",
+              "pseudoColumnVersion" : 1
+            },
+            "keyExpression" : [ "`id`" ]
+          },
+          "keyColumnNames" : [ "id" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "`transaction` AS `transaction`" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "transaction-rekey",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_TXS_REKEY_0",
+      "runtimeId" : null
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM MODEL_TXS_EVENT WITH (KAFKA_TOPIC='model-transaction', KEY_FORMAT='KAFKA', VALUE_FORMAT='AVRO', VALUE_SCHEMA_FULL_NAME='com.acme.namespace.Transaction', VALUE_SCHEMA_ID=102) AS SELECT\n  TXS.`id` `id`,\n  AS_VALUE(TXS.`id`) `eventID`,\n  STRUCT(`num_shares`:=CAST(EXTRACTJSONFIELD(TXS.`transaction`, '$.num_shares') AS INTEGER), `amount`:=CAST(EXTRACTJSONFIELD(TXS.`transaction`, '$.amount') AS INTEGER), `customer`:=STRUCT(`first_name`:=EXTRACTJSONFIELD(TXS.`transaction`, '$.customer.first_name'), `last_name`:=EXTRACTJSONFIELD(TXS.`transaction`, '$.customer.last_name'), `email`:=EXTRACTJSONFIELD(TXS.`transaction`, '$.customer.email'))) `transaction`\nFROM TXS_REKEY TXS\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "MODEL_TXS_EVENT",
+      "schema" : "`id` STRING KEY, `eventID` STRING, `transaction` STRUCT<`num_shares` INTEGER, `amount` INTEGER, `customer` STRUCT<`first_name` STRING, `last_name` STRING, `email` STRING>>",
+      "timestampColumn" : null,
+      "topicName" : "model-transaction",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : {
+            "fullSchemaName" : "com.acme.namespace.Transaction",
+            "schemaId" : "102"
+          }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TXS_REKEY" ],
+      "sink" : "MODEL_TXS_EVENT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "MODEL_TXS_EVENT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "transaction-rekey",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`id` STRING KEY, `transaction` STRING",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "id" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "AS_VALUE(`id`) AS `eventID`", "STRUCT(`num_shares`:=CAST(EXTRACTJSONFIELD(`transaction`, '$.num_shares') AS INTEGER), `amount`:=CAST(EXTRACTJSONFIELD(`transaction`, '$.amount') AS INTEGER), `customer`:=STRUCT(`first_name`:=EXTRACTJSONFIELD(`transaction`, '$.customer.first_name'), `last_name`:=EXTRACTJSONFIELD(`transaction`, '$.customer.last_name'), `email`:=EXTRACTJSONFIELD(`transaction`, '$.customer.email'))) AS `transaction`" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : {
+              "fullSchemaName" : "com.acme.namespace.Transaction",
+              "schemaId" : "102"
+            }
+          }
+        },
+        "topicName" : "model-transaction",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_MODEL_TXS_EVENT_1",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.websocket.connection.max.timeout.ms" : "3600000",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "true",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.json_sr.converter.deserializer.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_VALUE_SCHEMA_ID_with_compound_types_and_optional_value/7.4.0_1666063444480/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_VALUE_SCHEMA_ID_with_compound_types_and_optional_value/7.4.0_1666063444480/spec.json
@@ -1,0 +1,336 @@
+{
+  "version" : "7.4.0",
+  "timestamp" : 1666063444480,
+  "path" : "query-validation-tests/avro.json",
+  "schemas" : {
+    "CSAS_MODEL_TXS_EVENT_1.KsqlTopic.Source" : {
+      "schema" : "`id` STRING KEY, `transaction` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_MODEL_TXS_EVENT_1.MODEL_TXS_EVENT" : {
+      "schema" : "`id` STRING KEY, `eventID` STRING, `transaction` STRUCT<`num_shares` INTEGER, `amount` INTEGER, `customer` STRUCT<`first_name` STRING, `last_name` STRING, `email` STRING>>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO",
+        "properties" : {
+          "fullSchemaName" : "com.acme.namespace.Transaction",
+          "schemaId" : "102"
+        }
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "VALUE_SCHEMA_ID with compound types and optional value",
+    "inputs" : [ {
+      "topic" : "transaction",
+      "key" : null,
+      "value" : {
+        "id" : "1",
+        "transaction" : {
+          "txn_ts" : "2020-11-18 02:31:43",
+          "customer" : {
+            "first_name" : "Jill",
+            "last_name" : "Smith",
+            "id" : 1234567,
+            "email" : "jsmith@foo.com"
+          },
+          "company" : {
+            "name" : "ACME Corp",
+            "ticker" : "ACMC",
+            "id" : "ACME837275222752952",
+            "address" : "Anytown USA, 333333"
+          }
+        }
+      }
+    }, {
+      "topic" : "transaction",
+      "key" : null,
+      "value" : {
+        "id" : "2",
+        "transaction" : {
+          "txn_ts" : "2020-11-18 02:35:43",
+          "customer" : {
+            "first_name" : "Art",
+            "last_name" : "Vandeley",
+            "id" : 8976612,
+            "email" : "avendleay@foo.com"
+          },
+          "company" : {
+            "name" : "Imports Corp",
+            "ticker" : "IMPC",
+            "id" : "IMPC88875222752952",
+            "address" : "Anytown USA, 333333"
+          }
+        }
+      }
+    }, {
+      "topic" : "transaction",
+      "key" : null,
+      "value" : {
+        "id" : "3",
+        "transaction" : {
+          "txn_ts" : "2020-11-18 02:36:43",
+          "customer" : {
+            "first_name" : "John",
+            "last_name" : "England",
+            "id" : 456321,
+            "email" : "je@foo.com"
+          },
+          "company" : {
+            "name" : "Hechinger",
+            "ticker" : "HECH",
+            "id" : "HECH8333785222752952",
+            "address" : "Anytown USA, 333333"
+          }
+        }
+      }
+    }, {
+      "topic" : "transaction",
+      "key" : null,
+      "value" : {
+        "id" : "4",
+        "transaction" : {
+          "txn_ts" : "2020-11-18 02:37:43",
+          "customer" : {
+            "first_name" : "Fred",
+            "last_name" : "Pym",
+            "id" : 333567,
+            "email" : "fjone@foo.com"
+          },
+          "company" : {
+            "name" : "PymTech",
+            "ticker" : "PYMT",
+            "id" : "PYME837275222714197419202020",
+            "address" : "Anytown USA, 333333"
+          }
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "model-transaction",
+      "key" : "1",
+      "value" : {
+        "eventID" : "1",
+        "transaction" : {
+          "amount" : null,
+          "num_shares" : null,
+          "customer" : {
+            "last_name" : "Smith",
+            "first_name" : "Jill",
+            "email" : "jsmith@foo.com"
+          }
+        }
+      }
+    }, {
+      "topic" : "model-transaction",
+      "key" : "2",
+      "value" : {
+        "eventID" : "2",
+        "transaction" : {
+          "amount" : null,
+          "num_shares" : null,
+          "customer" : {
+            "last_name" : "Vandeley",
+            "first_name" : "Art",
+            "email" : "avendleay@foo.com"
+          }
+        }
+      }
+    }, {
+      "topic" : "model-transaction",
+      "key" : "3",
+      "value" : {
+        "eventID" : "3",
+        "transaction" : {
+          "amount" : null,
+          "num_shares" : null,
+          "customer" : {
+            "last_name" : "England",
+            "first_name" : "John",
+            "email" : "je@foo.com"
+          }
+        }
+      }
+    }, {
+      "topic" : "model-transaction",
+      "key" : "4",
+      "value" : {
+        "eventID" : "4",
+        "transaction" : {
+          "amount" : null,
+          "num_shares" : null,
+          "customer" : {
+            "last_name" : "Pym",
+            "first_name" : "Fred",
+            "email" : "fjone@foo.com"
+          }
+        }
+      }
+    } ],
+    "topics" : [ {
+      "name" : "model-transaction",
+      "valueSchemaId" : 102,
+      "valueSchema" : {
+        "type" : "record",
+        "name" : "Transaction",
+        "namespace" : "com.acme.namespace",
+        "fields" : [ {
+          "name" : "eventID",
+          "type" : "string"
+        }, {
+          "name" : "transaction",
+          "type" : {
+            "type" : "record",
+            "name" : "transaction",
+            "fields" : [ {
+              "name" : "num_shares",
+              "type" : [ "null", "int" ]
+            }, {
+              "name" : "amount",
+              "type" : [ "null", "int" ]
+            }, {
+              "name" : "customer",
+              "type" : {
+                "type" : "record",
+                "name" : "customer",
+                "fields" : [ {
+                  "name" : "first_name",
+                  "type" : "string"
+                }, {
+                  "name" : "last_name",
+                  "type" : "string"
+                }, {
+                  "name" : "email",
+                  "type" : "string"
+                } ]
+              }
+            } ]
+          }
+        } ]
+      },
+      "valueFormat" : "AVRO",
+      "replicas" : 1,
+      "numPartitions" : 1
+    }, {
+      "name" : "transaction",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TXS (`id` VARCHAR, `transaction` VARCHAR) WITH (KAFKA_TOPIC='transaction', VALUE_FORMAT='JSON', KEY_FORMAT='KAFKA');", "CREATE STREAM TXS_REKEY WITH (KAFKA_TOPIC='transaction-rekey', VALUE_FORMAT='JSON', KEY_FORMAT='KAFKA') AS SELECT `id`, `transaction` FROM TXS PARTITION BY `id`;", "CREATE STREAM MODEL_TXS_EVENT WITH  (KAFKA_TOPIC='model-transaction', KEY_FORMAT='KAFKA', VALUE_FORMAT='AVRO', VALUE_SCHEMA_ID=102) AS SELECT `id`, as_value(txs.`id`) AS `eventID`, STRUCT(`num_shares` := CAST(EXTRACTJSONFIELD(txs.`transaction`, '$.num_shares') AS INT), `amount` := CAST(EXTRACTJSONFIELD(txs.`transaction`, '$.amount') AS INT), `customer` := STRUCT(`first_name`:= EXTRACTJSONFIELD(txs.`transaction`, '$.customer.first_name'), `last_name`:= EXTRACTJSONFIELD(txs.`transaction`, '$.customer.last_name'), `email`:= EXTRACTJSONFIELD(txs.`transaction`, '$.customer.email'))) AS `transaction` FROM TXS_REKEY txs;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "MODEL_TXS_EVENT",
+        "type" : "STREAM",
+        "schema" : "`id` STRING KEY, `eventID` STRING, `transaction` STRUCT<`num_shares` INTEGER, `amount` INTEGER, `customer` STRUCT<`first_name` STRING, `last_name` STRING, `email` STRING>>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "AVRO",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TXS",
+        "type" : "STREAM",
+        "schema" : "`id` STRING, `transaction` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TXS_REKEY",
+        "type" : "STREAM",
+        "schema" : "`id` STRING KEY, `transaction` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "transaction-rekey",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "model-transaction",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : {
+              "fullSchemaName" : "com.acme.namespace.Transaction",
+              "schemaId" : "102"
+            }
+          },
+          "partitions" : 4,
+          "valueSchema" : {
+            "type" : "record",
+            "name" : "Transaction",
+            "namespace" : "com.acme.namespace",
+            "fields" : [ {
+              "name" : "eventID",
+              "type" : "string"
+            }, {
+              "name" : "transaction",
+              "type" : {
+                "type" : "record",
+                "name" : "transaction",
+                "fields" : [ {
+                  "name" : "num_shares",
+                  "type" : [ "null", "int" ]
+                }, {
+                  "name" : "amount",
+                  "type" : [ "null", "int" ]
+                }, {
+                  "name" : "customer",
+                  "type" : {
+                    "type" : "record",
+                    "name" : "customer",
+                    "fields" : [ {
+                      "name" : "first_name",
+                      "type" : "string"
+                    }, {
+                      "name" : "last_name",
+                      "type" : "string"
+                    }, {
+                      "name" : "email",
+                      "type" : "string"
+                    } ]
+                  }
+                } ]
+              }
+            } ]
+          }
+        }, {
+          "name" : "transaction",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_VALUE_SCHEMA_ID_with_compound_types_and_optional_value/7.4.0_1666063444480/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_VALUE_SCHEMA_ID_with_compound_types_and_optional_value/7.4.0_1666063444480/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [transaction-rekey])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: model-transaction)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/avro.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/avro.json
@@ -1183,6 +1183,118 @@
         "type": "io.confluent.ksql.util.KsqlStatementException",
         "message": "JSON does not support the following configs: [fullSchemaName]"
       }
+    },
+    {
+      "name": "VALUE_SCHEMA_ID with compound types",
+      "statements": [
+        "CREATE STREAM TXS (`id` VARCHAR, `transaction` VARCHAR) WITH (KAFKA_TOPIC='transaction', VALUE_FORMAT='JSON', KEY_FORMAT='KAFKA');",
+        "CREATE STREAM TXS_REKEY WITH (KAFKA_TOPIC='transaction-rekey', VALUE_FORMAT='JSON', KEY_FORMAT='KAFKA') AS SELECT `id`, `transaction` FROM TXS PARTITION BY `id`;",
+        "CREATE STREAM MODEL_TXS_EVENT WITH  (KAFKA_TOPIC='model-transaction', KEY_FORMAT='KAFKA', VALUE_FORMAT='AVRO', VALUE_SCHEMA_ID=102) AS SELECT `id`, as_value(txs.`id`) AS `eventID`, STRUCT(`num_shares` := CAST(EXTRACTJSONFIELD(txs.`transaction`, '$.num_shares') AS INT), `amount` := CAST(EXTRACTJSONFIELD(txs.`transaction`, '$.amount') AS INT), `customer` := STRUCT(`first_name`:= EXTRACTJSONFIELD(txs.`transaction`, '$.customer.first_name'), `last_name`:= EXTRACTJSONFIELD(txs.`transaction`, '$.customer.last_name'), `email`:= EXTRACTJSONFIELD(txs.`transaction`, '$.customer.email'))) AS `transaction` FROM TXS_REKEY txs;"
+      ],
+      "topics": [
+        {
+          "name": "model-transaction",
+          "valueFormat": "AVRO",
+          "valueSchemaId": 102,
+          "valueSchema": {"fields":[{"name":"eventID","type":"string"},{"name":"transaction","type":{"fields":[{"name":"num_shares","type":"int"},{"name":"amount","type":"int"},{"name":"customer","type":{"fields":[{"name":"first_name","type":"string"},{"name":"last_name","type":"string"},{"name":"email","type":"string"}],"name":"customer","type":"record"}}],"name":"transaction","type":"record"}}],"name":"Transaction","namespace":"com.acme.namespace","type":"record"}
+        }
+      ],
+      "inputs": [
+        {"topic": "transaction", "key": null, "value": {"id": "1", "transaction": {"num_shares": 50000, "amount": 50044568, "txn_ts": "2020-11-18 02:31:43", "customer": {"first_name": "Jill", "last_name": "Smith", "id": 1234567, "email": "jsmith@foo.com" }, "company": {"name": "ACME Corp", "ticker": "ACMC", "id": "ACME837275222752952", "address": "Anytown USA, 333333"}}}},
+        {"topic": "transaction", "key": null, "value": {"id": "2", "transaction": { "num_shares": 30000, "amount": 5004, "txn_ts": "2020-11-18 02:35:43", "customer": { "first_name": "Art", "last_name": "Vandeley", "id": 8976612, "email": "avendleay@foo.com" }, "company": { "name": "Imports Corp", "ticker": "IMPC", "id": "IMPC88875222752952", "address": "Anytown USA, 333333"}}}},
+        {"topic": "transaction", "key": null, "value": {"id": "3", "transaction": { "num_shares": 3000000, "amount": 50045, "txn_ts": "2020-11-18 02:36:43", "customer": { "first_name": "John", "last_name": "England", "id": 456321, "email": "je@foo.com" }, "company": { "name": "Hechinger", "ticker": "HECH", "id": "HECH8333785222752952", "address": "Anytown USA, 333333"}}}},
+        {"topic": "transaction", "key": null, "value": {"id": "4", "transaction": { "num_shares": 10000, "amount": 80044, "txn_ts": "2020-11-18 02:37:43", "customer": { "first_name": "Fred", "last_name": "Pym", "id": 333567, "email": "fjone@foo.com" }, "company": { "name": "PymTech", "ticker": "PYMT", "id": "PYME837275222714197419202020", "address": "Anytown USA, 333333"}}}}
+      ],
+      "outputs": [
+        {"topic": "model-transaction", "key": "1", "value": {"eventID": "1", "transaction": {"amount": 50044568, "num_shares": 50000, "customer": {"last_name": "Smith", "first_name": "Jill", "email": "jsmith@foo.com"}}}},
+        {"topic": "model-transaction", "key": "2", "value": {"eventID": "2", "transaction": {"amount": 5004, "num_shares": 30000, "customer": {"last_name": "Vandeley", "first_name": "Art", "email": "avendleay@foo.com"}}}},
+        {"topic": "model-transaction", "key": "3", "value": {"eventID": "3", "transaction": {"amount": 50045, "num_shares": 3000000, "customer": {"last_name": "England", "first_name": "John", "email": "je@foo.com"}}}},
+        {"topic": "model-transaction", "key": "4", "value": {"eventID": "4", "transaction": {"amount": 80044, "num_shares": 10000, "customer": {"last_name": "Pym", "first_name": "Fred", "email": "fjone@foo.com"}}}}
+      ]
+    },
+    {
+      "name": "VALUE_SCHEMA_ID with compound types and default value",
+      "statements": [
+        "CREATE STREAM TXS (`id` VARCHAR, `transaction` VARCHAR) WITH (KAFKA_TOPIC='transaction', VALUE_FORMAT='JSON', KEY_FORMAT='KAFKA');",
+        "CREATE STREAM TXS_REKEY WITH (KAFKA_TOPIC='transaction-rekey', VALUE_FORMAT='JSON', KEY_FORMAT='KAFKA') AS SELECT `id`, `transaction` FROM TXS PARTITION BY `id`;",
+        "CREATE STREAM MODEL_TXS_EVENT WITH  (KAFKA_TOPIC='model-transaction', KEY_FORMAT='KAFKA', VALUE_FORMAT='AVRO', VALUE_SCHEMA_ID=102) AS SELECT `id`, as_value(txs.`id`) AS `eventID`, STRUCT(`num_shares` := CAST(EXTRACTJSONFIELD(txs.`transaction`, '$.num_shares') AS INT), `amount` := CAST(EXTRACTJSONFIELD(txs.`transaction`, '$.amount') AS INT), `customer` := STRUCT(`first_name`:= EXTRACTJSONFIELD(txs.`transaction`, '$.customer.first_name'), `last_name`:= EXTRACTJSONFIELD(txs.`transaction`, '$.customer.last_name'), `email`:= EXTRACTJSONFIELD(txs.`transaction`, '$.customer.email'))) AS `transaction` FROM TXS_REKEY txs;"
+      ],
+      "topics": [
+        {
+          "name": "model-transaction",
+          "valueFormat": "AVRO",
+          "valueSchemaId": 102,
+          "valueSchema": {"fields":[{"name":"eventID","type":"string"},{"name":"transaction","type":{"fields":[{"name":"num_shares","type":"int","default": 0},{"name":"amount","type":"int","default": 0},{"name":"customer","type":{"fields":[{"name":"first_name","type":"string"},{"name":"last_name","type":"string"},{"name":"email","type":"string"}],"name":"customer","type":"record"}}],"name":"transaction","type":"record"}}],"name":"Transaction","namespace":"com.acme.namespace","type":"record"}
+        }
+      ],
+      "inputs": [
+        {"topic": "transaction", "key": null, "value": {"id": "1", "transaction": {"txn_ts": "2020-11-18 02:31:43", "customer": {"first_name": "Jill", "last_name": "Smith", "id": 1234567, "email": "jsmith@foo.com" }, "company": {"name": "ACME Corp", "ticker": "ACMC", "id": "ACME837275222752952", "address": "Anytown USA, 333333"}}}},
+        {"topic": "transaction", "key": null, "value": {"id": "2", "transaction": {"txn_ts": "2020-11-18 02:35:43", "customer": { "first_name": "Art", "last_name": "Vandeley", "id": 8976612, "email": "avendleay@foo.com" }, "company": { "name": "Imports Corp", "ticker": "IMPC", "id": "IMPC88875222752952", "address": "Anytown USA, 333333"}}}},
+        {"topic": "transaction", "key": null, "value": {"id": "3", "transaction": {"txn_ts": "2020-11-18 02:36:43", "customer": { "first_name": "John", "last_name": "England", "id": 456321, "email": "je@foo.com" }, "company": { "name": "Hechinger", "ticker": "HECH", "id": "HECH8333785222752952", "address": "Anytown USA, 333333"}}}},
+        {"topic": "transaction", "key": null, "value": {"id": "4", "transaction": {"txn_ts": "2020-11-18 02:37:43", "customer": { "first_name": "Fred", "last_name": "Pym", "id": 333567, "email": "fjone@foo.com" }, "company": { "name": "PymTech", "ticker": "PYMT", "id": "PYME837275222714197419202020", "address": "Anytown USA, 333333"}}}}
+      ],
+      "outputs": [
+        {"topic": "model-transaction", "key": "1", "value": {"eventID": "1", "transaction": {"amount": 0, "num_shares": 0, "customer": {"last_name": "Smith", "first_name": "Jill", "email": "jsmith@foo.com"}}}},
+        {"topic": "model-transaction", "key": "2", "value": {"eventID": "2", "transaction": {"amount": 0, "num_shares": 0, "customer": {"last_name": "Vandeley", "first_name": "Art", "email": "avendleay@foo.com"}}}},
+        {"topic": "model-transaction", "key": "3", "value": {"eventID": "3", "transaction": {"amount": 0, "num_shares": 0, "customer": {"last_name": "England", "first_name": "John", "email": "je@foo.com"}}}},
+        {"topic": "model-transaction", "key": "4", "value": {"eventID": "4", "transaction": {"amount": 0, "num_shares": 0, "customer": {"last_name": "Pym", "first_name": "Fred", "email": "fjone@foo.com"}}}}
+      ]
+    },
+    {
+      "name": "VALUE_SCHEMA_ID with compound types and optional value",
+      "statements": [
+        "CREATE STREAM TXS (`id` VARCHAR, `transaction` VARCHAR) WITH (KAFKA_TOPIC='transaction', VALUE_FORMAT='JSON', KEY_FORMAT='KAFKA');",
+        "CREATE STREAM TXS_REKEY WITH (KAFKA_TOPIC='transaction-rekey', VALUE_FORMAT='JSON', KEY_FORMAT='KAFKA') AS SELECT `id`, `transaction` FROM TXS PARTITION BY `id`;",
+        "CREATE STREAM MODEL_TXS_EVENT WITH  (KAFKA_TOPIC='model-transaction', KEY_FORMAT='KAFKA', VALUE_FORMAT='AVRO', VALUE_SCHEMA_ID=102) AS SELECT `id`, as_value(txs.`id`) AS `eventID`, STRUCT(`num_shares` := CAST(EXTRACTJSONFIELD(txs.`transaction`, '$.num_shares') AS INT), `amount` := CAST(EXTRACTJSONFIELD(txs.`transaction`, '$.amount') AS INT), `customer` := STRUCT(`first_name`:= EXTRACTJSONFIELD(txs.`transaction`, '$.customer.first_name'), `last_name`:= EXTRACTJSONFIELD(txs.`transaction`, '$.customer.last_name'), `email`:= EXTRACTJSONFIELD(txs.`transaction`, '$.customer.email'))) AS `transaction` FROM TXS_REKEY txs;"
+      ],
+      "topics": [
+        {
+          "name": "model-transaction",
+          "valueFormat": "AVRO",
+          "valueSchemaId": 102,
+          "valueSchema": {"fields":[{"name":"eventID","type":"string"},{"name":"transaction","type":{"fields":[{"name":"num_shares","type":["null","int"]},{"name":"amount","type":["null","int"]},{"name":"customer","type":{"fields":[{"name":"first_name","type":"string"},{"name":"last_name","type":"string"},{"name":"email","type":"string"}],"name":"customer","type":"record"}}],"name":"transaction","type":"record"}}],"name":"Transaction","namespace":"com.acme.namespace","type":"record"}
+        }
+      ],
+      "inputs": [
+        {"topic": "transaction", "key": null, "value": {"id": "1", "transaction": {"txn_ts": "2020-11-18 02:31:43", "customer": {"first_name": "Jill", "last_name": "Smith", "id": 1234567, "email": "jsmith@foo.com" }, "company": {"name": "ACME Corp", "ticker": "ACMC", "id": "ACME837275222752952", "address": "Anytown USA, 333333"}}}},
+        {"topic": "transaction", "key": null, "value": {"id": "2", "transaction": {"txn_ts": "2020-11-18 02:35:43", "customer": { "first_name": "Art", "last_name": "Vandeley", "id": 8976612, "email": "avendleay@foo.com" }, "company": { "name": "Imports Corp", "ticker": "IMPC", "id": "IMPC88875222752952", "address": "Anytown USA, 333333"}}}},
+        {"topic": "transaction", "key": null, "value": {"id": "3", "transaction": {"txn_ts": "2020-11-18 02:36:43", "customer": { "first_name": "John", "last_name": "England", "id": 456321, "email": "je@foo.com" }, "company": { "name": "Hechinger", "ticker": "HECH", "id": "HECH8333785222752952", "address": "Anytown USA, 333333"}}}},
+        {"topic": "transaction", "key": null, "value": {"id": "4", "transaction": {"txn_ts": "2020-11-18 02:37:43", "customer": { "first_name": "Fred", "last_name": "Pym", "id": 333567, "email": "fjone@foo.com" }, "company": { "name": "PymTech", "ticker": "PYMT", "id": "PYME837275222714197419202020", "address": "Anytown USA, 333333"}}}}
+      ],
+      "outputs": [
+        {"topic": "model-transaction", "key": "1", "value": {"eventID": "1", "transaction": {"amount": null, "num_shares": null, "customer": {"last_name": "Smith", "first_name": "Jill", "email": "jsmith@foo.com"}}}},
+        {"topic": "model-transaction", "key": "2", "value": {"eventID": "2", "transaction": {"amount": null, "num_shares": null, "customer": {"last_name": "Vandeley", "first_name": "Art", "email": "avendleay@foo.com"}}}},
+        {"topic": "model-transaction", "key": "3", "value": {"eventID": "3", "transaction": {"amount": null, "num_shares": null, "customer": {"last_name": "England", "first_name": "John", "email": "je@foo.com"}}}},
+        {"topic": "model-transaction", "key": "4", "value": {"eventID": "4", "transaction": {"amount": null, "num_shares": null, "customer": {"last_name": "Pym", "first_name": "Fred", "email": "fjone@foo.com"}}}}
+      ]
+    },
+    {
+      "name": "VALUE_SCHEMA_ID with compound types and default value in the end of schema",
+      "statements": [
+        "CREATE STREAM TXS (`id` VARCHAR, `transaction` VARCHAR) WITH (KAFKA_TOPIC='transaction', VALUE_FORMAT='JSON', KEY_FORMAT='KAFKA');",
+        "CREATE STREAM TXS_REKEY WITH (KAFKA_TOPIC='transaction-rekey', VALUE_FORMAT='JSON', KEY_FORMAT='KAFKA') AS SELECT `id`, `transaction` FROM TXS PARTITION BY `id`;",
+        "CREATE STREAM MODEL_TXS_EVENT WITH  (KAFKA_TOPIC='model-transaction', KEY_FORMAT='KAFKA', VALUE_FORMAT='AVRO', VALUE_SCHEMA_ID=102) AS SELECT `id`, as_value(txs.`id`) AS `eventID`, STRUCT(`num_shares` := CAST(EXTRACTJSONFIELD(txs.`transaction`, '$.num_shares') AS INT), `amount` := CAST(EXTRACTJSONFIELD(txs.`transaction`, '$.amount') AS INT), `customer` := STRUCT(`first_name`:= EXTRACTJSONFIELD(txs.`transaction`, '$.customer.first_name'), `last_name`:= EXTRACTJSONFIELD(txs.`transaction`, '$.customer.last_name'), `email`:= EXTRACTJSONFIELD(txs.`transaction`, '$.customer.email'))) AS `transaction` FROM TXS_REKEY txs;"
+      ],
+      "topics": [
+        {
+          "name": "model-transaction",
+          "valueFormat": "AVRO",
+          "valueSchemaId": 102,
+          "valueSchema": {"fields":[{"name":"eventID","type":"string"},{"name":"transaction","type":{"fields":[{"name":"num_shares","type":["null","int"]},{"name":"amount","type":["null","int"]},{"name":"customer","type":{"fields":[{"name":"first_name","type":"string"},{"name":"last_name","type":"string"},{"name":"email","type":"string"}],"name":"customer","type":"record"}}],"name":"transaction","type":"record"}},{"name":"optField","type":"string","default":"foo"}],"name":"Transaction","namespace":"com.acme.namespace","type":"record"}
+        }
+      ],
+      "inputs": [
+        {"topic": "transaction", "key": null, "value": {"id": "1", "transaction": {"txn_ts": "2020-11-18 02:31:43", "customer": {"first_name": "Jill", "last_name": "Smith", "id": 1234567, "email": "jsmith@foo.com" }, "company": {"name": "ACME Corp", "ticker": "ACMC", "id": "ACME837275222752952", "address": "Anytown USA, 333333"}}}},
+        {"topic": "transaction", "key": null, "value": {"id": "2", "transaction": {"txn_ts": "2020-11-18 02:35:43", "customer": { "first_name": "Art", "last_name": "Vandeley", "id": 8976612, "email": "avendleay@foo.com" }, "company": { "name": "Imports Corp", "ticker": "IMPC", "id": "IMPC88875222752952", "address": "Anytown USA, 333333"}}}},
+        {"topic": "transaction", "key": null, "value": {"id": "3", "transaction": {"txn_ts": "2020-11-18 02:36:43", "customer": { "first_name": "John", "last_name": "England", "id": 456321, "email": "je@foo.com" }, "company": { "name": "Hechinger", "ticker": "HECH", "id": "HECH8333785222752952", "address": "Anytown USA, 333333"}}}},
+        {"topic": "transaction", "key": null, "value": {"id": "4", "transaction": {"txn_ts": "2020-11-18 02:37:43", "customer": { "first_name": "Fred", "last_name": "Pym", "id": 333567, "email": "fjone@foo.com" }, "company": { "name": "PymTech", "ticker": "PYMT", "id": "PYME837275222714197419202020", "address": "Anytown USA, 333333"}}}}
+      ],
+      "outputs": [
+        {"topic": "model-transaction", "key": "1", "value": {"optField": "foo", "eventID": "1", "transaction": {"amount": null, "num_shares": null, "customer": {"last_name": "Smith", "first_name": "Jill", "email": "jsmith@foo.com"}}}},
+        {"topic": "model-transaction", "key": "2", "value": {"optField": "foo", "eventID": "2", "transaction": {"amount": null, "num_shares": null, "customer": {"last_name": "Vandeley", "first_name": "Art", "email": "avendleay@foo.com"}}}},
+        {"topic": "model-transaction", "key": "3", "value": {"optField": "foo", "eventID": "3", "transaction": {"amount": null, "num_shares": null, "customer": {"last_name": "England", "first_name": "John", "email": "je@foo.com"}}}},
+        {"topic": "model-transaction", "key": "4", "value": {"optField": "foo", "eventID": "4", "transaction": {"amount": null, "num_shares": null, "customer": {"last_name": "Pym", "first_name": "Fred", "email": "fjone@foo.com"}}}}
+      ]
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
@@ -603,6 +603,166 @@
         "message": "Inserting into column `ROWOFFSET` is not allowed.",
         "status": 400
       }
+    },
+    {
+      "name": "AVRO schema containing string, array, and struct with schema id",
+      "statements": [
+        "CREATE STREAM TEST WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='AVRO', VALUE_SCHEMA_ID=102);",
+        "INSERT INTO TEST(`template_id`, `from_`, `to_`, `dynamic_data`) VALUES ('abc', 'info@abc.org', ARRAY[STRUCT(`name`:='ABC', `email`:='abc@abc.com')], STRUCT(`num_votes`:=5, `donor_email`:='abc@abc.com'));"
+      ],
+      "topics": [
+        {
+          "name": "test_topic",
+          "valueFormat": "AVRO",
+          "valueSchemaId": 102,
+          "valueSchema": {"type":"record","name":"Test","fields":[{"name":"template_id","type":"string"},{"name":"from_","type":"string"},{"name":"to_","type":{"type":"array","items":{"type":"record","name":"To","fields":[{"name":"email","type":"string"},{"name":"name","type":"string"}]},"name":"to_"}},{"name":"dynamic_data","type":{"type":"record","name":"DynamicData","fields":[{"name":"num_votes","type":"long"},{"name":"donor_email","type":"string"}]}}]}
+        }
+      ],
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": null, "value": {"template_id": "abc", "from_": "info@abc.org", "to_": [{"name": "ABC", "email": "abc@abc.com"}], "dynamic_data": {"num_votes": 5, "donor_email": "abc@abc.com"}}}
+      ]
+    },
+    {
+      "name": "AVRO schema containing string and struct with schema id",
+      "statements": [
+        "CREATE STREAM TEST WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='AVRO', VALUE_SCHEMA_ID=102);",
+        "INSERT INTO TEST(ID, STRUCT_DATA) VALUES ('abc', STRUCT(NUM_VOTES:=5, DONOR_EMAIL:='abc@abc.com'));"
+      ],
+      "topics": [
+        {
+          "name": "test_topic",
+          "valueFormat": "AVRO",
+          "valueSchemaId": 102,
+          "valueSchema": {"type":"record","name":"Test","fields":[{"name":"ID","type":"string"},{"name":"STRUCT_DATA","type":{"type":"record","name":"DynamicData","fields":[{"name":"NUM_VOTES","type":"long"},{"name":"DONOR_EMAIL","type":"string"}]}}]}
+        }
+      ],
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": null, "value": {"ID": "abc", "STRUCT_DATA": {"NUM_VOTES": 5, "DONOR_EMAIL": "abc@abc.com"}}}
+      ]
+    },
+    {
+      "name": "AVRO schema containing string and map with schema id",
+      "statements": [
+        "CREATE STREAM TEST WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='AVRO', VALUE_SCHEMA_ID=102);",
+        "INSERT INTO TEST(ID, MAP_DATA) VALUES ('abc', MAP('NUM_VOTES':=5, 'DONOR_AMT':=50));"
+      ],
+      "topics": [
+        {
+          "name": "test_topic",
+          "valueFormat": "AVRO",
+          "valueSchemaId": 102,
+          "valueSchema": {"type":"record","name":"Test","fields":[{"name":"ID","type":"string"},{"name":"MAP_DATA","type":{"type":"map","values":"long"}}]}
+        }
+      ],
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": null, "value": {"ID": "abc", "MAP_DATA": {"NUM_VOTES": 5, "DONOR_AMT": 50}}}
+      ]
+    },
+    {
+      "name": "AVRO schema containing string and map of struct with schema id",
+      "statements": [
+        "CREATE STREAM TEST WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='AVRO', VALUE_SCHEMA_ID=102);",
+        "INSERT INTO TEST(ID, MAP_DATA) VALUES ('abc', MAP('KEY1':=STRUCT(NUM_VOTES:=5, DONOR_EMAIL:='abc@abc.com'), 'KEY2':=STRUCT(NUM_VOTES:=6, DONOR_EMAIL:='def@abc.com')));"
+      ],
+      "topics": [
+        {
+          "name": "test_topic",
+          "valueFormat": "AVRO",
+          "valueSchemaId": 102,
+          "valueSchema": {"type":"record","name":"Test","fields":[{"name":"ID","type":"string"},{"name":"MAP_DATA","type":{"type":"map", "values":{"type": "record", "name": "MapOfStruct", "fields": [{"name":"NUM_VOTES","type":"long"},{"name":"DONOR_EMAIL","type":"string"}]}}}]}
+        }
+      ],
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": null, "value": {"ID": "abc", "MAP_DATA": {"KEY1": {"NUM_VOTES": 5, "DONOR_EMAIL": "abc@abc.com"}, "KEY2": {"NUM_VOTES": 6, "DONOR_EMAIL": "def@abc.com"}}}}
+      ]
+    },
+    {
+      "name": "AVRO schema containing only string field with schema id",
+      "statements": [
+        "CREATE STREAM TEST WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='AVRO', VALUE_SCHEMA_ID=102);",
+        "INSERT INTO TEST(ID, DATA) VALUES ('abc', 5);"
+      ],
+      "topics": [
+        {
+          "name": "test_topic",
+          "valueFormat": "AVRO",
+          "valueSchemaId": 102,
+          "valueSchema": {"type":"record","name":"Test","fields":[{"name":"ID","type":"string"},{"name":"DATA","type":"long"}]}
+        }
+      ],
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": null, "value": {"ID": "abc", "DATA":  5}}
+      ]
+    },
+    {
+      "name": "AVRO schema containing string and struct with schema id with optional field",
+      "statements": [
+        "CREATE STREAM TEST WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='AVRO', VALUE_SCHEMA_ID=102);",
+        "INSERT INTO TEST(ID, STRUCT_DATA) VALUES ('abc', STRUCT(DONOR_EMAIL:='abc@abc.com'));"
+      ],
+      "topics": [
+        {
+          "name": "test_topic",
+          "valueFormat": "AVRO",
+          "valueSchemaId": 102,
+          "valueSchema": {"type":"record","name":"Test","fields":[{"name":"ID","type":"string"},{"name":"STRUCT_DATA","type":{"type":"record","name":"DynamicData","fields":[{"name":"NUM_VOTES","type":["null","long"]},{"name":"DONOR_EMAIL","type":"string"}]}}]}
+        }
+      ],
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": null, "value": {"ID": "abc", "STRUCT_DATA": {"NUM_VOTES": null, "DONOR_EMAIL": "abc@abc.com"}}}
+      ]
+    },
+    {
+      "name": "AVRO schema containing string and struct with schema id with default long value",
+      "statements": [
+        "CREATE STREAM TEST WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='AVRO', VALUE_SCHEMA_ID=102);",
+        "INSERT INTO TEST(ID, STRUCT_DATA) VALUES ('abc', STRUCT(DONOR_EMAIL:='abc@abc.com'));"
+      ],
+      "topics": [
+        {
+          "name": "test_topic",
+          "valueFormat": "AVRO",
+          "valueSchemaId": 102,
+          "valueSchema": {"type":"record","name":"Test","fields":[{"name":"ID","type":"string"},{"name":"STRUCT_DATA","type":{"type":"record","name":"DynamicData","fields":[{"name":"NUM_VOTES","type":"long", "default": 10},{"name":"DONOR_EMAIL","type":"string"}]}}]}
+        }
+      ],
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": null, "value": {"ID": "abc", "STRUCT_DATA": {"NUM_VOTES": 10, "DONOR_EMAIL": "abc@abc.com"}}}
+      ]
+    },
+    {
+      "name": "AVRO schema containing string and struct with schema id and unregistered field",
+      "statements": [
+        "CREATE STREAM TEST WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='AVRO', VALUE_SCHEMA_ID=102);",
+        "INSERT INTO TEST(ID, STRUCT_DATA) VALUES ('abc', STRUCT(DONOR_EMAIL:='abc@abc.com', UNREGISTERED_FIELD:='foo'));"
+      ],
+      "topics": [
+        {
+          "name": "test_topic",
+          "valueFormat": "AVRO",
+          "valueSchemaId": 102,
+          "valueSchema": {"type":"record","name":"Test","fields":[{"name":"ID","type":"string"},{"name":"STRUCT_DATA","type":{"type":"record","name":"DynamicData","fields":[{"name":"NUM_VOTES","type":"long", "default": 10},{"name":"DONOR_EMAIL","type":"string"}]}}]}
+        }
+      ],
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": null, "value": {"ID": "abc", "STRUCT_DATA": {"NUM_VOTES": 10, "DONOR_EMAIL": "abc@abc.com"}}}
+      ]
     }
   ]
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/avro/AvroSRSchemaDataTranslator.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/avro/AvroSRSchemaDataTranslator.java
@@ -18,6 +18,10 @@ package io.confluent.ksql.serde.avro;
 import io.confluent.ksql.serde.connect.ConnectSRSchemaDataTranslator;
 import io.confluent.ksql.serde.connect.ConnectSchemas;
 import io.confluent.ksql.util.KsqlException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
@@ -38,11 +42,103 @@ public class AvroSRSchemaDataTranslator extends ConnectSRSchemaDataTranslator {
     super(schema);
   }
 
+  private void copyArray(
+      final List originalData,
+      final Schema originalSchema,
+      final List array,
+      final Schema schema) {
+    for (Object field : originalData) {
+      if (field instanceof List) {
+        final List nestedArray = new ArrayList();
+        copyArray((List) field, originalSchema.valueSchema(), nestedArray, schema.valueSchema());
+        array.add(nestedArray);
+      } else if (field instanceof Map) {
+        final Map nestedMap = new HashMap();
+        copyMap((Map) field, originalSchema.valueSchema(), nestedMap, schema.valueSchema());
+        array.add(nestedMap);
+      } else if (field instanceof Struct) {
+        final Struct innerStruct = new Struct(schema.valueSchema());
+        copyStruct((Struct) field, ((Struct) field).schema(), innerStruct, schema.valueSchema());
+        array.add(innerStruct);
+      } else {
+        array.add(field);
+      }
+    }
+  }
+
+  private void copyMap(
+      final Map<String, Object> originalData,
+      final Schema originalSchema,
+      final Map map,
+      final Schema schema) {
+    for (Map.Entry<String, Object> entry : originalData.entrySet()) {
+      final String key = entry.getKey(); // KSQL supports only string keys for Map
+      final Object value = entry.getValue();
+      if (value instanceof List) {
+        final List nestedArray = new ArrayList();
+        copyArray((List) value, originalSchema.valueSchema(), nestedArray, schema.valueSchema());
+        map.put(key, nestedArray);
+      } else if (value instanceof Map) {
+        final Map nestedMap = new HashMap();
+        copyMap((Map) value, originalSchema.valueSchema(), nestedMap, schema.valueSchema());
+        map.put(key, nestedMap);
+      } else if (value instanceof Struct) {
+        final Struct innerStruct = new Struct(schema.valueSchema());
+        copyStruct((Struct) value, ((Struct) value).schema(), innerStruct, schema.valueSchema());
+        map.put(key, innerStruct);
+      } else {
+        map.put(key, value);
+      }
+    }
+  }
+
+  private void copyStruct(
+      final Struct originalData,
+      final Schema originalSchema,
+      final Struct struct,
+      final Schema schema) {
+    for (Field field : schema.fields()) {
+      final Optional<Field> originalField = originalSchema.fields().stream()
+          .filter(f -> field.name().equals(f.name())).findFirst();
+      if (originalField.isPresent()) {
+        final Object data = originalData.get(field);
+        final Schema dataSchema = originalField.get().schema();
+        if (data instanceof List) {
+          final List array = new ArrayList();
+          copyArray((List) data, dataSchema, array, field.schema());
+          struct.put(field, array);
+        } else if (data instanceof Map) {
+          final Map map = new HashMap();
+          copyMap((Map) data, dataSchema, map, field.schema());
+          struct.put(field, map);
+        } else if (data instanceof Struct) {
+          final Struct innerStruct = new Struct(field.schema());
+          copyStruct((Struct) data, dataSchema, innerStruct, field.schema());
+          struct.put(field, innerStruct);
+        } else {
+          struct.put(field, data);
+        }
+      } else {
+        addDefaultValueOrThrowException(field, struct);
+      }
+    }
+  }
+
+  private void addDefaultValueOrThrowException(final Field field, final Struct struct) {
+    if (field.schema().defaultValue() != null || field.schema().isOptional()) {
+      struct.put(field, field.schema().defaultValue());
+    } else {
+      throw new KsqlException("Missing default value for required Avro field: [" + field.name()
+          + "]. This field appears in Avro schema in Schema Registry");
+    }
+  }
+
   @Override
   public Object toConnectRow(final Object ksqlData) {
     if (!(ksqlData instanceof Struct)) {
       return ksqlData;
     }
+
     final Schema schema = getSchema();
     final Struct struct = new Struct(schema);
     Struct originalData = (Struct) ksqlData;
@@ -53,22 +149,12 @@ public class AvroSRSchemaDataTranslator extends ConnectSRSchemaDataTranslator {
       );
       originalData = ConnectSchemas.withCompatibleRowSchema(originalData, originalSchema);
     }
+
     validate(originalSchema, schema);
 
-    for (final Field field : schema.fields()) {
-      final Optional<Field> originalField = originalSchema.fields().stream()
-          .filter(f -> field.name().equals(f.name())).findFirst();
-      if (originalField.isPresent()) {
-        struct.put(field, originalData.get(originalField.get()));
-      } else {
-        if (field.schema().defaultValue() != null || field.schema().isOptional()) {
-          struct.put(field, field.schema().defaultValue());
-        } else {
-          throw new KsqlException("Missing default value for required Avro field: [" + field.name()
-              + "]. This field appears in Avro schema in Schema Registry");
-        }
-      }
-    }
+    copyStruct(originalData, originalSchema, struct, schema);
+
     return struct;
   }
+
 }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/AvroSRSchemaDataTranslatorTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/AvroSRSchemaDataTranslatorTest.java
@@ -1,15 +1,19 @@
 package io.confluent.ksql.serde.avro;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThrows;
 
+import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.util.KsqlException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -149,4 +153,197 @@ public class AvroSRSchemaDataTranslatorTest {
     assertThat(e.getMessage(), is("Invalid value: null used for required field: \"f1\", "
         + "schema type: STRING"));
   }
+
+  @Test
+  public void shouldTransformStructWithNestedStructs() {
+    // Given:
+    final Schema innerStructSchemaWithoutOptional = getInnerStructSchema(false);
+    final Schema innerStructSchemaWithOptional = getInnerStructSchema(true);
+
+    Struct innerInnerStructWithOptional = getNestedData(innerStructSchemaWithOptional);
+    Struct innerInnerStructWithoutOptional = getNestedData(innerStructSchemaWithoutOptional);
+
+    final Schema structSchemaInnerWithOptional = getStructSchemaWithNestedStruct(innerStructSchemaWithOptional, true);
+    final Schema structSchemaInnerWithOutOptional = getStructSchemaWithNestedStruct(innerStructSchemaWithoutOptional, false);
+
+    // Physical Schema retrieved from SR
+    final Schema schema = SchemaBuilder.struct()
+        .field("string_field", SchemaBuilder.STRING_SCHEMA)
+        .field("struct_field", structSchemaInnerWithOutOptional)
+        .build();
+
+    // Logical Schema created by Ksql
+    final Schema ORIGINAL_SCHEMA = SchemaBuilder.struct()
+        .field("string_field", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .field("struct_field", structSchemaInnerWithOptional)
+        .optional()
+        .build();
+
+    Struct innerStructWithoutOptional = getInnerStructData(structSchemaInnerWithOutOptional, innerInnerStructWithoutOptional);
+    Struct innerStructWithOptional = getInnerStructData(structSchemaInnerWithOptional, innerInnerStructWithOptional);
+
+    final Struct struct = new Struct(ORIGINAL_SCHEMA)
+        .put("string_field", "abc")
+        .put("struct_field", innerStructWithOptional);
+
+    // When:
+    final Object object = new AvroSRSchemaDataTranslator(schema).toConnectRow(struct);
+
+    // Then:
+    assertThat(object, instanceOf(Struct.class));
+    assertThat(((Struct) object).schema(), sameInstance(schema));
+    assertThat(((Struct) object).get("string_field"), is("abc"));
+    assertThat(((Struct) object).get("struct_field"), equalTo(innerStructWithoutOptional));
+  }
+
+  @Test
+  public void shouldTransformStructWithArrayOfStructs() {
+    // Given:
+    final Schema innerStructSchemaWithoutOptional = getInnerStructSchema(false);
+    final Schema innerStructSchemaWithOptional = getInnerStructSchema(true);
+
+    Struct innerInnerStructWithOptional = getNestedData(innerStructSchemaWithOptional);
+    Struct innerInnerStructWithoutOptional = getNestedData(innerStructSchemaWithoutOptional);
+
+    final Schema structSchemaInnerWithOptional = getStructSchemaWithNestedStruct(innerStructSchemaWithOptional, true);
+    final Schema structSchemaInnerWithOutOptional = getStructSchemaWithNestedStruct(innerStructSchemaWithoutOptional, false);
+
+    final Schema arraySchemaWithoutOptional = getArraySchema(false);
+    final Schema arraySchemaWithOptional = getArraySchema(true);
+
+    // Physical Schema retrieved from SR
+    final Schema schema = SchemaBuilder.struct()
+        .field("string_field", SchemaBuilder.STRING_SCHEMA)
+        .field("array_field", SchemaBuilder.array(arraySchemaWithoutOptional))
+        .field("struct_field", structSchemaInnerWithOutOptional)
+        .build();
+
+    // Logical Schema created by Ksql
+    final Schema ORIGINAL_SCHEMA = SchemaBuilder.struct()
+        .field("string_field", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .field("array_field", SchemaBuilder.array(arraySchemaWithOptional))
+        .field("struct_field", structSchemaInnerWithOptional)
+        .optional()
+        .build();
+
+    List<Struct> arrayListWithOptional = getArrayData(arraySchemaWithOptional);
+    List<Struct> arrayListWithoutOptional = getArrayData(arraySchemaWithoutOptional);
+
+    Struct innerStructWithoutOptional = getInnerStructData(structSchemaInnerWithOutOptional, innerInnerStructWithoutOptional);
+    Struct innerStructWithOptional = getInnerStructData(structSchemaInnerWithOptional, innerInnerStructWithOptional);
+
+    final Struct struct = new Struct(ORIGINAL_SCHEMA)
+        .put("string_field", "abc")
+        .put("array_field", arrayListWithOptional)
+        .put("struct_field", innerStructWithOptional);
+
+    // When:
+    final Object object = new AvroSRSchemaDataTranslator(schema).toConnectRow(struct);
+
+    // Then:
+    assertThat(object, instanceOf(Struct.class));
+    assertThat(((Struct) object).schema(), sameInstance(schema));
+    assertThat(((Struct) object).get("string_field"), is("abc"));
+    assertThat(((Struct) object).get("array_field"), equalTo(arrayListWithoutOptional));
+    assertThat(((Struct) object).get("struct_field"), equalTo(innerStructWithoutOptional));
+  }
+
+  @Test
+  public void shouldTransformStructWithMapOfStructs() {
+    // Given:
+    final Schema innerStructSchemaWithoutOptional = getInnerStructSchema(false);
+    final Schema innerStructSchemaWithOptional = getInnerStructSchema(true);
+
+    // Physical Schema retrieved from SR
+    final Schema schema = SchemaBuilder.struct()
+        .field("string_field", SchemaBuilder.STRING_SCHEMA)
+        .field("map_field", SchemaBuilder.map(Schema.STRING_SCHEMA, innerStructSchemaWithoutOptional))
+        .build();
+
+    // Logical Schema created by Ksql
+    final Schema ORIGINAL_SCHEMA = SchemaBuilder.struct()
+        .field("string_field", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .field("map_field", SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, innerStructSchemaWithOptional))
+        .optional()
+        .build();
+
+    final Struct struct = new Struct(ORIGINAL_SCHEMA)
+        .put("string_field", "abc")
+        .put("map_field", ImmutableMap.of(
+            "key1", getNestedData(innerStructSchemaWithOptional),
+            "key2", getNestedData(innerStructSchemaWithOptional)));
+
+    final Map<String, Object> mapWithoutOptional = ImmutableMap.of(
+        "key1", getNestedData(innerStructSchemaWithoutOptional),
+        "key2", getNestedData(innerStructSchemaWithoutOptional));
+
+    // When:
+    final Object object = new AvroSRSchemaDataTranslator(schema).toConnectRow(struct);
+
+    // Then:
+    assertThat(object, instanceOf(Struct.class));
+    assertThat(((Struct) object).schema(), sameInstance(schema));
+    assertThat(((Struct) object).get("string_field"), is("abc"));
+    assertThat(((Struct) object).get("map_field"), equalTo(mapWithoutOptional));
+  }
+
+  private Schema getInnerStructSchema(boolean optional) {
+    SchemaBuilder builder = SchemaBuilder.struct()
+        .field("ss1", optional ? SchemaBuilder.OPTIONAL_STRING_SCHEMA : SchemaBuilder.STRING_SCHEMA)
+        .field("ss2", optional ? SchemaBuilder.OPTIONAL_INT64_SCHEMA : SchemaBuilder.INT64_SCHEMA);
+
+    if (optional) {
+      builder.optional();
+    }
+
+    return builder.build();
+  }
+
+  private Schema getStructSchemaWithNestedStruct(Schema innerStructSchema, boolean optional) {
+    SchemaBuilder builder = SchemaBuilder.struct()
+        .field("s1", optional ? SchemaBuilder.OPTIONAL_STRING_SCHEMA : SchemaBuilder.STRING_SCHEMA)
+        .field("s2", optional ? SchemaBuilder.OPTIONAL_INT64_SCHEMA : SchemaBuilder.INT64_SCHEMA)
+        .field("s3", innerStructSchema.schema());
+
+    if (optional) {
+      builder.optional();
+    }
+
+    return builder.build();
+  }
+
+  private Schema getArraySchema(boolean optional) {
+    SchemaBuilder builder = SchemaBuilder.struct()
+        .field("a1", optional ? SchemaBuilder.OPTIONAL_STRING_SCHEMA : SchemaBuilder.STRING_SCHEMA)
+        .field("a2", optional ? SchemaBuilder.OPTIONAL_INT64_SCHEMA : SchemaBuilder.INT64_SCHEMA);
+
+    if (optional) {
+      builder.optional();
+    }
+
+    return builder.build();
+  }
+
+  private Struct getNestedData(Schema schema) {
+    return new Struct(schema)
+        .put("ss1", "ss1")
+        .put("ss2", 54444L);
+  }
+
+  private Struct getInnerStructData(Schema innerSchema, Struct nestedSchema) {
+    return new Struct(innerSchema)
+        .put("s1", "s1")
+        .put("s2", 64L)
+        .put("s3", nestedSchema);
+  }
+
+  private List<Struct> getArrayData(Schema schema) {
+    List<Struct> arrayData = new ArrayList<>();
+    arrayData.add(new Struct(schema)
+        .put("a1", "array_val1")
+        .put("a2", 23L));
+
+    return arrayData;
+  }
+
 }


### PR DESCRIPTION
### Description 
Fixes #8919 
- Logical schema generated by Ksql always contains optional fields.
- The Schema Registry registered Avro schema may or may not contain optional
  fields.
- If the SR schema doesn't contain optional fields for compound data types such
  as array, map, struct then the schema comparison between logical and physical
  schemas fails.
- To fix this, we create a copy of the data using the physical schema thus
  getting rid of any optional fields in the process. Schema type validation is
  done before this step and therefore copying the data using physical schema is
  a safe process.

### Testing done 
Added unit tests
Added QTTs
Added RQTT

Pending - generate historical plans

