### PR TITLE
test: add script to run yatt tests

### DIFF
--- a/bin/run-ksql-test
+++ b/bin/run-ksql-test
@@ -1,0 +1,17 @@
+#!/bin/bash
+# (Copyright) [2019 - 2019] Confluent, Inc.
+
+ #
+# Use shellcheck to lint this file
+#
+set -ue
+
+ base_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
+: "${KSQL_CONFIG_DIR:="$base_dir/config"}"
+
+ : "${KSQL_LOG4J_OPTS:=""}"
+if [ -z "$KSQL_LOG4J_OPTS" ] && [ -e "$KSQL_CONFIG_DIR/log4j-sql-test.properties" ]; then
+  export KSQL_LOG4J_OPTS="-Dlog4j.configuration=file:$KSQL_CONFIG_DIR/log4j-sql-test.properties"
+fi
+
+ exec "$base_dir"/bin/ksql-run-class io.confluent.ksql.test.tools.SqlTestingTool "$@"

--- a/config/log4j-sql-test.properties
+++ b/config/log4j-sql-test.properties
@@ -1,0 +1,10 @@
+# Root logger -- disable all non-sql-test logging
+log4j.rootLogger=OFF
+
+# SQL tester logger
+log4j.logger.io.confluent.ksql.test=INFO, console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.Target=System.out
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.consoleAppender.layout.ConversionPattern=[%t] %-5p %c %x - %m%n

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/SqlTestOptions.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/SqlTestOptions.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.tools;
+
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.restrictions.Once;
+import com.github.rvesse.airline.annotations.restrictions.Required;
+import io.confluent.ksql.test.tools.command.TestOptionsParser;
+import java.io.IOException;
+
+@Command(name = "sql-test-runner", description = "The KSQL SQL testing tool")
+public class SqlTestOptions {
+  @Required
+  @Once
+  @Option(
+      name = {"--test-directory", "-td"},
+      description = "A directory containing SQL files to test.")
+  private String testDirectory;
+
+  @Required
+  @Once
+  @Option(
+      name = {"--temp-folder", "-tf"},
+      description = "A folder to store temporary files")
+  private String tempFolder;
+
+  public static SqlTestOptions parse(final String... args) throws IOException {
+    return TestOptionsParser.parse(args, SqlTestOptions.class);
+  }
+
+  public String getTestDirectory() {
+    return testDirectory;
+  }
+
+  public String getTempFolder() {
+    return tempFolder;
+  }
+}

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/SqlTestingTool.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/SqlTestingTool.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.tools;
+
+import io.confluent.ksql.test.parser.SqlTestLoader;
+import io.confluent.ksql.test.parser.SqlTestLoader.SqlTest;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.apache.commons.io.FileUtils;
+
+public final class SqlTestingTool {
+
+  private SqlTestingTool() {
+  }
+
+  public static void main(final String[] args) throws IOException {
+    SqlTestOptions testOptions = null;
+    try {
+      testOptions = SqlTestOptions.parse(args);
+    } catch (final Exception e) {
+      System.err.println("Invalid arguments: " + e.getMessage());
+      System.exit(1);
+      return;
+    }
+
+    final Path tempFolder = Paths.get(testOptions.getTempFolder());
+    final SqlTestLoader loader = new SqlTestLoader(Paths.get(testOptions.getTestDirectory()));
+    loader.load().forEach(
+        test -> executeTest(test, SqlTestExecutor.create(tempFolder), tempFolder.toFile()));
+
+    System.exit(0);
+    return;
+  }
+
+  private static void executeTest(
+      final SqlTest test,
+      final SqlTestExecutor executor,
+      final File tempFolder
+  ) {
+    try {
+      executor.executeTest(test);
+      System.out.println("\t >>> Test passed!");
+    } catch (final Throwable e) {
+      System.err.println("\t>>>>> Test failed: " + e.getMessage());
+    } finally {
+      cleanUp(executor, tempFolder);
+    }
+  }
+
+  private static void cleanUp(final SqlTestExecutor executor, final File tempFolder) {
+    executor.close();
+    try {
+      FileUtils.cleanDirectory(tempFolder);
+    } catch (final Exception e) {
+      System.err.println("Failed to clean up temp folder: " + e.getMessage());
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/SqlTestingToolTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/SqlTestingToolTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.tools;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import io.confluent.ksql.test.util.KsqlTestFolder;
+import java.io.IOException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class SqlTestingToolTest {
+
+  private final static String TESTS_FOLDER = "src/test/resources/sql-test-runner";
+  @Rule
+  public final TemporaryFolder tmpFolder = KsqlTestFolder.temporaryFolder();
+
+  @Test
+  public void shouldRunTests() throws IOException {
+    final int result = SqlTestingTool.run(new String[]{"-td", TESTS_FOLDER, "-tf", tmpFolder.getRoot().getPath()});
+    assertThat(result, is(0));
+  }
+
+  @Test
+  public void shouldThrowOnInvalidArguments() throws IOException {
+    final int result = SqlTestingTool.run(new String[]{"-abc"});
+    assertThat(result, is(1));
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/sql-test-runner/test1.sql
+++ b/ksqldb-functional-tests/src/test/resources/sql-test-runner/test1.sql
@@ -1,0 +1,141 @@
+-- this test file is a "meta-test" that tests the basic functionality of the KsqlTester
+
+----------------------------------------------------------------------------------------------------
+--@test: basic test
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar AS SELECT * FROM foo;
+
+ASSERT STREAM bar (id INT KEY, col1 INT) WITH (kafka_topic='BAR', value_format='JSON');
+
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 1);
+ASSERT VALUES bar (rowtime, id, col1) VALUES (1, 1, 1);
+
+----------------------------------------------------------------------------------------------------
+--@test: basic test with tables
+----------------------------------------------------------------------------------------------------
+CREATE TABLE foo (id INT PRIMARY KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE TABLE bar AS SELECT * FROM foo;
+
+ASSERT TABLE bar (id INT PRIMARY KEY, col1 INT) WITH (kafka_topic='BAR', value_format='JSON');
+
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 1);
+ASSERT VALUES bar (rowtime, id, col1) VALUES (1, 1, 1);
+
+----------------------------------------------------------------------------------------------------
+--@test: basic test without rowtime comparison
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar AS SELECT * FROM foo;
+
+INSERT INTO foo (id, col1) VALUES (1, 1);
+ASSERT VALUES bar (id, col1) VALUES (1, 1);
+
+----------------------------------------------------------------------------------------------------
+--@test: basic test with aggregation
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE TABLE bar AS SELECT id, COUNT(*) as count FROM foo GROUP BY id;
+
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 1);
+ASSERT VALUES bar (rowtime, id, count) VALUES (1, 1, 1);
+
+----------------------------------------------------------------------------------------------------
+--@test: basic test (format AVRO)
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='AVRO');
+CREATE STREAM bar AS SELECT * FROM foo;
+
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 1);
+ASSERT VALUES bar (rowtime, id, col1) VALUES (1, 1, 1);
+
+----------------------------------------------------------------------------------------------------
+--@test: basic chained test
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar AS SELECT * FROM foo;
+CREATE STREAM baz AS SELECT * FROM bar;
+
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 1);
+ASSERT VALUES baz (rowtime, id, col1) VALUES (1, 1, 1);
+
+----------------------------------------------------------------------------------------------------
+--@test: basic join test
+----------------------------------------------------------------------------------------------------
+CREATE STREAM s (id INT KEY, foo INT) WITH (kafka_topic='s', value_format='JSON');
+CREATE TABLE t (id INT PRIMARY KEY, bar INT) WITH (kafka_topic='t', value_format='JSON');
+
+CREATE STREAM j AS SELECT s.id, s.foo, t.bar FROM s JOIN t ON s.id = t.id;
+
+INSERT INTO t (rowtime, id, bar) VALUES (1, 1, 1);
+INSERT INTO s (rowtime, id, foo) VALUES (1, 1, 2);
+
+ASSERT VALUES j (rowtime, s_id, foo, bar) VALUES (1, 1, 2, 1);
+
+----------------------------------------------------------------------------------------------------
+--@test: basic create or replace test
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar AS SELECT * FROM foo;
+
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 1);
+ASSERT VALUES bar (rowtime, id, col1) VALUES (1, 1, 1);
+
+SET 'ksql.create.or.replace.enabled'='true';
+CREATE OR REPLACE STREAM bar AS SELECT id, col1 + 1 as col1 FROM foo;
+
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 1);
+ASSERT VALUES bar (rowtime, id, col1) VALUES (1, 1, 2);
+
+----------------------------------------------------------------------------------------------------
+--@test: basic test with run script
+----------------------------------------------------------------------------------------------------
+-- contents of script:
+-- CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+-- CREATE STREAM bar AS SELECT * FROM foo;
+RUN SCRIPT '/test-script.sql';
+
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 1);
+ASSERT VALUES bar (rowtime, id, col1) VALUES (1, 1, 1);
+
+----------------------------------------------------------------------------------------------------
+--@test: bad assert statement should fail
+
+--@expected.error: java.lang.AssertionError
+--@expected.message: Expected record does not match actual
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar AS SELECT * FROM foo;
+
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 1);
+ASSERT VALUES bar (rowtime, id, col1) VALUES (2, 2, 2);
+
+----------------------------------------------------------------------------------------------------
+--@test: bad engine statement should fail
+
+--@expected.error: io.confluent.ksql.util.KsqlException
+--@expected.message: Exception while preparing statement: FOO does not exist.
+----------------------------------------------------------------------------------------------------
+CREATE STREAM bar AS SELECT * FROM foo;
+
+----------------------------------------------------------------------------------------------------
+--@test: assert stream with wrong schema should fail
+
+--@expected.error: io.confluent.ksql.util.KsqlException
+--@expected.message: Expected schema does not match actual
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar AS SELECT * FROM foo;
+
+ASSERT STREAM bar (id INT KEY, col1 VARCHAR) WITH (kafka_topic='BAR', value_format='JSON');
+
+----------------------------------------------------------------------------------------------------
+--@test: assert stream with wrong schema (key) should fail
+
+--@expected.error: io.confluent.ksql.util.KsqlException
+--@expected.message: Expected schema does not match actual
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar AS SELECT * FROM foo;
+
+ASSERT STREAM bar (id INT, col1 VARCHAR) WITH (kafka_topic='BAR', value_format='JSON');

--- a/ksqldb-functional-tests/src/test/resources/sql-test-runner/test2.sql
+++ b/ksqldb-functional-tests/src/test/resources/sql-test-runner/test2.sql
@@ -1,0 +1,144 @@
+----------------------------------------------------------------------------------------------------
+--@test: assert stream with wrong type should fail
+
+--@expected.error: io.confluent.ksql.util.KsqlException
+--@expected.message: Expected type does not match actual for source BAR
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar AS SELECT * FROM foo;
+
+ASSERT TABLE bar (id INT PRIMARY KEY, col1 INT) WITH (kafka_topic='BAR', value_format='JSON');
+
+----------------------------------------------------------------------------------------------------
+--@test: assert stream with wrong topic should fail
+
+--@expected.error: io.confluent.ksql.util.KsqlException
+--@expected.message: Expected kafka topic does not match actual for source BAR
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar AS SELECT * FROM foo;
+
+ASSERT STREAM bar (id INT KEY, col1 INT) WITH (kafka_topic='BAZ', value_format='JSON');
+
+----------------------------------------------------------------------------------------------------
+--@test: assert stream with wrong key format should fail
+
+--@expected.error: io.confluent.ksql.util.KsqlException
+--@expected.message: Expected key format does not match actual for source BAR
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', key_format='KAFKA', value_format='JSON');
+CREATE STREAM bar AS SELECT * FROM foo;
+
+ASSERT STREAM bar (id INT KEY, col1 INT) WITH (kafka_topic='BAR', key_format='AVRO', value_format='JSON');
+
+----------------------------------------------------------------------------------------------------
+--@test: assert stream with wrong value format should fail
+
+--@expected.error: io.confluent.ksql.util.KsqlException
+--@expected.message: Expected value format does not match actual for source BAR
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar AS SELECT * FROM foo;
+
+ASSERT STREAM bar (id INT KEY, col1 INT) WITH (kafka_topic='BAR', value_format='AVRO');
+
+----------------------------------------------------------------------------------------------------
+--@test: assert stream with wrong format should fail
+
+--@expected.error: io.confluent.ksql.util.KsqlException
+--@expected.message: Expected value format does not match actual for source BAR
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', format='KAFKA');
+CREATE STREAM bar AS SELECT * FROM foo;
+
+ASSERT STREAM bar (id INT KEY, col1 INT) WITH (kafka_topic='BAR', key_format='KAFKA', value_format='JSON');
+
+----------------------------------------------------------------------------------------------------
+--@test: assert stream with explicit format
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', format='KAFKA');
+CREATE STREAM bar AS SELECT * FROM foo;
+
+ASSERT STREAM bar (id INT KEY, col1 INT) WITH (kafka_topic='BAR', key_format='KAFKA', value_format='KAFKA');
+
+----------------------------------------------------------------------------------------------------
+--@test: assert stream with explicit expected format
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', key_format='KAFKA', value_format='KAFKA');
+CREATE STREAM bar AS SELECT * FROM foo;
+
+ASSERT STREAM bar (id INT KEY, col1 INT) WITH (kafka_topic='BAR', format='KAFKA');
+
+----------------------------------------------------------------------------------------------------
+--@test: assert stream with wrong timestamp column
+
+--@expected.error: io.confluent.ksql.util.KsqlException
+--@expected.message: Expected timestamp column does not match actual for source BAR.
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 BIGINT, col2 BIGINT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar WITH(timestamp='col1') AS SELECT * FROM foo;
+
+ASSERT STREAM bar (id INT KEY, col1 BIGINT, col2 BIGINT) WITH (kafka_topic='BAR', value_format='JSON', timestamp='col2');
+
+----------------------------------------------------------------------------------------------------
+--@test: assert stream with wrong timestamp format
+
+--@expected.error: io.confluent.ksql.util.KsqlException
+--@expected.message: Expected timestamp format does not match actual for source BAR.
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 VARCHAR) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar WITH(timestamp='col1', timestamp_format='yyyy') AS SELECT * FROM foo;
+
+ASSERT STREAM bar (id INT KEY, col1 VARCHAR) WITH (kafka_topic='BAR', value_format='JSON', timestamp='col1', timestamp_format='mm');
+
+----------------------------------------------------------------------------------------------------
+--@test: assert stream with wrong topic should fail
+
+--@expected.error: io.confluent.ksql.util.KsqlException
+--@expected.message: Expected value serde features does not match actual for source BAR
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar AS SELECT * FROM foo;
+
+ASSERT STREAM bar (id INT KEY, col1 INT) WITH (kafka_topic='BAR', value_format='JSON', wrap_single_value=false);
+
+----------------------------------------------------------------------------------------------------
+--@test: assert contents of a DDL source
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 2, 1);
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 1);
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 3, 1);
+ASSERT VALUES foo (rowtime, id, col1) VALUES (1, 2, 1);
+ASSERT VALUES foo (rowtime, id, col1) VALUES (1, 1, 1);
+ASSERT VALUES foo (rowtime, id, col1) VALUES (1, 3, 1);
+
+----------------------------------------------------------------------------------------------------
+--@test: assert a subset of columns
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT, col2 STRING) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar AS SELECT * FROM foo;
+
+INSERT INTO foo (rowtime, id, col1, col2) VALUES (1, 2, 3, 'ABC');
+ASSERT VALUES bar (col1) VALUES (3);
+INSERT INTO foo (rowtime, id, col1, col2) VALUES (1, 2, 3, 'ABC');
+ASSERT VALUES bar (col2, col1) VALUES ('ABC', 3);
+INSERT INTO foo (rowtime, id, col1, col2) VALUES (1, 2, 3, 'ABC');
+ASSERT VALUES bar (col2, rowtime, id) VALUES ('ABC', 1, 2);
+INSERT INTO foo (rowtime, id, col1, col2) VALUES (1, 2, 3, 'ABC');
+ASSERT VALUES bar (col1, id) VALUES (3, 2);
+
+----------------------------------------------------------------------------------------------------
+--@test: assert tombstones
+--@expected.error: java.lang.AssertionError
+--@expected.message: Expected record does not match actual
+----------------------------------------------------------------------------------------------------
+CREATE TABLE a (id INT PRIMARY KEY, col1 INT) WITH (kafka_topic='a', value_format='JSON');
+CREATE TABLE b AS SELECT * FROM a WHERE col1 > 0;
+
+INSERT INTO a (id, col1) VALUES (1, 0);
+INSERT INTO a (id, col1) VALUES (2, 2);
+
+ASSERT NULL VALUES b (id) KEY (1);
+ASSERT NULL VALUES b (id) KEY (2);


### PR DESCRIPTION
### Description 
Adds a script to run YATT tests from CLI.

### Testing done 
unit tests, manually tested by running all of our yatt tests from the cli

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

