### PR TITLE
fix: Allows table scans to be disabled, even for multi key lookups

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/PullPhysicalPlanBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/PullPhysicalPlanBuilder.java
@@ -210,6 +210,13 @@ public class PullPhysicalPlanBuilder {
     } else if (lookupConstraints.stream().anyMatch(lc -> lc instanceof NonKeyConstraint)) {
       lookupConstraints = Collections.emptyList();
       return PullPhysicalPlanType.TABLE_SCAN;
+      // For issue #7174. Temporarily enable table scans if there are more than one key or if that
+      // key is a multi-column key.
+    } else if ((lookupConstraints.size() > 1 || lookupConstraints.size() == 1 &&
+        ((KeyConstraint) lookupConstraints.get(0)).getKey().size() > 1) &&
+        queryPlannerOptions.getTableScansEnabled()) {
+      lookupConstraints = Collections.emptyList();
+      return PullPhysicalPlanType.TABLE_SCAN;
     } else if (lookupConstraints.stream().allMatch(lc -> ((KeyConstraint) lc).getOperator()
         == ConstraintOperator.EQUAL)) {
       return PullPhysicalPlanType.KEY_LOOKUP;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/execution/pull/PullPhysicalPlanBuilderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/execution/pull/PullPhysicalPlanBuilderTest.java
@@ -1,0 +1,166 @@
+package io.confluent.ksql.execution.pull;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.GenericKey;
+import io.confluent.ksql.analyzer.ImmutableAnalysis;
+import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.streams.materialization.Materialization;
+import io.confluent.ksql.execution.transform.ExpressionEvaluator;
+import io.confluent.ksql.logging.processing.ProcessingLogContext;
+import io.confluent.ksql.logging.processing.ProcessingLogger;
+import io.confluent.ksql.logging.processing.ProcessingLoggerFactory;
+import io.confluent.ksql.planner.LogicalPlanNode;
+import io.confluent.ksql.planner.QueryPlannerOptions;
+import io.confluent.ksql.planner.plan.DataSourceNode;
+import io.confluent.ksql.planner.plan.KeyConstraint;
+import io.confluent.ksql.planner.plan.KeyConstraint.ConstraintOperator;
+import io.confluent.ksql.planner.plan.KsqlBareOutputNode;
+import io.confluent.ksql.planner.plan.QueryFilterNode;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.PersistentQueryMetadata;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PullPhysicalPlanBuilderTest {
+
+  @Mock
+  private ProcessingLogContext processingLogContext;
+  @Mock
+  private PersistentQueryMetadata persistentQueryMetadata;
+  @Mock
+  private ImmutableAnalysis immutableAnalysis;
+  @Mock
+  private QueryPlannerOptions queryPlannerOptions;
+  @Mock
+  private LogicalPlanNode logicalPlanNode;
+  @Mock
+  private KsqlBareOutputNode outputNode;
+  @Mock
+  private DataSourceNode dataSourceNode;
+  @Mock
+  private QueryFilterNode queryFilterNode;
+  @Mock
+  private Materialization materialization;
+  @Mock
+  private ProcessingLoggerFactory processingLoggerFactory;
+  @Mock
+  private ProcessingLogger processingLogger;
+
+  private CompletableFuture<Void> cancel = new CompletableFuture<>();
+
+  private PullPhysicalPlanBuilder builder;
+
+  @Before
+  public void setUp() {
+    when(persistentQueryMetadata.getMaterialization(any(), any()))
+        .thenReturn(Optional.of(materialization));
+    when(processingLogContext.getLoggerFactory()).thenReturn(processingLoggerFactory);
+    when(processingLoggerFactory.getLogger(any())).thenReturn(processingLogger);
+    when(queryPlannerOptions.getTableScansEnabled()).thenReturn(true);
+
+    // Setup query filter node
+    when(queryFilterNode.getRewrittenPredicate()).thenReturn(mock(Expression.class));
+    ExpressionEvaluator evaluator = mock(ExpressionEvaluator.class);
+    when(evaluator.getExpressionType()).thenReturn(SqlTypes.BOOLEAN);
+    when(queryFilterNode.getCompiledWhereClause()).thenReturn(evaluator);
+    LogicalSchema logicalSchema = mock(LogicalSchema.class);
+    when(queryFilterNode.getSchema()).thenReturn(logicalSchema);
+
+    // Chain of sources
+    when(logicalPlanNode.getNode()).thenReturn(Optional.of(outputNode));
+    when(outputNode.getSource()).thenReturn(queryFilterNode);
+    when(queryFilterNode.getSources()).thenReturn(ImmutableList.of(dataSourceNode));
+
+    // Build
+    builder = new PullPhysicalPlanBuilder(
+        processingLogContext, persistentQueryMetadata, immutableAnalysis, queryPlannerOptions,
+        cancel, Optional.empty());
+  }
+
+  @Test
+  public void shouldBuildPlan_singleKeyFilter() {
+    // Given:
+    when(queryFilterNode.getLookupConstraints()).thenReturn(ImmutableList.of(new KeyConstraint(
+        ConstraintOperator.EQUAL, GenericKey.fromList(ImmutableList.of(1)), Optional.empty())));
+
+    // When:
+    PullPhysicalPlan pullPhysicalPlan = builder.buildPullPhysicalPlan(logicalPlanNode);
+
+    // Then:
+    assertThat(pullPhysicalPlan.getKeys().size(), is(1));
+  }
+
+  @Test
+  public void shouldBuildPlan_singleMultiColumnKey() {
+    // Given:
+    when(queryFilterNode.getLookupConstraints()).thenReturn(ImmutableList.of(new KeyConstraint(
+        ConstraintOperator.EQUAL, GenericKey.fromList(ImmutableList.of(1, 2)), Optional.empty())));
+
+    // When:
+    PullPhysicalPlan pullPhysicalPlan = builder.buildPullPhysicalPlan(logicalPlanNode);
+
+    // Then:
+    assertThat(pullPhysicalPlan.getKeys().size(), is(0));
+  }
+
+  @Test
+  public void shouldBuildPlan_multipleKeys() {
+    // Given:
+    when(queryFilterNode.getLookupConstraints()).thenReturn(ImmutableList.of(
+        new KeyConstraint(
+            ConstraintOperator.EQUAL, GenericKey.fromList(ImmutableList.of(1)), Optional.empty()),
+        new KeyConstraint(
+            ConstraintOperator.EQUAL, GenericKey.fromList(ImmutableList.of(2)), Optional.empty())));
+
+    // When:
+    PullPhysicalPlan pullPhysicalPlan = builder.buildPullPhysicalPlan(logicalPlanNode);
+
+    // Then:
+    assertThat(pullPhysicalPlan.getKeys().size(), is(0));
+  }
+
+  @Test
+  public void shouldBuildPlan_singleMultiColumnKey_scansDisabled() {
+    // Given:
+    when(queryFilterNode.getLookupConstraints()).thenReturn(ImmutableList.of(new KeyConstraint(
+        ConstraintOperator.EQUAL, GenericKey.fromList(ImmutableList.of(1, 2)), Optional.empty())));
+    when(queryPlannerOptions.getTableScansEnabled()).thenReturn(false);
+
+    // When:
+    PullPhysicalPlan pullPhysicalPlan = builder.buildPullPhysicalPlan(logicalPlanNode);
+
+    // Then:
+    assertThat(pullPhysicalPlan.getKeys().size(), is(1));
+  }
+
+  @Test
+  public void shouldBuildPlan_multipleKeys_scansDisabled() {
+    // Given:
+    when(queryFilterNode.getLookupConstraints()).thenReturn(ImmutableList.of(
+        new KeyConstraint(
+            ConstraintOperator.EQUAL, GenericKey.fromList(ImmutableList.of(1)), Optional.empty()),
+        new KeyConstraint(
+            ConstraintOperator.EQUAL, GenericKey.fromList(ImmutableList.of(2)), Optional.empty())));
+    when(queryPlannerOptions.getTableScansEnabled()).thenReturn(false);
+
+    // When:
+    PullPhysicalPlan pullPhysicalPlan = builder.buildPullPhysicalPlan(logicalPlanNode);
+
+    // Then:
+    assertThat(pullPhysicalPlan.getKeys().size(), is(2));
+  }
+}

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
@@ -116,10 +116,8 @@ public final class KsLocator implements Locator {
     // Depending on whether this is a key-based lookup, determine which metadata method to use.
     // If we don't have keys, find the metadata for all partitions since we'll run the query for
     // all partitions of the state store rather than a particular one.
-    //For issue #7174. Temporarily turn off metadata finding for a partition with keys
-    //if there are more than one key.
     final List<PartitionMetadata> metadata;
-    if (keys.size() == 1 && keys.get(0).getKey().size() == 1 && !isRangeScan) {
+    if (keys.size() > 0 && !isRangeScan) {
       metadata = getMetadataForKeys(keys, filterPartitions);
     } else {
       metadata = getMetadataForAllPartitions(filterPartitions, keySet);


### PR DESCRIPTION
### Description 
Allows table scans to be disabled, even when there are multiple keys or multi-column keys.  Table scans were introduced to fix a serde bug in https://github.com/confluentinc/ksql/pull/8876/files#diff-ebcd3b261b6ef2904811e7d63a7158f0c4273b0f814c81bbfb8c8fc139a31322R125 .  This worked, but always stopped the key lookup optimization for multiple keys or multi-column keys.  

Now, this PR gives the option to set `ksql.query.pull.table.scan.enabled=false` in a request to still get the optimization, if the serde bug isn't an issue.  Ideally, we would fix the issue so that table scans weren't attempted in this scenario anyway, but that's for a followup PR.

### Testing done 
Added unit tests, ran manually.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

