### PR TITLE
test: Makes PullQueryLimitHARoutingTest more reliable

### DIFF
--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
@@ -43,6 +43,7 @@ import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlStatementErrorMessage;
 import io.confluent.ksql.rest.entity.StreamedRow;
+import io.confluent.ksql.rest.integration.IntegrationTestUtil;
 import io.confluent.ksql.rest.integration.QueryStreamSubscriber;
 import io.confluent.ksql.serde.protobuf.ProtobufNoSRConverter;
 import io.confluent.ksql.services.ServiceContext;
@@ -108,8 +109,6 @@ public class RestTestExecutor implements Closeable {
 
   private static final String STATEMENT_MACRO = "\\{STATEMENT}";
   private static final Duration MAX_QUERY_RUNNING_CHECK = Duration.ofSeconds(45);
-  private static final Duration MAX_STATIC_WARM_UP = Duration.ofSeconds(45);
-  private static final Duration MAX_TOPIC_NAME_LOOKUP = Duration.ofSeconds(45);
   private static final Duration MAX_TRANSIENT_QUERY_COMPLETION_TIME = Duration.ofSeconds(10);
   private static final String MATCH_OPERATOR_DELIMITER = "|";
   private static final String QUERY_KEY = "query";
@@ -208,7 +207,7 @@ public class RestTestExecutor implements Closeable {
 
       if (!testCase.expectedError().isPresent()
           && testCase.getExpectedResponses().size() > statements.admin.size()) {
-        waitForPersistentQueriesToProcessInputs();
+        IntegrationTestUtil.waitForPersistentQueriesToProcessInputs(kafkaCluster, engine);
       }
 
       final List<RqttResponse> queryResults = sendQueryStatements(testCase, statements.queries,
@@ -662,150 +661,6 @@ public class RestTestExecutor implements Closeable {
     }
   }
 
-  /**
-   * This method looks at all of the source topics that feed into all of the subtopologies and waits
-   * for the consumer group associated with each application to reach the end offsets for those
-   * topics.  This effectively ensures that nothing is lagging when it completes successfully.
-   * This should ensure that any materialized state has been built up correctly and is ready for
-   * pull queries.
-   */
-  private void waitForPersistentQueriesToProcessInputs() {
-    // First wait for the queries to be in the RUNNING state
-    boolean allRunning = false;
-    final long queryRunningThreshold = System.currentTimeMillis()
-        + MAX_QUERY_RUNNING_CHECK.toMillis();
-    while (System.currentTimeMillis() < queryRunningThreshold) {
-      boolean notReady = false;
-      for (PersistentQueryMetadata persistentQueryMetadata : engine.getPersistentQueries()) {
-        if (persistentQueryMetadata.getState() != State.RUNNING) {
-          LOG.info("Not all persistent queries are running yet");
-          notReady = true;
-        }
-      }
-      if (notReady) {
-        threadYield();
-      } else {
-        allRunning = true;
-        LOG.info("All persistent queries are now running");
-        break;
-      }
-    }
-    if (!allRunning) {
-      throw new AssertionError("Timed out while trying to wait for queries to begin running");
-    }
-
-    // Collect all application ids
-    List<String> queryApplicationIds = engine.getPersistentQueries().stream()
-        .map(QueryMetadata::getQueryApplicationId)
-        .collect(Collectors.toList());
-
-    // Collect all possible source topic names for each application id
-    Map<String, Set<String>> possibleTopicNamesByAppId = engine.getPersistentQueries().stream()
-        .collect(Collectors.toMap(
-            QueryMetadata::getQueryApplicationId,
-            m -> {
-              Set<String> topics = getSourceTopics(m);
-              Set<String> possibleInternalNames = topics.stream()
-                  .map(t -> m.getQueryApplicationId() + "-" + t)
-                  .collect(Collectors.toSet());
-              Set<String> all = new HashSet<>();
-              all.addAll(topics);
-              all.addAll(possibleInternalNames);
-              return all;
-            }
-        ));
-    final Set<String> possibleTopicNames = possibleTopicNamesByAppId.values()
-        .stream()
-        .flatMap(Collection::stream)
-        .collect(Collectors.toSet());
-    // Every topic is either internal or not, so we expect to match exactly half of them.
-    int expectedTopics = possibleTopicNames.size() / 2;
-
-    // Find the intersection of possible topic names and real topic names, and wait until the
-    // expected number are all there
-    final Set<String> topics = new HashSet<>();
-    boolean foundTopics = false;
-    final long topicThreshold = System.currentTimeMillis() + MAX_TOPIC_NAME_LOOKUP.toMillis();
-    while (System.currentTimeMillis() < topicThreshold) {
-      Set<String> expectedNames = kafkaCluster.
-          getTopics();
-      expectedNames.retainAll(possibleTopicNames);
-      if (expectedNames.size() == expectedTopics) {
-        foundTopics = true;
-        topics.addAll(expectedNames);
-        LOG.info("All expected topics have now been found");
-        break;
-      }
-    }
-    if (!foundTopics) {
-      throw new AssertionError("Timed out while trying to find topics");
-    }
-
-    // Only retain topic names which are known to exist.
-    Map<String, Set<String>> topicNamesByAppId = possibleTopicNamesByAppId.entrySet().stream()
-        .collect(Collectors.toMap(
-            Entry::getKey,
-            e -> {
-              e.getValue().retainAll(topics);
-              return e.getValue();
-            }
-        ));
-
-    Map<String, Integer> partitionCount = kafkaCluster.getPartitionCount(topics);
-    Map<String, List<TopicPartition>> topicPartitionsByAppId = queryApplicationIds.stream()
-        .collect(Collectors.toMap(
-            appId -> appId,
-            appId -> {
-              final List<TopicPartition> allTopicPartitions = new ArrayList<>();
-              for (String topic : topicNamesByAppId.get(appId)) {
-                for (int i = 0; i < partitionCount.get(topic); i++) {
-                  final TopicPartition tp = new TopicPartition(topic, i);
-                  allTopicPartitions.add(tp);
-                }
-              }
-              return allTopicPartitions;
-            }));
-
-    final long threshold = System.currentTimeMillis() + MAX_STATIC_WARM_UP.toMillis();
-    mainloop:
-    while (System.currentTimeMillis() < threshold) {
-      for (String queryApplicationId : queryApplicationIds) {
-        final List<TopicPartition> topicPartitions
-            = topicPartitionsByAppId.get(queryApplicationId);
-
-        Map<TopicPartition, Long> currentOffsets =
-            kafkaCluster.getConsumerGroupOffset(queryApplicationId);
-        Map<TopicPartition, Long> endOffsets = kafkaCluster.getEndOffsets(topicPartitions,
-            // Since we're doing At Least Once, we can do read uncommitted.
-            IsolationLevel.READ_COMMITTED);
-
-        for (final TopicPartition tp : topicPartitions) {
-            if (!currentOffsets.containsKey(tp) && endOffsets.get(tp) > 0) {
-              LOG.info("Haven't committed offsets yet for " + tp + " end offset " + endOffsets.get(tp));
-              threadYield();
-              continue mainloop;
-            }
-        }
-
-        for (final Map.Entry<TopicPartition, Long> entry : currentOffsets.entrySet()) {
-          final TopicPartition tp = entry.getKey();
-          final long currentOffset = entry.getValue();
-          final long endOffset = endOffsets.get(tp);
-          if (currentOffset < endOffset) {
-            LOG.info("Offsets are not caught up current: " + currentOffsets + " end: "
-                + endOffsets);
-            threadYield();
-            continue mainloop;
-          }
-        }
-      }
-      LOG.info("Offsets are all up to date");
-      return;
-    }
-    LOG.info("Timed out waiting for correct response");
-    throw new AssertionError("Timed out while trying to wait for offsets");
-  }
-
   private void waitForTransientQueriesToComplete() {
     // Wait for the transient queries to complete
     final long queryRunningThreshold = System.currentTimeMillis()
@@ -826,23 +681,6 @@ public class RestTestExecutor implements Closeable {
         break;
       }
     }
-  }
-
-  private Set<String> getSourceTopics(
-      final PersistentQueryMetadata persistentQueryMetadata
-  ) {
-    Set<String> topics = new HashSet<>();
-    for (final Subtopology subtopology :
-        persistentQueryMetadata.getTopology().describe().subtopologies()) {
-      for (final TopologyDescription.Node node : subtopology.nodes()) {
-        if (node instanceof Source) {
-          final Source source = (Source) node;
-          Preconditions.checkNotNull(source.topicSet(), "Expecting topic set, not regex");
-          topics.addAll(source.topicSet());
-        }
-      }
-    }
-    return topics;
   }
 
   private static void threadYield() {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HighAvailabilityTestUtil.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HighAvailabilityTestUtil.java
@@ -303,7 +303,7 @@ class HighAvailabilityTestUtil {
   // Ensures that lags have been reported for the cluster.  Makes the simplified assumption that
   // there's just one state store.
   static BiFunction<KsqlHostInfoEntity, Map<KsqlHostInfoEntity, HostStatusEntity>, Boolean>
-  zeroLagsReported(
+  lagsReported(
       final int expectedClusterSize
   ) {
     return (remoteServer, clusterStatus) -> {
@@ -352,8 +352,8 @@ class HighAvailabilityTestUtil {
     };
   }
 
-  // Ensures that lags have been reported for the given host.  Makes the simplified assumption that
-  // there's just one state store.
+  // Ensures that lags have been reported for the given host, but that the value is zero.
+  // Makes the simplified assumption that there's just one state store.
   static BiFunction<KsqlHostInfoEntity, Map<KsqlHostInfoEntity, HostStatusEntity>, Boolean>
   zeroLagsReported(
       final KsqlHostInfoEntity server

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HighAvailabilityTestUtil.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HighAvailabilityTestUtil.java
@@ -411,7 +411,7 @@ class HighAvailabilityTestUtil {
         .flatMap(stateStoreLags -> stateStoreLags.getLagByPartition().values().stream())
         .mapToLong(LagInfoEntity::getOffsetLag)
         .max()
-        .orElse(0);
+        .orElse(-1);
     return Pair.of(lag, end);
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HighAvailabilityTestUtil.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HighAvailabilityTestUtil.java
@@ -303,7 +303,7 @@ class HighAvailabilityTestUtil {
   // Ensures that lags have been reported for the cluster.  Makes the simplified assumption that
   // there's just one state store.
   static BiFunction<KsqlHostInfoEntity, Map<KsqlHostInfoEntity, HostStatusEntity>, Boolean>
-  lagsReported(
+  zeroLagsReported(
       final int expectedClusterSize
   ) {
     return (remoteServer, clusterStatus) -> {
@@ -352,6 +352,31 @@ class HighAvailabilityTestUtil {
     };
   }
 
+  // Ensures that lags have been reported for the given host.  Makes the simplified assumption that
+  // there's just one state store.
+  static BiFunction<KsqlHostInfoEntity, Map<KsqlHostInfoEntity, HostStatusEntity>, Boolean>
+  zeroLagsReported(
+      final KsqlHostInfoEntity server
+  ) {
+    return (remote, clusterStatus) -> {
+      HostStatusEntity hostStatusEntity = clusterStatus.get(server);
+      if (hostStatusEntity == null) {
+        LOG.info("Didn't find {}", server.toString());
+        return false;
+      }
+      Pair<Long, Long> pair = getLag(server,clusterStatus);
+      long lag = pair.left;
+      long end = pair.right;
+      if (end > 0 && lag == 0) {
+        LOG.info("Found zero lag for {}: {}", server, clusterStatus.toString());
+        return true;
+      }
+      LOG.info("Didn't yet find > 0 end offset: {} and zero lag: {} for {}: {}", end, lag, server,
+          clusterStatus.toString());
+      return false;
+    };
+  }
+
   // Gets (current, end) offsets for the given host.  Makes the simplified assumption that there's
   // just one state store.
   public static Pair<Long, Long> getOffsets(
@@ -369,6 +394,25 @@ class HighAvailabilityTestUtil {
         .max()
         .orElse(0);
     return Pair.of(current, end);
+  }
+
+  // Gets (lag, end) for the given host.  Makes the simplified assumption that there's
+  // just one state store.
+  public static Pair<Long, Long> getLag(
+      final KsqlHostInfoEntity server,
+      final Map<KsqlHostInfoEntity, HostStatusEntity> clusterStatus) {
+    HostStatusEntity hostStatusEntity = clusterStatus.get(server);
+    long end = hostStatusEntity.getHostStoreLags().getStateStoreLags().values().stream()
+        .flatMap(stateStoreLags -> stateStoreLags.getLagByPartition().values().stream())
+        .mapToLong(LagInfoEntity::getEndOffsetPosition)
+        .max()
+        .orElse(0);
+    long lag = hostStatusEntity.getHostStoreLags().getStateStoreLags().values().stream()
+        .flatMap(stateStoreLags -> stateStoreLags.getLagByPartition().values().stream())
+        .mapToLong(LagInfoEntity::getOffsetLag)
+        .max()
+        .orElse(0);
+    return Pair.of(lag, end);
   }
 
   // A class that holds shutoff switches for various network components in our system to simulate

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/IntegrationTestUtil.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/IntegrationTestUtil.java
@@ -1,0 +1,205 @@
+package io.confluent.ksql.rest.integration;
+
+import com.google.common.base.Preconditions;
+import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
+import io.confluent.ksql.util.PersistentQueryMetadata;
+import io.confluent.ksql.util.QueryMetadata;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.IsolationLevel;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.streams.KafkaStreams.State;
+import org.apache.kafka.streams.TopologyDescription;
+import org.apache.kafka.streams.TopologyDescription.Source;
+import org.apache.kafka.streams.TopologyDescription.Subtopology;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class IntegrationTestUtil {
+
+  private static final Logger LOG = LoggerFactory.getLogger(IntegrationTestUtil.class);
+  private static final Duration MAX_QUERY_RUNNING_CHECK = Duration.ofSeconds(45);
+  private static final Duration MAX_STATIC_WARM_UP = Duration.ofSeconds(45);
+  private static final Duration MAX_TOPIC_NAME_LOOKUP = Duration.ofSeconds(45);
+
+  /**
+   * This method looks at all of the source topics that feed into all of the subtopologies and waits
+   * for the consumer group associated with each application to reach the end offsets for those
+   * topics.  This effectively ensures that nothing is lagging when it completes successfully.
+   * This should ensure that any materialized state has been built up correctly and is ready for
+   * pull queries.
+   */
+  public static void waitForPersistentQueriesToProcessInputs(
+      final EmbeddedSingleNodeKafkaCluster kafkaCluster,
+      final KsqlExecutionContext engine
+  ) {
+    // First wait for the queries to be in the RUNNING state
+    boolean allRunning = false;
+    final long queryRunningThreshold = System.currentTimeMillis()
+        + MAX_QUERY_RUNNING_CHECK.toMillis();
+    while (System.currentTimeMillis() < queryRunningThreshold) {
+      boolean notReady = false;
+      for (PersistentQueryMetadata persistentQueryMetadata : engine.getPersistentQueries()) {
+        if (persistentQueryMetadata.getState() != State.RUNNING) {
+          LOG.info("Not all persistent queries are running yet");
+          notReady = true;
+        }
+      }
+      if (notReady) {
+        threadYield();
+      } else {
+        allRunning = true;
+        LOG.info("All persistent queries are now running");
+        break;
+      }
+    }
+    if (!allRunning) {
+      throw new AssertionError("Timed out while trying to wait for queries to begin running");
+    }
+
+    // Collect all application ids
+    List<String> queryApplicationIds = engine.getPersistentQueries().stream()
+        .map(QueryMetadata::getQueryApplicationId)
+        .collect(Collectors.toList());
+
+    // Collect all possible source topic names for each application id
+    Map<String, Set<String>> possibleTopicNamesByAppId = engine.getPersistentQueries().stream()
+        .collect(Collectors.toMap(
+            QueryMetadata::getQueryApplicationId,
+            m -> {
+              Set<String> topics = getSourceTopics(m);
+              Set<String> possibleInternalNames = topics.stream()
+                  .map(t -> m.getQueryApplicationId() + "-" + t)
+                  .collect(Collectors.toSet());
+              Set<String> all = new HashSet<>();
+              all.addAll(topics);
+              all.addAll(possibleInternalNames);
+              return all;
+            }
+        ));
+    final Set<String> possibleTopicNames = possibleTopicNamesByAppId.values()
+        .stream()
+        .flatMap(Collection::stream)
+        .collect(Collectors.toSet());
+    // Every topic is either internal or not, so we expect to match exactly half of them.
+    int expectedTopics = possibleTopicNames.size() / 2;
+
+    // Find the intersection of possible topic names and real topic names, and wait until the
+    // expected number are all there
+    final Set<String> topics = new HashSet<>();
+    boolean foundTopics = false;
+    final long topicThreshold = System.currentTimeMillis() + MAX_TOPIC_NAME_LOOKUP.toMillis();
+    while (System.currentTimeMillis() < topicThreshold) {
+      Set<String> expectedNames = kafkaCluster.
+          getTopics();
+      expectedNames.retainAll(possibleTopicNames);
+      if (expectedNames.size() == expectedTopics) {
+        foundTopics = true;
+        topics.addAll(expectedNames);
+        LOG.info("All expected topics have now been found");
+        break;
+      }
+    }
+    if (!foundTopics) {
+      throw new AssertionError("Timed out while trying to find topics");
+    }
+
+    // Only retain topic names which are known to exist.
+    Map<String, Set<String>> topicNamesByAppId = possibleTopicNamesByAppId.entrySet().stream()
+        .collect(Collectors.toMap(
+            Entry::getKey,
+            e -> {
+              e.getValue().retainAll(topics);
+              return e.getValue();
+            }
+        ));
+
+    Map<String, Integer> partitionCount = kafkaCluster.getPartitionCount(topics);
+    Map<String, List<TopicPartition>> topicPartitionsByAppId = queryApplicationIds.stream()
+        .collect(Collectors.toMap(
+            appId -> appId,
+            appId -> {
+              final List<TopicPartition> allTopicPartitions = new ArrayList<>();
+              for (String topic : topicNamesByAppId.get(appId)) {
+                for (int i = 0; i < partitionCount.get(topic); i++) {
+                  final TopicPartition tp = new TopicPartition(topic, i);
+                  allTopicPartitions.add(tp);
+                }
+              }
+              return allTopicPartitions;
+            }));
+
+    final long threshold = System.currentTimeMillis() + MAX_STATIC_WARM_UP.toMillis();
+    mainloop:
+    while (System.currentTimeMillis() < threshold) {
+      for (String queryApplicationId : queryApplicationIds) {
+        final List<TopicPartition> topicPartitions
+            = topicPartitionsByAppId.get(queryApplicationId);
+
+        Map<TopicPartition, Long> currentOffsets =
+            kafkaCluster.getConsumerGroupOffset(queryApplicationId);
+        Map<TopicPartition, Long> endOffsets = kafkaCluster.getEndOffsets(topicPartitions,
+            // Since we're doing At Least Once, we can do read uncommitted.
+            IsolationLevel.READ_COMMITTED);
+
+        for (final TopicPartition tp : topicPartitions) {
+          if (!currentOffsets.containsKey(tp) && endOffsets.get(tp) > 0) {
+            LOG.info("Haven't committed offsets yet for " + tp + " end offset " + endOffsets.get(tp));
+            threadYield();
+            continue mainloop;
+          }
+        }
+
+        for (final Map.Entry<TopicPartition, Long> entry : currentOffsets.entrySet()) {
+          final TopicPartition tp = entry.getKey();
+          final long currentOffset = entry.getValue();
+          final long endOffset = endOffsets.get(tp);
+          if (currentOffset < endOffset) {
+            LOG.info("Offsets are not caught up current: " + currentOffsets + " end: "
+                + endOffsets);
+            threadYield();
+            continue mainloop;
+          }
+        }
+      }
+      LOG.info("Offsets are all up to date");
+      return;
+    }
+    LOG.info("Timed out waiting for correct response");
+    throw new AssertionError("Timed out while trying to wait for offsets");
+  }
+
+  private static Set<String> getSourceTopics(
+      final PersistentQueryMetadata persistentQueryMetadata
+  ) {
+    Set<String> topics = new HashSet<>();
+    for (final Subtopology subtopology :
+        persistentQueryMetadata.getTopology().describe().subtopologies()) {
+      for (final TopologyDescription.Node node : subtopology.nodes()) {
+        if (node instanceof Source) {
+          final Source source = (Source) node;
+          Preconditions.checkNotNull(source.topicSet(), "Expecting topic set, not regex");
+          topics.addAll(source.topicSet());
+        }
+      }
+    }
+    return topics;
+  }
+
+  private static void threadYield() {
+    try {
+      // More reliable than Thread.yield
+      Thread.sleep(10);
+    } catch (final InterruptedException e) {
+      // ignore
+    }
+  }
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryLimitHARoutingTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryLimitHARoutingTest.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.rest.integration;
 
-import static io.confluent.ksql.rest.entity.StreamedRowMatchers.matchersRowsAnyOrder;
 import static io.confluent.ksql.rest.integration.HighAvailabilityTestUtil.extractQueryId;
 import static io.confluent.ksql.rest.integration.HighAvailabilityTestUtil.makeAdminRequest;
 import static io.confluent.ksql.rest.integration.HighAvailabilityTestUtil.makeAdminRequestWithResponse;
@@ -26,7 +25,6 @@ import static io.confluent.ksql.util.KsqlConfig.KSQL_STREAMS_PREFIX;
 import static org.apache.kafka.streams.StreamsConfig.CONSUMER_PREFIX;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -163,9 +161,9 @@ public class PullQueryLimitHARoutingTest {
             .withProperties(COMMON_CONFIG)
             .build();
 
-    public final TestApp TEST_APP_0 = new TestApp(HOST0, REST_APP_0, APP_SHUTOFFS_0);
-    public final TestApp TEST_APP_1 = new TestApp(HOST1, REST_APP_1, APP_SHUTOFFS_1);
-    public final TestApp TEST_APP_2 = new TestApp(HOST2, REST_APP_2, APP_SHUTOFFS_2);
+    public final TestApp TEST_APP_0 = new TestApp(HOST0, REST_APP_0);
+    public final TestApp TEST_APP_1 = new TestApp(HOST1, REST_APP_1);
+    public final TestApp TEST_APP_2 = new TestApp(HOST2, REST_APP_2);
 
     public final List<TestApp> ALL_TEST_APPS = ImmutableList.of(TEST_APP_0, TEST_APP_1, TEST_APP_2);
 
@@ -265,35 +263,6 @@ public class PullQueryLimitHARoutingTest {
 
         // check that we only got limit number of rows
         assertThat(rows_1, hasSize(limitSubsetSize));
-
-        // Partition off one test app
-        TEST_APP_1.getShutoffs().shutOffAll();
-
-        waitForRemoteServerToChangeStatus(
-                TEST_APP_0.getApp(),
-                TEST_APP_2.getHost(),
-                HighAvailabilityTestUtil::remoteServerIsUp,
-                USER_CREDS);
-        waitForRemoteServerToChangeStatus(
-                TEST_APP_0.getApp(),
-                TEST_APP_1.getHost(),
-                HighAvailabilityTestUtil::remoteServerIsDown,
-                USER_CREDS);
-
-        // issue table scan after partitioning an app
-        final List<StreamedRow> rows_2 = makePullQueryRequestDistinct(TEST_APP_0.getApp(),
-                sqlTableScan, null, USER_CREDS);
-
-        // check that we get all rows back
-        assertThat(rows_2, hasSize(HEADER + TOTAL_RECORDS));
-        assertThat(rows_0, is(matchersRowsAnyOrder(rows_2)));
-
-        // issue pull query with limit after partitioning an app
-        final List<StreamedRow> rows_3 = makePullQueryRequestDistinct(TEST_APP_0.getApp(),
-                sqlLimit, null, USER_CREDS);
-
-        // check that we only got limit number of rows
-        assertThat(rows_3, hasSize(limitSubsetSize));
     }
 
     @Test
@@ -308,7 +277,7 @@ public class PullQueryLimitHARoutingTest {
             REST_APP_0.getEngine());
         for (TestApp testApp : ALL_TEST_APPS) {
             // Ensure that lags are reported
-            waitForRemoteServerToChangeStatus(TEST_APP_0.getApp(),
+            waitForRemoteServerToChangeStatus(REST_APP_0,
                 testApp.getHost(),
                 HighAvailabilityTestUtil.zeroLagsReported(testApp.getHost()),
                 USER_CREDS);
@@ -330,36 +299,6 @@ public class PullQueryLimitHARoutingTest {
 
         // check that we only got limit number of rows
         assertThat(rows_1, hasSize(limitSubsetSize));
-
-        // Partition off an app
-        TEST_APP_1.getShutoffs().shutOffAll();
-
-        waitForRemoteServerToChangeStatus(
-                TEST_APP_0.getApp(),
-                TEST_APP_2.getHost(),
-                HighAvailabilityTestUtil::remoteServerIsUp,
-                USER_CREDS);
-        waitForRemoteServerToChangeStatus(
-                TEST_APP_0.getApp(),
-                TEST_APP_1.getHost(),
-                HighAvailabilityTestUtil::remoteServerIsDown,
-                USER_CREDS);
-
-
-        // issue stream scan after partitioning an app
-        final List<StreamedRow> rows_2 = makePullQueryRequest(TEST_APP_0.getApp(),
-                sqlStreamPull, null, USER_CREDS);
-
-        // check that we get all rows back
-        assertThat(rows_2, hasSize(HEADER + TOTAL_RECORDS + COMPLETE_MESSAGE));
-        assertThat(rows_0, is(matchersRowsAnyOrder(rows_2)));
-
-        // issue pull query with limit after partitioning an app
-        final List<StreamedRow> rows_3 = makePullQueryRequest(TEST_APP_0.getApp(),
-                sqlLimit, null, USER_CREDS);
-
-        // check that we only got limit number of rows
-        assertThat(rows_3, hasSize(limitSubsetSize));
     }
 
     private void waitForTableRows() {
@@ -384,12 +323,10 @@ public class PullQueryLimitHARoutingTest {
 
         private final KsqlHostInfoEntity host;
         private final TestKsqlRestApp app;
-        private final HighAvailabilityTestUtil.Shutoffs shutoffs;
 
-        public TestApp(KsqlHostInfoEntity host, TestKsqlRestApp app, HighAvailabilityTestUtil.Shutoffs shutoffs) {
+        public TestApp(KsqlHostInfoEntity host, TestKsqlRestApp app) {
             this.host = host;
             this.app = app;
-            this.shutoffs = shutoffs;
         }
 
         public KsqlHostInfoEntity getHost() {
@@ -398,10 +335,6 @@ public class PullQueryLimitHARoutingTest {
 
         public TestKsqlRestApp getApp() {
             return app;
-        }
-
-        public HighAvailabilityTestUtil.Shutoffs getShutoffs() {
-            return shutoffs;
         }
     }
 


### PR DESCRIPTION
### Description 
Previously, we weren't ensuring that the active was actually caught up with input, so refactored logic from RQTT to be used.   Also, we didn't ensure that the reported lags were zero, ensuring that standbys were caught up.

These introduced race conditions. where we would query a state store that wasn't guaranteed to be up to date with the upstream topics.

After discussing with @cprasad1, I decided to also remove the HA checks since we have these elsewhere and they have little to do with limit functionality.

Also, makes the test dedupe the results.  This is because after hitting the limit, the last row appears periodically (but rarely) to be duplicated.  I tried for a while to debug this, but this will have to wait for a future PR.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

