### PR TITLE
feat: add endpoint to run sql tests

### DIFF
--- a/ksqldb-rest-app/pom.xml
+++ b/ksqldb-rest-app/pom.xml
@@ -63,6 +63,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.confluent.ksql</groupId>
+            <artifactId>ksqldb-testing-tool</artifactId>
+            <version>${io.confluent.ksql.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-json-serializer</artifactId>
         </dependency>

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -235,7 +235,7 @@ public class ServerVerticle extends AbstractVerticle {
         .handler(this::handleIsValidPropertyRequest);
     router.route(HttpMethod.POST, "/test")
         .handler(BodyHandler.create(false))
-        .produces(JSON_CONTENT_TYPE)
+        .produces(KsqlMediaType.KSQL_V1_JSON.mediaType())
         .handler(this::handleTest);
     return router;
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -235,7 +235,6 @@ public class ServerVerticle extends AbstractVerticle {
         .handler(this::handleIsValidPropertyRequest);
     router.route(HttpMethod.POST, "/test")
         .handler(BodyHandler.create(false))
-        .produces(KsqlMediaType.KSQL_V1_JSON.mediaType())
         .produces(JSON_CONTENT_TYPE)
         .handler(this::handleTest);
     return router;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -233,7 +233,11 @@ public class ServerVerticle extends AbstractVerticle {
         .produces(KsqlMediaType.KSQL_V1_JSON.mediaType())
         .produces(JSON_CONTENT_TYPE)
         .handler(this::handleIsValidPropertyRequest);
-
+    router.route(HttpMethod.POST, "/test")
+        .handler(BodyHandler.create(false))
+        .produces(KsqlMediaType.KSQL_V1_JSON.mediaType())
+        .produces(JSON_CONTENT_TYPE)
+        .handler(this::handleTest);
     return router;
   }
 
@@ -382,6 +386,14 @@ public class ServerVerticle extends AbstractVerticle {
                 context);
           }
         }
+    );
+  }
+
+  private void handleTest(final RoutingContext routingContext) {
+    handleOldApiRequest(server, routingContext, String.class, Optional.empty(),
+        (test, apiSecurityContext) ->
+            endpoints
+                .executeTest(test, DefaultApiSecurityContext.create(routingContext, server))
     );
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/spi/Endpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/spi/Endpoints.java
@@ -123,4 +123,7 @@ public interface Endpoints {
       WorkerExecutor workerExecutor, ApiSecurityContext apiSecurityContext,
       Context context);
 
+  CompletableFuture<EndpointResponse> executeTest(
+      String test, ApiSecurityContext apiSecurityContext);
+
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
@@ -323,7 +323,7 @@ public class KsqlServerEndpoints implements Endpoints {
 
   @Override
   public CompletableFuture<EndpointResponse> executeTest(
-      final String test, ApiSecurityContext apiSecurityContext) {
+      final String test, final ApiSecurityContext apiSecurityContext) {
     return executeOldApiEndpoint(
         apiSecurityContext, ksqlSecurityContext -> ksqlResource.runTest(test));
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
@@ -321,6 +321,13 @@ public class KsqlServerEndpoints implements Endpoints {
     }, workerExecutor);
   }
 
+  @Override
+  public CompletableFuture<EndpointResponse> executeTest(
+      final String test, ApiSecurityContext apiSecurityContext) {
+    return executeOldApiEndpoint(
+        apiSecurityContext, ksqlSecurityContext -> ksqlResource.runTest(test));
+  }
+
   private <R> CompletableFuture<R> executeOnWorker(final Supplier<R> supplier,
       final WorkerExecutor workerExecutor) {
     final VertxCompletableFuture<R> vcf = new VertxCompletableFuture<>();

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -41,6 +41,7 @@ import io.confluent.ksql.rest.entity.ClusterTerminateRequest;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlRequest;
+import io.confluent.ksql.rest.entity.KsqlTestResult;
 import io.confluent.ksql.rest.entity.KsqlWarning;
 import io.confluent.ksql.rest.entity.PropertiesList;
 import io.confluent.ksql.rest.server.ServerUtil;
@@ -60,6 +61,9 @@ import io.confluent.ksql.services.SandboxedServiceContext;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.Injector;
 import io.confluent.ksql.statement.Injectors;
+import io.confluent.ksql.tools.test.SqlTestExecutor;
+import io.confluent.ksql.tools.test.parser.SqlTestLoader;
+import io.confluent.ksql.tools.test.parser.SqlTestLoader.SqlTest;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConfigurable;
 import io.confluent.ksql.util.KsqlException;
@@ -67,8 +71,12 @@ import io.confluent.ksql.util.KsqlHostInfo;
 import io.confluent.ksql.util.KsqlRequestConfig;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.version.metrics.ActivenessRegistrar;
+import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -79,6 +87,7 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.regex.PatternSyntaxException;
+import org.apache.commons.io.FileUtils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.state.HostInfo;
 import org.slf4j.Logger;
@@ -350,6 +359,43 @@ public class KsqlResource implements KsqlConfigurable {
       LOG.info("Processed unsuccessfully: " + request + ", reason: ", e);
       return errorHandler.generateResponse(
           e, Errors.serverErrorForStatement(e, request.getMaskedKsql()));
+    }
+  }
+
+  public EndpointResponse runTest(final String test) {
+    try {
+      final List<SqlTest> tests = SqlTestLoader.loadTest(test);
+      return EndpointResponse.ok(runTests(tests));
+    } catch (final Exception e) {
+      return errorHandler.generateResponse(e, Errors.badRequest(e));
+    }
+  }
+
+  private List<KsqlTestResult> runTests(final List<SqlTest> tests) throws IOException {
+    final List<KsqlTestResult> results = new ArrayList<>();
+    for (final SqlTest test : tests) {
+      final Path tempFolder = Files.createTempDirectory("test-temp");
+      final SqlTestExecutor executor = SqlTestExecutor.create(tempFolder);
+
+      try {
+        executor.executeTest(test);
+        results.add(new KsqlTestResult(true, test.getName(), ""));
+      } catch (final Throwable e) {
+        results.add(new KsqlTestResult(false, test.getName(), e.getMessage()));
+      } finally {
+        cleanUp(executor, tempFolder);
+        executor.close();
+      }
+    }
+    return results;
+  }
+
+  private static void cleanUp(final SqlTestExecutor executor, final Path tempFolder) {
+    executor.close();
+    try {
+      FileUtils.deleteDirectory(tempFolder.toFile());
+    } catch (final Exception e) {
+      LOG.warn("Failed to clean up temporary test folder: " + e.getMessage());
     }
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestEndpoints.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestEndpoints.java
@@ -237,6 +237,12 @@ public class TestEndpoints implements Endpoints {
 
   }
 
+  @Override
+  public CompletableFuture<EndpointResponse> executeTest(String test,
+      ApiSecurityContext apiSecurityContext) {
+    return null;
+  }
+
   public synchronized void setRowGeneratorFactory(
       final Supplier<RowGenerator> rowGeneratorFactory) {
     this.rowGeneratorFactory = rowGeneratorFactory;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/InsertsStreamRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/InsertsStreamRunner.java
@@ -267,6 +267,12 @@ public class InsertsStreamRunner extends BasePerfRunner {
         WorkerExecutor workerExecutor, ApiSecurityContext apiSecurityContext, Context context) {
 
     }
+
+    @Override
+    public CompletableFuture<EndpointResponse> executeTest(String test,
+        ApiSecurityContext apiSecurityContext) {
+      return null;
+    }
   }
 
   private class InsertsSubscriber extends BaseSubscriber<JsonObject> implements

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
@@ -233,6 +233,12 @@ public class PullQueryRunner extends BasePerfRunner {
 
     }
 
+    @Override
+    public CompletableFuture<EndpointResponse> executeTest(String test,
+        ApiSecurityContext apiSecurityContext) {
+      return null;
+    }
+
     synchronized void closePublishers() {
       for (PullQueryPublisher publisher : publishers) {
         publisher.close();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/QueryStreamRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/QueryStreamRunner.java
@@ -221,6 +221,12 @@ public class QueryStreamRunner extends BasePerfRunner {
 
     }
 
+    @Override
+    public CompletableFuture<EndpointResponse> executeTest(String test,
+        ApiSecurityContext apiSecurityContext) {
+      return null;
+    }
+
     synchronized void closePublishers() {
       for (QueryStreamPublisher publisher : publishers) {
         publisher.close();

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlTestResult.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlTestResult.java
@@ -68,6 +68,6 @@ public class KsqlTestResult {
 
   @Override
   public String toString() {
-    return String.format("name: %s\nresult: %s\nmessage: %s", name, result, message);
+    return String.format("name: %s%nresult: %s%nmessage: %s", name, result, message);
   }
 }

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlTestResult.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlTestResult.java
@@ -68,6 +68,6 @@ public class KsqlTestResult {
 
   @Override
   public String toString() {
-    return "awoo";
+    return String.format("name: %s\nresult: %s\nmessage: %s", name, result, message);
   }
 }

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlTestResult.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlTestResult.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KsqlTestResult {
+  private final boolean result;
+  private final String name;
+  private final String message;
+
+  public KsqlTestResult(
+      @JsonProperty("result") final boolean result,
+      @JsonProperty("name") final String name,
+      @JsonProperty("message") final String message
+  ) {
+    this.result = result;
+    this.name = name;
+    this.message = message;
+  }
+
+  public boolean getResult() {
+    return result;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof KsqlTestResult)) {
+      return false;
+    }
+    final KsqlTestResult that = (KsqlTestResult) o;
+    return getResult() == that.getResult()
+        && Objects.equals(getName(), that.getName())
+        && Objects.equals(getMessage(), that.getMessage());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getResult(), getName(), getMessage());
+  }
+
+  @Override
+  public String toString() {
+    return "awoo";
+  }
+}

--- a/ksqldb-testing-tool/src/main/java/io/confluent/ksql/tools/test/KsqlTestException.java
+++ b/ksqldb-testing-tool/src/main/java/io/confluent/ksql/tools/test/KsqlTestException.java
@@ -59,7 +59,7 @@ public class KsqlTestException extends KsqlException {
       final String message,
       final Path file
   ) {
-    final Path srcFile = toSourcePath(file);
+    final Path srcFile = file == null ? null: toSourcePath(file);
 
     return stmt.apply(
         parsed -> engineMessage(parsed, message, srcFile),
@@ -81,7 +81,7 @@ public class KsqlTestException extends KsqlException {
         parsedStatement.getMaskedStatementText(),
         loc.map(NodeLocation::toString).orElse("unknown"),
         message,
-        new LocationWithinFile(
+        getFileLocation(
             file,
             loc.map(NodeLocation::getStartLineNumber).orElse(1))
     );
@@ -97,7 +97,7 @@ public class KsqlTestException extends KsqlException {
         SqlFormatter.formatSql(assertStatement),
         assertStatement.getLocation().map(Objects::toString).orElse("unknown"),
         message,
-        new LocationWithinFile(
+        getFileLocation(
             file,
             assertStatement.getLocation().map(NodeLocation::getStartLineNumber).orElse(1))
     );
@@ -109,14 +109,18 @@ public class KsqlTestException extends KsqlException {
       final Path file
   ) {
     return String.format(
-        "Test failure during directive evaluation `%s` (%s):%n\t%s%n\t%s",
+        "Test failure during directive evaluation `%s` (%s):%n\t%s%s",
         directive,
         directive.getLocation(),
         message,
-        new LocationWithinFile(
-            file,
-            directive.getLocation().getStartLineNumber())
+        getFileLocation(file, directive.getLocation().getStartLineNumber())
     );
+  }
+
+  private static String getFileLocation(final Path file, final int startLineNumber) {
+    return file == null
+        ? ""
+        : "%n\t" + new LocationWithinFile(file, startLineNumber).toString();
   }
 
   /**

--- a/ksqldb-testing-tool/src/main/java/io/confluent/ksql/tools/test/KsqlTestException.java
+++ b/ksqldb-testing-tool/src/main/java/io/confluent/ksql/tools/test/KsqlTestException.java
@@ -59,7 +59,7 @@ public class KsqlTestException extends KsqlException {
       final String message,
       final Path file
   ) {
-    final Path srcFile = file == null ? null: toSourcePath(file);
+    final Path srcFile = file == null ? null : toSourcePath(file);
 
     return stmt.apply(
         parsed -> engineMessage(parsed, message, srcFile),

--- a/ksqldb-testing-tool/src/main/java/io/confluent/ksql/tools/test/parser/SqlTestLoader.java
+++ b/ksqldb-testing-tool/src/main/java/io/confluent/ksql/tools/test/parser/SqlTestLoader.java
@@ -79,12 +79,28 @@ public class SqlTestLoader implements TestLoader<SqlTest> {
    * @return the list of tests to run
    */
   public List<SqlTest> loadTest(final Path path) throws IOException {
+    return loadTest(SqlTestReader.of(path), path, shouldRun);
+  }
+
+  /**
+   * @param test a single sql test, containing possibly many tests
+   *
+   * @return the list of tests to run
+   */
+  public static List<SqlTest> loadTest(final String test)  {
+    return loadTest(SqlTestReader.of(test), null, t -> true);
+  }
+
+  private static List<SqlTest> loadTest(
+      final SqlTestReader reader,
+      final Path path,
+      final Predicate<SqlTest> shouldRun
+  ) {
     final ImmutableList.Builder<SqlTest> builder = ImmutableList.builder();
 
     List<TestStatement> statements = null;
     String name = null;
 
-    final SqlTestReader reader = SqlTestReader.of(path);
     while (reader.hasNext()) {
       final TestStatement statement = reader.next();
       final Optional<String> nextName = statement.consumeDirective(
@@ -94,7 +110,7 @@ public class SqlTestLoader implements TestLoader<SqlTest> {
       if (nextName.isPresent()) {
         // flush the previous test
         if (statements != null) {
-          builder.add(new SqlTest(path, name, statements));
+          builder.add(new SqlTest(null, name, statements));
         }
 
         statements = new ArrayList<>();
@@ -106,7 +122,7 @@ public class SqlTestLoader implements TestLoader<SqlTest> {
       statements.add(statement);
     }
 
-    builder.add(new SqlTest(path, name, statements));
+    builder.add(new SqlTest(null, name, statements));
     return builder.build().stream().filter(shouldRun).collect(ImmutableList.toImmutableList());
   }
 

--- a/ksqldb-testing-tool/src/main/java/io/confluent/ksql/tools/test/parser/SqlTestLoader.java
+++ b/ksqldb-testing-tool/src/main/java/io/confluent/ksql/tools/test/parser/SqlTestLoader.java
@@ -110,7 +110,7 @@ public class SqlTestLoader implements TestLoader<SqlTest> {
       if (nextName.isPresent()) {
         // flush the previous test
         if (statements != null) {
-          builder.add(new SqlTest(null, name, statements));
+          builder.add(new SqlTest(path, name, statements));
         }
 
         statements = new ArrayList<>();
@@ -122,7 +122,7 @@ public class SqlTestLoader implements TestLoader<SqlTest> {
       statements.add(statement);
     }
 
-    builder.add(new SqlTest(null, name, statements));
+    builder.add(new SqlTest(path, name, statements));
     return builder.build().stream().filter(shouldRun).collect(ImmutableList.toImmutableList());
   }
 


### PR DESCRIPTION
### Description 
Adds a rest endpoint to run YATT tests. The endpoint is `/test` and the request body would be a string of one or more YATT tests.

Output is a list of objects:

```
[{
  name: <name of test>,
  result: {true if pass, false if fail},
  message: <error message if test failed>
}]
```

### Testing done 
integration test passes

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

