### PR TITLE
fix: use QueryLogger for logging queries

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -53,6 +53,7 @@ import io.confluent.ksql.execution.streams.RoutingOptions;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.internal.PullQueryExecutorMetrics;
 import io.confluent.ksql.internal.ScalablePushQueryMetrics;
+import io.confluent.ksql.logging.query.QueryLogger;
 import io.confluent.ksql.logicalplanner.LogicalPlan;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.MetaStoreImpl;
@@ -220,10 +221,11 @@ final class EngineExecutor {
     // must be executed.
     if (persistentQueryType == KsqlConstants.PersistentQueryType.CREATE_SOURCE
         && !isSourceTableMaterializationEnabled()) {
-      LOG.info(String.format(
-          "Source table query '%s' won't be materialized because '%s' is disabled.",
-          plan.getStatementText(),
-          KsqlConfig.KSQL_SOURCE_TABLE_MATERIALIZATION_ENABLED));
+      final String message = String.format(
+          "Source table query won't be materialized because '%s' is disabled.",
+          KsqlConfig.KSQL_SOURCE_TABLE_MATERIALIZATION_ENABLED
+      );
+      QueryLogger.info(message, plan.getStatementText());
       return ExecuteResult.of(ddlResult.get());
     }
 


### PR DESCRIPTION
### Description 
We should always use the QueryLogger when logging query text, to allow anonymization in sensitive environments.

### Testing done 
Running CIT.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

