### PR TITLE
Fix/9533

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
@@ -383,10 +383,12 @@ public class QueryMetadataImpl implements QueryMetadata {
   public static class TimeBoundedQueue {
     private final Duration duration;
     private final Queue<QueryError> queue;
+    private final int capacity;
 
     TimeBoundedQueue(final Duration duration, final int capacity) {
       queue = new ConcurrentLinkedQueue<>(EvictingQueue.create(capacity));
       this.duration = duration;
+      this.capacity = capacity;
     }
 
     public void add(final QueryError e) {
@@ -401,7 +403,7 @@ public class QueryMetadataImpl implements QueryMetadata {
     
     private void evict() {
       while (queue.peek() != null) {
-        if (queue.peek().getTimestamp() > System.currentTimeMillis() - duration.toMillis()) {
+        if (queue.peek().getTimestamp() > System.currentTimeMillis() - duration.toMillis() && queue.size()< capacity) {
           break;
         }
         queue.poll();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
@@ -344,6 +344,17 @@ public class QueryMetadataTest {
   }
 
   @Test
+  public void shouldEvictBasedOnSize() {
+    // Given:
+    final QueryMetadataImpl.TimeBoundedQueue queue = new QueryMetadataImpl.TimeBoundedQueue(Duration.ofHours(1), 1);
+    queue.add(new QueryError(System.currentTimeMillis(), "test", Type.SYSTEM));
+    queue.add(new QueryError(System.currentTimeMillis(), "test2", Type.SYSTEM));
+
+    //Then:
+    assertThat(queue.toImmutableList().size(), is(1));
+  }
+
+  @Test
   public void shouldCloseProcessingLoggers() {
     // Given:
     final ProcessingLogger processingLogger1 = mock(ProcessingLogger.class);


### PR DESCRIPTION
### Description 
TimeBoundedQueue has been fixed to bounded by both time and capacity 

Currently, When a query has errors, a list of errors collected is displayed by the SHOW QUERIES EXTENDED or EXPLAIN <query> commands. This list has a config to limit the number of errors displayed. The config is ksql.query.error.max.queue.size and is default to 10. However, the SHOW QUERIES command is displaying more errors than what it is configured and it keeps growing. This was due to [this fix](https://github.com/confluentinc/ksql/pull/8875)

So to prevent this, I have added a capacity member in the TimeBoundedQueue Class and in evict method, if the elements are less than capacity than only we will skip poll else we will evict out the elements, For more context refer code change. 

### Testing done 
Have added Unit Tests for the same

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

