### PR TITLE
fix: show command must list the exact names of sources

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionFactory.java
@@ -21,9 +21,9 @@ import com.google.common.collect.Streams;
 import io.confluent.ksql.execution.timestamp.TimestampColumn;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metrics.MetricCollectors;
-import io.confluent.ksql.rest.server.execution.ListSourceExecutor;
 import io.confluent.ksql.rest.util.EntityUtil;
 import io.confluent.ksql.schema.utils.FormatOptions;
+import io.confluent.ksql.util.IdentifierUtil;
 import io.confluent.ksql.util.KsqlHostInfo;
 import java.util.List;
 import java.util.Optional;
@@ -87,7 +87,7 @@ public final class SourceDescriptionFactory {
         .map((stat) -> QueryHostStat.fromStat(stat, hostEntity));
 
     return new SourceDescription(
-        ListSourceExecutor.getFullname(dataSource.getName().toString(FormatOptions.noEscape())),
+        dataSource.getName().toString(FormatOptions.of(IdentifierUtil::needsQuotes)),
         dataSource.getKsqlTopic().getKeyFormat().getWindowType(),
         readQueries,
         writeQueries,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionFactory.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Streams;
 import io.confluent.ksql.execution.timestamp.TimestampColumn;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metrics.MetricCollectors;
+import io.confluent.ksql.rest.server.execution.ListSourceExecutor;
 import io.confluent.ksql.rest.util.EntityUtil;
 import io.confluent.ksql.schema.utils.FormatOptions;
 import io.confluent.ksql.util.KsqlHostInfo;
@@ -86,7 +87,7 @@ public final class SourceDescriptionFactory {
         .map((stat) -> QueryHostStat.fromStat(stat, hostEntity));
 
     return new SourceDescription(
-        dataSource.getName().toString(FormatOptions.noEscape()),
+        ListSourceExecutor.getFullname(dataSource.getName().toString(FormatOptions.noEscape())),
         dataSource.getKsqlTopic().getKeyFormat().getWindowType(),
         readQueries,
         writeQueries,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -477,7 +477,8 @@ public final class ListSourceExecutor {
   }
 
   public static String getFullname(final String name) {
-    if (name.contains("\"") || name.chars().noneMatch(Character::isLowerCase)) {
+    if (name.contains("\"")
+        || (!name.contains("-") && name.chars().noneMatch(Character::isLowerCase))) {
       return name;
     }
     return "\"" + name + "\"";

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -50,8 +50,10 @@ import io.confluent.ksql.rest.entity.SourceInfo.Table;
 import io.confluent.ksql.rest.entity.StreamsList;
 import io.confluent.ksql.rest.entity.TablesList;
 import io.confluent.ksql.rest.server.KsqlRestApplication;
+import io.confluent.ksql.schema.utils.FormatOptions;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.IdentifierUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlStatementException;
@@ -445,7 +447,7 @@ public final class ListSourceExecutor {
 
   private static Stream sourceSteam(final KsqlStream<?> dataSource) {
     return new Stream(
-        getFullname(dataSource.getName().text()),
+        dataSource.getName().toString(FormatOptions.of(IdentifierUtil::needsQuotes)),
         dataSource.getKsqlTopic().getKafkaTopicName(),
         dataSource.getKsqlTopic().getKeyFormat().getFormat(),
         dataSource.getKsqlTopic().getValueFormat().getFormat(),
@@ -455,7 +457,7 @@ public final class ListSourceExecutor {
 
   private static Table sourceTable(final KsqlTable<?> dataSource) {
     return new Table(
-        getFullname(dataSource.getName().text()),
+        dataSource.getName().toString(FormatOptions.of(IdentifierUtil::needsQuotes)),
         dataSource.getKsqlTopic().getKafkaTopicName(),
         dataSource.getKsqlTopic().getKeyFormat().getFormat(),
         dataSource.getKsqlTopic().getValueFormat().getFormat(),
@@ -474,13 +476,5 @@ public final class ListSourceExecutor {
       this.warnings = warnings;
       this.description = description;
     }
-  }
-
-  public static String getFullname(final String name) {
-    if (name.contains("\"")
-        || (!name.contains("-") && name.chars().noneMatch(Character::isLowerCase))) {
-      return name;
-    }
-    return "\"" + name + "\"";
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -445,7 +445,7 @@ public final class ListSourceExecutor {
 
   private static Stream sourceSteam(final KsqlStream<?> dataSource) {
     return new Stream(
-        dataSource.getName().text(),
+        getFullname(dataSource.getName().text()),
         dataSource.getKsqlTopic().getKafkaTopicName(),
         dataSource.getKsqlTopic().getKeyFormat().getFormat(),
         dataSource.getKsqlTopic().getValueFormat().getFormat(),
@@ -455,7 +455,7 @@ public final class ListSourceExecutor {
 
   private static Table sourceTable(final KsqlTable<?> dataSource) {
     return new Table(
-        dataSource.getName().text(),
+        getFullname(dataSource.getName().text()),
         dataSource.getKsqlTopic().getKafkaTopicName(),
         dataSource.getKsqlTopic().getKeyFormat().getFormat(),
         dataSource.getKsqlTopic().getValueFormat().getFormat(),
@@ -474,5 +474,12 @@ public final class ListSourceExecutor {
       this.warnings = warnings;
       this.description = description;
     }
+  }
+
+  public static String getFullname(final String name) {
+    if (name.contains("\"") || name.chars().noneMatch(Character::isLowerCase)) {
+      return name;
+    }
+    return "\"" + name + "\"";
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -44,12 +44,15 @@ import io.confluent.ksql.rest.server.services.TestDefaultKsqlClientFactory;
 import io.confluent.ksql.rest.server.services.TestRestServiceContextFactory;
 import io.confluent.ksql.rest.server.services.TestRestServiceContextFactory.InternalSimpleKsqlClientFactory;
 import io.confluent.ksql.rest.server.state.ServerState;
+import io.confluent.ksql.schema.utils.FormatOptions;
+import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.services.DisabledKsqlClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.ServiceContextFactory;
 import io.confluent.ksql.services.SimpleKsqlClient;
 import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
 import io.confluent.ksql.test.util.KsqlTestFolder;
+import io.confluent.ksql.util.IdentifierUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants.KsqlQueryType;
 import io.confluent.ksql.util.ReservedInternalTopics;
@@ -500,12 +503,12 @@ public class TestKsqlRestApp extends ExternalResource {
       if (!sourcesDropped.contains(source)) {
         final Iterator<String> dropInOrder = getOrderedSourcesToDrop(source, client);
         dropInOrder.forEachRemaining(s -> {
-          if (streams.contains(s)) {
+          if (streams.contains(FormatOptions.of(IdentifierUtil::needsQuotes).escape(s))) {
             dropStream(s, client);
           } else {
             dropTable(s, client);
           }
-          sourcesDropped.add(s);
+          sourcesDropped.add(FormatOptions.of(IdentifierUtil::needsQuotes).escape(s));
         });
       }
     });

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
@@ -61,6 +61,7 @@ import io.confluent.ksql.services.ConnectClient;
 import io.confluent.ksql.services.ConnectClient.ConnectResponse;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.IdentifierUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Collections;
 import java.util.List;
@@ -192,7 +193,7 @@ public class DescribeConnectorExecutorTest {
     assertThat(description.getConnectorClass(), is(CONNECTOR_CLASS));
     assertThat(description.getStatus(), is(STATUS));
     assertThat(description.getSources().size(), is(1));
-    assertThat(description.getSources().get(0).getName(), is("\"source\""));
+    assertThat(description.getSources().get(0).getName(), is("`source`"));
     assertThat(description.getSources().get(0).getTopic(), is(TOPIC));
     assertThat(description.getTopics().size(), is(1));
     assertThat(description.getTopics().get(0), is(TOPIC));

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
@@ -192,7 +192,7 @@ public class DescribeConnectorExecutorTest {
     assertThat(description.getConnectorClass(), is(CONNECTOR_CLASS));
     assertThat(description.getStatus(), is(STATUS));
     assertThat(description.getSources().size(), is(1));
-    assertThat(description.getSources().get(0).getName(), is("source"));
+    assertThat(description.getSources().get(0).getName(), is("\"source\""));
     assertThat(description.getSources().get(0).getTopic(), is(TOPIC));
     assertThat(description.getTopics().size(), is(1));
     assertThat(description.getTopics().get(0), is(TOPIC));

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
@@ -57,6 +57,7 @@ import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.TestServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.IdentifierUtil;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlHostInfo;
 import io.confluent.ksql.util.KsqlStatementException;
@@ -119,14 +120,14 @@ public class ListSourceExecutorTest {
     // Then:
     assertThat(descriptionList.getStreams(), containsInAnyOrder(
         new SourceInfo.Stream(
-            ListSourceExecutor.getFullname(stream1.getName().toString(FormatOptions.noEscape())),
+            stream1.getName().toString(FormatOptions.of(IdentifierUtil::needsQuotes)),
             stream1.getKafkaTopicName(),
             stream1.getKsqlTopic().getKeyFormat().getFormat(),
             stream1.getKsqlTopic().getValueFormat().getFormat(),
             stream1.getKsqlTopic().getKeyFormat().isWindowed()
         ),
         new SourceInfo.Stream(
-            ListSourceExecutor.getFullname(stream2.getName().toString(FormatOptions.noEscape())),
+            stream2.getName().toString(FormatOptions.of(IdentifierUtil::needsQuotes)),
             stream2.getKafkaTopicName(),
             stream2.getKsqlTopic().getKeyFormat().getFormat(),
             stream2.getKsqlTopic().getValueFormat().getFormat(),
@@ -238,14 +239,14 @@ public class ListSourceExecutorTest {
     // Then:
     assertThat(descriptionList.getTables(), containsInAnyOrder(
         new SourceInfo.Table(
-            ListSourceExecutor.getFullname(table1.getName().toString(FormatOptions.noEscape())),
+            table1.getName().toString(FormatOptions.of(IdentifierUtil::needsQuotes)),
             table1.getKsqlTopic().getKafkaTopicName(),
             table2.getKsqlTopic().getKeyFormat().getFormat(),
             table1.getKsqlTopic().getValueFormat().getFormat(),
             table1.getKsqlTopic().getKeyFormat().isWindowed()
         ),
         new SourceInfo.Table(
-            ListSourceExecutor.getFullname(table2.getName().toString(FormatOptions.noEscape())),
+            table2.getName().toString(FormatOptions.of(IdentifierUtil::needsQuotes)),
             table2.getKsqlTopic().getKafkaTopicName(),
             table2.getKsqlTopic().getKeyFormat().getFormat(),
             table2.getKsqlTopic().getValueFormat().getFormat(),

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
@@ -103,7 +103,7 @@ public class ListSourceExecutorTest {
   @Test
   public void shouldShowStreams() {
     // Given:
-    final KsqlStream<?> stream1 = engine.givenSource(DataSourceType.KSTREAM, "stream1");
+    final KsqlStream<?> stream1 = engine.givenSource(DataSourceType.KSTREAM, "STREAM1");
     final KsqlStream<?> stream2 = engine.givenSource(DataSourceType.KSTREAM, "stream2");
     engine.givenSource(DataSourceType.KTABLE, "table");
 
@@ -119,14 +119,14 @@ public class ListSourceExecutorTest {
     // Then:
     assertThat(descriptionList.getStreams(), containsInAnyOrder(
         new SourceInfo.Stream(
-            stream1.getName().toString(FormatOptions.noEscape()),
+            ListSourceExecutor.getFullname(stream1.getName().toString(FormatOptions.noEscape())),
             stream1.getKafkaTopicName(),
             stream1.getKsqlTopic().getKeyFormat().getFormat(),
             stream1.getKsqlTopic().getValueFormat().getFormat(),
             stream1.getKsqlTopic().getKeyFormat().isWindowed()
         ),
         new SourceInfo.Stream(
-            stream2.getName().toString(FormatOptions.noEscape()),
+            ListSourceExecutor.getFullname(stream2.getName().toString(FormatOptions.noEscape())),
             stream2.getKafkaTopicName(),
             stream2.getKsqlTopic().getKeyFormat().getFormat(),
             stream2.getKsqlTopic().getValueFormat().getFormat(),
@@ -139,7 +139,7 @@ public class ListSourceExecutorTest {
   public void shouldShowStreamsExtended() {
     // Given:
     final KsqlStream<?> stream1 = engine.givenSource(DataSourceType.KSTREAM, "stream1");
-    final KsqlStream<?> stream2 = engine.givenSource(DataSourceType.KSTREAM, "stream2",
+    final KsqlStream<?> stream2 = engine.givenSource(DataSourceType.KSTREAM, "STREAM2",
         ImmutableSet.of(SourceName.of("stream1")));
     engine.givenSource(DataSourceType.KTABLE, "table");
 
@@ -161,7 +161,7 @@ public class ListSourceExecutorTest {
             ImmutableList.of(),
             Optional.of(topicWith1PartitionAndRfOf1),
             ImmutableList.of(),
-            ImmutableList.of("stream2"),
+            ImmutableList.of("STREAM2"),
             new MetricCollectors()
         ),
         SourceDescriptionFactory.create(
@@ -222,7 +222,7 @@ public class ListSourceExecutorTest {
   @Test
   public void shouldShowTables() {
     // Given:
-    final KsqlTable<?> table1 = engine.givenSource(DataSourceType.KTABLE, "table1");
+    final KsqlTable<?> table1 = engine.givenSource(DataSourceType.KTABLE, "TABLE1");
     final KsqlTable<?> table2 = engine.givenSource(DataSourceType.KTABLE, "table2");
     engine.givenSource(DataSourceType.KSTREAM, "stream");
 
@@ -238,14 +238,14 @@ public class ListSourceExecutorTest {
     // Then:
     assertThat(descriptionList.getTables(), containsInAnyOrder(
         new SourceInfo.Table(
-            table1.getName().toString(FormatOptions.noEscape()),
+            ListSourceExecutor.getFullname(table1.getName().toString(FormatOptions.noEscape())),
             table1.getKsqlTopic().getKafkaTopicName(),
             table2.getKsqlTopic().getKeyFormat().getFormat(),
             table1.getKsqlTopic().getValueFormat().getFormat(),
             table1.getKsqlTopic().getKeyFormat().isWindowed()
         ),
         new SourceInfo.Table(
-            table2.getName().toString(FormatOptions.noEscape()),
+            ListSourceExecutor.getFullname(table2.getName().toString(FormatOptions.noEscape())),
             table2.getKsqlTopic().getKafkaTopicName(),
             table2.getKsqlTopic().getKeyFormat().getFormat(),
             table2.getKsqlTopic().getValueFormat().getFormat(),
@@ -258,7 +258,7 @@ public class ListSourceExecutorTest {
   public void shouldShowTablesExtended() {
     // Given:
     final KsqlTable<?> table1 = engine.givenSource(DataSourceType.KTABLE, "table1");
-    final KsqlTable<?> table2 = engine.givenSource(DataSourceType.KTABLE, "table2",
+    final KsqlTable<?> table2 = engine.givenSource(DataSourceType.KTABLE, "TABLE2",
         ImmutableSet.of(SourceName.of("table1")));
     engine.givenSource(DataSourceType.KSTREAM, "stream");
 
@@ -281,7 +281,7 @@ public class ListSourceExecutorTest {
             ImmutableList.of(),
             Optional.of(client.describeTopic(table1.getKafkaTopicName())),
             ImmutableList.of(),
-            ImmutableList.of("table2"),
+            ImmutableList.of("TABLE2"),
             new MetricCollectors()
         ),
         SourceDescriptionFactory.create(


### PR DESCRIPTION
Related to [issue#9243 ](https://github.com/confluentinc/ksql/issues/9243) ([PR#9531](https://github.com/confluentinc/ksql/pull/9531))
### Description 
The output of `SHOW STREAMS/TABLES` must list the source names that contain small letters wrapped in double quotes.  This avoids the confusion for using the source names in other commands such as `SELECT`, `DROP`, and etc.

### Testing done 
Unit test
Manual testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

