### PR TITLE
test: fix flaky ClientTest.shouldFailPollStreamedQueryResultIfFailed

### DIFF
--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
@@ -347,6 +347,7 @@ public class ClientTest extends BaseApiTest {
     // Given
     final StreamedQueryResult streamedQueryResult =
         javaClient.streamQuery(DEFAULT_PUSH_QUERY, DEFAULT_PUSH_QUERY_REQUEST_PROPERTIES).get();
+    waitForQueryPublisherSubscribed();
     sendQueryPublisherError();
     assertThatEventually(streamedQueryResult::isFailed, is(true));
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.api;
 
 import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 
@@ -51,6 +52,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -131,22 +133,6 @@ public class BaseApiTest {
     createServer(serverConfig);
     this.client = createClient();
     setDefaultRowGenerator();
-
-    testEndpoints.getQueryPublishers().forEach(
-        publisher -> {
-          final long timeout = System.currentTimeMillis() + 30_000L;
-          while (publisher.getSubscriber() == null) {
-            try {
-              Thread.sleep(100L);
-            } catch (InterruptedException swallow) {
-            }
-
-            if (System.currentTimeMillis() > timeout) {
-              throw new RuntimeException("Test setup failed; no subscriber registered.");
-            }
-          }
-        }
-    );
   }
 
   @After
@@ -280,6 +266,26 @@ public class BaseApiTest {
       final String uri,
       final Consumer<HttpRequest<Buffer>> requestSender) {
     requestSender.accept(client.post(uri));
+  }
+
+  protected void waitForQueryPublisherSubscribed() {
+      final Set<TestQueryPublisher> queryPublishers = testEndpoints.getQueryPublishers();
+      assertThat(queryPublishers, hasSize(1));
+      queryPublishers.forEach(
+          publisher -> {
+              final long timeout = System.currentTimeMillis() + 30_000L;
+              while (publisher.getSubscriber() == null) {
+                  try {
+                      Thread.sleep(100L);
+                  } catch (InterruptedException swallow) {
+                  }
+
+                  if (System.currentTimeMillis() > timeout) {
+                      throw new RuntimeException("Subscribers not registered.");
+                  }
+              }
+          }
+      );
   }
 
   protected static void validateError(final int errorCode, final String message,


### PR DESCRIPTION
### Description 

This is a follow-up to https://github.com/confluentinc/ksql/pull/9303. The source of the flakiness is indeed because the subscriber is registered async. However, the query publisher is not registered until after the streamQuery() call is made, which means the first fix (which places the wait into the setup() method) is a no-op. This patch moves the wait into the test itself to be after streamQuery() is called.

### Testing done 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

