### PR TITLE
fix: null handling in headers

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/BytesUtils.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/BytesUtils.java
@@ -221,35 +221,35 @@ public final class BytesUtils {
   }
 
   private static String hexEncoding(final byte[] value) {
-    return DatatypeConverter.printHexBinary(value);
+    return value == null ? null : DatatypeConverter.printHexBinary(value);
   }
 
   private static byte[] hexDecoding(final String value) {
-    return DatatypeConverter.parseHexBinary(value);
+    return value == null ? null : DatatypeConverter.parseHexBinary(value);
   }
 
   private static String utf8Encoding(final byte[] value) {
-    return new String(value, StandardCharsets.UTF_8);
+    return value == null ? null : new String(value, StandardCharsets.UTF_8);
   }
 
   private static byte[] utf8Decoding(final String value) {
-    return value.getBytes(StandardCharsets.UTF_8);
+    return value == null ? null : value.getBytes(StandardCharsets.UTF_8);
   }
 
   private static String asciiEncoding(final byte[] value) {
-    return new String(value, StandardCharsets.US_ASCII);
+    return value == null ? null : new String(value, StandardCharsets.US_ASCII);
   }
 
   private static byte[] asciiDecoding(final String value) {
-    return value.getBytes(StandardCharsets.US_ASCII);
+    return value == null ? null : value.getBytes(StandardCharsets.US_ASCII);
   }
 
   private static String base64Encoding(final byte[] value) {
     // Use getEncoder() because it does not add \r\n to the base64 string
-    return Base64.getEncoder().encodeToString(value);
+    return value == null ? null : Base64.getEncoder().encodeToString(value);
   }
 
   private static byte[] base64Decoding(final String value) {
-    return Base64.getDecoder().decode(value);
+    return value == null ? null : Base64.getDecoder().decode(value);
   }
 }

--- a/ksqldb-common/src/test/java/io/confluent/ksql/util/BytesUtilTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/util/BytesUtilTest.java
@@ -15,12 +15,14 @@
 
 package io.confluent.ksql.util;
 
+import io.confluent.ksql.util.BytesUtils.Encoding;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 public class BytesUtilTest {
     @Test
@@ -89,5 +91,21 @@ public class BytesUtilTest {
 
         // Then
         assertThat(bytes, is(new byte[]{2, 3}));
+    }
+
+    @Test
+    public void shouldHandleNullEncoding() {
+        assertThat(BytesUtils.encode(null, Encoding.UTF8), nullValue());
+        assertThat(BytesUtils.encode(null, Encoding.BASE64), nullValue());
+        assertThat(BytesUtils.encode(null, Encoding.ASCII), nullValue());
+        assertThat(BytesUtils.encode(null, Encoding.HEX), nullValue());
+    }
+
+    @Test
+    public void shouldHandleNullDecoding() {
+        assertThat(BytesUtils.decode(null, Encoding.UTF8), nullValue());
+        assertThat(BytesUtils.decode(null, Encoding.BASE64), nullValue());
+        assertThat(BytesUtils.decode(null, Encoding.ASCII), nullValue());
+        assertThat(BytesUtils.decode(null, Encoding.HEX), nullValue());
     }
 }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/TestHeader.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/TestHeader.java
@@ -37,7 +37,7 @@ public class TestHeader implements Header {
       @JsonProperty("VALUE") final byte[] value
   ) {
     this.key = requireNonNull(key, "key");
-    this.value = value;
+    this.value = Arrays.copyOf(value, value.length);
   }
 
   @Override

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/TestHeader.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/TestHeader.java
@@ -37,7 +37,7 @@ public class TestHeader implements Header {
       @JsonProperty("VALUE") final byte[] value
   ) {
     this.key = requireNonNull(key, "key");
-    this.value = requireNonNull(value, "value");
+    this.value = value;
   }
 
   @Override
@@ -47,7 +47,7 @@ public class TestHeader implements Header {
 
   @Override
   public byte[] value() {
-    return Arrays.copyOf(value, value.length);
+    return value == null ? null : Arrays.copyOf(value, value.length);
   }
 
   @Override

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/TestHeader.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/TestHeader.java
@@ -37,7 +37,7 @@ public class TestHeader implements Header {
       @JsonProperty("VALUE") final byte[] value
   ) {
     this.key = requireNonNull(key, "key");
-    this.value = Arrays.copyOf(value, value.length);
+    this.value = value == null ? null : Arrays.copyOf(value, value.length);
   }
 
   @Override

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/headers.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/headers.json
@@ -44,12 +44,14 @@
       "inputs": [
         {"topic": "stream-source", "key": "k1", "value": {"v": 40000}, "headers": []},
         {"topic": "stream-source", "key": "k2", "value": {"v": 40000}, "headers": [{"KEY": "abc", "VALUE": "IQ=="}]},
-        {"topic": "stream-source", "key": "k3", "value": {"v": 40000}, "headers": [{"KEY": "abc", "VALUE": "Gg=="}, {"KEY": "abc", "VALUE": "IQ=="}, {"KEY": "def", "VALUE": "Iw=="}]}
+        {"topic": "stream-source", "key": "k3", "value": {"v": 40000}, "headers": [{"KEY": "abc", "VALUE": "Gg=="}, {"KEY": "abc", "VALUE": "IQ=="}, {"KEY": "def", "VALUE": "Iw=="}]},
+        {"topic": "stream-source", "key": "k2", "value": {"v": 40000}, "headers": [{"KEY": "abc", "VALUE": null}]}
       ],
       "outputs": [
         {"topic": "OUTPUT", "key": "k1", "value": {"H1": null, "H2": null}, "headers": []},
         {"topic": "OUTPUT", "key": "k2", "value": {"H1": "IQ==", "H2": null}, "headers": [{"KEY": "abc", "VALUE": "IQ=="}]},
-        {"topic": "OUTPUT", "key": "k3", "value": {"H1": "IQ==", "H2": "Iw=="}, "headers": [{"KEY": "abc", "VALUE": "Gg=="}, {"KEY": "abc", "VALUE": "IQ=="}, {"KEY": "def", "VALUE": "Iw=="}]}
+        {"topic": "OUTPUT", "key": "k3", "value": {"H1": "IQ==", "H2": "Iw=="}, "headers": [{"KEY": "abc", "VALUE": "Gg=="}, {"KEY": "abc", "VALUE": "IQ=="}, {"KEY": "def", "VALUE": "Iw=="}]},
+        {"topic": "OUTPUT", "key": "k2", "value": {"H1": null, "H2": null}, "headers": [{"KEY": "abc", "VALUE": null}]}
       ]
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/headers.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/headers.json
@@ -11,11 +11,13 @@
       ],
       "inputs": [
         {"topic": "stream-source", "key": "k1", "value": {"v": 40000}, "headers": []},
-        {"topic": "stream-source", "key": "k2", "value": {"v": 40000}, "headers": [{"KEY": "abc", "VALUE": "IQ=="}]}
+        {"topic": "stream-source", "key": "k2", "value": {"v": 40000}, "headers": [{"KEY": "abc", "VALUE": "IQ=="}]},
+        {"topic": "stream-source", "key": "k2", "value": {"v": 40000}, "headers": [{"KEY": "abc", "VALUE": null}]}
       ],
       "outputs": [
         {"topic": "OUTPUT", "key": "k1", "value": {"V": 40000, "H": []}, "headers": []},
-        {"topic": "OUTPUT", "key": "k2", "value": {"V": 40000, "H": [{"KEY": "abc", "VALUE": "IQ=="}]}, "headers": [{"KEY": "abc", "VALUE": "IQ=="}]}
+        {"topic": "OUTPUT", "key": "k2", "value": {"V": 40000, "H": [{"KEY": "abc", "VALUE": "IQ=="}]}, "headers": [{"KEY": "abc", "VALUE": "IQ=="}]},
+        {"topic": "OUTPUT", "key": "k2", "value": {"V": 40000, "H": [{"KEY": "abc", "VALUE": null}]}, "headers": [{"KEY": "abc", "VALUE": null}]}
       ]
     },
     {

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilderUtils.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilderUtils.java
@@ -328,7 +328,7 @@ final class SourceBuilderUtils {
 
   static ByteBuffer extractHeader(final Headers headers, final String key) {
     final Header header = headers.lastHeader(key);
-    return header == null
+    return header == null || header.value() == null
         ? null
         : ByteBuffer.wrap(header.value());
   }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilderUtils.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilderUtils.java
@@ -322,7 +322,7 @@ final class SourceBuilderUtils {
             .optional()
             .build())
             .put("KEY", header.key())
-            .put("VALUE", ByteBuffer.wrap(header.value())))
+            .put("VALUE", header.value() == null ? null : ByteBuffer.wrap(header.value())))
         .collect(Collectors.toList());
   }
 


### PR DESCRIPTION
### Description 
Headers with null fields were not being handled, which caused NPEs:

```
./bin/kafka-console-consumer --bootstrap-server localhost:9092 --topic headersbugtopic --from-beginning --property print.headers=true
some_value_header:0,null_header:null	Value123


ksql> create stream headerbugstr(key string key, value string, h1 ARRAY<STRUCT<key STRING, value BYTES>> HEADERS) with (kafka_topic='headersbugtopic',value_format='kafka');

 Message        
----------------
 Stream created 
----------------
ksql> select * from headerbugstr emit changes;
+--------------------------------------------------------------------+--------------------------------------------------------------------+--------------------------------------------------------------------+
|KEY                                                                 |VALUE                                                               |H1                                                                  |
+--------------------------------------------------------------------+--------------------------------------------------------------------+--------------------------------------------------------------------+
org.apache.kafka.streams.errors.StreamsException: Exception caught in process. taskId=0_0, processor=KSTREAM-SOURCE-0000000000, topic=headersbugtopic, partition=0, offset=0, stacktrace=java.lang.NullPointerExcep
tion
```

### Testing done 
Unit tests + QTT

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

