### PR TITLE
fix: struct be converted to String for json_sr format

### DIFF
--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/json_sr.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/json_sr.json
@@ -865,6 +865,20 @@
         "type": "io.confluent.ksql.util.KsqlStatementException",
         "message": "JSON only supports MAP types with STRING keys"
       }
+    },
+    {
+      "name": "struct must be converted to String",
+      "statements": [
+        "CREATE STREAM TEST (FOO STRUCT <F0 INT>) WITH (kafka_topic='test_topic', value_format='JSON_SR', partitions=1);",
+        "CREATE STREAM INPUT (FOO VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON_SR');",
+        "CREATE STREAM OUTPUT as select * from INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "value": {"FOO": {"F0": 1}}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"FOO": "Struct{F0=1}"}}
+      ]
     }
   ]
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectDataTranslator.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectDataTranslator.java
@@ -129,7 +129,8 @@ public class ConnectDataTranslator implements DataTranslator {
       Schema.Type.FLOAT32,
       Schema.Type.FLOAT64,
       Schema.Type.BOOLEAN,
-      Schema.Type.STRING
+      Schema.Type.STRING,
+      Schema.Type.STRUCT
   };
 
   private static void validateSchema(
@@ -170,7 +171,7 @@ public class ConnectDataTranslator implements DataTranslator {
     if (connectSchema.name() == null) {
       return connectValue;
     }
-    switch  (connectSchema.name()) {
+    switch (connectSchema.name()) {
       case Date.LOGICAL_NAME:
         return Date.fromLogical(connectSchema, (java.util.Date) connectValue);
       case Time.LOGICAL_NAME:
@@ -231,7 +232,7 @@ public class ConnectDataTranslator implements DataTranslator {
       case STRUCT:
         return toKsqlStruct(schema, connectSchema, (Struct) convertedValue, pathStr);
       case STRING:
-        // use String.valueOf to convert various int types and Boolean to string
+        // use String.valueOf to convert various int types, Struct and Boolean to string
         return String.valueOf(convertedValue);
       case BYTES:
         if (convertedValue instanceof byte[]) {


### PR DESCRIPTION
fixes issue #9580 
### Description 
A topic that has a STRUCT column cannot be deserialized from KSQL if VARCHAR is used in the KSQL schema. This issue is found only on JSON_SR topics. This fix addresses this issue. 

### Testing done 
manual testing
QTT

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

