### PR TITLE
fix: fix tag pattern in doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,14 +64,14 @@ drop the `-daemon` switch, and start the CLI in a second console.
 #### Building a released version
 
 The source for standalone ksqlDB versions is tagged with the pattern vN.NN.N. For
-example, the tag for the 0.18.0 standalone release is v0.18.0.
+example, the tag for the 0.28.2 standalone release is v0.28.2.
 
-If you wish to build a released version, run the following commands, replacing `0.18.0`
+If you wish to build a released version, run the following commands, replacing `0.28.2`
 with the desired version:
 
 ```shell
 $ git fetch origin --tags
-$ git checkout v0.18.0
+$ git checkout v0.28.2
 $ ./mvnw --settings maven-settings.xml clean package -DskipTests
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,15 +63,15 @@ drop the `-daemon` switch, and start the CLI in a second console.
 
 #### Building a released version
 
-The source for standalone ksqlDB versions is tagged with the pattern vN.NN.N-ksqldb. For
-example, the tag for the 0.18.0 standalone release is v0.18.0-ksqldb.
+The source for standalone ksqlDB versions is tagged with the pattern vN.NN.N. For
+example, the tag for the 0.18.0 standalone release is v0.18.0.
 
 If you wish to build a released version, run the following commands, replacing `0.18.0`
 with the desired version:
 
 ```shell
 $ git fetch origin --tags
-$ git checkout v0.18.0-ksqldb
+$ git checkout v0.18.0
 $ ./mvnw --settings maven-settings.xml clean package -DskipTests
 ```
 


### PR DESCRIPTION
### Description 
release tag doesn't have `ksqlDB` in it now

### Testing done 
![tip](https://i.imgflip.com/5q1ui3.jpg)

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

