### PR TITLE
fix: remove spurious consistency error message

### DIFF
--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ExecuteQueryResponseHandler.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ExecuteQueryResponseHandler.java
@@ -83,16 +83,6 @@ public class ExecuteQueryResponseHandler extends QueryResponseHandler<BatchedQue
                           + "Increase the limit via ClientOptions#setExecuteQueryMaxResultRows(). "
                           + "Current limit: " + maxRows);
         }
-      } else if (json.getMap() != null) {
-        // This is the serialized consistency vector
-        // Don't add it to the result list since the user should not see it
-        if (json.getMap().containsKey("consistencyToken")) {
-          log.info("Response contains consistency vector " + json);
-          serializedConsistencyVector.set((String) json.getMap().get(
-              "consistencyToken"));
-        } else {
-          throw new RuntimeException("Could not decode JSON, expected consistency token: " + json);
-        }
       } else {
         throw new RuntimeException("Could not decode JSON: " + json);
       }


### PR DESCRIPTION
This was a block we missed when reverting the consistency feature.