### PR TITLE
cleanup fix

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/TransientQueryCleanupService.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/TransientQueryCleanupService.java
@@ -112,12 +112,12 @@ public class TransientQueryCleanupService extends AbstractScheduledService {
 
   public void setLocalCommandsQueryAppIds(final Set<String> ids) {
     localCommandsQueryAppIds = ImmutableSet.copyOf(ids);
-    ImmutableSet.Builder<String> builder = ImmutableSet.builder();
+    final ImmutableSet.Builder<String> builder = ImmutableSet.builder();
     for (String id : ids) {
-      Matcher matcher = leakedAppIdPattern.matcher(id);
+      final Matcher matcher = leakedAppIdPattern.matcher(id);
       if (matcher.find()) {
         // Get the query id and prepend it with prefix to get the incorrect topic pattern to match
-        String queryId = matcher.group(1);
+        final String queryId = matcher.group(1);
         builder.add(internalTopicPrefix + queryId);
       }
     }
@@ -226,8 +226,8 @@ public class TransientQueryCleanupService extends AbstractScheduledService {
   }
 
   boolean foundInLocalCommands(final String resourceName) {
-    return localCommandsQueryAppIds.stream().anyMatch(resourceName::contains) ||
-        altLocalCommandsQueryAppIds.stream().anyMatch(resourceName::contains);
+    return localCommandsQueryAppIds.stream().anyMatch(resourceName::contains)
+        || altLocalCommandsQueryAppIds.stream().anyMatch(resourceName::contains);
   }
 
   KafkaTopicClient getTopicClient() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/TransientQueryCleanupService.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/TransientQueryCleanupService.java
@@ -114,11 +114,13 @@ public class TransientQueryCleanupService extends AbstractScheduledService {
     localCommandsQueryAppIds = ImmutableSet.copyOf(ids);
     final ImmutableSet.Builder<String> builder = ImmutableSet.builder();
     for (String id : ids) {
+      LOG.debug("Found local command: {}", id);
       final Matcher matcher = leakedAppIdPattern.matcher(id);
       if (matcher.find()) {
         // Get the query id and prepend it with prefix to get the incorrect topic pattern to match
-        final String queryId = matcher.group(1);
-        builder.add(internalTopicPrefix + queryId);
+        final String queryId = internalTopicPrefix + matcher.group(1);
+        builder.add(queryId);
+        LOG.debug("Alternative query id: {}", queryId);
       }
     }
     altLocalCommandsQueryAppIds = builder.build();


### PR DESCRIPTION
### Description 
There were leaked transient topics not cleaned up due to a bug. The leaked transient topic pattern is `<topic_prefix>_<query_id>_<suffix>`. But the pattern in local commands file is `<topic_prefix>_transient_<query_id>_<timestamp>`. This PR extracts `query_id` from local commands and construct the leaked transient topic pattern with it to match leaked transient topic so that they could be cleaned up.

### Testing done 
unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

