### PR TITLE
fix: EXPLAIN command displays invalid command

### DIFF
--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -781,7 +781,7 @@ public class Console implements Closeable {
       for (final String sources : query.getSources()) {
         writer().println(sources);
       }
-      writer().println("\nFor source description please run: DESCRIBE [EXTENDED] <SourceId>");
+      writer().println("\nFor source description please run: DESCRIBE <SourceId> [EXTENDED]");
     }
   }
 
@@ -795,7 +795,7 @@ public class Console implements Closeable {
       for (final String sinks : query.getSinks()) {
         writer().println(sinks);
       }
-      writer().println("\nFor sink description please run: DESCRIBE [EXTENDED] <SinkId>");
+      writer().println("\nFor sink description please run: DESCRIBE <SinkId> [EXTENDED]");
     }
   }
 

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.shouldPrintExplainQueryWithError.approved.tabular
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.shouldPrintExplainQueryWithError.approved.tabular
@@ -13,13 +13,13 @@ Sources that this query reads from:
 -----------------------------------
 source
 
-For source description please run: DESCRIBE [EXTENDED] <SourceId>
+For source description please run: DESCRIBE <SourceId> [EXTENDED]
 
 Sinks that this query writes to: 
 -----------------------------------
 sink
 
-For sink description please run: DESCRIBE [EXTENDED] <SinkId>
+For sink description please run: DESCRIBE <SinkId> [EXTENDED]
 
 Execution plan      
 --------------      


### PR DESCRIPTION
### Description 
Fix #9532 
The EXPLAIN command for users to get more info about a stream or table, [EXTENDED] should be show at last.

### Testing done 
Manual testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

