### PR TITLE
test: Removes race in KsqlResourceFunctionalTest and ups timeout elsewhere

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/KsqlResourceFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/KsqlResourceFunctionalTest.java
@@ -19,10 +19,12 @@ import static io.confluent.ksql.GenericKey.genericKey;
 import static io.confluent.ksql.GenericRow.genericRow;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.ArgumentMatchers.eq;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.common.utils.IntegrationTest;
@@ -118,7 +120,7 @@ public class KsqlResourceFunctionalTest {
 
     assertSuccessful(results);
 
-    assertThat(REST_APP.getPersistentQueries(), hasItems(
+    assertThatEventually(REST_APP::getPersistentQueries, hasItems(
         startsWith("CSAS_S_"),
         startsWith("CSAS_S2_")
     ));
@@ -145,6 +147,8 @@ public class KsqlResourceFunctionalTest {
     final List<KsqlEntity> results = makeKsqlRequest(
         "CREATE STREAM SS AS SELECT * FROM " + PAGE_VIEW_STREAM + ";"
     );
+
+    assertThatEventually(() -> REST_APP.getPersistentQueries().size(), is(1));
 
     final String query = REST_APP.getPersistentQueries().iterator().next();
     results.addAll(makeKsqlRequest("TERMINATE " + query + ";"

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/TerminateTransientQueryFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/TerminateTransientQueryFunctionalTest.java
@@ -81,7 +81,7 @@ public class TerminateTransientQueryFunctionalTest {
       .around(REST_APP_1);
 
   @Rule
-  public final Timeout timeout = Timeout.seconds(60);
+  public final Timeout timeout = Timeout.seconds(120);
 
   private ExecutorService service;
   private Runnable backgroundTask;


### PR DESCRIPTION
### Description 
`KsqlResourceFunctionalTest` had a race where a stream would be created, and then it would be assumed it would be there.  In reality, the command must be written to the command topic and read back before it's running on a node.

Also, gives `TerminateTransientQueryFunctionalTest` two minutes rather than 1.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

