### PR TITLE
fix: give hint when source name has extra/lacks dquotes

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -275,7 +275,9 @@ public final class ListSourceExecutor {
     final DataSource dataSource = ksqlExecutionContext.getMetaStore().getSource(name);
     if (dataSource == null) {
       throw new KsqlStatementException(String.format(
-          "Could not find STREAM/TABLE '%s' in the Metastore",
+          "Could not find STREAM/TABLE '%s' in the Metastore"
+              + ksqlExecutionContext.getMetaStore().checkAlternatives(
+                  name, Optional.empty()),
           name.text()
       ), statement.getMaskedStatementText());
     }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
@@ -410,6 +410,48 @@ public class ListSourceExecutorTest {
   }
 
   @Test
+  public void shouldThrowOnDescribeSourceNameWithoutQuotes() {
+    // Given:
+    engine.givenSource(DataSourceType.KTABLE, "table1");
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlStatementException.class,
+        () -> CustomExecutors.SHOW_COLUMNS.execute(
+            engine.configure("DESCRIBE table1;"),
+            SESSION_PROPERTIES,
+            engine.getEngine(),
+            engine.getServiceContext()
+        )
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString(
+        "Could not find STREAM/TABLE 'TABLE1' in the Metastore\nDid you mean \"table1\"? Hint: wrap the source name in double quotes to make it case-sensitive."));
+  }
+
+  @Test
+  public void shouldThrowOnDescribeSourceNameWithQuotes() {
+    // Given:
+    engine.givenSource(DataSourceType.KSTREAM, "STREAM1");
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlStatementException.class,
+        () -> CustomExecutors.SHOW_COLUMNS.execute(
+            engine.configure("DESCRIBE \"stream1\";"),
+            SESSION_PROPERTIES,
+            engine.getEngine(),
+            engine.getServiceContext()
+        )
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString(
+        "Could not find STREAM/TABLE 'stream1' in the Metastore\nDid you mean STREAM1? Hint: try removing double quotes from the source name."));
+  }
+
+  @Test
   public void shouldNotCallTopicClientForExtendedDescription() {
     // Given:
     engine.givenSource(DataSourceType.KSTREAM, "stream1");


### PR DESCRIPTION
Generalises the solution for [issue#9243](https://github.com/confluentinc/ksql/issues/9243)

### Description 
When performing `DESCRIBE` on a source name with a very special case of typo (typing source name mistakenly with/without double quotes), the error message is the same as when the source is not existing at all. This fix adds a Hint to the error message to make it more informative.



### Testing done 
Unit test
Manual testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

