### PR TITLE
fix: enhance error messages when source has extra/lacks double quotes…

### DIFF
--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/insert-into.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/insert-into.json
@@ -360,6 +360,28 @@
         "type": "io.confluent.ksql.util.KsqlStatementException",
         "message": "Result schema is `K` STRING KEY, `DATA_1` STRING, `DATA_2` STRING, `DATA_3` STRING\nSink schema is `K` STRING KEY, `DATA_1` STRING, `DATA_2` STRING"
       }
+    },
+    {
+      "name": "insert into source name without quotes",
+      "statements": [
+        "CREATE STREAM \"input\" (id INT KEY, val STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "INSERT INTO input (id, val) VALUES (1, 'hello');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Cannot insert values into an unknown stream/table: `INPUT`\nDid you mean \"input\"? Hint: wrap the source name in double quotes to make it case-sensitive."
+      }
+    },
+    {
+      "name": "insert into source name with quotes",
+      "statements": [
+        "CREATE STREAM input (id INT KEY, val STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "INSERT INTO \"input\" (id, val) VALUES (1, 'hello');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Cannot insert values into an unknown stream/table: `input`\nDid you mean INPUT? Hint: try removing double quotes from the source name."
+      }
     }
   ]
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/InsertsStreamEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/InsertsStreamEndpoint.java
@@ -34,6 +34,7 @@ import io.confluent.ksql.util.VertxUtils;
 import io.vertx.core.Context;
 import io.vertx.core.WorkerExecutor;
 import io.vertx.core.json.JsonObject;
+import java.util.Optional;
 import org.reactivestreams.Subscriber;
 
 public class InsertsStreamEndpoint {
@@ -86,7 +87,8 @@ public class InsertsStreamEndpoint {
     final DataSource dataSource = metaStore.getSource(sourceName);
     if (dataSource == null) {
       throw new KsqlApiException(
-          "Cannot insert values into an unknown stream/table: " + sourceName,
+          "Cannot insert values into an unknown stream/table: " + sourceName
+          + metaStore.checkAlternatives(sourceName, Optional.empty()),
             ERROR_CODE_BAD_STATEMENT);
     }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
@@ -234,7 +234,8 @@ public class InsertValuesExecutor {
     final DataSource dataSource = metaStore.getSource(insertValues.getTarget());
     if (dataSource == null) {
       throw new KsqlException("Cannot insert values into an unknown stream/table: "
-          + insertValues.getTarget());
+          + insertValues.getTarget()
+          + metaStore.checkAlternatives(insertValues.getTarget(), Optional.empty()));
     }
 
     if (dataSource.getKsqlTopic().getKeyFormat().isWindowed()) {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
@@ -521,7 +521,8 @@ public class ApiIntegrationTest {
 
     // Then: request fails because stream name is invalid
     shouldRejectInsertRequest(target, row,
-        "Cannot insert values into an unknown stream/table: " + target);
+        "Cannot insert values into an unknown stream/table: " + target
+            + "\nDid you mean STRUCTURED_TYPES_KSTREAM? Hint: try removing double quotes from the source name.");
   }
 
   @Test
@@ -541,7 +542,8 @@ public class ApiIntegrationTest {
 
     // Then: request fails because stream name is invalid
     shouldRejectInsertRequest(target, row,
-        "Cannot insert values into an unknown stream/table: `" + TEST_STREAM.toLowerCase() + "`");
+        "Cannot insert values into an unknown stream/table: `" + TEST_STREAM.toLowerCase() + "`"
+            + "\nDid you mean STRUCTURED_TYPES_KSTREAM? Hint: try removing double quotes from the source name.");
   }
 
   @Test
@@ -704,7 +706,7 @@ public class ApiIntegrationTest {
 
     QueryResponse queryResponse = new QueryResponse(response.bodyAsString());
     assertThat(queryResponse.responseObject.getInteger("error_code"), is(ERROR_CODE_BAD_STATEMENT));
-    assertThat(queryResponse.responseObject.getString("message"), containsString(message));
+    assertThat(queryResponse.responseObject.getString("message"), is(message));
   }
 
   private HttpResponse<Buffer> makeInsertsRequest(final String target, final JsonObject row) {


### PR DESCRIPTION
Generalises the solution for [issue#9243](https://github.com/confluentinc/ksql/issues/9243)

### Description 
When performing `INSERT VALUES` on a source name with a very special case of typo (typing source name mistakenly with/without double quotes), the error message is the same as when the source is not existing at all. This fix adds a Hint to the error message to make it more informative.

### Testing done 
Unit test
QTT
Manual testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

