### PR TITLE
chore: bump vert.x to 3.9.14 and netty to 4.1.84.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <wiremock.version>2.24.0</wiremock.version>
         <clearspring-analytics.version>2.9.5</clearspring-analytics.version>
         <icu.version>67.1</icu.version>
-        <vertx.version>3.9.12</vertx.version>
+        <vertx.version>3.9.14</vertx.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <skip.docker.build>true</skip.docker.build>
         <skip.docker.test>true</skip.docker.test>
@@ -140,8 +140,8 @@
              Please check top level `pom.xml` at https://github.com/netty/netty
              for the netty version we bump to (ie, corresponding git tag),
              to find the correct `tcnative` version. -->
-        <netty.version>4.1.72.Final</netty.version>
-        <netty-codec-http2-version>4.1.72.Final</netty-codec-http2-version>
+        <netty.version>4.1.84.Final</netty.version>
+        <netty-codec-http2-version>4.1.84.Final</netty-codec-http2-version>
         <jersey-common>2.34</jersey-common>
     </properties>
 


### PR DESCRIPTION
### Description 
bump vert.x to 3.9.14 and netty to 4.1.84.Final

output of `mvn dependency:tree -Dincludes=io.netty:netty-codec-http`:
```           
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Detecting the operating system and CPU architecture
[INFO] ------------------------------------------------------------------------
[INFO] os.detected.name: osx
[INFO] os.detected.arch: x86_64
[INFO] os.detected.version: 12.6
[INFO] os.detected.version.major: 12
[INFO] os.detected.version.minor: 6
[INFO] os.detected.classifier: osx-x86_64
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] ksqldb-parent                                                      [pom]
[INFO] ksqldb-test-util                                                   [jar]
[INFO] ksqldb-udf                                                         [jar]
[INFO] ksqldb-common                                                      [jar]
[INFO] ksqlDB UDF / UDAF :: Quickstart                        [maven-archetype]
[INFO] ksqldb-serde                                                       [jar]
[INFO] ksqldb-rest-model                                                  [jar]
[INFO] ksqldb-execution                                                   [jar]
[INFO] ksqldb-metastore                                                   [jar]
[INFO] ksqldb-parser                                                      [jar]
[INFO] ksqldb-streams                                                     [jar]
[INFO] ksqldb-engine                                                      [jar]
[INFO] ksqldb-tools                                                       [jar]
[INFO] ksqldb-rest-client                                                 [jar]
[INFO] ksqldb-version-metrics-client                                      [jar]
[INFO] ksqldb-rest-app                                                    [jar]
[INFO] ksqldb-cli                                                         [jar]
[INFO] ksqldb-examples                                                    [jar]
[INFO] ksqldb-console-scripts                                             [pom]
[INFO] ksqldb-etc                                                         [pom]
[INFO] ksqldb-functional-tests                                            [jar]
[INFO] ksqldb-package                                                     [pom]
[INFO] ksqldb-benchmark                                                   [jar]
[INFO] ksqlDB RocksDB Config Setter                                       [jar]
[INFO] ksqldb-docker                                                      [jar]
[INFO] ksqldb-api-reactive-streams-tck                                    [jar]
[INFO] ksqldb-api-client                                                  [jar]
[INFO] 
[INFO] ------------------< io.confluent.ksql:ksqldb-parent >-------------------
[INFO] Building ksqldb-parent 6.0.11-SNAPSHOT                            [1/27]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-parent ---
[INFO] 
[INFO] -----------------< io.confluent.ksql:ksqldb-test-util >-----------------
[INFO] Building ksqldb-test-util 6.0.11-SNAPSHOT                         [2/27]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-test-util ---
[INFO] 
[INFO] --------------------< io.confluent.ksql:ksqldb-udf >--------------------
[INFO] Building ksqldb-udf 6.0.11-SNAPSHOT                               [3/27]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-udf ---
[INFO] 
[INFO] ------------------< io.confluent.ksql:ksqldb-common >-------------------
[INFO] Building ksqldb-common 6.0.11-SNAPSHOT                            [4/27]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-common ---
[INFO] io.confluent.ksql:ksqldb-common:jar:6.0.11-SNAPSHOT
[INFO] \- io.vertx:vertx-core:jar:3.9.14:compile
[INFO]    \- io.netty:netty-codec-http:jar:4.1.84.Final:compile
[INFO] 
[INFO] --------------< io.confluent.ksql:ksqldb-udf-quickstart >---------------
[INFO] Building ksqlDB UDF / UDAF :: Quickstart 6.0.11-SNAPSHOT          [5/27]
[INFO] --------------------------[ maven-archetype ]---------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-udf-quickstart ---
[INFO] 
[INFO] -------------------< io.confluent.ksql:ksqldb-serde >-------------------
[INFO] Building ksqldb-serde 6.0.11-SNAPSHOT                             [6/27]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-serde ---
[INFO] io.confluent.ksql:ksqldb-serde:jar:6.0.11-SNAPSHOT
[INFO] \- io.confluent.ksql:ksqldb-common:jar:6.0.11-SNAPSHOT:compile
[INFO]    \- io.vertx:vertx-core:jar:3.9.14:compile
[INFO]       \- io.netty:netty-codec-http:jar:4.1.84.Final:compile
[INFO] 
[INFO] ----------------< io.confluent.ksql:ksqldb-rest-model >-----------------
[INFO] Building ksqldb-rest-model 6.0.11-SNAPSHOT                        [7/27]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-rest-model ---
[INFO] io.confluent.ksql:ksqldb-rest-model:jar:6.0.11-SNAPSHOT
[INFO] \- io.confluent.ksql:ksqldb-common:jar:6.0.11-SNAPSHOT:compile
[INFO]    \- io.vertx:vertx-core:jar:3.9.14:compile
[INFO]       \- io.netty:netty-codec-http:jar:4.1.84.Final:compile
[INFO] 
[INFO] -----------------< io.confluent.ksql:ksqldb-execution >-----------------
[INFO] Building ksqldb-execution 6.0.11-SNAPSHOT                         [8/27]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-execution ---
[INFO] io.confluent.ksql:ksqldb-execution:jar:6.0.11-SNAPSHOT
[INFO] \- io.confluent.ksql:ksqldb-common:jar:6.0.11-SNAPSHOT:compile
[INFO]    \- io.vertx:vertx-core:jar:3.9.14:compile
[INFO]       \- io.netty:netty-codec-http:jar:4.1.84.Final:compile
[INFO] 
[INFO] -----------------< io.confluent.ksql:ksqldb-metastore >-----------------
[INFO] Building ksqldb-metastore 6.0.11-SNAPSHOT                         [9/27]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-metastore ---
[INFO] io.confluent.ksql:ksqldb-metastore:jar:6.0.11-SNAPSHOT
[INFO] \- io.confluent.ksql:ksqldb-common:jar:6.0.11-SNAPSHOT:compile
[INFO]    \- io.vertx:vertx-core:jar:3.9.14:compile
[INFO]       \- io.netty:netty-codec-http:jar:4.1.84.Final:compile
[INFO] 
[INFO] ------------------< io.confluent.ksql:ksqldb-parser >-------------------
[INFO] Building ksqldb-parser 6.0.11-SNAPSHOT                           [10/27]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-parser ---
[INFO] io.confluent.ksql:ksqldb-parser:jar:6.0.11-SNAPSHOT
[INFO] \- io.confluent.ksql:ksqldb-common:jar:6.0.11-SNAPSHOT:compile
[INFO]    \- io.vertx:vertx-core:jar:3.9.14:compile
[INFO]       \- io.netty:netty-codec-http:jar:4.1.84.Final:compile
[INFO] 
[INFO] ------------------< io.confluent.ksql:ksqldb-streams >------------------
[INFO] Building ksqldb-streams 6.0.11-SNAPSHOT                          [11/27]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-streams ---
[INFO] io.confluent.ksql:ksqldb-streams:jar:6.0.11-SNAPSHOT
[INFO] \- io.confluent.ksql:ksqldb-common:jar:6.0.11-SNAPSHOT:compile
[INFO]    \- io.vertx:vertx-core:jar:3.9.14:compile
[INFO]       \- io.netty:netty-codec-http:jar:4.1.84.Final:compile
[INFO] 
[INFO] ------------------< io.confluent.ksql:ksqldb-engine >-------------------
[INFO] Building ksqldb-engine 6.0.11-SNAPSHOT                           [12/27]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-engine ---
[INFO] io.confluent.ksql:ksqldb-engine:jar:6.0.11-SNAPSHOT
[INFO] \- io.confluent.ksql:ksqldb-common:jar:6.0.11-SNAPSHOT:compile
[INFO]    \- io.vertx:vertx-core:jar:3.9.14:compile
[INFO]       \- io.netty:netty-codec-http:jar:4.1.84.Final:compile
[INFO] 
[INFO] -------------------< io.confluent.ksql:ksqldb-tools >-------------------
[INFO] Building ksqldb-tools 6.0.11-SNAPSHOT                            [13/27]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-tools ---
[INFO] 
[INFO] ----------------< io.confluent.ksql:ksqldb-rest-client >----------------
[INFO] Building ksqldb-rest-client 6.0.11-SNAPSHOT                      [14/27]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-rest-client ---
[INFO] io.confluent.ksql:ksqldb-rest-client:jar:6.0.11-SNAPSHOT
[INFO] \- io.confluent.ksql:ksqldb-common:jar:6.0.11-SNAPSHOT:compile
[INFO]    \- io.vertx:vertx-core:jar:3.9.14:compile
[INFO]       \- io.netty:netty-codec-http:jar:4.1.84.Final:compile
[INFO] 
[INFO] ----------< io.confluent.ksql:ksqldb-version-metrics-client >-----------
[INFO] Building ksqldb-version-metrics-client 6.0.11-SNAPSHOT           [15/27]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-version-metrics-client ---
[INFO] io.confluent.ksql:ksqldb-version-metrics-client:jar:6.0.11-SNAPSHOT
[INFO] \- io.confluent.ksql:ksqldb-common:jar:6.0.11-SNAPSHOT:compile
[INFO]    \- io.vertx:vertx-core:jar:3.9.14:compile
[INFO]       \- io.netty:netty-codec-http:jar:4.1.84.Final:compile
[INFO] 
[INFO] -----------------< io.confluent.ksql:ksqldb-rest-app >------------------
[INFO] Building ksqldb-rest-app 6.0.11-SNAPSHOT                         [16/27]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-rest-app ---
[INFO] io.confluent.ksql:ksqldb-rest-app:jar:6.0.11-SNAPSHOT
[INFO] \- io.vertx:vertx-core:jar:3.9.14:compile
[INFO]    \- io.netty:netty-codec-http:jar:4.1.84.Final:compile
[INFO] 
[INFO] --------------------< io.confluent.ksql:ksqldb-cli >--------------------
[INFO] Building ksqldb-cli 6.0.11-SNAPSHOT                              [17/27]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-cli ---
[INFO] io.confluent.ksql:ksqldb-cli:jar:6.0.11-SNAPSHOT
[INFO] \- io.confluent.ksql:ksqldb-rest-app:jar:6.0.11-SNAPSHOT:test
[INFO]    \- io.vertx:vertx-core:jar:3.9.14:compile
[INFO]       \- io.netty:netty-codec-http:jar:4.1.84.Final:compile
[INFO] 
[INFO] -----------------< io.confluent.ksql:ksqldb-examples >------------------
[INFO] Building ksqldb-examples 6.0.11-SNAPSHOT                         [18/27]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-examples ---
[INFO] io.confluent.ksql:ksqldb-examples:jar:6.0.11-SNAPSHOT
[INFO] \- io.confluent.ksql:ksqldb-engine:jar:6.0.11-SNAPSHOT:compile
[INFO]    \- io.confluent.ksql:ksqldb-common:jar:6.0.11-SNAPSHOT:compile
[INFO]       \- io.vertx:vertx-core:jar:3.9.14:compile
[INFO]          \- io.netty:netty-codec-http:jar:4.1.84.Final:compile
[INFO] 
[INFO] --------------< io.confluent.ksql:ksqldb-console-scripts >--------------
[INFO] Building ksqldb-console-scripts 6.0.11-SNAPSHOT                  [19/27]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-console-scripts ---
[INFO] 
[INFO] --------------------< io.confluent.ksql:ksqldb-etc >--------------------
[INFO] Building ksqldb-etc 6.0.11-SNAPSHOT                              [20/27]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-etc ---
[INFO] 
[INFO] -------------< io.confluent.ksql:ksqldb-functional-tests >--------------
[INFO] Building ksqldb-functional-tests 6.0.11-SNAPSHOT                 [21/27]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-functional-tests ---
[INFO] io.confluent.ksql:ksqldb-functional-tests:jar:6.0.11-SNAPSHOT
[INFO] \- io.confluent.ksql:ksqldb-common:test-jar:tests:6.0.11-SNAPSHOT:test
[INFO]    \- io.vertx:vertx-core:jar:3.9.14:compile
[INFO]       \- io.netty:netty-codec-http:jar:4.1.84.Final:compile
[INFO] 
[INFO] ------------------< io.confluent.ksql:ksqldb-package >------------------
[INFO] Building ksqldb-package 6.0.11-SNAPSHOT                          [22/27]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-package ---
[INFO] io.confluent.ksql:ksqldb-package:pom:6.0.11-SNAPSHOT
[INFO] \- io.confluent.ksql:ksqldb-common:jar:6.0.11-SNAPSHOT:compile
[INFO]    \- io.vertx:vertx-core:jar:3.9.14:compile
[INFO]       \- io.netty:netty-codec-http:jar:4.1.84.Final:compile
[INFO] 
[INFO] -----------------< io.confluent.ksql:ksqldb-benchmark >-----------------
[INFO] Building ksqldb-benchmark 6.0.11-SNAPSHOT                        [23/27]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-benchmark ---
[INFO] io.confluent.ksql:ksqldb-benchmark:jar:6.0.11-SNAPSHOT
[INFO] \- io.confluent.ksql:ksqldb-serde:jar:6.0.11-SNAPSHOT:compile
[INFO]    \- io.confluent.ksql:ksqldb-common:jar:6.0.11-SNAPSHOT:compile
[INFO]       \- io.vertx:vertx-core:jar:3.9.14:compile
[INFO]          \- io.netty:netty-codec-http:jar:4.1.84.Final:compile
[INFO] 
[INFO] -----------< io.confluent.ksql:ksqldb-rocksdb-config-setter >-----------
[INFO] Building ksqlDB RocksDB Config Setter 6.0.11-SNAPSHOT            [24/27]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-rocksdb-config-setter ---
[INFO] 
[INFO] ------------------< io.confluent.ksql:ksqldb-docker >-------------------
[INFO] Building ksqldb-docker 6.0.11-SNAPSHOT                           [25/27]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-docker ---
[INFO] io.confluent.ksql:ksqldb-docker:jar:6.0.11-SNAPSHOT
[INFO] \- io.confluent.ksql:ksqldb-rest-app:jar:6.0.11-SNAPSHOT:compile
[INFO]    \- io.vertx:vertx-core:jar:3.9.14:compile
[INFO]       \- io.netty:netty-codec-http:jar:4.1.84.Final:compile
[INFO] 
[INFO] ---------< io.confluent.ksql:ksqldb-api-reactive-streams-tck >----------
[INFO] Building ksqldb-api-reactive-streams-tck 6.0.11-SNAPSHOT         [26/27]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-api-reactive-streams-tck ---
[INFO] io.confluent.ksql:ksqldb-api-reactive-streams-tck:jar:6.0.11-SNAPSHOT
[INFO] \- io.confluent.ksql:ksqldb-rest-app:jar:6.0.11-SNAPSHOT:compile
[INFO]    \- io.vertx:vertx-core:jar:3.9.14:compile
[INFO]       \- io.netty:netty-codec-http:jar:4.1.84.Final:compile
[INFO] 
[INFO] ----------------< io.confluent.ksql:ksqldb-api-client >-----------------
[INFO] Building ksqldb-api-client 6.0.11-SNAPSHOT                       [27/27]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-api-client ---
[INFO] io.confluent.ksql:ksqldb-api-client:jar:6.0.11-SNAPSHOT
[INFO] \- io.vertx:vertx-core:jar:3.9.14:compile
[INFO]    \- io.netty:netty-codec-http:jar:4.1.84.Final:compile
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for ksqldb-parent 6.0.11-SNAPSHOT:
[INFO] 
[INFO] ksqldb-parent ...................................... SUCCESS [  0.541 s]
[INFO] ksqldb-test-util ................................... SUCCESS [  0.118 s]
[INFO] ksqldb-udf ......................................... SUCCESS [  0.020 s]
[INFO] ksqldb-common ...................................... SUCCESS [  0.157 s]
[INFO] ksqlDB UDF / UDAF :: Quickstart .................... SUCCESS [  0.190 s]
[INFO] ksqldb-serde ....................................... SUCCESS [  0.141 s]
[INFO] ksqldb-rest-model .................................. SUCCESS [  0.141 s]
[INFO] ksqldb-execution ................................... SUCCESS [  0.066 s]
[INFO] ksqldb-metastore ................................... SUCCESS [  0.062 s]
[INFO] ksqldb-parser ...................................... SUCCESS [  0.067 s]
[INFO] ksqldb-streams ..................................... SUCCESS [  0.047 s]
[INFO] ksqldb-engine ...................................... SUCCESS [  0.133 s]
[INFO] ksqldb-tools ....................................... SUCCESS [  0.011 s]
[INFO] ksqldb-rest-client ................................. SUCCESS [  0.074 s]
[INFO] ksqldb-version-metrics-client ...................... SUCCESS [  0.072 s]
[INFO] ksqldb-rest-app .................................... SUCCESS [  0.114 s]
[INFO] ksqldb-cli ......................................... SUCCESS [  0.064 s]
[INFO] ksqldb-examples .................................... SUCCESS [  0.048 s]
[INFO] ksqldb-console-scripts ............................. SUCCESS [  0.004 s]
[INFO] ksqldb-etc ......................................... SUCCESS [  0.002 s]
[INFO] ksqldb-functional-tests ............................ SUCCESS [  0.064 s]
[INFO] ksqldb-package ..................................... SUCCESS [  0.062 s]
[INFO] ksqldb-benchmark ................................... SUCCESS [  0.071 s]
[INFO] ksqlDB RocksDB Config Setter ....................... SUCCESS [  0.005 s]
[INFO] ksqldb-docker ...................................... SUCCESS [  0.051 s]
[INFO] ksqldb-api-reactive-streams-tck .................... SUCCESS [  0.067 s]
[INFO] ksqldb-api-client .................................. SUCCESS [  0.078 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.980 s
[INFO] Finished at: 2022-11-03T12:02:01-07:00
```

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

