### PR TITLE
fix: SCHEMA_FULL_NAME should not be case sensitive

### DIFF
--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSchemaTranslator.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSchemaTranslator.java
@@ -111,10 +111,11 @@ public class ProtobufSchemaTranslator implements ConnectSchemaTranslator {
 
   private ProtobufSchema withSchemaFullName(final ProtobufSchema origSchema) {
     if (fullNameSchema.isPresent()) {
-      Optional<List<String>> matchedList = Optional.of(origSchema.rawSchema().getTypes().stream()
-          .map(TypeElement::getName).filter(nn -> nn.equalsIgnoreCase(fullNameSchema.get()))
+      final Optional<List<String>> matchedList = Optional.of(origSchema.rawSchema().getTypes()
+          .stream().map(TypeElement::getName)
+          .filter(nn -> nn.equalsIgnoreCase(fullNameSchema.get()))
           .collect(Collectors.toList()));
-      String name = matchedList.filter(list -> list.size() == 1).map(list -> list.get(0))
+      final String name = matchedList.filter(list -> list.size() == 1).map(list -> list.get(0))
           .orElse(fullNameSchema.get());
       return origSchema.copy(name);
     }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/ProtobufSchemaTranslatorTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/ProtobufSchemaTranslatorTest.java
@@ -64,6 +64,26 @@ public class ProtobufSchemaTranslatorTest {
   }
 
   @Test
+  public void shouldAddCorrectNameToConnectSchema() {
+    // Given:
+    schemaTranslator = givenSchemaFullName("bar");
+    final ProtobufSchema protoSchema = new ProtobufSchema("syntax = \"proto3\";\n" +
+        "\n" +
+        "message FOO {\n" +
+        "  int32 K1 = 1;\n" +
+        "}\n" +
+        "message BAR {\n" +
+            "  int32 K2 = 1;\n" +
+        "}");
+
+    // When:
+    final Schema connectSchema = schemaTranslator.toConnectSchema(protoSchema);
+
+    // Then:
+    assertThat(connectSchema.name(), is("BAR"));
+  }
+
+  @Test
   public void shouldUnwrapPrimitives() {
     // Given:
     givenUnwrapPrimitives();
@@ -246,9 +266,10 @@ public class ProtobufSchemaTranslatorTest {
     schemaTranslator = new ProtobufSchemaTranslator(new ProtobufProperties(ImmutableMap.of()));
   }
 
-  private void givenSchemaFullName(final String fullSchemaName) {
+  private ProtobufSchemaTranslator givenSchemaFullName(final String fullSchemaName) {
     schemaTranslator = new ProtobufSchemaTranslator(new ProtobufProperties(ImmutableMap.of(
         ProtobufProperties.FULL_SCHEMA_NAME, fullSchemaName
     )));
+    return schemaTranslator;
   }
 }


### PR DESCRIPTION
Solves [issue#9477](https://github.com/confluentinc/ksql/issues/9477)
### Description 
Reusing existing protobuf schemas by name (SCHEMA_FULL_NAME) in command such as `ct/cs` was case-sensitive. This PR fixes the issue. 

### Testing done 
Unit test
Manual testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

