### PR TITLE
fix: dont throw persistent query limit errors for non-queries

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/RequestValidator.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/RequestValidator.java
@@ -126,16 +126,17 @@ public class RequestValidator {
           SessionConfig.of(ksqlConfig, sessionProperties.getMutableScopedProperties())
       );
 
-      numPersistentQueries +=
-          validate(
-              serviceContext,
-              configured,
-              sessionProperties,
-              ctx,
-              injector
-          );
+      final int currNumPersistentQueries = validate(
+          serviceContext,
+          configured,
+          sessionProperties,
+          ctx,
+          injector
+      );
+      numPersistentQueries += currNumPersistentQueries;
 
-      if (QueryCapacityUtil.exceedsPersistentQueryCapacity(ctx, ksqlConfig)) {
+      if (currNumPersistentQueries > 0
+          && QueryCapacityUtil.exceedsPersistentQueryCapacity(ctx, ksqlConfig)) {
         QueryCapacityUtil.throwTooManyActivePersistentQueriesException(ctx, ksqlConfig, sql);
       }
     }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -1933,6 +1933,21 @@ public class KsqlResourceTest {
   }
 
   @Test
+  public void shouldNotFailIfNotQueryDespiteReachedActivePersistentQueriesLimit() {
+    // Given:
+    givenKsqlConfigWith(
+        ImmutableMap.of(KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG, 3));
+
+    givenMockEngine();
+
+    // mock 3 queries already running + 1 new query to execute
+    givenPersistentQueryCount(4);
+
+    // When/Then:
+    makeSingleRequest("SHOW STREAMS;", StreamsList.class);
+  }
+
+  @Test
   public void shouldListPropertiesWithOverrides() {
     // Given:
     final Map<String, Object> overrides = Collections.singletonMap("auto.offset.reset", "latest");

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -1940,8 +1940,8 @@ public class KsqlResourceTest {
 
     givenMockEngine();
 
-    // mock 3 queries already running + 1 new query to execute
-    givenPersistentQueryCount(4);
+    // mock 6 queries already running
+    givenPersistentQueryCount(6);
 
     // When/Then:
     makeSingleRequest("SHOW STREAMS;", StreamsList.class);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/RequestValidatorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/RequestValidatorTest.java
@@ -259,9 +259,8 @@ public class RequestValidatorTest {
   }
 
   @Test
-  public void ff() {
+  public void shouldNotThrowIfNotQueryDespiteTooManyPersistentQueries() {
     // Given:
-    when(ksqlConfig.getInt(KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG)).thenReturn(1);
     givenPersistentQueryCount(2);
     givenRequestValidator(ImmutableMap.of(ListStreams.class, StatementValidator.NO_VALIDATION));
 
@@ -282,7 +281,6 @@ public class RequestValidatorTest {
             CreateStream.class, StatementValidator.NO_VALIDATION,
             Explain.class, StatementValidator.NO_VALIDATION)
     );
-    when(ksqlConfig.getInt(KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG)).thenReturn(1);
 
     final List<ParsedStatement> statements =
         givenParsed(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/RequestValidatorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/RequestValidatorTest.java
@@ -47,6 +47,7 @@ import io.confluent.ksql.parser.KsqlParser;
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.tree.CreateStream;
 import io.confluent.ksql.parser.tree.Explain;
+import io.confluent.ksql.parser.tree.ListStreams;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.server.computation.ValidatedCommandFactory;
@@ -255,6 +256,22 @@ public class RequestValidatorTest {
     // Then:
     assertThat(e.getMessage(), containsString(
         "persistent queries to exceed the configured limit"));
+  }
+
+  @Test
+  public void ff() {
+    // Given:
+    when(ksqlConfig.getInt(KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG)).thenReturn(1);
+    givenPersistentQueryCount(2);
+    givenRequestValidator(ImmutableMap.of(ListStreams.class, StatementValidator.NO_VALIDATION));
+
+    final List<ParsedStatement> statements =
+        givenParsed(
+            "SHOW STREAMS;"
+        );
+
+    // When/Then:
+    validator.validate(serviceContext, statements, sessionProperties, "sql");
   }
 
   @Test


### PR DESCRIPTION
### Description 
If persistent query limit count has been reached, don't an error for statements like `SHOW STREAMS;` because that would cause the healthcheck to fail.

### Testing done 
unit tests + manual test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

