### PR TITLE
fix: prevent null values in runtimeID cmd records from throwing errors

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
@@ -424,7 +424,7 @@ public class KsqlRestoreCommandTopic {
         final JSONObject queryPlan = plan.getJSONObject("queryPlan");
         queryId = queryPlan.getString("queryId");
         if (hasKey(queryPlan, "runtimeId")
-            && queryPlan.get("runtimeId") != null
+            && !queryPlan.isNull("runtimeId")
             && ((Optional<String>) queryPlan.get("runtimeId")).isPresent()) {
           streamsProperties.put(
               StreamsConfig.APPLICATION_ID_CONFIG,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
@@ -249,7 +249,7 @@ public class KsqlRestoreCommandTopic {
       backupCommands = loadBackup(backupFile, restoreOptions, serverConfig);
     } catch (final Exception e) {
       System.err.printf("Failed loading backup file.%nError = %s%n", e.getMessage());
-      for(final StackTraceElement s: e.getStackTrace()) {
+      for(final StackTraceElement s: e.getStackTrace()){
         System.err.printf("%s\n", s.toString());
       }
       systemExit.exit(1);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
@@ -250,7 +250,7 @@ public class KsqlRestoreCommandTopic {
     } catch (final Exception e) {
       System.err.printf("Failed loading backup file.%nError = %s%n", e.getMessage());
       for (final StackTraceElement s: e.getStackTrace()) {
-        System.err.printf("%s\n", s.toString());
+        System.err.printf("%s%n", s.toString());
       }
       systemExit.exit(1);
     }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
@@ -249,6 +249,9 @@ public class KsqlRestoreCommandTopic {
       backupCommands = loadBackup(backupFile, restoreOptions, serverConfig);
     } catch (final Exception e) {
       System.err.printf("Failed loading backup file.%nError = %s%n", e.getMessage());
+      for(final StackTraceElement s: e.getStackTrace()) {
+        System.err.printf("%s\n", s.toString());
+      }
       systemExit.exit(1);
     }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
@@ -249,7 +249,7 @@ public class KsqlRestoreCommandTopic {
       backupCommands = loadBackup(backupFile, restoreOptions, serverConfig);
     } catch (final Exception e) {
       System.err.printf("Failed loading backup file.%nError = %s%n", e.getMessage());
-      for(final StackTraceElement s: e.getStackTrace()){
+      for (final StackTraceElement s: e.getStackTrace()) {
         System.err.printf("%s\n", s.toString());
       }
       systemExit.exit(1);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
@@ -424,6 +424,7 @@ public class KsqlRestoreCommandTopic {
         final JSONObject queryPlan = plan.getJSONObject("queryPlan");
         queryId = queryPlan.getString("queryId");
         if (hasKey(queryPlan, "runtimeId")
+            && queryPlan.get("runtimeId") != null
             && ((Optional<String>) queryPlan.get("runtimeId")).isPresent()) {
           streamsProperties.put(
               StreamsConfig.APPLICATION_ID_CONFIG,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/RestoreCommandTopicIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/RestoreCommandTopicIntegrationTest.java
@@ -223,6 +223,73 @@ public class RestoreCommandTopicIntegrationTest {
     assertThat("Server should not be in degraded state", isDegradedState(), is(false));
   }
 
+  @Test
+  public void shouldSkipIncompatibleCommandsWithExecutionPlan() throws Exception {
+    // Given
+    TEST_HARNESS.ensureTopics("topic3", "topic4");
+
+    makeKsqlRequest("CREATE STREAM TOPIC3 (ID INT) "
+        + "WITH (KAFKA_TOPIC='topic3', VALUE_FORMAT='JSON');");
+    makeKsqlRequest("CREATE STREAM TOPIC4 (ID INT) "
+        + "WITH (KAFKA_TOPIC='topic4', VALUE_FORMAT='JSON');");
+    makeKsqlRequest("CREATE STREAM stream3 AS SELECT * FROM topic3;");
+
+
+
+    final CommandId commandId = new CommandId("TOPIC", "entity", "CREATE");
+    final String command = "{\"statement\":\"CREATE STREAM \"," 
+        + "\"streamsProperties\":{},"
+        + "\"originalProperties\":{},"
+        + "\"plan\":{"
+        + "\"@type\":\"ksqlPlanV1\","
+        + "\"statementText\":\"CREATE STREAM \","
+        + "\"ddlCommand\":{},"
+        + "\"queryPlan\":{"
+        + "\"sources\":[\"RIDERLOCATIONSFILTERED\"],"
+        + "\"sink\":\"0_29_0_STREAM\","
+        + "\"physicalPlan\":{"
+        + "\"@type\":\"streamSinkV1\","
+        + "\"properties\":{\"queryContext\":\"0_29_0_STREAM\"},"
+        + "\"source\":{"
+        + "\"@type\":\"streamSelectV1\","
+        + "\"properties\":{\"queryContext\":\"Project\"},"
+        + "\"source\":{},"
+        + "\"keyColumnNames\":[],"
+        + "\"selectedKeys\":null,"
+        + "\"selectExpressions\":[\"PROFILEID AS PROFILEID\",\"LATITUDE AS LATITUDE\",\"LONGITUDE AS LONGITUDE\"]},"
+        + "\"formats\":{},"
+        + "\"topicName\":\"0_29_0_STREAM\",\"timestampColumn\":null},"
+        + "\"queryId\":\"CSAS_0_29_0_STREAM_5\","
+        + "\"runtimeId\":null}},"
+        + "\"version\":"
+        + Command.VERSION + 1
+        + "}";
+
+    writeStringToBackupFile(commandId, command, backupFile);
+
+    // Delete the command topic again and restore with skip flag
+    TEST_HARNESS.deleteTopics(Collections.singletonList(commandTopic));
+    REST_APP.stop();
+    KsqlRestoreCommandTopic.mainInternal(
+        new String[]{
+            "--yes",
+            "-s",
+            "--config-file", propertiesFile.toString(),
+            backupFile.toString()
+        },
+        mockSystem
+    );
+
+    // Re-load the command topic
+    REST_APP.start();
+    final List<String> streamsNames = showStreams();
+    assertThat("Should have 3 things", streamsNames.size(), is(3));
+    assertThat("Should have TOPIC3", streamsNames.contains("TOPIC3"), is(true));
+    assertThat("Should have TOPIC4", streamsNames.contains("TOPIC4"), is(true));
+    assertThat("Should have STREAM3", streamsNames.contains("STREAM3"), is(true));
+    assertThat("Server should not be in degraded state", isDegradedState(), is(false));
+  }
+
   @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
   @Test
   public void shouldCleanUpLeftoverStateStores() throws InterruptedException {
@@ -284,6 +351,20 @@ public class RestoreCommandTopicIntegrationTest {
             0L,
             InternalTopicSerdes.serializer().serialize("", commandId),
             InternalTopicSerdes.serializer().serialize("", command))
+        );
+  }
+  private static void writeStringToBackupFile(
+      final CommandId commandId,
+      final String command,
+      final Path backUpFileLocation
+  ) throws IOException {
+    BackupReplayFile.writable(new File(String.valueOf(backUpFileLocation)))
+        .write(new ConsumerRecord<>(
+            "",
+            0,
+            0L,
+            InternalTopicSerdes.serializer().serialize("", commandId),
+            command.getBytes())
         );
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/RestoreCommandTopicIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/RestoreCommandTopicIntegrationTest.java
@@ -364,7 +364,7 @@ public class RestoreCommandTopicIntegrationTest {
             0,
             0L,
             InternalTopicSerdes.serializer().serialize("", commandId),
-            command.getBytes())
+            command.getBytes(StandardCharsets.UTF_8))
         );
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>7.4.0-498</version>
+        <version>7.4.0-499</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>


### PR DESCRIPTION
### Description 
It seems that old records have a null value for runtime ID and the deserializer doesn't interrupt that as an empty optional. Se we add a new check to filter those out.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

