### PR TITLE
chore: update org.apache.commons:commons-text to 0.10 to address CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <airlift.version>0.29</airlift.version>
         <airline.version>2.6.0</airline.version>
         <antlr.version>4.9.2</antlr.version>
-        <commons-text.version>1.8</commons-text.version>
+        <commons-text.version>1.10.0</commons-text.version>
         <csv.version>1.4</csv.version>
         <commons.compress.version>1.21</commons.compress.version>
         <lang3.version>3.5</lang3.version>


### PR DESCRIPTION
### Description 
We need to update commons-text to 0.10.0 to address CVE-2022-42889.
Fixes #9651

### Testing done 
No behavioural changes expected. Relying on existing test suite.

### Reviewer checklist
- [x] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

