### PR TITLE
chore: Use QueryLogger any time we log a query (#9681)

### DIFF
--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/Cli.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/Cli.java
@@ -271,7 +271,7 @@ public class Cli implements KsqlRequestExecutor, Closeable {
       LOGGER.error("An error occurred while running a script file. Error = "
           + exception.getMessage(), exception);
 
-      terminal.printError(ErrorMessageUtil.buildErrorMessage(exception),
+      terminal.printError(ErrorMessageUtil.buildErrorMessageWithStatements(exception),
           exception.toString());
     }
 
@@ -296,7 +296,7 @@ public class Cli implements KsqlRequestExecutor, Closeable {
       LOGGER.error("An error occurred while running a command. Error = "
           + exception.getMessage(), exception);
 
-      terminal.printError(ErrorMessageUtil.buildErrorMessage(exception),
+      terminal.printError(ErrorMessageUtil.buildErrorMessageWithStatements(exception),
           exception.toString());
     }
 
@@ -319,7 +319,7 @@ public class Cli implements KsqlRequestExecutor, Closeable {
       } catch (final Exception exception) {
         LOGGER.error("An error occurred while running a command. Error = "
             + exception.getMessage(), exception);
-        terminal.printError(ErrorMessageUtil.buildErrorMessage(exception),
+        terminal.printError(ErrorMessageUtil.buildErrorMessageWithStatements(exception),
             exception.toString());
       }
       terminal.flush();

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -342,7 +342,7 @@ public class Console implements Closeable {
     if (errorMessage instanceof KsqlStatementErrorMessage) {
       printKsqlEntityList(((KsqlStatementErrorMessage) errorMessage).getEntities());
     }
-    printError(errorMessage.getMessage(), errorMessage.toString());
+    printError(errorMessage.toString(), errorMessage.toString());
   }
 
   public void printError(final String shortMsg, final String fullMsg) {

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/JLineReader.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/JLineReader.java
@@ -79,8 +79,9 @@ public class JLineReader implements io.confluent.ksql.cli.console.LineReader {
       history.save();
     } catch (final IOException e) {
       LOGGER.error("Error saving history file", e);
-      terminal.writer()
-          .println("Error saving history file:" + ErrorMessageUtil.buildErrorMessage(e));
+      terminal.writer().println(
+          "Error saving history file:" + ErrorMessageUtil.buildErrorMessageWithStatements(e)
+      );
     }
   }
 

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/cmd/RemoteServerSpecificCommand.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/cmd/RemoteServerSpecificCommand.java
@@ -126,7 +126,7 @@ public final class RemoteServerSpecificCommand implements CliSpecificCommand {
 
       writer.println("");
       writer.println("The server responded with the following error: ");
-      writer.println(ErrorMessageUtil.buildErrorMessage(exception));
+      writer.println(ErrorMessageUtil.buildErrorMessageWithStatements(exception));
       writer.println(StringUtils.repeat('*', CONSOLE_WIDTH));
       writer.println();
     } finally {

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -69,6 +69,7 @@ import io.confluent.ksql.rest.entity.CommandStatusEntity;
 import io.confluent.ksql.rest.entity.ConnectorList;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
+import io.confluent.ksql.rest.entity.KsqlStatementErrorMessage;
 import io.confluent.ksql.rest.entity.ServerInfo;
 import io.confluent.ksql.rest.entity.StreamedRow.DataRow;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
@@ -1167,6 +1168,33 @@ public class CliTest {
     // Then:
     assertThat(terminal.getOutputString(),
         containsString("Created query with ID CSAS_SHOULDRUNCOMMAND"));
+  }
+
+  @Test
+  public void shouldPrintStatementInError() throws Exception {
+    // Given:
+    final KsqlRestClient mockRestClient = givenMockRestClient();
+    when(mockRestClient.makeKsqlRequest(anyString(), anyLong()))
+        .thenReturn(RestResponse.erroneous(
+            NOT_ACCEPTABLE.code(),
+            new KsqlStatementErrorMessage(
+                Errors.toErrorCode(NOT_ACCEPTABLE.code()),
+                "error message",
+                "this is a statement",
+                new KsqlEntityList()
+            )
+        ));
+
+    final StringBuilder builder = new StringBuilder();
+    builder.append("CREATE STREAM shouldRunCommand AS SELECT * FROM Asdf;");
+
+    // When:
+    localCli.runCommand(builder.toString());
+
+    // Then:
+    final String outputString = terminal.getOutputString();
+    assertThat(outputString, containsString("error message"));
+    assertThat(outputString, containsString("this is a statement"));
   }
 
   @Test

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/ErrorMessageUtil.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/ErrorMessageUtil.java
@@ -55,6 +55,32 @@ public final class ErrorMessageUtil {
   }
 
   /**
+   * Build an error message containing the message and potential query text
+   * of each throwable in the chain.
+   *
+   * <p>Throwable messages are separated by new lines.
+   *
+   * @param throwable the top level error.
+   * @return the error message.
+   */
+  public static String buildErrorMessageWithStatements(final Throwable throwable) {
+    if (throwable == null) {
+      return "";
+    }
+
+    final List<String> messages = dedup(getErrorMessagesWithStatements(throwable));
+
+    final String msg = messages.remove(0);
+
+    final String causeMsg = messages.stream()
+        .filter(s -> !s.isEmpty())
+        .map(cause -> WordUtils.wrap(PREFIX + cause, 80, "\n\t", true))
+        .collect(Collectors.joining(System.lineSeparator()));
+
+    return causeMsg.isEmpty() ? msg : msg + System.lineSeparator() + causeMsg;
+  }
+
+  /**
    * Build a list containing the error message for each throwable in the chain.
    *
    * @param e the top level error.
@@ -66,10 +92,41 @@ public final class ErrorMessageUtil {
         .collect(Collectors.toList());
   }
 
+  /**
+   * Build a list containing the error message for each throwable in the chain.
+   *
+   * @param e the top level error.
+   * @return the list of error messages.
+   */
+  public static List<String> getErrorMessagesWithStatements(final Throwable e) {
+    return getThrowables(e).stream()
+        .map(ErrorMessageUtil::getErrorMessageWithStatement)
+        .collect(Collectors.toList());
+  }
+
   private static String getErrorMessage(final Throwable e) {
     if (e instanceof ConnectException) {
       return "Could not connect to the server. "
           + "Please check the server details are correct and that the server is running.";
+    } else {
+      return e.getMessage() == null ? e.toString() : e.getMessage();
+    }
+  }
+
+  private static String getErrorMessageWithStatement(final Throwable e) {
+    if (e instanceof ConnectException) {
+      return "Could not connect to the server. "
+          + "Please check the server details are correct and that the server is running.";
+    } else if (e instanceof KsqlStatementException) {
+      final String message = e.getMessage() == null ? e.toString() : e.getMessage();
+      final String statement = ((KsqlStatementException) e).getSqlStatement();
+      final String result;
+      if (statement == null || statement.isEmpty()) {
+        result = message;
+      } else {
+        result = message + "\nStatement: " + statement;
+      }
+      return result;
     } else {
       return e.getMessage() == null ? e.toString() : e.getMessage();
     }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlStatementException.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlStatementException.java
@@ -18,21 +18,33 @@ package io.confluent.ksql.util;
 public class KsqlStatementException extends KsqlException {
 
   private final String sqlStatement;
+  private final boolean isProblemWithStatement;
   private final String rawMessage;
 
   public KsqlStatementException(final String message, final String sqlStatement) {
-    super(buildMessage(message, sqlStatement));
+    super(message);
     this.rawMessage = message == null ? "" : message;
     this.sqlStatement = sqlStatement == null ? "" : sqlStatement;
+    this.isProblemWithStatement = true;
+  }
+
+  public KsqlStatementException(final String message,
+                                final String sqlStatement,
+                                final boolean isProblemWithStatement) {
+    super(message);
+    this.rawMessage = message == null ? "" : message;
+    this.sqlStatement = sqlStatement == null ? "" : sqlStatement;
+    this.isProblemWithStatement = isProblemWithStatement;
   }
 
   public KsqlStatementException(
       final String message,
       final String sqlStatement,
       final Throwable cause) {
-    super(buildMessage(message, sqlStatement), cause);
+    super(message, cause);
     this.rawMessage = message == null ? "" : message;
     this.sqlStatement = sqlStatement == null ? "" : sqlStatement;
+    this.isProblemWithStatement = true;
   }
 
   public String getSqlStatement() {
@@ -43,12 +55,12 @@ public class KsqlStatementException extends KsqlException {
     return rawMessage;
   }
 
-  private static String buildMessage(final String message, final String sqlStatement) {
-    return message + System.lineSeparator() + "Statement: " + sqlStatement;
+  public boolean isProblemWithStatement() {
+    return isProblemWithStatement;
   }
 
   @Override
   public String toString() {
-    return buildMessage(rawMessage, "<retracted>");
+    return rawMessage;
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -52,6 +52,7 @@ import io.confluent.ksql.execution.streams.RoutingOptions;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.internal.PullQueryExecutorMetrics;
 import io.confluent.ksql.internal.ScalablePushQueryMetrics;
+import io.confluent.ksql.logging.query.QueryLogger;
 import io.confluent.ksql.logicalplanner.LogicalPlan;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.MetaStoreImpl;
@@ -220,10 +221,11 @@ final class EngineExecutor {
     // must be executed.
     if (persistentQueryType == KsqlConstants.PersistentQueryType.CREATE_SOURCE
         && !isSourceTableMaterializationEnabled()) {
-      LOG.info(String.format(
-          "Source table query '%s' won't be materialized because '%s' is disabled.",
-          plan.getStatementText(),
-          KsqlConfig.KSQL_SOURCE_TABLE_MATERIALIZATION_ENABLED));
+      final String message = String.format(
+          "Source table query won't be materialized because '%s' is disabled.",
+          KsqlConfig.KSQL_SOURCE_TABLE_MATERIALIZATION_ENABLED
+      );
+      QueryLogger.info(message, plan.getStatementText());
       return ExecuteResult.of(ddlResult.get());
     }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/QueryAnonymizer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/QueryAnonymizer.java
@@ -311,6 +311,18 @@ public class QueryAnonymizer {
     }
 
     @Override
+    public String visitListTables(final SqlBaseParser.ListTablesContext context) {
+      final TerminalNode listOrVisit = context.LIST() != null ? context.LIST() : context.SHOW();
+      final StringBuilder stringBuilder = new StringBuilder(listOrVisit.toString() + " TABLES");
+
+      if (context.EXTENDED() != null) {
+        stringBuilder.append(" EXTENDED");
+      }
+
+      return stringBuilder.toString();
+    }
+
+    @Override
     public String visitListFunctions(final ListFunctionsContext context) {
       final TerminalNode listOrVisit = context.LIST() != null ? context.LIST() : context.SHOW();
       return String.format("%s FUNCTIONS", listOrVisit.toString());

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/logging/query/QueryLogger.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/logging/query/QueryLogger.java
@@ -15,7 +15,6 @@ package io.confluent.ksql.logging.query;
 import com.google.common.annotations.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.engine.rewrite.QueryAnonymizer;
-import io.confluent.ksql.parser.ParsingException;
 import io.confluent.ksql.parser.SqlFormatter;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.util.KsqlConfig;
@@ -60,25 +59,44 @@ public final class QueryLogger {
     anonymizeQueries = config.getBoolean(KsqlConfig.KSQL_QUERYANONYMIZER_ENABLED);
   }
 
+  private static void log(final Level level, final Object message, final Statement query) {
+    final String queryString = SqlFormatter.formatSql(query);
+    log(level, message, queryString);
+  }
+
   private static void log(final Level level, final Object message, final String query) {
+    log(level, message, query, null);
+  }
+
+  private static void log(final Level level,
+                          final Object message,
+                          final String query,
+                          final Throwable t) {
     try {
       final String anonQuery = anonymizeQueries
           ? anonymizer.anonymize(query) : query;
       final QueryGuid queryGuids = buildGuids(query, anonQuery);
-      logger.log(level, buildPayload(message, anonQuery, queryGuids));
-    } catch (ParsingException e) {
-      if (logger.isDebugEnabled()) {
-        Logger.getRootLogger()
-            .log(
-                Level.DEBUG,
-                String.format("Failed to parse a query in query logger, message: %s", message));
-      }
+      final QueryLoggerMessage payload = buildPayload(message, anonQuery, queryGuids);
+      innerLog(level, payload, t);
+    } catch (final Exception e) {
+      final String unparsable = "<unparsable query>";
+      final QueryLoggerMessage payload = buildPayload(
+          message,
+          unparsable,
+          buildGuids(query, unparsable)
+      );
+      innerLog(level, payload, t);
     }
   }
 
-  private static void log(final Level level, final Object message, final Statement query) {
-    final String queryString = SqlFormatter.formatSql(query);
-    log(level, message, queryString);
+  private static void innerLog(final Level level,
+                               final QueryLoggerMessage payload,
+                               final Throwable t) {
+    if (t == null) {
+      logger.log(level, payload);
+    } else {
+      logger.log(level, payload, t);
+    }
   }
 
   private static QueryGuid buildGuids(final String query, final String anonymizedQuery) {
@@ -86,7 +104,7 @@ public final class QueryLogger {
   }
 
   private static QueryLoggerMessage buildPayload(final Object message, final String query,
-      final QueryGuid guid) {
+                                                 final QueryGuid guid) {
     return new QueryLoggerMessage(message, query, guid);
   }
 
@@ -110,6 +128,10 @@ public final class QueryLogger {
     log(Level.WARN, message, query);
   }
 
+  public static void warn(final Object message, final String query, final Throwable t) {
+    log(Level.WARN, message, query, t);
+  }
+
   public static void warn(final Object message, final Statement query) {
     log(Level.WARN, message, query);
   }
@@ -120,5 +142,9 @@ public final class QueryLogger {
 
   public static void error(final Object message, final Statement query) {
     log(Level.ERROR, message, query);
+  }
+
+  public static void error(final String message, final String query, final Throwable t) {
+    log(Level.ERROR, message, query, t);
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/logging/query/QueryLoggerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/logging/query/QueryLoggerTest.java
@@ -17,22 +17,27 @@ import io.confluent.ksql.engine.rewrite.QueryAnonymizer;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.QueryGuid;
 import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.List;
+
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class QueryLoggerTest {
-  @Mock public KsqlConfig config;
+  @Mock
+  public KsqlConfig config;
   private final TestAppender testAppender = new TestAppender();
 
   private final QueryAnonymizer anonymizer = new QueryAnonymizer();
@@ -72,7 +77,7 @@ public class QueryLoggerTest {
   }
 
   @Test
-  public void shouldNotLogIfQueryCannotBeParsed() {
+  public void shouldNotLogQueryIfQueryCannotBeParsed() {
     String message = " I love cats";
     String query = "CREATE CAT;";
 
@@ -80,13 +85,36 @@ public class QueryLoggerTest {
     QueryLogger.error(message, query);
     QueryLogger.info(message, query);
     QueryLogger.warn(message, query);
-    testAppender
-        .getLog()
+    final List<LoggingEvent> events = testAppender.getLog();
+    events
         .forEach(
             (e) -> {
               final QueryLoggerMessage msg = (QueryLoggerMessage) e.getMessage();
-              assertNotEquals(msg.getMessage(), message);
+              assertEquals(msg.getMessage(), message);
               assertNotEquals(msg.getQuery(), query);
+              assertEquals(msg.getQuery(), "<unparsable query>");
+            });
+  }
+
+  @Test
+  public void shouldLogQueryIfQueryCannotBeParsedIfAnonymizerIsDisabled() {
+    when(config.getBoolean(KsqlConfig.KSQL_QUERYANONYMIZER_ENABLED)).thenReturn(false);
+    QueryLogger.configure(config);
+
+    String message = " I love cats";
+    String query = "CREATE CAT;";
+
+    QueryLogger.debug(message, query);
+    QueryLogger.error(message, query);
+    QueryLogger.info(message, query);
+    QueryLogger.warn(message, query);
+    final List<LoggingEvent> events = testAppender.getLog();
+    events
+        .forEach(
+            (e) -> {
+              final QueryLoggerMessage msg = (QueryLoggerMessage) e.getMessage();
+              assertEquals(msg.getMessage(), message);
+              assertEquals(msg.getQuery(), query);
             });
   }
 
@@ -146,5 +174,20 @@ public class QueryLoggerTest {
                   msg.getQueryIdentifier().getQueryGuid(),
                   msg.getQueryIdentifier().getStructuralGuid());
             });
+  }
+
+  @Test
+  public void shouldAnonymizeMultipleStatements() {
+    QueryLogger.configure(config);
+    QueryLogger.info("a message", "list streams; list tables; select a, b from mytable; list queries;");
+    final List<LoggingEvent> events = testAppender.getLog();
+    assertThat(events, hasSize(1));
+    final LoggingEvent event = events.get(0);
+    final QueryLoggerMessage message = (QueryLoggerMessage) event.getMessage();
+    assertThat(message.getMessage(), is("a message"));
+    assertThat(message.getQuery(), is("list STREAMS;\n" +
+        "list TABLES;\n" +
+        "SELECT column1, column2 FROM source1;\n" +
+        "list QUERIES;"));
   }
 }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
@@ -540,7 +540,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Key format does not support schema.\nformat: KAFKA\nschema: Persistence{columns=[`F1` INTEGER KEY, `F2` INTEGER KEY], features=[]}\nreason: The 'KAFKA' format only supports a single field. Got: [`F1` INTEGER KEY, `F2` INTEGER KEY]\nStatement: CREATE TABLE OUTPUT AS SELECT\n  TEST.F2 F2,\n  TEST.F1 F1,\n  (TEST.F2 + TEST.F1) KSQL_COL_0,\n  COUNT(*) KSQL_COL_1\nFROM TEST TEST\nGROUP BY TEST.F1, TEST.F2\nEMIT CHANGES"
+        "message": "Key format does not support schema.\nformat: KAFKA\nschema: Persistence{columns=[`F1` INTEGER KEY, `F2` INTEGER KEY], features=[]}\nreason: The 'KAFKA' format only supports a single field. Got: [`F1` INTEGER KEY, `F2` INTEGER KEY]"
       }
     },
     {
@@ -606,7 +606,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Key format does not support schema.\nformat: KAFKA\nschema: Persistence{columns=[`KEY` DECIMAL(2, 1) KEY], features=[]}\nreason: The 'KAFKA' format does not support type 'DECIMAL'\nStatement: CREATE TABLE OUTPUT AS SELECT\n  TEST.F2 KEY,\n  COUNT(*) TOTAL\nFROM TEST TEST\nGROUP BY TEST.F2\nEMIT CHANGES"
+        "message": "Key format does not support schema.\nformat: KAFKA\nschema: Persistence{columns=[`KEY` DECIMAL(2, 1) KEY], features=[]}\nreason: The 'KAFKA' format does not support type 'DECIMAL'"
       }
     },
     {
@@ -688,7 +688,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Key format does not support schema.\nformat: KAFKA\nschema: Persistence{columns=[`K1` INTEGER KEY, `K2` INTEGER KEY], features=[]}\nreason: The 'KAFKA' format only supports a single field. Got: [`K1` INTEGER KEY, `K2` INTEGER KEY]\nStatement: CREATE TABLE OUTPUT WITH (KEY_FORMAT='KAFKA') AS SELECT\n  TEST.F1 K1,\n  TEST.F2 K2,\n  COUNT(*) TOTAL\nFROM TEST TEST\nGROUP BY TEST.F1, TEST.F2\nEMIT CHANGES"
+        "message": "Key format does not support schema.\nformat: KAFKA\nschema: Persistence{columns=[`K1` INTEGER KEY, `K2` INTEGER KEY], features=[]}\nreason: The 'KAFKA' format only supports a single field. Got: [`K1` INTEGER KEY, `K2` INTEGER KEY]"
       }
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/key-schemas.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/key-schemas.json
@@ -466,7 +466,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.parser.exception.ParseFailedException",
-        "message": "line 1:32: mismatched input 'KEY' expecting {'STRING', INTEGER_VALUE}\nStatement: CREATE STREAM INPUT (K STRING (KEY)) WITH (kafka_topic='input',value_format='JSON');"
+        "message": "line 1:32: mismatched input 'KEY' expecting {'STRING', INTEGER_VALUE}"
       }
     },
     {
@@ -476,7 +476,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.parser.exception.ParseFailedException",
-        "message": "line 1:33: mismatched input 'KEY' expecting {'STRING', INTEGER_VALUE}\nStatement: CREATE STREAM INPUT (K INTEGER (KEY)) WITH (kafka_topic='input',value_format='JSON');"
+        "message": "line 1:33: mismatched input 'KEY' expecting {'STRING', INTEGER_VALUE}"
       }
     },
     {
@@ -486,7 +486,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.parser.exception.ParseFailedException",
-        "message": "line 1:32: mismatched input 'KEY' expecting {'STRING', INTEGER_VALUE}\nStatement: CREATE STREAM INPUT (K DOUBLE (KEY)) WITH (kafka_topic='input',value_format='JSON');"
+        "message": "line 1:32: mismatched input 'KEY' expecting {'STRING', INTEGER_VALUE}"
       }
     },
     {
@@ -496,7 +496,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.parser.exception.ParseFailedException",
-        "message": "line 1:33: mismatched input 'KEY' expecting {'STRING', INTEGER_VALUE}\nStatement: CREATE STREAM INPUT (K VARCHAR (KEY)) WITH (kafka_topic='input',value_format='JSON');"
+        "message": "line 1:33: mismatched input 'KEY' expecting {'STRING', INTEGER_VALUE}"
       }
     },
     {
@@ -506,7 +506,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.parser.exception.ParseFailedException",
-        "message": "line 1:29: mismatched input 'KEY' expecting {'STRING', INTEGER_VALUE}\nStatement: CREATE STREAM INPUT (K INT (KEY)) WITH (kafka_topic='input',value_format='JSON');"
+        "message": "line 1:29: mismatched input 'KEY' expecting {'STRING', INTEGER_VALUE}"
       }
     },
     {
@@ -516,7 +516,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.parser.exception.ParseFailedException",
-        "message": "line 1:33: mismatched input 'KEY' expecting {'STRING', INTEGER_VALUE}\nStatement: CREATE STREAM INPUT (K BOOLEAN (KEY)) WITH (kafka_topic='input',value_format='JSON');"
+        "message": "line 1:33: mismatched input 'KEY' expecting {'STRING', INTEGER_VALUE}"
       }
     },
     {
@@ -526,7 +526,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.parser.exception.ParseFailedException",
-        "message": "line 1:32: mismatched input 'KEY' expecting {'STRING', INTEGER_VALUE}\nStatement: CREATE STREAM INPUT (K BIGINT (KEY)) WITH (kafka_topic='input',value_format='JSON');"
+        "message": "line 1:32: mismatched input 'KEY' expecting {'STRING', INTEGER_VALUE}"
       }
     },
     {
@@ -536,7 +536,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.parser.exception.ParseFailedException",
-        "message": "line 1:40: mismatched input '(' expecting {',', ')'}\nStatement: CREATE STREAM INPUT (K VARCHAR(STRING) (KEY)) WITH (kafka_topic='input',value_format='JSON');"
+        "message": "line 1:40: mismatched input '(' expecting {',', ')'}"
       }
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-ctas-materialized.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-ctas-materialized.json
@@ -240,7 +240,7 @@
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "Error in WHERE expression: Cannot compare ID (STRING) to 11 (INTEGER) with EQUAL.\nStatement: (ID = 11)",
+        "message": "Error in WHERE expression: Cannot compare ID (STRING) to 11 (INTEGER) with EQUAL.",
         "status": 400
       }
     },

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -133,7 +133,7 @@
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "Error in WHERE expression: Cannot compare ID (INTEGER) to '10' (STRING) with EQUAL.\nStatement: (ID = '10')",
+        "message": "Error in WHERE expression: Cannot compare ID (INTEGER) to '10' (STRING) with EQUAL.",
         "status": 400
       }
     },
@@ -286,7 +286,7 @@
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "Error in WHERE expression: Cannot compare ID (INTEGER) to '10' (STRING) with EQUAL.\nStatement: (ID = '10')",
+        "message": "Error in WHERE expression: Cannot compare ID (INTEGER) to '10' (STRING) with EQUAL.",
         "status": 400
       }
     },
@@ -1205,7 +1205,7 @@
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "Error in WHERE expression: Comparison with NULL not supported: INTEGER = NULL\nUse 'IS NULL' or 'IS NOT NULL' instead.\nStatement: (ID = null)",
+        "message": "Error in WHERE expression: Comparison with NULL not supported: INTEGER = NULL\nUse 'IS NULL' or 'IS NOT NULL' instead.",
         "status": 400
       }
     },

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-streams.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-streams.json
@@ -37,7 +37,7 @@
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "line 1:24: mismatched input 'BY' expecting {';', 'EMIT', 'WHERE', 'WINDOW', 'GROUP', 'HAVING', 'LIMIT', 'PARTITION'}\nStatement: SELECT * FROM S1 ORDER BY MYKEY DESC;\nCaused by: line 1:24: mismatched input 'BY' expecting {';', 'EMIT', 'WHERE',\n\t'WINDOW', 'GROUP', 'HAVING', 'LIMIT', 'PARTITION'}\nCaused by: org.antlr.v4.runtime.InputMismatchException",
+        "message": "line 1:24: mismatched input 'BY' expecting {';', 'EMIT', 'WHERE', 'WINDOW', 'GROUP', 'HAVING', 'LIMIT', 'PARTITION'}",
         "status": 400
       }
     },

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -608,6 +608,7 @@ public class KsqlParserTest {
     } catch (final ParseFailedException e) {
       final String errorMessage = e.getMessage();
       Assert.assertTrue(errorMessage.toLowerCase().contains(("line 1:1: mismatched input 'SELLECT'" + " expecting").toLowerCase()));
+      Assert.assertTrue(e.getSqlStatement().contains(("SELLECT col0, col2, col3 FROM test1 WHERE col0 > 100")));
     }
   }
 
@@ -1206,13 +1207,14 @@ public class KsqlParserTest {
     final String simpleQuery = "SELECT ONLY, COLUMNS;";
 
     // When:
-    final Exception e = assertThrows(
+    final ParseFailedException e = assertThrows(
         ParseFailedException.class,
         () -> KsqlParserTestUtil.buildSingleAst(simpleQuery, metaStore)
     );
 
     // Then:
     assertThat(e.getMessage(), containsString("line 1:21: extraneous input ';' expecting {',', 'FROM'}"));
+    assertThat(e.getSqlStatement(), containsString("SELECT ONLY, COLUMNS"));
   }
 
   @Test
@@ -1221,13 +1223,14 @@ public class KsqlParserTest {
     final String simpleQuery = "SELECT A B C FROM address;";
 
     // When:
-    final Exception e = assertThrows(
+    final ParseFailedException e = assertThrows(
         ParseFailedException.class,
         () -> KsqlParserTestUtil.buildSingleAst(simpleQuery, metaStore)
     );
 
     // Then:
     assertThat(e.getMessage(), containsString("line 1:12: extraneous input 'C' expecting"));
+    assertThat(e.getSqlStatement(), containsString("SELECT A B C FROM address"));
   }
 
   @Test
@@ -1237,13 +1240,14 @@ public class KsqlParserTest {
             "  WITH (kafka_topic='ords', value_format='json');";
 
     // When:
-    final Exception e = assertThrows(
+    final ParseFailedException e = assertThrows(
             ParseFailedException.class,
             () -> KsqlParserTestUtil.buildSingleAst(simpleQuery, metaStore)
     );
 
     // Then:
     assertThat(e.getMessage(), containsString("\"size\" is a reserved keyword and it can't be used as an identifier"));
+    assertThat(e.getSqlStatement(), containsString("CREATE STREAM ORDERS (c1 VARCHAR, size INTEGER)"));
   }
 
   @Test
@@ -1280,13 +1284,14 @@ public class KsqlParserTest {
     final String simpleQuery = "SELECT * FROM address, itemid;";
 
     // When:
-    final Exception e = assertThrows(
+    final ParseFailedException e = assertThrows(
         ParseFailedException.class,
         () -> KsqlParserTestUtil.buildSingleAst(simpleQuery, metaStore)
     );
 
     // Then:
     assertThat(e.getMessage(), containsString("line 1:22: mismatched input ',' expecting"));
+    assertThat(e.getSqlStatement(), containsString("SELECT * FROM address, itemid;"));
   }
 
   @Test

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/RestoreCommandsCompactor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/RestoreCommandsCompactor.java
@@ -19,6 +19,7 @@ import io.confluent.ksql.engine.KsqlPlan;
 import io.confluent.ksql.execution.ddl.commands.CreateSourceCommand;
 import io.confluent.ksql.execution.ddl.commands.DdlCommand;
 import io.confluent.ksql.execution.ddl.commands.DropSourceCommand;
+import io.confluent.ksql.logging.query.QueryLogger;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.tree.TerminateQuery;
 import io.confluent.ksql.query.QueryId;
@@ -152,10 +153,11 @@ public final class RestoreCommandsCompactor {
               // hitting a known bug that wrote IF NOT EXISTS statements to the command topic.
               // See https://github.com/confluentinc/ksql/issues/8173
               if (createAsIfNotExistsBugDetection.contains(sourceName)) {
-                LOG.warn("A known bug is found while restoring the command topic. The restoring "
+                QueryLogger.warn(
+                    "A known bug is found while restoring the command topic. The restoring "
                     + "process will continue, but the query of the affected stream or table won't "
                     + "be executed until https://github.com/confluentinc/ksql/issues/8173 "
-                    + "is fixed. Invalid statement is: " + command.getStatement());
+                    + "is fixed.", command.getStatement());
               }
             }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/query/QueryExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/query/QueryExecutor.java
@@ -402,7 +402,7 @@ public class QueryExecutor {
 
     localCommands.ifPresent(lc -> lc.write(query));
 
-    log.info("Streaming query '{}'", statement.getMaskedStatementText());
+    QueryLogger.info("Streaming query", statement.getMaskedStatementText());
     return QueryMetadataHolder.of(query);
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -276,7 +276,7 @@ public class KsqlResource implements KsqlConfigurable {
     // Set masked sql statement if request is not from OldApiUtils.handleOldApiRequest
     ApiServerUtils.setMaskedSqlIfNeeded(request);
 
-    LOG.info("Received: " + request);
+    QueryLogger.info("Received: " + request.toStringWithoutQuery(), request.getMaskedKsql());
     throwIfNotConfigured();
 
     activenessRegistrar.updateLastRequestTime();
@@ -329,24 +329,54 @@ public class KsqlResource implements KsqlConfigurable {
           )
       );
 
-      LOG.info("Processed successfully: " + request);
+      QueryLogger.info(
+          "Processed successfully: " + request.toStringWithoutQuery(),
+          request.getMaskedKsql()
+      );
       addCommandRunnerWarning(
           entities,
           commandRunnerWarning);
       return EndpointResponse.ok(entities);
     } catch (final KsqlRestException e) {
-      LOG.info("Processed unsuccessfully: " + request + ", reason: ", e);
+      QueryLogger.warn(
+          "Processed unsuccessfully: " + request.toStringWithoutQuery(),
+          request.getMaskedKsql(),
+          e
+      );
       throw e;
     } catch (final KsqlStatementException e) {
-      LOG.info("Processed unsuccessfully: " + request + ", reason: ", e);
-      return Errors.badStatement(e.getRawMessage(), e.getSqlStatement());
+      QueryLogger.warn(
+          "Processed unsuccessfully: " + request.toStringWithoutQuery(),
+          request.getMaskedKsql(),
+          e
+      );
+      final EndpointResponse response;
+      if (e.isProblemWithStatement()) {
+        response = Errors.badStatement(e.getRawMessage(), e.getSqlStatement());
+      } else {
+        response = Errors.badRequestWithStatement(e, e.getSqlStatement());
+      }
+      return errorHandler.generateResponse(e, response);
     } catch (final KsqlException e) {
-      LOG.info("Processed unsuccessfully: " + request + ", reason: ", e);
-      return errorHandler.generateResponse(e, Errors.badRequest(e));
-    } catch (final Exception e) {
-      LOG.info("Processed unsuccessfully: " + request + ", reason: ", e);
+      QueryLogger.warn(
+          "Processed unsuccessfully: " + request.toStringWithoutQuery(),
+          request.getMaskedKsql(),
+          e
+      );
       return errorHandler.generateResponse(
-          e, Errors.serverErrorForStatement(e, request.getMaskedKsql()));
+          e,
+          Errors.badRequestWithStatement(e, request.getMaskedKsql())
+      );
+    } catch (final Exception e) {
+      QueryLogger.warn(
+          "Processed unsuccessfully: " + request.toStringWithoutQuery(),
+          request.getMaskedKsql(),
+          e
+      );
+      return errorHandler.generateResponse(
+          e,
+          Errors.serverErrorForStatement(e, request.getMaskedKsql())
+      );
     }
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/QueryCapacityUtil.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/QueryCapacityUtil.java
@@ -18,7 +18,7 @@ package io.confluent.ksql.rest.util;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.KsqlStatementException;
 
 public final class QueryCapacityUtil {
   private QueryCapacityUtil() {
@@ -36,18 +36,19 @@ public final class QueryCapacityUtil {
       final KsqlConfig ksqlConfig,
       final String statementStr
   ) {
-    throw new KsqlException(
+    throw new KsqlStatementException(
         String.format(
-            "Not executing statement(s) '%s' as it would cause the number "
+            "Not executing statement(s) as it would cause the number "
                 + "of active, persistent queries to exceed the configured limit. "
                 + "Use the TERMINATE command to terminate existing queries, "
                 + "or increase the '%s' setting via the 'ksql-server.properties' file. "
                 + "Current persistent query count: %d. Configured limit: %d.",
-            statementStr,
             KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG,
             executionContext.getPersistentQueries().size(),
             getQueryLimit(ksqlConfig)
-        )
+        ),
+        statementStr,
+        false
     );
   }
 
@@ -67,18 +68,18 @@ public final class QueryCapacityUtil {
           final KsqlRestConfig ksqlRestConfig,
           final String statementStr
   ) {
-    throw new KsqlException(
-            String.format(
-                    "Not executing statement(s) '%s' as it would cause the number "
-                            + "of active, push queries to exceed the configured limit. "
-                            + "Terminate existing PUSH queries, "
-                            + "or increase the '%s' setting via the 'ksql-server.properties' file. "
-                            + "Current push query count: %d. Configured limit: %d.",
-                    statementStr,
-                    KsqlRestConfig.MAX_PUSH_QUERIES,
-                    getNumLivePushQueries(executionContext),
-                    getPushQueryLimit(ksqlRestConfig)
-            )
+    throw new KsqlStatementException(
+        String.format(
+            "Not executing statement(s) as it would cause the number "
+                + "of active, push queries to exceed the configured limit. "
+                + "Terminate existing PUSH queries, "
+                + "or increase the '%s' setting via the 'ksql-server.properties' file. "
+                + "Current push query count: %d. Configured limit: %d.",
+            KsqlRestConfig.MAX_PUSH_QUERIES,
+            getNumLivePushQueries(executionContext),
+            getPushQueryLimit(ksqlRestConfig)
+        ),
+        statementStr
     );
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PauseResumeIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PauseResumeIntegrationTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.integration;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.integration.IntegrationTestHarness;
 import io.confluent.ksql.integration.Retry;
@@ -236,6 +237,7 @@ public class PauseResumeIntegrationTest {
     TEST_HARNESS.getKafkaCluster().waitForTopicsToBePresent(SINK_TOPIC + suffix);
   }
 
+  @SuppressFBWarnings("NP_NONNULL_RETURN_VIOLATION")
   @NotNull
   private Supplier<Integer> getSupplier(int streamNumber) {
     return () -> RestIntegrationTestUtil.makeQueryRequest(REST_APP,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/query/QueryExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/query/QueryExecutorTest.java
@@ -211,7 +211,7 @@ public class QueryExecutorTest {
     when(mockDataSource.getDataSourceType()).thenReturn(dataSourceType);
 
     // When:
-    final Exception e = assertThrows(
+    final KsqlStatementException e = assertThrows(
         KsqlStatementException.class,
         () -> queryExecutor.handleStatement(serviceContext, ImmutableMap.of(), ImmutableMap.of(),
             pullQuery, Optional.empty(), metricsCallbackHolder, context, false)
@@ -221,10 +221,9 @@ public class QueryExecutorTest {
     final String errorMsg =
         "Pull queries are disabled. See https://cnfl.io/queries for more info.\n"
         + "Add EMIT CHANGES if you intended to issue a push query.\n"
-        + "Please set ksql.pull.queries.enable=true to enable this feature.\n"
-        + "\n"
-        + "Statement: SELECT * FROM test_stream WHERE ROWKEY='null';";
+        + "Please set ksql.pull.queries.enable=true to enable this feature.\n";
     assertThat(e.getMessage(), is(errorMsg));
+    assertThat(e.getSqlStatement(), is("SELECT * FROM test_stream WHERE ROWKEY='null';"));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -2100,6 +2100,7 @@ public class KsqlResourceTest {
     assertThat(result.getMessage(),
         containsString("Statement is too large to parse. "
             + "This may be caused by having too many nested expressions in the statement."));
+    assertThat(((KsqlStatementErrorMessage) result).getStatementText(), is(secondStatement));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/QueryCapacityUtilTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/QueryCapacityUtilTest.java
@@ -17,10 +17,8 @@ package io.confluent.ksql.rest.util;
 
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
-import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlException;
-import io.confluent.ksql.util.PersistentQueryMetadata;
-import io.confluent.ksql.util.QueryMetadata;
+import io.confluent.ksql.util.*;
+
 import java.util.List;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -73,20 +71,21 @@ public class QueryCapacityUtilTest {
     givenQueryLimit(2);
 
     // When:
-    final KsqlException e = assertThrows(
-        KsqlException.class,
+    final KsqlStatementException e = assertThrows(
+        KsqlStatementException.class,
         () -> QueryCapacityUtil.throwTooManyActivePersistentQueriesException(
         ksqlEngine, ksqlConfig, statementStr)
     );
 
     // Then:
     assertThat(e.getMessage(), containsString(
-        "Not executing statement(s) 'my statement' as it would cause the number "
+        "Not executing statement(s) as it would cause the number "
             + "of active, persistent queries to exceed the configured limit. "
             + "Use the TERMINATE command to terminate existing queries, "
             + "or increase the 'ksql.query.persistent.active.limit' setting "
             + "via the 'ksql-server.properties' file. "
             + "Current persistent query count: 3. Configured limit: 2."));
+    assertThat(e.getSqlStatement(), containsString("my statement"));
   }
 
   @Test
@@ -122,19 +121,20 @@ public class QueryCapacityUtilTest {
     givenPushQueryLimit(3);
 
     // When:
-    final KsqlException e = assertThrows(
-            KsqlException.class,
+    final KsqlStatementException e = assertThrows(
+            KsqlStatementException.class,
             () -> QueryCapacityUtil.throwTooManyActivePushQueriesException(ksqlEngine, ksqlRestConfig, statementStr)
     );
 
     // Then:
     assertThat(e.getMessage(), containsString(
-            "Not executing statement(s) 'my statement' as it would cause the number "
+            "Not executing statement(s) as it would cause the number "
                     + "of active, push queries to exceed the configured limit. "
                     + "Terminate existing PUSH queries, "
                     + "or increase the 'ksql.max.push.queries' setting "
                     + "via the 'ksql-server.properties' file. "
                     + "Current push query count: 6. Configured limit: 3."));
+    assertThat(e.getSqlStatement(), containsString("my statement"));
   }
 
   @SuppressWarnings("unchecked")

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/Errors.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/Errors.java
@@ -124,6 +124,21 @@ public final class Errors {
         .build();
   }
 
+  public static EndpointResponse badRequestWithStatement(final Throwable t,
+                                                         final String maskedKsql) {
+    return EndpointResponse.create()
+        .status(BAD_REQUEST.code())
+        .entity(
+            new KsqlStatementErrorMessage(
+                ERROR_CODE_BAD_REQUEST,
+                t,
+                maskedKsql,
+                new KsqlEntityList()
+            )
+        )
+        .build();
+  }
+
   public static EndpointResponse badStatement(final String msg, final String statementText) {
     return badStatement(msg, statementText, new KsqlEntityList());
   }

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlRequest.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlRequest.java
@@ -148,11 +148,11 @@ public class KsqlRequest {
         + '}';
   }
 
+  // Skip session variables as well since they can contain sensitive info
   public String toStringWithoutQuery() {
     return "KsqlRequest{"
         + "configOverrides=" + configOverrides
         + ", requestProperties=" + requestProperties
-        + ", sessionVariables=" + sessionVariables
         + ", commandSequenceNumber=" + commandSequenceNumber
         + '}';
   }

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlRequest.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlRequest.java
@@ -148,6 +148,15 @@ public class KsqlRequest {
         + '}';
   }
 
+  public String toStringWithoutQuery() {
+    return "KsqlRequest{"
+        + "configOverrides=" + configOverrides
+        + ", requestProperties=" + requestProperties
+        + ", sessionVariables=" + sessionVariables
+        + ", commandSequenceNumber=" + commandSequenceNumber
+        + '}';
+  }
+
   /**
    * Converts all Class references values to their canonical String value.
    * </p>

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlStatementErrorMessage.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlStatementErrorMessage.java
@@ -74,4 +74,9 @@ public class KsqlStatementErrorMessage extends KsqlErrorMessage {
   public int hashCode() {
     return Objects.hash(super.hashCode(), statementText, entities);
   }
+
+  @Override
+  public String toString() {
+    return super.toString() + "\nStatement: " + statementText;
+  }
 }


### PR DESCRIPTION
* fix: use QueryLogger for logging queries

* anonymize processed queries

* logging for unparsable queries

* anonymized query handling logs

* anonymized received queries

* anonymized streaming query

* checkstyle

* prevent exception from querylogger

* don't include statement text in exception message

* don't include statement text in exception messages

* fix tests

* fix tests

* fix tests

* checkstyle

* checkstyle

* fix parser test

* fix tests

* checkstyle

* restore ability to print errors in CLI

* checkstyle

* checkstyle

* fix error code

* One more fix for RestoreCommandsCompactor

* Fix style bug

Co-authored-by: Alan Sheinberg <asheinberg@confluent.io>

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

