### PR TITLE
feat: Alternative representations for nullable protobuf fields

### DIFF
--- a/docs/developer-guide/ksqldb-reference/create-stream-as-select.md
+++ b/docs/developer-guide/ksqldb-reference/create-stream-as-select.md
@@ -189,6 +189,15 @@ table.
 You can't use the `KEY_FORMAT` property with the `FORMAT` property in the
 same `CREATE STREAM AS SELECT` statement.
 
+### KEY_PROTOBUF_NULLABLE_REPRESENTATION
+
+In the default configuration, primitive fields in protobuf do not distinguish `null` from the
+default values (such as zero, empty string). To enable the use of a protobuf schema that can make
+this distinction, set `KEY_PROTOBUF_NULLABLE_REPRESENTATION` to either `OPTIONAL` or `WRAPPER`.
+The schema will be used to serialize keys for the stream created by this `CREATE` statement.
+For more details, see the corresponding section in the
+[Serialization Formats](/reference/serialization#protobuf) documentation.
+
 ### KEY_SCHEMA_ID
 
 The schema ID of the key schema in {{ site.sr }}.
@@ -296,6 +305,15 @@ table.
 
 You can't use the `VALUE_FORMAT` property with the `FORMAT` property in the
 same `CREATE STREAM AS SELECT` statement.
+
+### VALUE_PROTOBUF_NULLABLE_REPRESENTATION
+
+In the default configuration, primitive fields in protobuf do not distinguish `null` from the
+default values (such as zero, empty string). To enable the use of a protobuf schema that can make
+this distinction, set `VALUE_PROTOBUF_NULLABLE_REPRESENTATION` to either `OPTIONAL` or `WRAPPER`.
+The schema will be used to serialize values for the stream created by this `CREATE` statement.
+For more details, see the corresponding section in the
+[Serialization Formats](/reference/serialization#protobuf) documentation.
 
 ### VALUE_SCHEMA_ID
 

--- a/docs/developer-guide/ksqldb-reference/create-stream.md
+++ b/docs/developer-guide/ksqldb-reference/create-stream.md
@@ -192,6 +192,15 @@ If the default is also not set, the statement is rejected as invalid.
 You can't use the `KEY_FORMAT` property with the `FORMAT` property in the
 same `CREATE STREAM` statement.
 
+### KEY_PROTOBUF_NULLABLE_REPRESENTATION
+
+In the default configuration, primitive fields in protobuf do not distinguish `null` from the
+default values (such as zero, empty string). To enable the use of a protobuf schema that can make
+this distinction, set `KEY_PROTOBUF_NULLABLE_REPRESENTATION` to either `OPTIONAL` or `WRAPPER`.
+The schema will be used to serialize keys for the stream created by this `CREATE` statement.
+For more details, see the corresponding section in the
+[Serialization Formats](/reference/serialization#protobuf) documentation.
+
 ### KEY_SCHEMA_ID
 
 The schema ID of the key schema in {{ site.sr }}.
@@ -273,6 +282,15 @@ If the default is also not set, the statement is rejected as invalid.
 
 You can't use the `VALUE_FORMAT` property with the `FORMAT` property in the
 same CREATE STREAM statement.
+
+### VALUE_PROTOBUF_NULLABLE_REPRESENTATION
+
+In the default configuration, primitive fields in protobuf do not distinguish `null` from the
+default values (such as zero, empty string). To enable the use of a protobuf schema that can make
+this distinction, set `VALUE_PROTOBUF_NULLABLE_REPRESENTATION` to either `OPTIONAL` or `WRAPPER`.
+The schema will be used to serialize values for the stream created by this `CREATE` statement.
+For more details, see the corresponding section in the
+[Serialization Formats](/reference/serialization#protobuf) documentation.
 
 ### VALUE_SCHEMA_ID
 

--- a/docs/developer-guide/ksqldb-reference/create-table-as-select.md
+++ b/docs/developer-guide/ksqldb-reference/create-table-as-select.md
@@ -165,6 +165,15 @@ table.
 You can't use the `KEY_FORMAT` property with the `FORMAT` property in the
 same `CREATE TABLE AS SELECT` statement.
 
+### KEY_PROTOBUF_NULLABLE_REPRESENTATION
+
+In the default configuration, primitive fields in protobuf do not distinguish `null` from the
+default values (such as zero, empty string). To enable the use of a protobuf schema that can make
+this distinction, set `KEY_PROTOBUF_NULLABLE_REPRESENTATION` to either `OPTIONAL` or `WRAPPER`.
+The schema will be used to serialize keys for the table created by this `CREATE` statement.
+For more details, see the corresponding section in the
+[Serialization Formats](/reference/serialization#protobuf) documentation.
+
 ### KEY_SCHEMA_ID
 
 The schema ID of the key schema in {{ site.sr }}.
@@ -284,6 +293,15 @@ If the default is also not set, the statement is rejected as invalid.
 
 You can't use the `VALUE_FORMAT` property with the `FORMAT` property in the
 same `CREATE TABLE AS SELECT` statement.
+
+### VALUE_PROTOBUF_NULLABLE_REPRESENTATION
+
+In the default configuration, primitive fields in protobuf do not distinguish `null` from the
+default values (such as zero, empty string). To enable the use of a protobuf schema that can make
+this distinction, set `VALUE_PROTOBUF_NULLABLE_REPRESENTATION` to either `OPTIONAL` or `WRAPPER`.
+The schema will be used to serialize values for the table created by this `CREATE` statement.
+For more details, see the corresponding section in the
+[Serialization Formats](/reference/serialization#protobuf) documentation.
 
 ### VALUE_SCHEMA_ID
 

--- a/docs/developer-guide/ksqldb-reference/create-table.md
+++ b/docs/developer-guide/ksqldb-reference/create-table.md
@@ -204,6 +204,15 @@ If the default is also not set, the statement is rejected as invalid.
 You can't use the `KEY_FORMAT` property with the `FORMAT` property in the
 same `CREATE TABLE` statement.
 
+### KEY_PROTOBUF_NULLABLE_REPRESENTATION
+
+In the default configuration, primitive fields in protobuf do not distinguish `null` from the
+default values (such as zero, empty string). To enable the use of a protobuf schema that can make
+this distinction, set `KEY_PROTOBUF_NULLABLE_REPRESENTATION` to either `OPTIONAL` or `WRAPPER`.
+The schema will be used to serialize keys for the table created by this `CREATE` statement.
+For more details, see the corresponding section in the
+[Serialization Formats](/reference/serialization#protobuf) documentation.
+
 ### KEY_SCHEMA_ID
 
 The schema ID of the key schema in {{ site.sr }}.
@@ -276,6 +285,15 @@ If the default is also not set, the statement is rejected as invalid.
 
 You can't use the `VALUE_FORMAT` property with the `FORMAT` property in the
 same `CREATE TABLE` statement.
+
+### VALUE_PROTOBUF_NULLABLE_REPRESENTATION
+
+In the default configuration, primitive fields in protobuf do not distinguish `null` from the
+default values (such as zero, empty string). To enable the use of a protobuf schema that can make
+this distinction, set `VALUE_PROTOBUF_NULLABLE_REPRESENTATION` to either `OPTIONAL` or `WRAPPER`.
+The schema will be used to serialize values for the table created by this `CREATE` statement.
+For more details, see the corresponding section in the
+[Serialization Formats](/reference/serialization#protobuf) documentation.
 
 ### VALUE_SCHEMA_ID
 

--- a/docs/reference/serialization.md
+++ b/docs/reference/serialization.md
@@ -506,6 +506,22 @@ have the concept of a `null` value, so the conversion between PROTOBUF and Java
 - **Message field:** the field is not set. Its exact value is language-dependent.
   See the generated code guide for details.
 
+To enable alternative representations for `null` values in protobuf, protobuf-specific properties
+can be passed to `CREATE` statements. For example, the following `CREATE` statement will
+create a protobuf schema that wraps all primitive types into the corresponding standard wrappers 
+(e.g. `google.protobuf.StringValue` for `string`). 
+
+```sql
+CREATE STREAM USERS (ID STRING KEY, i INTEGER, s STRING) WITH (VALUE_FORMAT='PROTOBUF', VALUE_PROTOBUF_NULLABLE_REPRESENTATION='WRAPPER');
+```
+
+This way, `null` can be distinguished from default values. Similarly, when 
+`VALUE_PROTOBUF_NULLABLE_REPRESENTATION` is set to `OPTIONAL`, all fields in protobuf will be
+declared optional, also allowing `null` primitive fields to be distinguished from default values. 
+
+The same property values can be used with the `KEY_PROTOBUF_NULLABLE_REPRESENTATION` property to
+customize the protobuf serialization of the key.
+
 Single field (un)wrapping
 -------------------------
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CommonCreateConfigs.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CommonCreateConfigs.java
@@ -47,6 +47,15 @@ public final class CommonCreateConfigs {
   public static final String KEY_FORMAT_PROPERTY = "KEY_FORMAT";
   public static final String FORMAT_PROPERTY = "FORMAT";
   public static final String WRAP_SINGLE_VALUE = "WRAP_SINGLE_VALUE";
+  public static final String KEY_PROTOBUF_NULLABLE_REPRESENTATION =
+      "KEY_PROTOBUF_NULLABLE_REPRESENTATION";
+  public static final String VALUE_PROTOBUF_NULLABLE_REPRESENTATION =
+      "VALUE_PROTOBUF_NULLABLE_REPRESENTATION";
+
+  public enum ProtobufNullableConfigValues {
+    OPTIONAL,
+    WRAPPER
+  }
 
   public static final String VALUE_DELIMITER_PROPERTY = "VALUE_DELIMITER";
   public static final String KEY_DELIMITER_PROPERTY = "KEY_DELIMITER";
@@ -133,6 +142,32 @@ public final class CommonCreateConfigs {
                 + "only a single field.  If set to true, KSQL expects the field to have been "
                 + "serialized as a named field within a record. If set to false, KSQL expects the "
                 + "field to have been serialized as an anonymous value."
+        )
+        .define(
+            KEY_PROTOBUF_NULLABLE_REPRESENTATION,
+            ConfigDef.Type.STRING,
+            null,
+            ConfigValidators.enumValues(ProtobufNullableConfigValues.class),
+            Importance.LOW,
+            "If supplied, protobuf schema generation will use fields that distinguish "
+                + "null from default values for primitive values. The value `"
+                + ProtobufNullableConfigValues.OPTIONAL.name()
+                + "` will enable using the `optional` on all fields, whereas `"
+                + ProtobufNullableConfigValues.WRAPPER.name()
+                + "` will use wrappers for all primitive value fields, including strings."
+        )
+        .define(
+            VALUE_PROTOBUF_NULLABLE_REPRESENTATION,
+            ConfigDef.Type.STRING,
+            null,
+            ConfigValidators.enumValues(ProtobufNullableConfigValues.class),
+            Importance.LOW,
+            "If supplied, protobuf schema generation will use fields that distinguish "
+                + "null from default values for primitive values. The value `"
+                + ProtobufNullableConfigValues.OPTIONAL.name()
+                + "` will enable using the `optional` on all fields, whereas `"
+                + ProtobufNullableConfigValues.WRAPPER.name()
+                + "` will use wrappers for all primitive value fields, including strings."
         )
         .define(
             VALUE_AVRO_SCHEMA_FULL_NAME,

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/ConnectSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/ConnectSerdeSupplier.java
@@ -63,6 +63,13 @@ public abstract class ConnectSerdeSupplier<T extends ParsedSchema>
 
   protected abstract Schema fromParsedSchema(T schema);
 
+  protected void configureConverter(final Converter c, final boolean isKey) {
+    c.configure(
+        ImmutableMap.of(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "foo"),
+        isKey
+    );
+  }
+
   private final class SpecSerializer implements Serializer<Object> {
 
     private final SchemaRegistryClient srClient;
@@ -72,10 +79,7 @@ public abstract class ConnectSerdeSupplier<T extends ParsedSchema>
     SpecSerializer(final SchemaRegistryClient srClient, final boolean isKey) {
       this.srClient = Objects.requireNonNull(srClient, "srClient");
       this.converter = converterFactory.apply(srClient);
-      converter.configure(
-          ImmutableMap.of(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "foo"),
-          isKey
-      );
+      configureConverter(converter, isKey);
       this.isKey = isKey;
     }
 
@@ -111,10 +115,7 @@ public abstract class ConnectSerdeSupplier<T extends ParsedSchema>
 
     SpecDeserializer(final SchemaRegistryClient srClient, final boolean isKey) {
       this.converter = converterFactory.apply(srClient);
-      converter.configure(
-          ImmutableMap.of(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "foo"),
-          isKey
-      );
+      configureConverter(converter, isKey);
     }
 
     @Override

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/protobuf/ValueSpecProtobufSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/protobuf/ValueSpecProtobufSerdeSupplier.java
@@ -15,8 +15,13 @@
 
 package io.confluent.ksql.test.serde.protobuf;
 
+import static io.confluent.connect.protobuf.ProtobufDataConfig.OPTIONAL_FOR_NULLABLES_CONFIG;
+import static io.confluent.connect.protobuf.ProtobufDataConfig.WRAPPER_FOR_NULLABLES_CONFIG;
+import static io.confluent.connect.protobuf.ProtobufDataConfig.WRAPPER_FOR_RAW_PRIMITIVES_CONFIG;
+
 import com.google.common.collect.ImmutableMap;
 import io.confluent.connect.protobuf.ProtobufConverter;
+import io.confluent.connect.protobuf.ProtobufDataConfig;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
@@ -30,9 +35,15 @@ public class ValueSpecProtobufSerdeSupplier extends ConnectSerdeSupplier<Protobu
 
   private final ProtobufSchemaTranslator schemaTranslator;
 
+  private final ImmutableMap<String, Boolean> converterConfig;
+
   public ValueSpecProtobufSerdeSupplier(final ProtobufProperties protobufProperties) {
     super(ProtobufConverter::new);
     this.schemaTranslator = new ProtobufSchemaTranslator(protobufProperties);
+    this.converterConfig = ImmutableMap.of(
+        OPTIONAL_FOR_NULLABLES_CONFIG, protobufProperties.isNullableAsOptional(),
+        WRAPPER_FOR_NULLABLES_CONFIG, protobufProperties.isNullableAsWrapper()
+    );
   }
 
   @Override
@@ -43,7 +54,7 @@ public class ValueSpecProtobufSerdeSupplier extends ConnectSerdeSupplier<Protobu
   protected void configureConverter(final Converter c, final boolean isKey) {
     c.configure(
         ImmutableMap.<String, Object>builder()
-            .putAll(schemaTranslator.getConfigs())
+            .putAll(converterConfig)
             .put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "foo")
             .build(),
         isKey

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/protobuf/ValueSpecProtobufSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/protobuf/ValueSpecProtobufSerdeSupplier.java
@@ -17,12 +17,9 @@ package io.confluent.ksql.test.serde.protobuf;
 
 import static io.confluent.connect.protobuf.ProtobufDataConfig.OPTIONAL_FOR_NULLABLES_CONFIG;
 import static io.confluent.connect.protobuf.ProtobufDataConfig.WRAPPER_FOR_NULLABLES_CONFIG;
-import static io.confluent.connect.protobuf.ProtobufDataConfig.WRAPPER_FOR_RAW_PRIMITIVES_CONFIG;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.connect.protobuf.ProtobufConverter;
-import io.confluent.connect.protobuf.ProtobufDataConfig;
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.ksql.serde.protobuf.ProtobufProperties;

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/protobuf/ValueSpecProtobufSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/protobuf/ValueSpecProtobufSerdeSupplier.java
@@ -15,12 +15,16 @@
 
 package io.confluent.ksql.test.serde.protobuf;
 
+import com.google.common.collect.ImmutableMap;
 import io.confluent.connect.protobuf.ProtobufConverter;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.ksql.serde.protobuf.ProtobufProperties;
 import io.confluent.ksql.serde.protobuf.ProtobufSchemaTranslator;
 import io.confluent.ksql.test.serde.ConnectSerdeSupplier;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.storage.Converter;
 
 public class ValueSpecProtobufSerdeSupplier extends ConnectSerdeSupplier<ProtobufSchema> {
 
@@ -35,4 +39,15 @@ public class ValueSpecProtobufSerdeSupplier extends ConnectSerdeSupplier<Protobu
   protected Schema fromParsedSchema(final ProtobufSchema schema) {
     return schemaTranslator.toConnectSchema(schema);
   }
+
+  protected void configureConverter(final Converter c, final boolean isKey) {
+    c.configure(
+        ImmutableMap.<String, Object>builder()
+            .putAll(schemaTranslator.getConfigs())
+            .put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "foo")
+            .build(),
+        isKey
+    );
+  }
+
 }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/protobuf/ValueSpecProtobufSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/protobuf/ValueSpecProtobufSerdeSupplier.java
@@ -51,6 +51,7 @@ public class ValueSpecProtobufSerdeSupplier extends ConnectSerdeSupplier<Protobu
     return schemaTranslator.toConnectSchema(schema);
   }
 
+  @Override
   protected void configureConverter(final Converter c, final boolean isKey) {
     c.configure(
         ImmutableMap.<String, Object>builder()

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/protobuf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/protobuf.json
@@ -92,7 +92,27 @@
       "outputs": [
         {"topic": "OUTPUT", "value": {"i": 0, "l": 0, "d": 0.0, "b": false, "s": ""}},
         {"topic": "OUTPUT", "value": {"i": 0, "l": 0, "d": 0.0, "b": false, "s": ""}}
-      ]
+      ],
+      "post": {
+        "topics": {
+          "topics": [
+            {
+              "name": "input",
+              "keyFormat": {"format": "KAFKA"},
+              "partitions": 4,
+              "valueFormat": {"format": "PROTOBUF", "properties": {"unwrapPrimitives": "true"}},
+              "valueSchema": "syntax = \"proto3\";\n\nmessage ConnectDefault1 {\n  int32 I = 1;\n  int64 L = 2;\n  double D = 3;\n  bool B = 4;\n  string S = 5;\n}\n"
+            },
+            {
+              "name": "OUTPUT",
+              "keyFormat": {"format": "KAFKA"},
+              "partitions": 4,
+              "valueFormat": {"format": "PROTOBUF", "properties": {"unwrapPrimitives": "true"}},
+              "valueSchema": "syntax = \"proto3\";\n\nmessage ConnectDefault1 {\n  int32 I = 1;\n  int64 L = 2;\n  double D = 3;\n  bool B = 4;\n  string S = 5;\n}\n"
+            }
+          ]
+        }
+      }
     },
     {
       "name": "protobuf primitives with null and nullable as optional",
@@ -107,7 +127,27 @@
       "outputs": [
         {"topic": "OUTPUT", "value": {"i": null, "l": 0, "d": null, "b": false, "s": null}},
         {"topic": "OUTPUT", "value": {"i": 0, "l": null, "d": 0.0, "b": null, "s": ""}}
-      ]
+      ],
+      "post": {
+        "topics": {
+          "topics": [
+            {
+              "name": "input",
+              "keyFormat": {"format": "KAFKA"},
+              "partitions": 4,
+              "valueFormat": {"format": "PROTOBUF", "properties": {"unwrapPrimitives": "true", "nullableRepresentation": "optional"}},
+              "valueSchema": "syntax = \"proto3\";\n\nmessage ConnectDefault1 {\n  optional int32 I = 1 [deprecated = false];\n  optional int64 L = 2 [deprecated = false];\n  optional double D = 3 [deprecated = false];\n  optional bool B = 4 [deprecated = false];\n  optional string S = 5 [deprecated = false];\n}\n"
+            },
+            {
+              "name": "OUTPUT",
+              "keyFormat": {"format": "KAFKA"},
+              "partitions": 4,
+              "valueFormat": {"format": "PROTOBUF", "properties": {"unwrapPrimitives": "true", "nullableRepresentation": "optional"}},
+              "valueSchema": "syntax = \"proto3\";\n\nmessage ConnectDefault1 {\n  optional int32 I = 1 [deprecated = false];\n  optional int64 L = 2 [deprecated = false];\n  optional double D = 3 [deprecated = false];\n  optional bool B = 4 [deprecated = false];\n  optional string S = 5 [deprecated = false];\n}\n"
+            }
+          ]
+        }
+      }
     },
     {
       "name": "protobuf primitives with null and nullable as wrapper",
@@ -122,7 +162,27 @@
       "outputs": [
         {"topic": "OUTPUT", "value": {"i": null, "l": 0, "d": null, "b": false, "s": null}},
         {"topic": "OUTPUT", "value": {"i": 0, "l": null, "d": 0.0, "b": null, "s": ""}}
-      ]
+      ],
+      "post": {
+        "topics": {
+          "topics": [
+            {
+              "name": "input",
+              "keyFormat": {"format": "KAFKA"},
+              "partitions": 4,
+              "valueFormat": {"format": "PROTOBUF", "properties": {"unwrapPrimitives": "true", "nullableRepresentation": "wrapper"}},
+              "valueSchema": "syntax = \"proto3\";\n\nimport \"google/protobuf/wrappers.proto\";\n\nmessage ConnectDefault1 {\n  google.protobuf.Int32Value I = 1;\n  google.protobuf.Int64Value L = 2;\n  google.protobuf.DoubleValue D = 3;\n  google.protobuf.BoolValue B = 4;\n  google.protobuf.StringValue S = 5;\n}\n"
+            },
+            {
+              "name": "OUTPUT",
+              "keyFormat": {"format": "KAFKA"},
+              "partitions": 4,
+              "valueFormat": {"format": "PROTOBUF", "properties": {"unwrapPrimitives": "true", "nullableRepresentation": "wrapper"}},
+              "valueSchema": "syntax = \"proto3\";\n\nimport \"google/protobuf/wrappers.proto\";\n\nmessage ConnectDefault1 {\n  google.protobuf.Int32Value I = 1;\n  google.protobuf.Int64Value L = 2;\n  google.protobuf.DoubleValue D = 3;\n  google.protobuf.BoolValue B = 4;\n  google.protobuf.StringValue S = 5;\n}\n"
+            }
+          ]
+        }
+      }
     },
     {
       "name": "protobuf containers",

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/protobuf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/protobuf.json
@@ -80,6 +80,51 @@
       "outputs": [{"topic": "OUTPUT", "value": {"I": 1, "L": 1, "D": 1.2, "B": true, "S": "foo"}}]
     },
     {
+      "name": "protobuf primitives with null",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, i INTEGER, l BIGINT, d DOUBLE, b BOOLEAN, s STRING) WITH (kafka_topic='input', value_format='PROTOBUF');",
+        "CREATE STREAM OUTPUT as SELECT * FROM input;"
+      ],
+      "inputs": [
+        {"topic": "input", "value": {"i": null, "l": 0, "d": null, "b": false, "s": null}},
+        {"topic": "input", "value": {"i": 0, "l": null, "d": 0.0, "b": null, "s": ""}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"i": 0, "l": 0, "d": 0.0, "b": false, "s": ""}},
+        {"topic": "OUTPUT", "value": {"i": 0, "l": 0, "d": 0.0, "b": false, "s": ""}}
+      ]
+    },
+    {
+      "name": "protobuf primitives with null and nullable as optional",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, i INTEGER, l BIGINT, d DOUBLE, b BOOLEAN, s STRING) WITH (kafka_topic='input', value_format='PROTOBUF', value_protobuf_nullable_representation='OPTIONAL');",
+        "CREATE STREAM OUTPUT WITH (value_format='PROTOBUF', value_protobuf_nullable_representation='OPTIONAL') as SELECT * FROM input;"
+      ],
+      "inputs": [
+        {"topic": "input", "value": {"i": null, "l": 0, "d": null, "b": false, "s": null}},
+        {"topic": "input", "value": {"i": 0, "l": null, "d": 0.0, "b": null, "s": ""}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"i": null, "l": 0, "d": null, "b": false, "s": null}},
+        {"topic": "OUTPUT", "value": {"i": 0, "l": null, "d": 0.0, "b": null, "s": ""}}
+      ]
+    },
+    {
+      "name": "protobuf primitives with null and nullable as wrapper",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, i INTEGER, l BIGINT, d DOUBLE, b BOOLEAN, s STRING) WITH (kafka_topic='input', value_format='PROTOBUF', value_protobuf_nullable_representation='WRAPPER');",
+        "CREATE STREAM OUTPUT WITH (value_format='PROTOBUF', value_protobuf_nullable_representation='WRAPPER') as SELECT * FROM input;"
+      ],
+      "inputs": [
+        {"topic": "input", "value": {"i": null, "l": 0, "d": null, "b": false, "s": null}},
+        {"topic": "input", "value": {"i": 0, "l": null, "d": 0.0, "b": null, "s": ""}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"i": null, "l": 0, "d": null, "b": false, "s": null}},
+        {"topic": "OUTPUT", "value": {"i": 0, "l": null, "d": 0.0, "b": null, "s": ""}}
+      ]
+    },
+    {
       "name": "protobuf containers",
       "statements": [
         "CREATE STREAM INPUT (astr ARRAY<STRING>, mstr MAP<STRING, STRING>) WITH (kafka_topic='input', value_format='PROTOBUF');",

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceAsProperties.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceAsProperties.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.ColumnReferenceParser;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
+import io.confluent.ksql.properties.with.CommonCreateConfigs.ProtobufNullableConfigValues;
 import io.confluent.ksql.properties.with.CreateAsConfigs;
 import io.confluent.ksql.serde.SerdeFeature;
 import io.confluent.ksql.serde.SerdeFeatures;
@@ -154,6 +155,22 @@ public final class CreateSourceAsProperties {
       builder.put(ProtobufProperties.UNWRAP_PRIMITIVES, ProtobufProperties.UNWRAP);
     }
 
+    final String nullableRep = props.getString(
+        CommonCreateConfigs.KEY_PROTOBUF_NULLABLE_REPRESENTATION);
+    if (ProtobufFormat.NAME.equalsIgnoreCase(keyFormat) && nullableRep != null) {
+      switch (ProtobufNullableConfigValues.valueOf(nullableRep)) {
+        case WRAPPER:
+          builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
+              ProtobufProperties.NULLABLE_AS_WRAPPER);
+          break;
+        case OPTIONAL:
+          builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
+              ProtobufProperties.NULLABLE_AS_OPTIONAL);
+          break;
+        default:
+      }
+    }
+
     final Optional<Integer> keySchemaId = getKeySchemaId();
     keySchemaId.ifPresent(id -> builder.put(ConnectProperties.SCHEMA_ID, String.valueOf(id)));
 
@@ -178,6 +195,22 @@ public final class CreateSourceAsProperties {
 
     if (ProtobufFormat.NAME.equalsIgnoreCase(valueFormat) && unwrapProtobufPrimitives) {
       builder.put(ProtobufProperties.UNWRAP_PRIMITIVES, ProtobufProperties.UNWRAP);
+    }
+
+    final String nullableRep = props.getString(
+        CommonCreateConfigs.VALUE_PROTOBUF_NULLABLE_REPRESENTATION);
+    if (ProtobufFormat.NAME.equalsIgnoreCase(valueFormat) && nullableRep != null) {
+      switch (ProtobufNullableConfigValues.valueOf(nullableRep)) {
+        case WRAPPER:
+          builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
+              ProtobufProperties.NULLABLE_AS_WRAPPER);
+          break;
+        case OPTIONAL:
+          builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
+              ProtobufProperties.NULLABLE_AS_OPTIONAL);
+          break;
+        default:
+      }
     }
 
     final Optional<Integer> valueSchemaId = getValueSchemaId();

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceAsProperties.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceAsProperties.java
@@ -151,25 +151,40 @@ public final class CreateSourceAsProperties {
       builder.put(DelimitedFormat.DELIMITER, delimiter);
     }
 
-    if (ProtobufFormat.NAME.equalsIgnoreCase(keyFormat) && unwrapProtobufPrimitives) {
-      builder.put(ProtobufProperties.UNWRAP_PRIMITIVES, ProtobufProperties.UNWRAP);
-    }
+    if (ProtobufFormat.NAME.equalsIgnoreCase(keyFormat)) {
 
-    final String nullableRep = props.getString(
-        CommonCreateConfigs.KEY_PROTOBUF_NULLABLE_REPRESENTATION);
-    if (ProtobufFormat.NAME.equalsIgnoreCase(keyFormat) && nullableRep != null) {
-      switch (ProtobufNullableConfigValues.valueOf(nullableRep)) {
-        case WRAPPER:
-          builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
-              ProtobufProperties.NULLABLE_AS_WRAPPER);
-          break;
-        case OPTIONAL:
-          builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
-              ProtobufProperties.NULLABLE_AS_OPTIONAL);
-          break;
-        default:
+      if (unwrapProtobufPrimitives) {
+        builder.put(ProtobufProperties.UNWRAP_PRIMITIVES, ProtobufProperties.UNWRAP);
+      }
+
+      final String nullableRep = props.getString(
+          CommonCreateConfigs.KEY_PROTOBUF_NULLABLE_REPRESENTATION);
+      if (nullableRep != null) {
+        switch (ProtobufNullableConfigValues.valueOf(nullableRep)) {
+          case WRAPPER:
+            builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
+                ProtobufProperties.NULLABLE_AS_WRAPPER);
+            break;
+          case OPTIONAL:
+            builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
+                ProtobufProperties.NULLABLE_AS_OPTIONAL);
+            break;
+          default:
+            throw new RuntimeException(String.format(
+                "Unexpected nullable representation %s. This indicates an implementation error.",
+                nullableRep));
+        }
+      }
+
+    } else {
+      // Reject protobuf options for non-protobuf formats
+      if (props.getString(CommonCreateConfigs.KEY_PROTOBUF_NULLABLE_REPRESENTATION) != null) {
+        throw new KsqlException(
+            String.format("Property %s can only be enabled with protobuf format",
+                CommonCreateConfigs.KEY_PROTOBUF_NULLABLE_REPRESENTATION));
       }
     }
+
 
     final Optional<Integer> keySchemaId = getKeySchemaId();
     keySchemaId.ifPresent(id -> builder.put(ConnectProperties.SCHEMA_ID, String.valueOf(id)));
@@ -193,23 +208,37 @@ public final class CreateSourceAsProperties {
       builder.put(DelimitedFormat.DELIMITER, delimiter);
     }
 
-    if (ProtobufFormat.NAME.equalsIgnoreCase(valueFormat) && unwrapProtobufPrimitives) {
-      builder.put(ProtobufProperties.UNWRAP_PRIMITIVES, ProtobufProperties.UNWRAP);
-    }
+    if (ProtobufFormat.NAME.equalsIgnoreCase(valueFormat)) {
 
-    final String nullableRep = props.getString(
-        CommonCreateConfigs.VALUE_PROTOBUF_NULLABLE_REPRESENTATION);
-    if (ProtobufFormat.NAME.equalsIgnoreCase(valueFormat) && nullableRep != null) {
-      switch (ProtobufNullableConfigValues.valueOf(nullableRep)) {
-        case WRAPPER:
-          builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
-              ProtobufProperties.NULLABLE_AS_WRAPPER);
-          break;
-        case OPTIONAL:
-          builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
-              ProtobufProperties.NULLABLE_AS_OPTIONAL);
-          break;
-        default:
+      if (unwrapProtobufPrimitives) {
+        builder.put(ProtobufProperties.UNWRAP_PRIMITIVES, ProtobufProperties.UNWRAP);
+      }
+
+      final String nullableRep = props.getString(
+          CommonCreateConfigs.VALUE_PROTOBUF_NULLABLE_REPRESENTATION);
+      if (nullableRep != null) {
+        switch (ProtobufNullableConfigValues.valueOf(nullableRep)) {
+          case WRAPPER:
+            builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
+                ProtobufProperties.NULLABLE_AS_WRAPPER);
+            break;
+          case OPTIONAL:
+            builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
+                ProtobufProperties.NULLABLE_AS_OPTIONAL);
+            break;
+          default:
+            throw new RuntimeException(String.format(
+                "Unexpected nullable representation %s. This indicates an implementation error.",
+                nullableRep));
+        }
+      }
+
+    } else {
+      // Reject protobuf options for non-protobuf formats
+      if (props.getString(CommonCreateConfigs.VALUE_PROTOBUF_NULLABLE_REPRESENTATION) != null) {
+        throw new KsqlException(
+            String.format("Property %s can only be enabled with protobuf format",
+                CommonCreateConfigs.VALUE_PROTOBUF_NULLABLE_REPRESENTATION));
       }
     }
 

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
@@ -30,6 +30,7 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.ColumnReferenceParser;
 import io.confluent.ksql.parser.DurationParser;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
+import io.confluent.ksql.properties.with.CommonCreateConfigs.ProtobufNullableConfigValues;
 import io.confluent.ksql.properties.with.CreateConfigs;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeFeature;
@@ -194,6 +195,22 @@ public final class CreateSourceProperties {
       builder.put(ProtobufProperties.UNWRAP_PRIMITIVES, ProtobufProperties.UNWRAP);
     }
 
+    final String nullableRep = props.getString(
+        CommonCreateConfigs.KEY_PROTOBUF_NULLABLE_REPRESENTATION);
+    if (ProtobufFormat.NAME.equalsIgnoreCase(keyFormat) && nullableRep != null) {
+      switch (ProtobufNullableConfigValues.valueOf(nullableRep)) {
+        case WRAPPER:
+          builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
+              ProtobufProperties.NULLABLE_AS_WRAPPER);
+          break;
+        case OPTIONAL:
+          builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
+              ProtobufProperties.NULLABLE_AS_OPTIONAL);
+          break;
+        default:
+      }
+    }
+
     final Optional<Integer> keySchemaId = getKeySchemaId();
     keySchemaId.ifPresent(id -> builder.put(ConnectProperties.SCHEMA_ID, String.valueOf(id)));
 
@@ -229,6 +246,22 @@ public final class CreateSourceProperties {
 
     if (ProtobufFormat.NAME.equalsIgnoreCase(valueFormat) && unwrapProtobufPrimitives) {
       builder.put(ProtobufProperties.UNWRAP_PRIMITIVES, ProtobufProperties.UNWRAP);
+    }
+
+    final String nullableRep = props.getString(
+        CommonCreateConfigs.VALUE_PROTOBUF_NULLABLE_REPRESENTATION);
+    if (ProtobufFormat.NAME.equalsIgnoreCase(valueFormat) && nullableRep != null) {
+      switch (ProtobufNullableConfigValues.valueOf(nullableRep)) {
+        case WRAPPER:
+          builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
+              ProtobufProperties.NULLABLE_AS_WRAPPER);
+          break;
+        case OPTIONAL:
+          builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
+              ProtobufProperties.NULLABLE_AS_OPTIONAL);
+          break;
+        default:
+      }
     }
 
     final Optional<Integer> valueSchemaId = getValueSchemaId();

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
@@ -191,23 +191,37 @@ public final class CreateSourceProperties {
       builder.put(DelimitedFormat.DELIMITER, delimiter);
     }
 
-    if (ProtobufFormat.NAME.equalsIgnoreCase(keyFormat) && unwrapProtobufPrimitives) {
-      builder.put(ProtobufProperties.UNWRAP_PRIMITIVES, ProtobufProperties.UNWRAP);
-    }
+    if (ProtobufFormat.NAME.equalsIgnoreCase(keyFormat)) {
 
-    final String nullableRep = props.getString(
-        CommonCreateConfigs.KEY_PROTOBUF_NULLABLE_REPRESENTATION);
-    if (ProtobufFormat.NAME.equalsIgnoreCase(keyFormat) && nullableRep != null) {
-      switch (ProtobufNullableConfigValues.valueOf(nullableRep)) {
-        case WRAPPER:
-          builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
-              ProtobufProperties.NULLABLE_AS_WRAPPER);
-          break;
-        case OPTIONAL:
-          builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
-              ProtobufProperties.NULLABLE_AS_OPTIONAL);
-          break;
-        default:
+      if (unwrapProtobufPrimitives) {
+        builder.put(ProtobufProperties.UNWRAP_PRIMITIVES, ProtobufProperties.UNWRAP);
+      }
+
+      final String nullableRep = props.getString(
+          CommonCreateConfigs.KEY_PROTOBUF_NULLABLE_REPRESENTATION);
+      if (nullableRep != null) {
+        switch (ProtobufNullableConfigValues.valueOf(nullableRep)) {
+          case WRAPPER:
+            builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
+                ProtobufProperties.NULLABLE_AS_WRAPPER);
+            break;
+          case OPTIONAL:
+            builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
+                ProtobufProperties.NULLABLE_AS_OPTIONAL);
+            break;
+          default:
+            throw new RuntimeException(String.format(
+                "Unexpected nullable representation %s. This indicates an implementation error.",
+                nullableRep));
+        }
+      }
+
+    } else {
+      // Reject protobuf options for non-protobuf formats
+      if (props.getString(CommonCreateConfigs.KEY_PROTOBUF_NULLABLE_REPRESENTATION) != null) {
+        throw new KsqlException(
+            String.format("Property %s can only be enabled with protobuf format",
+                CommonCreateConfigs.KEY_PROTOBUF_NULLABLE_REPRESENTATION));
       }
     }
 
@@ -244,23 +258,37 @@ public final class CreateSourceProperties {
       builder.put(DelimitedFormat.DELIMITER, delimiter);
     }
 
-    if (ProtobufFormat.NAME.equalsIgnoreCase(valueFormat) && unwrapProtobufPrimitives) {
-      builder.put(ProtobufProperties.UNWRAP_PRIMITIVES, ProtobufProperties.UNWRAP);
-    }
+    if (ProtobufFormat.NAME.equalsIgnoreCase(valueFormat)) {
 
-    final String nullableRep = props.getString(
-        CommonCreateConfigs.VALUE_PROTOBUF_NULLABLE_REPRESENTATION);
-    if (ProtobufFormat.NAME.equalsIgnoreCase(valueFormat) && nullableRep != null) {
-      switch (ProtobufNullableConfigValues.valueOf(nullableRep)) {
-        case WRAPPER:
-          builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
-              ProtobufProperties.NULLABLE_AS_WRAPPER);
-          break;
-        case OPTIONAL:
-          builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
-              ProtobufProperties.NULLABLE_AS_OPTIONAL);
-          break;
-        default:
+      if (unwrapProtobufPrimitives) {
+        builder.put(ProtobufProperties.UNWRAP_PRIMITIVES, ProtobufProperties.UNWRAP);
+      }
+
+      final String nullableRep = props.getString(
+          CommonCreateConfigs.VALUE_PROTOBUF_NULLABLE_REPRESENTATION);
+      if (nullableRep != null) {
+        switch (ProtobufNullableConfigValues.valueOf(nullableRep)) {
+          case WRAPPER:
+            builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
+                ProtobufProperties.NULLABLE_AS_WRAPPER);
+            break;
+          case OPTIONAL:
+            builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
+                ProtobufProperties.NULLABLE_AS_OPTIONAL);
+            break;
+          default:
+            throw new RuntimeException(String.format(
+                "Unexpected nullable representation %s. This indicates an implementation error.",
+                nullableRep));
+        }
+      }
+
+    } else {
+      // Reject protobuf options for non-protobuf formats
+      if (props.getString(CommonCreateConfigs.VALUE_PROTOBUF_NULLABLE_REPRESENTATION) != null) {
+        throw new KsqlException(
+            String.format("Property %s can only be enabled with protobuf format",
+                CommonCreateConfigs.VALUE_PROTOBUF_NULLABLE_REPRESENTATION));
       }
     }
 

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
@@ -19,11 +19,13 @@ import static com.google.common.collect.ImmutableMap.of;
 import static io.confluent.ksql.parser.properties.with.CreateSourceAsProperties.from;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.FORMAT_PROPERTY;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.KEY_FORMAT_PROPERTY;
+import static io.confluent.ksql.properties.with.CommonCreateConfigs.KEY_PROTOBUF_NULLABLE_REPRESENTATION;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.KEY_SCHEMA_FULL_NAME;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.KEY_SCHEMA_ID;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.TIMESTAMP_FORMAT_PROPERTY;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_AVRO_SCHEMA_FULL_NAME;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_FORMAT_PROPERTY;
+import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_PROTOBUF_NULLABLE_REPRESENTATION;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_SCHEMA_FULL_NAME;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_SCHEMA_ID;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -43,6 +45,7 @@ import io.confluent.ksql.execution.expression.tree.Literal;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
+import io.confluent.ksql.properties.with.CommonCreateConfigs.ProtobufNullableConfigValues;
 import io.confluent.ksql.properties.with.CreateConfigs;
 import io.confluent.ksql.serde.SerdeFeature;
 import io.confluent.ksql.serde.SerdeFeatures;
@@ -476,5 +479,90 @@ public class CreateSourceAsPropertiesTest {
 
     // Then:
     assertThat(e.getMessage(), containsString("Invalid config variable(s) in the WITH clause: SOURCED_BY_CONNECTOR"));
+  }
+
+  @Test
+  public void shouldGetProtobufKeyFormatPropertiesWithNullableAsWrapper() {
+    // Given:
+    final CreateSourceAsProperties props = CreateSourceAsProperties
+        .from(ImmutableMap.of(
+            FORMAT_PROPERTY, new StringLiteral("PROTOBUF"),
+            KEY_PROTOBUF_NULLABLE_REPRESENTATION, new StringLiteral(
+                ProtobufNullableConfigValues.WRAPPER.name())
+        ));
+
+    // When / Then:
+    assertThat(props.getKeyFormatProperties("foo", "PROTOBUF"),
+        hasEntry(ProtobufProperties.NULLABLE_REPRESENTATION,
+            ProtobufProperties.NULLABLE_AS_WRAPPER));
+  }
+
+  @Test
+  public void shouldGetProtobufKeyFormatPropertiesWithNullableAsOptional() {
+    // Given:
+    final CreateSourceAsProperties props = CreateSourceAsProperties
+        .from(ImmutableMap.of(
+            FORMAT_PROPERTY, new StringLiteral("PROTOBUF"),
+            KEY_PROTOBUF_NULLABLE_REPRESENTATION, new StringLiteral(
+                ProtobufNullableConfigValues.OPTIONAL.name())));
+
+    // When / Then:
+    assertThat(props.getKeyFormatProperties("foo", "PROTOBUF"),
+        hasEntry(ProtobufProperties.NULLABLE_REPRESENTATION,
+            ProtobufProperties.NULLABLE_AS_OPTIONAL));
+  }
+
+  @Test
+  public void shouldGetProtobufKeyFormatPropertiesWithoutNullableRepresentation() {
+    // Given:
+    final CreateSourceAsProperties props = CreateSourceAsProperties
+        .from(ImmutableMap.of(FORMAT_PROPERTY, new StringLiteral("PROTOBUF")));
+
+    // When / Then:
+    assertThat(props.getKeyFormatProperties("foo", "PROTOBUF"),
+        not(hasKey(ProtobufProperties.NULLABLE_REPRESENTATION)));
+  }
+
+  @Test
+  public void shouldGetProtobufValueFormatPropertiesWithNullableAsWrapper() {
+    // Given:
+
+    final CreateSourceAsProperties props = CreateSourceAsProperties
+        .from(ImmutableMap.of(
+            FORMAT_PROPERTY, new StringLiteral("PROTOBUF"),
+            VALUE_PROTOBUF_NULLABLE_REPRESENTATION, new StringLiteral(
+                ProtobufNullableConfigValues.WRAPPER.name())));
+
+    // When / Then:
+    assertThat(props.getValueFormatProperties("PROTOBUF"),
+        hasEntry(ProtobufProperties.NULLABLE_REPRESENTATION,
+            ProtobufProperties.NULLABLE_AS_WRAPPER));
+  }
+
+  @Test
+  public void shouldGetProtobufValueFormatPropertiesWithNullableAsOptional() {
+    // Given:
+
+    final CreateSourceAsProperties props = CreateSourceAsProperties
+        .from(ImmutableMap.of(
+            FORMAT_PROPERTY, new StringLiteral("PROTOBUF"),
+            VALUE_PROTOBUF_NULLABLE_REPRESENTATION, new StringLiteral(
+                ProtobufNullableConfigValues.OPTIONAL.name())));
+
+    // When / Then:
+    assertThat(props.getValueFormatProperties("PROTOBUF"),
+        hasEntry(ProtobufProperties.NULLABLE_REPRESENTATION,
+            ProtobufProperties.NULLABLE_AS_OPTIONAL));
+  }
+
+  @Test
+  public void shouldGetProtobufValueFormatPropertiesWithoutNullableRepresentation() {
+    // Given:
+    final CreateSourceAsProperties props = CreateSourceAsProperties
+        .from(ImmutableMap.of(FORMAT_PROPERTY, new StringLiteral("PROTOBUF")));
+
+    // When / Then:
+    assertThat(props.getValueFormatProperties("PROTOBUF"),
+        not(hasKey(ProtobufProperties.NULLABLE_REPRESENTATION)));
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
@@ -30,6 +30,7 @@ import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_SCHEMA
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_SCHEMA_ID;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
@@ -564,5 +565,37 @@ public class CreateSourceAsPropertiesTest {
     // When / Then:
     assertThat(props.getValueFormatProperties("PROTOBUF"),
         not(hasKey(ProtobufProperties.NULLABLE_REPRESENTATION)));
+  }
+
+  @Test
+  public void shouldFailWhenProtobufPropertiesAreUsedOnOtherKeyFormats() {
+    // Given:
+    final CreateSourceAsProperties props = CreateSourceAsProperties
+        .from(ImmutableMap.of(
+            FORMAT_PROPERTY, new StringLiteral("JSON"),
+            KEY_PROTOBUF_NULLABLE_REPRESENTATION, new StringLiteral(
+                ProtobufNullableConfigValues.OPTIONAL.name())));
+
+    // When / Then:
+    final Exception e = assertThrows(KsqlException.class,
+        () -> props.getKeyFormatProperties("", "JSON"));
+    assertThat(e.getMessage(), is(equalTo(
+        "Property KEY_PROTOBUF_NULLABLE_REPRESENTATION can only be enabled with protobuf format")));
+  }
+
+  @Test
+  public void shouldFailWhenProtobufPropertiesAreUsedOnOtherValueFormats() {
+    // Given:
+    final CreateSourceAsProperties props = CreateSourceAsProperties
+        .from(ImmutableMap.of(
+            FORMAT_PROPERTY, new StringLiteral("JSON"),
+            VALUE_PROTOBUF_NULLABLE_REPRESENTATION, new StringLiteral(
+                ProtobufNullableConfigValues.OPTIONAL.name())));
+
+    // When / Then:
+    final Exception e = assertThrows(KsqlException.class,
+        () -> props.getValueFormatProperties("JSON"));
+    assertThat(e.getMessage(), is(equalTo(
+        "Property VALUE_PROTOBUF_NULLABLE_REPRESENTATION can only be enabled with protobuf format")));
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourcePropertiesTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourcePropertiesTest.java
@@ -33,6 +33,7 @@ import static io.confluent.ksql.properties.with.CreateConfigs.WINDOW_SIZE_PROPER
 import static io.confluent.ksql.properties.with.CreateConfigs.WINDOW_TYPE_PROPERTY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
@@ -887,5 +888,35 @@ public class CreateSourcePropertiesTest {
     assertThat(props.getValueFormat().get().getFormat(), is("PROTOBUF"));
     assertThat(props.getValueFormat().get().getProperties(),
         not(hasKey(ProtobufProperties.NULLABLE_REPRESENTATION)));
+  }
+
+  @Test
+  public void shouldFailWhenProtobufPropertiesAreUsedOnOtherKeyFormats() {
+    // Given:
+    final CreateSourceAsProperties props = CreateSourceAsProperties.from(
+        ImmutableMap.of(FORMAT_PROPERTY, new StringLiteral("JSON"),
+            KEY_PROTOBUF_NULLABLE_REPRESENTATION,
+            new StringLiteral(ProtobufNullableConfigValues.OPTIONAL.name())));
+
+    // When / Then:
+    final Exception e = assertThrows(KsqlException.class,
+        () -> props.getKeyFormatProperties("", "JSON"));
+    assertThat(e.getMessage(), is(equalTo(
+        "Property KEY_PROTOBUF_NULLABLE_REPRESENTATION can only be enabled with protobuf format")));
+  }
+
+  @Test
+  public void shouldFailWhenProtobufPropertiesAreUsedOnOtherValueFormats() {
+    // Given:
+    final CreateSourceAsProperties props = CreateSourceAsProperties.from(
+        ImmutableMap.of(FORMAT_PROPERTY, new StringLiteral("JSON"),
+            VALUE_PROTOBUF_NULLABLE_REPRESENTATION,
+            new StringLiteral(ProtobufNullableConfigValues.OPTIONAL.name())));
+
+    // When / Then:
+    final Exception e = assertThrows(KsqlException.class,
+        () -> props.getValueFormatProperties("JSON"));
+    assertThat(e.getMessage(), is(equalTo(
+        "Property VALUE_PROTOBUF_NULLABLE_REPRESENTATION can only be enabled with protobuf format")));
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourcePropertiesTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourcePropertiesTest.java
@@ -20,11 +20,13 @@ import static io.confluent.ksql.parser.properties.with.CreateSourceAsProperties.
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.FORMAT_PROPERTY;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.KAFKA_TOPIC_NAME_PROPERTY;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.KEY_FORMAT_PROPERTY;
+import static io.confluent.ksql.properties.with.CommonCreateConfigs.KEY_PROTOBUF_NULLABLE_REPRESENTATION;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.KEY_SCHEMA_FULL_NAME;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.KEY_SCHEMA_ID;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.TIMESTAMP_FORMAT_PROPERTY;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_AVRO_SCHEMA_FULL_NAME;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_FORMAT_PROPERTY;
+import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_PROTOBUF_NULLABLE_REPRESENTATION;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_SCHEMA_FULL_NAME;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_SCHEMA_ID;
 import static io.confluent.ksql.properties.with.CreateConfigs.WINDOW_SIZE_PROPERTY;
@@ -49,6 +51,7 @@ import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
+import io.confluent.ksql.properties.with.CommonCreateConfigs.ProtobufNullableConfigValues;
 import io.confluent.ksql.properties.with.CreateConfigs;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeFeature;
@@ -779,5 +782,110 @@ public class CreateSourcePropertiesTest {
     assertThat(props.getValueFormat().get().getFormat(), is("PROTOBUF"));
     assertThat(props.getValueFormat().get().getProperties(),
         not(hasKey(ProtobufProperties.UNWRAP_PRIMITIVES)));
+  }
+
+  @Test
+  public void shouldGetProtobufKeyFormatPropertiesWithNullableAsWrapper() {
+    // Given:
+    final CreateSourceProperties props = CreateSourceProperties
+        .from(ImmutableMap.<String, Literal>builder()
+            .putAll(MINIMUM_VALID_PROPS)
+            .put(FORMAT_PROPERTY, new StringLiteral("PROTOBUF"))
+            .put(KEY_PROTOBUF_NULLABLE_REPRESENTATION, new StringLiteral(
+                ProtobufNullableConfigValues.WRAPPER.name()))
+            .build());
+
+    // When / Then:
+    assertThat(props.getKeyFormat(SourceName.of("foo")).get().getFormat(), is("PROTOBUF"));
+    assertThat(props.getKeyFormat(
+            SourceName.of("foo")).get().getProperties(),
+        hasEntry(ProtobufProperties.NULLABLE_REPRESENTATION,
+            ProtobufProperties.NULLABLE_AS_WRAPPER));
+  }
+
+  @Test
+  public void shouldGetProtobufKeyFormatPropertiesWithNullableAsOptional() {
+    // Given:
+    final CreateSourceProperties props = CreateSourceProperties
+        .from(ImmutableMap.<String, Literal>builder()
+            .putAll(MINIMUM_VALID_PROPS)
+            .put(FORMAT_PROPERTY, new StringLiteral("PROTOBUF"))
+            .put(KEY_PROTOBUF_NULLABLE_REPRESENTATION, new StringLiteral(
+                ProtobufNullableConfigValues.OPTIONAL.name()))
+            .build());
+
+    // When / Then:
+    assertThat(props.getKeyFormat(SourceName.of("foo")).get().getFormat(), is("PROTOBUF"));
+    assertThat(props.getKeyFormat(
+            SourceName.of("foo")).get().getProperties(),
+        hasEntry(ProtobufProperties.NULLABLE_REPRESENTATION,
+            ProtobufProperties.NULLABLE_AS_OPTIONAL));
+  }
+
+  @Test
+  public void shouldGetProtobufKeyFormatPropertiesWithoutNullableRepresentation() {
+    // Given:
+    final CreateSourceProperties props = CreateSourceProperties
+        .from(ImmutableMap.<String, Literal>builder()
+            .putAll(MINIMUM_VALID_PROPS)
+            .put(FORMAT_PROPERTY, new StringLiteral("PROTOBUF"))
+            .build());
+
+    // When / Then:
+    assertThat(props.getKeyFormat(SourceName.of("foo")).get().getFormat(), is("PROTOBUF"));
+    assertThat(props.getKeyFormat(
+            SourceName.of("foo")).get().getProperties(),
+        not(hasKey(ProtobufProperties.NULLABLE_REPRESENTATION)));
+  }
+
+  @Test
+  public void shouldGetProtobufValueFormatPropertiesWithNullableAsWrapper() {
+    // Given:
+    final CreateSourceProperties props = CreateSourceProperties
+        .from(ImmutableMap.<String, Literal>builder()
+            .putAll(MINIMUM_VALID_PROPS)
+            .put(FORMAT_PROPERTY, new StringLiteral("PROTOBUF"))
+            .put(VALUE_PROTOBUF_NULLABLE_REPRESENTATION, new StringLiteral(
+                ProtobufNullableConfigValues.WRAPPER.name()))
+            .build());
+
+    // When / Then:
+    assertThat(props.getValueFormat().get().getFormat(), is("PROTOBUF"));
+    assertThat(props.getValueFormat().get().getProperties(),
+        hasEntry(ProtobufProperties.NULLABLE_REPRESENTATION,
+            ProtobufProperties.NULLABLE_AS_WRAPPER));
+  }
+
+  @Test
+  public void shouldGetProtobufValueFormatPropertiesWithNullableAsOptional() {
+    // Given:
+    final CreateSourceProperties props = CreateSourceProperties
+        .from(ImmutableMap.<String, Literal>builder()
+            .putAll(MINIMUM_VALID_PROPS)
+            .put(FORMAT_PROPERTY, new StringLiteral("PROTOBUF"))
+            .put(VALUE_PROTOBUF_NULLABLE_REPRESENTATION, new StringLiteral(
+                ProtobufNullableConfigValues.OPTIONAL.name()))
+            .build());
+
+    // When / Then:
+    assertThat(props.getValueFormat().get().getFormat(), is("PROTOBUF"));
+    assertThat(props.getValueFormat().get().getProperties(),
+        hasEntry(ProtobufProperties.NULLABLE_REPRESENTATION,
+            ProtobufProperties.NULLABLE_AS_OPTIONAL));
+  }
+
+  @Test
+  public void shouldGetProtobufValueFormatPropertiesWithoutNullableRepresentation() {
+    // Given:
+    final CreateSourceProperties props = CreateSourceProperties
+        .from(ImmutableMap.<String, Literal>builder()
+            .putAll(MINIMUM_VALID_PROPS)
+            .put(FORMAT_PROPERTY, new StringLiteral("PROTOBUF"))
+            .build());
+
+    // When / Then:
+    assertThat(props.getValueFormat().get().getFormat(), is("PROTOBUF"));
+    assertThat(props.getValueFormat().get().getProperties(),
+        not(hasKey(ProtobufProperties.NULLABLE_REPRESENTATION)));
   }
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufProperties.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufProperties.java
@@ -27,10 +27,15 @@ public class ProtobufProperties extends ConnectProperties {
   public static final String UNWRAP = "true";
   private static final String WRAP = "false";
 
+  public static final String NULLABLE_REPRESENTATION = "nullableRepresentation";
+  public static final String NULLABLE_AS_OPTIONAL = "optional";
+  public static final String NULLABLE_AS_WRAPPER = "wrapper";
+
   static final ImmutableSet<String> SUPPORTED_PROPERTIES = ImmutableSet.of(
       FULL_SCHEMA_NAME,
       SCHEMA_ID,
       UNWRAP_PRIMITIVES,
+      NULLABLE_REPRESENTATION,
       SUBJECT_NAME
   );
 
@@ -56,6 +61,18 @@ public class ProtobufProperties extends ConnectProperties {
 
   public boolean getUnwrapPrimitives() {
     return UNWRAP.equalsIgnoreCase(properties.getOrDefault(UNWRAP_PRIMITIVES, WRAP));
+  }
+
+  public boolean isNullableAsOptional() {
+    return NULLABLE_AS_OPTIONAL.equals(getNullableRepresentation());
+  }
+
+  public boolean isNullableAsWrapper() {
+    return NULLABLE_AS_WRAPPER.equals(getNullableRepresentation());
+  }
+
+  private String getNullableRepresentation() {
+    return properties.getOrDefault(NULLABLE_REPRESENTATION, null);
   }
 
   public ProtobufProperties withFullSchemaName(final String name) {

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSchemaTranslator.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSchemaTranslator.java
@@ -110,10 +110,6 @@ public class ProtobufSchemaTranslator implements ConnectSchemaTranslator {
         .fromConnectSchema(injectSchemaFullName(schema));
   }
 
-  public Map<String, Object> getConfigs() {
-    return this.updatedConfigs;
-  }
-
   private ProtobufSchema withSchemaFullName(final ProtobufSchema origSchema) {
     return fullNameSchema.map(origSchema::copy).orElse(origSchema);
   }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSchemaTranslator.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSchemaTranslator.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.serde.protobuf;
 
+import static io.confluent.connect.protobuf.ProtobufDataConfig.OPTIONAL_FOR_NULLABLES_CONFIG;
+import static io.confluent.connect.protobuf.ProtobufDataConfig.WRAPPER_FOR_NULLABLES_CONFIG;
 import static io.confluent.connect.protobuf.ProtobufDataConfig.WRAPPER_FOR_RAW_PRIMITIVES_CONFIG;
 
 import com.google.common.base.Strings;
@@ -47,6 +49,8 @@ public class ProtobufSchemaTranslator implements ConnectSchemaTranslator {
 
     this.baseConfigs = ImmutableMap.of(
         WRAPPER_FOR_RAW_PRIMITIVES_CONFIG, properties.getUnwrapPrimitives(),
+        OPTIONAL_FOR_NULLABLES_CONFIG, properties.isNullableAsOptional(),
+        WRAPPER_FOR_NULLABLES_CONFIG, properties.isNullableAsWrapper(),
 
         // This flag is needed so that the schema translation in toConnectRow() adds the
         // package name information to the row schema
@@ -104,6 +108,10 @@ public class ProtobufSchemaTranslator implements ConnectSchemaTranslator {
     // default naming.
     return new ProtobufData(new ProtobufDataConfig(updatedConfigs))
         .fromConnectSchema(injectSchemaFullName(schema));
+  }
+
+  public Map<String, Object> getConfigs() {
+    return this.updatedConfigs;
   }
 
   private ProtobufSchema withSchemaFullName(final ProtobufSchema origSchema) {

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSerdeFactory.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSerdeFactory.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
+import org.apache.commons.collections.map.UnmodifiableMap;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
@@ -247,10 +248,11 @@ final class ProtobufSerdeFactory implements SerdeFactory {
       protobufConfig.put(AbstractKafkaSchemaSerDeConfig.ID_COMPATIBILITY_STRICT, false);
     }
 
-    protobufConfig.put(
-        ProtobufDataConfig.WRAPPER_FOR_RAW_PRIMITIVES_CONFIG,
-        properties.getUnwrapPrimitives()
-    );
+    protobufConfig.putAll(ImmutableMap.of(
+        ProtobufDataConfig.WRAPPER_FOR_RAW_PRIMITIVES_CONFIG, properties.getUnwrapPrimitives(),
+        ProtobufDataConfig.OPTIONAL_FOR_NULLABLES_CONFIG, properties.isNullableAsOptional(),
+        ProtobufDataConfig.WRAPPER_FOR_NULLABLES_CONFIG, properties.isNullableAsWrapper()
+    ));
 
     final ProtobufConverter converter = new ProtobufConverter(schemaRegistryClient);
     converter.configure(protobufConfig, isKey);

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSerdeFactory.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSerdeFactory.java
@@ -38,7 +38,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
-import org.apache.commons.collections.map.UnmodifiableMap;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/ProtobufPropertiesTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/ProtobufPropertiesTest.java
@@ -80,6 +80,40 @@ public class ProtobufPropertiesTest {
   }
 
   @Test
+  public void shouldGetDefaultNullableRepresentation() {
+    // Given:
+    final ProtobufProperties properties = new ProtobufProperties(ImmutableMap.of());
+
+    // When/Then:
+    assertThat(properties.isNullableAsWrapper(), is(false));
+    assertThat(properties.isNullableAsOptional(), is(false));
+  }
+
+  @Test
+  public void shouldGetNullableAsOptional() {
+    // Given:
+    final ProtobufProperties properties = new ProtobufProperties(ImmutableMap.of(
+        ProtobufProperties.NULLABLE_REPRESENTATION, ProtobufProperties.NULLABLE_AS_OPTIONAL
+    ));
+
+    // When/Then:
+    assertThat(properties.isNullableAsWrapper(), is(false));
+    assertThat(properties.isNullableAsOptional(), is(true));
+  }
+
+  @Test
+  public void shouldGetNullableAsWrapper() {
+    // Given:
+    final ProtobufProperties properties = new ProtobufProperties(ImmutableMap.of(
+        ProtobufProperties.NULLABLE_REPRESENTATION, ProtobufProperties.NULLABLE_AS_WRAPPER
+    ));
+
+    // When/Then:
+    assertThat(properties.isNullableAsWrapper(), is(true));
+    assertThat(properties.isNullableAsOptional(), is(false));
+  }
+
+  @Test
   public void shouldThrowWithUnsupportedProperty() {
     // When:
     final Exception e = assertThrows(KsqlException.class,

--- a/ksqldb-testing-tool/src/main/java/io/confluent/ksql/tools/test/driver/AssertExecutor.java
+++ b/ksqldb-testing-tool/src/main/java/io/confluent/ksql/tools/test/driver/AssertExecutor.java
@@ -90,7 +90,8 @@ public final class AssertExecutor {
           ),
           "key format properties",
           CommonCreateConfigs.KEY_DELIMITER_PROPERTY,
-          CommonCreateConfigs.KEY_SCHEMA_FULL_NAME
+          CommonCreateConfigs.KEY_SCHEMA_FULL_NAME,
+          CommonCreateConfigs.KEY_PROTOBUF_NULLABLE_REPRESENTATION
       )).add(new SourceProperty(
           ds -> ds.getKsqlTopic().getValueFormat().getFormatInfo().getFormat(),
           (cs, cfg) -> cs.getProperties().getValueFormat().map(FormatInfo::getFormat)
@@ -107,7 +108,8 @@ public final class AssertExecutor {
           "value format properties",
           CommonCreateConfigs.VALUE_AVRO_SCHEMA_FULL_NAME,
           CommonCreateConfigs.VALUE_SCHEMA_FULL_NAME,
-          CommonCreateConfigs.VALUE_DELIMITER_PROPERTY
+          CommonCreateConfigs.VALUE_DELIMITER_PROPERTY,
+          CommonCreateConfigs.VALUE_PROTOBUF_NULLABLE_REPRESENTATION
       )).add(new SourceProperty(
           ds -> ds.getKsqlTopic().getValueFormat().getFormatInfo().getProperties()
               .get(CommonCreateConfigs.VALUE_SCHEMA_ID),


### PR DESCRIPTION
### Description 

The protobuf support in schema registry by default represents an optional field (corresponding in KSQL to a nullable SQL column) by a singular protobuf field. For primitive types, singular protobuf fields cannot distinguish default values (such as `0` for `int32` and `""` for `string`) from `null`.

This change introduces two properties for the KSQL `CREATE` statements that can enable two alternative representations of nullable fields. The properties are named `KEY_PROTOBUF_NULLABLE_REPRESENTATION`and `VALUE_PROTOBUF_NULLABLE_REPRESENTATION` which control the nullable behavior for keys and value serialization, respectively. Both new properties can take the values `OPTIONAL`, to use protobuf's `optional` keyword, or `WRAPPER`, to use nullable protobuf wrappers (e.g. using `google.protobuf.StringValue` for strings). Setting the properties will allow KSQL and downstream consumers to clearly distinguish between default values and `null`. Leaving the properties undefined will let KSQL use singular protobuf fields - the current default behavior.

Fixes #9333.

### Testing done 

New unit tests are added to cover that the properties are propagated from the `CREATE` statement to the `Serde` implementation. We use query translation tests to test end-to-end test cases.

### Reviewer checklist

- [x] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

