### PR TITLE
fix: use args map instead of method args in generated java code

### DIFF
--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
@@ -57,7 +57,6 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.kafka.connect.data.Schema;
 import org.codehaus.commons.compiler.CompileException;
 import org.codehaus.commons.compiler.CompilerFactoryFactory;
@@ -164,8 +163,7 @@ public class CodeGenRunner {
 
       final Class<?> expressionType = SQL_TO_JAVA_TYPE_CONVERTER.toJavaType(returnType);
 
-      final IExpressionEvaluator ee =
-          cook(javaCode, expressionType, spec.argumentNames(), spec.argumentTypes());
+      final IExpressionEvaluator ee = cook(javaCode, expressionType);
 
       return new CompiledExpression(ee, spec, returnType, expression);
     } catch (KsqlException | CompileException e) {
@@ -185,17 +183,15 @@ public class CodeGenRunner {
   @VisibleForTesting
   public static IExpressionEvaluator cook(
       final String javaCode,
-      final Class<?> expressionType,
-      final String[] argNames,
-      final Class<?>[] argTypes
+      final Class<?> expressionType
   ) throws Exception {
     final IExpressionEvaluator ee = CompilerFactoryFactory.getDefaultCompilerFactory()
         .newExpressionEvaluator();
 
     ee.setDefaultImports(SqlToJavaVisitor.JAVA_IMPORTS.toArray(new String[0]));
     ee.setParameters(
-        ArrayUtils.addAll(argNames, "defaultValue", "logger", "row"),
-        ArrayUtils.addAll(argTypes, Object.class, ProcessingLogger.class, GenericRow.class)
+            new String[]{"arguments", "defaultValue", "logger", "row"},
+            new Class[]{Map.class, Object.class, ProcessingLogger.class, GenericRow.class}
     );
     ee.setExpressionType(expressionType);
     ee.cook(javaCode);

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenSpec.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenSpec.java
@@ -56,14 +56,6 @@ public final class CodeGenSpec {
     this.structToCodeName = structToCodeName;
   }
 
-  public String[] argumentNames() {
-    return arguments.stream().map(ArgumentSpec::name).toArray(String[]::new);
-  }
-
-  public Class<?>[] argumentTypes() {
-    return arguments.stream().map(ArgumentSpec::type).toArray(Class[]::new);
-  }
-
   @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "arguments is ImmutableList")
   public List<ArgumentSpec> arguments() {
     return arguments;
@@ -81,10 +73,14 @@ public final class CodeGenSpec {
     return names.get(index);
   }
 
-  public void resolve(final GenericRow row, final Object[] parameters) {
+  public Map<String, Object> resolveArguments(final GenericRow row) {
+    final Map<String, Object> resolvedArguments = new HashMap<>(arguments.size());
     for (int paramIdx = 0; paramIdx < arguments.size(); paramIdx++) {
-      parameters[paramIdx] = arguments.get(paramIdx).resolve(row);
+      final String name = arguments.get(paramIdx).name();
+      final Object value = arguments.get(paramIdx).resolve(row);
+      resolvedArguments.put(name, value);
     }
+    return resolvedArguments;
   }
 
   public String getStructSchemaName(final CreateStructExpression createStructExpression) {

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenUtil.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenUtil.java
@@ -16,6 +16,8 @@
 package io.confluent.ksql.execution.codegen;
 
 import io.confluent.ksql.name.FunctionName;
+import io.confluent.ksql.schema.ksql.SchemaConverters;
+import io.confluent.ksql.schema.ksql.types.SqlType;
 
 public final class CodeGenUtil {
 
@@ -35,6 +37,17 @@ public final class CodeGenUtil {
 
   public static String functionName(final FunctionName fun, final int index) {
     return fun.text() + "_" + index;
+  }
+
+  public static String argumentAccessor(final String name,
+                                        final SqlType type) {
+    final Class<?> javaType = SchemaConverters.sqlToJavaConverter().toJavaType(type);
+    return argumentAccessor(name, javaType);
+  }
+
+  public static String argumentAccessor(final String name,
+                                        final Class<?> type) {
+    return String.format("((%s) arguments.get(\"%s\"))", type.getCanonicalName(), name);
   }
 
 }

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitorTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitorTest.java
@@ -84,6 +84,7 @@ import io.confluent.ksql.function.udf.UdfMetadata;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.schema.Operator;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlConfig;
@@ -91,10 +92,15 @@ import io.confluent.ksql.util.KsqlException;
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Time;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -137,7 +143,7 @@ public class SqlToJavaVisitorTest {
     final String javaExpression = sqlToJavaVisitor.process(expression);
 
     // Then:
-    assertThat(javaExpression, equalTo("(COL0 + COL3)"));
+    assertThat(javaExpression, equalTo("(((java.lang.Long) arguments.get(\"COL0\")) + ((java.lang.Double) arguments.get(\"COL3\")))"));
   }
 
   @Test
@@ -151,7 +157,7 @@ public class SqlToJavaVisitorTest {
     // Then:
     assertThat(
         javaExpression,
-        equalTo("((Double) (COL4 == null ? null : (ArrayAccess.arrayAccess((java.util.List) COL4, ((int) 0)))))")
+        equalTo("((Double) (((java.util.List) arguments.get(\"COL4\")) == null ? null : (ArrayAccess.arrayAccess((java.util.List) ((java.util.List) arguments.get(\"COL4\")), ((int) 0)))))")
     );
   }
 
@@ -164,7 +170,7 @@ public class SqlToJavaVisitorTest {
     final String javaExpression = sqlToJavaVisitor.process(expression);
 
     // Then:
-    assertThat(javaExpression, equalTo("((Double) (COL5 == null ? null : ((java.util.Map)COL5).get(\"key1\")))"));
+    assertThat(javaExpression, equalTo("((Double) (((java.util.Map) arguments.get(\"COL5\")) == null ? null : ((java.util.Map)((java.util.Map) arguments.get(\"COL5\"))).get(\"key1\")))"));
   }
 
   @Test
@@ -183,9 +189,9 @@ public class SqlToJavaVisitorTest {
     // Then:
     assertThat(
         java,
-        equalTo("((List)new ArrayBuilder(2)"
-            + ".add( (new Supplier<Object>() {@Override public Object get() { try {  return ((Double) (COL5 == null ? null : ((java.util.Map)COL5).get(\"key1\"))); } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing array item\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get())"
-            + ".add( (new Supplier<Object>() {@Override public Object get() { try {  return 1E0; } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing array item\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get()).build())"));
+        equalTo("((List)new ArrayBuilder(2)" +
+                ".add( (new Supplier<Object>() {@Override public Object get() { try {  return ((Double) (((java.util.Map) arguments.get(\"COL5\")) == null ? null : ((java.util.Map)((java.util.Map) arguments.get(\"COL5\"))).get(\"key1\"))); } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing array item\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get())" +
+                ".add( (new Supplier<Object>() {@Override public Object get() { try {  return 1E0; } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing array item\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get()).build())"));
     }
 
   @Test
@@ -204,9 +210,7 @@ public class SqlToJavaVisitorTest {
     String java = sqlToJavaVisitor.process(expression);
 
     // Then:
-    assertThat(java, equalTo("((Map)new MapBuilder(2)"
-        + ".put( (new Supplier<Object>() {@Override public Object get() { try {  return \"foo\"; } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing map key\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get(),  (new Supplier<Object>() {@Override public Object get() { try {  return ((Double) (COL5 == null ? null : ((java.util.Map)COL5).get(\"key1\"))); } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing map value\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get())"
-        + ".put( (new Supplier<Object>() {@Override public Object get() { try {  return \"bar\"; } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing map key\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get(),  (new Supplier<Object>() {@Override public Object get() { try {  return 1E0; } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing map value\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get()).build())"));
+    assertThat(java, equalTo("((Map)new MapBuilder(2).put( (new Supplier<Object>() {@Override public Object get() { try {  return \"foo\"; } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing map key\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get(),  (new Supplier<Object>() {@Override public Object get() { try {  return ((Double) (((java.util.Map) arguments.get(\"COL5\")) == null ? null : ((java.util.Map)((java.util.Map) arguments.get(\"COL5\"))).get(\"key1\"))); } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing map value\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get()).put( (new Supplier<Object>() {@Override public Object get() { try {  return \"bar\"; } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing map key\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get(),  (new Supplier<Object>() {@Override public Object get() { try {  return 1E0; } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing map value\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get()).build())"));
   }
 
   @Test
@@ -225,9 +229,7 @@ public class SqlToJavaVisitorTest {
     // Then:
     assertThat(
         javaExpression,
-        equalTo("((Struct)new Struct(schema0)"
-            + ".put(\"col1\", (new Supplier<Object>() {@Override public Object get() { try {  return \"foo\"; } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing struct field\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get())"
-            + ".put(\"col2\", (new Supplier<Object>() {@Override public Object get() { try {  return ((Double) (COL5 == null ? null : ((java.util.Map)COL5).get(\"key1\"))); } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing struct field\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get()))"));
+        equalTo("((Struct)new Struct(((org.apache.kafka.connect.data.Schema) arguments.get(\"schema0\"))).put(\"col1\", (new Supplier<Object>() {@Override public Object get() { try {  return \"foo\"; } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing struct field\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get()).put(\"col2\", (new Supplier<Object>() {@Override public Object get() { try {  return ((Double) (((java.util.Map) arguments.get(\"COL5\")) == null ? null : ((java.util.Map)((java.util.Map) arguments.get(\"COL5\"))).get(\"key1\"))); } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing struct field\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get()))"));
  }
 
   @Test
@@ -251,9 +253,7 @@ public class SqlToJavaVisitorTest {
     // Then:
     assertThat(
         javaExpression,
-        equalTo("((Double)(((Struct)new Struct(schema0).put(\"col1\", (new Supplier<Object>() "
-            + "{@Override public Object get() { try {  return \"foo\"; } catch (Exception e) {  "
-            + "logger.error(RecordProcessingError.recordProcessingError(    \"Error processing struct field\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get()).put(\"col2\", (new Supplier<Object>() {@Override public Object get() { try {  return ((Double) (COL5 == null ? null : ((java.util.Map)COL5).get(\"key1\"))); } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing struct field\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get())) == null ? null : ((Struct)new Struct(schema0).put(\"col1\", (new Supplier<Object>() {@Override public Object get() { try {  return \"foo\"; } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing struct field\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get()).put(\"col2\", (new Supplier<Object>() {@Override public Object get() { try {  return ((Double) (COL5 == null ? null : ((java.util.Map)COL5).get(\"key1\"))); } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing struct field\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get())).get(\"col2\")))"));
+        equalTo("((Double)(((Struct)new Struct(((org.apache.kafka.connect.data.Schema) arguments.get(\"schema0\"))).put(\"col1\", (new Supplier<Object>() {@Override public Object get() { try {  return \"foo\"; } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing struct field\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get()).put(\"col2\", (new Supplier<Object>() {@Override public Object get() { try {  return ((Double) (((java.util.Map) arguments.get(\"COL5\")) == null ? null : ((java.util.Map)((java.util.Map) arguments.get(\"COL5\"))).get(\"key1\"))); } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing struct field\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get())) == null ? null : ((Struct)new Struct(((org.apache.kafka.connect.data.Schema) arguments.get(\"schema0\"))).put(\"col1\", (new Supplier<Object>() {@Override public Object get() { try {  return \"foo\"; } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing struct field\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get()).put(\"col2\", (new Supplier<Object>() {@Override public Object get() { try {  return ((Double) (((java.util.Map) arguments.get(\"COL5\")) == null ? null : ((java.util.Map)((java.util.Map) arguments.get(\"COL5\"))).get(\"key1\"))); } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing struct field\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get())).get(\"col2\")))"));
   }
 
   @Test
@@ -292,21 +292,7 @@ public class SqlToJavaVisitorTest {
     final String javaExpression = sqlToJavaVisitor.process(expression);
 
     // Then:
-    final String expected = "((String) CONCAT_0.evaluate( (new Supplier<Object>() "
-        + "{@Override public Object get() { try {  return ((String) "
-        + "SUBSTRING_1.evaluate(COL1, 1, 3)); } catch (Exception e) {  "
-        + "logger.error(RecordProcessingError.recordProcessingError(    "
-        + "\"Error processing SUBSTRING\",    e instanceof InvocationTargetException? "
-        + "e.getCause() : e,    row));  return defaultValue; }}}).get(),  (new Supplier<Object>() "
-        + "{@Override public Object get() { try {  return ((String) CONCAT_2.evaluate(\"-\",  "
-        + "(new Supplier<Object>() {@Override public Object get() { try {  return ((String) "
-        + "SUBSTRING_3.evaluate(COL1, 4, 5)); } catch (Exception e) {  "
-        + "logger.error(RecordProcessingError.recordProcessingError(    "
-        + "\"Error processing SUBSTRING\",    e instanceof InvocationTargetException? "
-        + "e.getCause() : e,    row));  return defaultValue; }}}).get())); } catch (Exception e) "
-        + "{  logger.error(RecordProcessingError.recordProcessingError(    "
-        + "\"Error processing CONCAT\",    e instanceof InvocationTargetException? "
-        + "e.getCause() : e,    row));  return defaultValue; }}}).get()))";
+    final String expected = "((String) ((io.confluent.ksql.function.udf.Kudf) arguments.get(\"CONCAT_0\")).evaluate( (new Supplier<Object>() {@Override public Object get() { try {  return ((String) ((io.confluent.ksql.function.udf.Kudf) arguments.get(\"SUBSTRING_1\")).evaluate(((java.lang.String) arguments.get(\"COL1\")), 1, 3)); } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing SUBSTRING\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get(),  (new Supplier<Object>() {@Override public Object get() { try {  return ((String) ((io.confluent.ksql.function.udf.Kudf) arguments.get(\"CONCAT_2\")).evaluate(\"-\",  (new Supplier<Object>() {@Override public Object get() { try {  return ((String) ((io.confluent.ksql.function.udf.Kudf) arguments.get(\"SUBSTRING_3\")).evaluate(((java.lang.String) arguments.get(\"COL1\")), 4, 5)); } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing SUBSTRING\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get())); } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing CONCAT\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return defaultValue; }}}).get()))";
 
     assertThat(javaExpression, is(expected));
   }
@@ -337,7 +323,7 @@ public class SqlToJavaVisitorTest {
               new io.confluent.ksql.execution.expression.tree.Type(SqlTypes.BIGINT)));
 
     assertThat(javaExpression, is(
-        "((String) FOO_0.evaluate(" +doubleCast + ", " + longCast + "))"
+        "((String) ((io.confluent.ksql.function.udf.Kudf) arguments.get(\"FOO_0\")).evaluate(" +doubleCast + ", " + longCast + "))"
     ));
   }
 
@@ -371,7 +357,7 @@ public class SqlToJavaVisitorTest {
             new io.confluent.ksql.execution.expression.tree.Type(SqlTypes.BIGINT)));
 
     assertThat(javaExpression, is(
-        "((String) FOO_0.evaluate(" +doubleCast + ", " + longCast + ", " + longCast + "))"
+        "((String) ((io.confluent.ksql.function.udf.Kudf) arguments.get(\"FOO_0\")).evaluate(" +doubleCast + ", " + longCast + ", " + longCast + "))"
     ));
   }
 
@@ -394,7 +380,7 @@ public class SqlToJavaVisitorTest {
     );
 
     // Then:
-    assertThat(javaExpression, is("((String) FOO_0.evaluate(1, 1))"));
+    assertThat(javaExpression, is("((String) ((io.confluent.ksql.function.udf.Kudf) arguments.get(\"FOO_0\")).evaluate(1, 1))"));
   }
 
   @Test
@@ -436,7 +422,7 @@ public class SqlToJavaVisitorTest {
     // Then:
     assertThat(
         javaExpression, equalTo(
-            "((((Object)(COL3)) == null || ((Object)(-1E1)) == null) ? false : (COL3 > -1E1))"));
+            "((((Object)(((java.lang.Double) arguments.get(\"COL3\")))) == null || ((Object)(-1E1)) == null) ? false : (((java.lang.Double) arguments.get(\"COL3\")) > -1E1))"));
   }
 
   @Test
@@ -448,7 +434,7 @@ public class SqlToJavaVisitorTest {
     final String javaExpression = sqlToJavaVisitor.process(expression);
 
     // Then:
-    assertThat(javaExpression, equalTo("LikeEvaluator.matches(COL1, \"%foo\")"));
+    assertThat(javaExpression, equalTo("LikeEvaluator.matches(((java.lang.String) arguments.get(\"COL1\")), \"%foo\")"));
   }
 
   @Test
@@ -460,7 +446,7 @@ public class SqlToJavaVisitorTest {
     final String javaExpression = sqlToJavaVisitor.process(expression);
 
     // Then:
-    assertThat(javaExpression, equalTo("LikeEvaluator.matches(COL1, \"%foo\", '!')"));
+    assertThat(javaExpression, equalTo("LikeEvaluator.matches(((java.lang.String) arguments.get(\"COL1\")), \"%foo\", '!')"));
   }
 
   @Test
@@ -472,7 +458,7 @@ public class SqlToJavaVisitorTest {
     final String javaExpression = sqlToJavaVisitor.process(expression);
 
     // Then:
-    assertThat(javaExpression, equalTo("LikeEvaluator.matches(COL1, COL1)"));
+    assertThat(javaExpression, equalTo("LikeEvaluator.matches(((java.lang.String) arguments.get(\"COL1\")), ((java.lang.String) arguments.get(\"COL1\")))"));
   }
 
   @Test
@@ -500,7 +486,7 @@ public class SqlToJavaVisitorTest {
     // ThenL
     assertThat(
         javaExpression, equalTo(
-            "((java.lang.String)SearchedCaseFunction.searchedCaseFunction(ImmutableList.copyOf(Arrays.asList( SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(COL7)) == null || ((Object)(10)) == null) ? false : (COL7 < 10)); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"small\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(COL7)) == null || ((Object)(100)) == null) ? false : (COL7 < 100)); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"medium\"; }}))), new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"large\"; }}))"));
+            "((java.lang.String)SearchedCaseFunction.searchedCaseFunction(ImmutableList.copyOf(Arrays.asList( SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(((java.lang.Integer) arguments.get(\"COL7\")))) == null || ((Object)(10)) == null) ? false : (((java.lang.Integer) arguments.get(\"COL7\")) < 10)); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"small\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(((java.lang.Integer) arguments.get(\"COL7\")))) == null || ((Object)(100)) == null) ? false : (((java.lang.Integer) arguments.get(\"COL7\")) < 100)); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"medium\"; }}))), new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"large\"; }}))"));
   }
 
   @Test
@@ -530,7 +516,7 @@ public class SqlToJavaVisitorTest {
     // ThenL
     assertThat(
             javaExpression, equalTo(
-                    "((java.lang.String)SearchedCaseFunction.searchedCaseFunction(ImmutableList.copyOf(Arrays.asList( SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(COL7)) == null || ((Object)(0)) == null) ? false : ((COL7 <= 0) && (COL7 >= 0))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"zero\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(COL7)) == null || ((Object)(1)) == null) ? false : ((COL7 <= 1) && (COL7 >= 1))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"one\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(COL7)) == null || ((Object)(2)) == null) ? false : ((COL7 <= 2) && (COL7 >= 2))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"two\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(COL7)) == null || ((Object)(3)) == null) ? false : ((COL7 <= 3) && (COL7 >= 3))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"three\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(COL7)) == null || ((Object)(4)) == null) ? false : ((COL7 <= 4) && (COL7 >= 4))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"four\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(COL7)) == null || ((Object)(5)) == null) ? false : ((COL7 <= 5) && (COL7 >= 5))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"five\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(COL7)) == null || ((Object)(6)) == null) ? false : ((COL7 <= 6) && (COL7 >= 6))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"six\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(COL7)) == null || ((Object)(7)) == null) ? false : ((COL7 <= 7) && (COL7 >= 7))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"seven\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(COL7)) == null || ((Object)(8)) == null) ? false : ((COL7 <= 8) && (COL7 >= 8))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"eight\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(COL7)) == null || ((Object)(9)) == null) ? false : ((COL7 <= 9) && (COL7 >= 9))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"nine\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(COL7)) == null || ((Object)(10)) == null) ? false : ((COL7 <= 10) && (COL7 >= 10))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"ten\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(COL7)) == null || ((Object)(11)) == null) ? false : ((COL7 <= 11) && (COL7 >= 11))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"eleven\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(COL7)) == null || ((Object)(12)) == null) ? false : ((COL7 <= 12) && (COL7 >= 12))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"twelve\"; }}))), new Supplier<java.lang.String>() { @Override public java.lang.String get() { return null; }}))"));
+                    "((java.lang.String)SearchedCaseFunction.searchedCaseFunction(ImmutableList.copyOf(Arrays.asList( SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(((java.lang.Integer) arguments.get(\"COL7\")))) == null || ((Object)(0)) == null) ? false : ((((java.lang.Integer) arguments.get(\"COL7\")) <= 0) && (((java.lang.Integer) arguments.get(\"COL7\")) >= 0))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"zero\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(((java.lang.Integer) arguments.get(\"COL7\")))) == null || ((Object)(1)) == null) ? false : ((((java.lang.Integer) arguments.get(\"COL7\")) <= 1) && (((java.lang.Integer) arguments.get(\"COL7\")) >= 1))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"one\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(((java.lang.Integer) arguments.get(\"COL7\")))) == null || ((Object)(2)) == null) ? false : ((((java.lang.Integer) arguments.get(\"COL7\")) <= 2) && (((java.lang.Integer) arguments.get(\"COL7\")) >= 2))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"two\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(((java.lang.Integer) arguments.get(\"COL7\")))) == null || ((Object)(3)) == null) ? false : ((((java.lang.Integer) arguments.get(\"COL7\")) <= 3) && (((java.lang.Integer) arguments.get(\"COL7\")) >= 3))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"three\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(((java.lang.Integer) arguments.get(\"COL7\")))) == null || ((Object)(4)) == null) ? false : ((((java.lang.Integer) arguments.get(\"COL7\")) <= 4) && (((java.lang.Integer) arguments.get(\"COL7\")) >= 4))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"four\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(((java.lang.Integer) arguments.get(\"COL7\")))) == null || ((Object)(5)) == null) ? false : ((((java.lang.Integer) arguments.get(\"COL7\")) <= 5) && (((java.lang.Integer) arguments.get(\"COL7\")) >= 5))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"five\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(((java.lang.Integer) arguments.get(\"COL7\")))) == null || ((Object)(6)) == null) ? false : ((((java.lang.Integer) arguments.get(\"COL7\")) <= 6) && (((java.lang.Integer) arguments.get(\"COL7\")) >= 6))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"six\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(((java.lang.Integer) arguments.get(\"COL7\")))) == null || ((Object)(7)) == null) ? false : ((((java.lang.Integer) arguments.get(\"COL7\")) <= 7) && (((java.lang.Integer) arguments.get(\"COL7\")) >= 7))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"seven\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(((java.lang.Integer) arguments.get(\"COL7\")))) == null || ((Object)(8)) == null) ? false : ((((java.lang.Integer) arguments.get(\"COL7\")) <= 8) && (((java.lang.Integer) arguments.get(\"COL7\")) >= 8))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"eight\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(((java.lang.Integer) arguments.get(\"COL7\")))) == null || ((Object)(9)) == null) ? false : ((((java.lang.Integer) arguments.get(\"COL7\")) <= 9) && (((java.lang.Integer) arguments.get(\"COL7\")) >= 9))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"nine\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(((java.lang.Integer) arguments.get(\"COL7\")))) == null || ((Object)(10)) == null) ? false : ((((java.lang.Integer) arguments.get(\"COL7\")) <= 10) && (((java.lang.Integer) arguments.get(\"COL7\")) >= 10))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"ten\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(((java.lang.Integer) arguments.get(\"COL7\")))) == null || ((Object)(11)) == null) ? false : ((((java.lang.Integer) arguments.get(\"COL7\")) <= 11) && (((java.lang.Integer) arguments.get(\"COL7\")) >= 11))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"eleven\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(((java.lang.Integer) arguments.get(\"COL7\")))) == null || ((Object)(12)) == null) ? false : ((((java.lang.Integer) arguments.get(\"COL7\")) <= 12) && (((java.lang.Integer) arguments.get(\"COL7\")) >= 12))); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"twelve\"; }}))), new Supplier<java.lang.String>() { @Override public java.lang.String get() { return null; }}))"));
   }
 
   @Test
@@ -558,7 +544,7 @@ public class SqlToJavaVisitorTest {
     // ThenL
     assertThat(
         javaExpression, equalTo(
-            "((java.lang.String)SearchedCaseFunction.searchedCaseFunction(ImmutableList.copyOf(Arrays.asList( SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(COL7)) == null || ((Object)(10)) == null) ? false : (COL7 < 10)); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"small\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(COL7)) == null || ((Object)(100)) == null) ? false : (COL7 < 100)); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"medium\"; }}))), new Supplier<java.lang.String>() { @Override public java.lang.String get() { return null; }}))"));
+            "((java.lang.String)SearchedCaseFunction.searchedCaseFunction(ImmutableList.copyOf(Arrays.asList( SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(((java.lang.Integer) arguments.get(\"COL7\")))) == null || ((Object)(10)) == null) ? false : (((java.lang.Integer) arguments.get(\"COL7\")) < 10)); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"small\"; }}), SearchedCaseFunction.whenClause( new Supplier<Boolean>() { @Override public Boolean get() { return ((((Object)(((java.lang.Integer) arguments.get(\"COL7\")))) == null || ((Object)(100)) == null) ? false : (((java.lang.Integer) arguments.get(\"COL7\")) < 100)); }},  new Supplier<java.lang.String>() { @Override public java.lang.String get() { return \"medium\"; }}))), new Supplier<java.lang.String>() { @Override public java.lang.String get() { return null; }}))"));
   }
 
   @Test
@@ -576,7 +562,7 @@ public class SqlToJavaVisitorTest {
     // Then:
     assertThat(
         java,
-        is("(COL8.add(COL8, new MathContext(3, RoundingMode.UNNECESSARY)).setScale(1))")
+        is("(((java.math.BigDecimal) arguments.get(\"COL8\")).add(((java.math.BigDecimal) arguments.get(\"COL8\")), new MathContext(3, RoundingMode.UNNECESSARY)).setScale(1))")
     );
   }
 
@@ -593,7 +579,7 @@ public class SqlToJavaVisitorTest {
     final String java = sqlToJavaVisitor.process(binExp);
 
     // Then:
-    assertThat(java, containsString("DecimalUtil.cast(COL0, 19, 0)"));
+    assertThat(java, containsString("DecimalUtil.cast(((java.lang.Long) arguments.get(\"COL0\")), 19, 0)"));
   }
 
   @Test
@@ -610,7 +596,7 @@ public class SqlToJavaVisitorTest {
 
     // Then:
     final String doubleCast = CastEvaluator.generateCode(
-        "COL8", SqlTypes.decimal(2, 1), SqlTypes.DOUBLE, ksqlConfig);
+        "((java.math.BigDecimal) arguments.get(\"COL8\"))", SqlTypes.decimal(2, 1), SqlTypes.DOUBLE, ksqlConfig);
     assertThat(java, containsString(doubleCast));
   }
 
@@ -625,7 +611,7 @@ public class SqlToJavaVisitorTest {
 
         // Then:
         final Evaluator evaluator = CodeGenTestUtil.cookCode(java, Boolean.class);
-        evaluator.evaluate(Collections.emptyList());
+        evaluator.evaluate();
     }
 
   @Test
@@ -643,7 +629,7 @@ public class SqlToJavaVisitorTest {
     // Then:
     assertThat(
         java,
-        is("(COL8.subtract(COL8, new MathContext(3, RoundingMode.UNNECESSARY)).setScale(1))")
+        is("(((java.math.BigDecimal) arguments.get(\"COL8\")).subtract(((java.math.BigDecimal) arguments.get(\"COL8\")), new MathContext(3, RoundingMode.UNNECESSARY)).setScale(1))")
     );
   }
 
@@ -662,7 +648,7 @@ public class SqlToJavaVisitorTest {
     // Then:
     assertThat(
         java,
-        is("(COL8.multiply(COL8, new MathContext(5, RoundingMode.UNNECESSARY)).setScale(2))")
+        is("(((java.math.BigDecimal) arguments.get(\"COL8\")).multiply(((java.math.BigDecimal) arguments.get(\"COL8\")), new MathContext(5, RoundingMode.UNNECESSARY)).setScale(2))")
     );
   }
 
@@ -681,7 +667,7 @@ public class SqlToJavaVisitorTest {
     // Then:
     assertThat(
         java,
-        is("(COL8.divide(COL8, new MathContext(8, RoundingMode.UNNECESSARY)).setScale(6))")
+        is("(((java.math.BigDecimal) arguments.get(\"COL8\")).divide(((java.math.BigDecimal) arguments.get(\"COL8\")), new MathContext(8, RoundingMode.UNNECESSARY)).setScale(6))")
     );
   }
 
@@ -700,7 +686,7 @@ public class SqlToJavaVisitorTest {
     // Then:
     assertThat(
         java,
-        is("(COL8.remainder(COL8, new MathContext(2, RoundingMode.UNNECESSARY)).setScale(1))")
+        is("(((java.math.BigDecimal) arguments.get(\"COL8\")).remainder(((java.math.BigDecimal) arguments.get(\"COL8\")), new MathContext(2, RoundingMode.UNNECESSARY)).setScale(1))")
     );
   }
 
@@ -717,7 +703,7 @@ public class SqlToJavaVisitorTest {
     final String java = sqlToJavaVisitor.process(compExp);
 
     // Then:
-    assertThat(java, containsString("(COL8.compareTo(COL9) == 0))"));
+    assertThat(java, containsString("(((java.math.BigDecimal) arguments.get(\"COL8\")).compareTo(((java.math.BigDecimal) arguments.get(\"COL9\"))) == 0)"));
   }
 
   @Test
@@ -733,7 +719,7 @@ public class SqlToJavaVisitorTest {
     final String java = sqlToJavaVisitor.process(compExp);
 
     // Then:
-    assertThat(java, containsString("(COL8.compareTo(COL9) > 0))"));
+    assertThat(java, containsString("(((java.math.BigDecimal) arguments.get(\"COL8\")).compareTo(((java.math.BigDecimal) arguments.get(\"COL9\"))) > 0)"));
   }
 
   @Test
@@ -749,7 +735,7 @@ public class SqlToJavaVisitorTest {
     final String java = sqlToJavaVisitor.process(compExp);
 
     // Then:
-    assertThat(java, containsString("(COL8.compareTo(COL9) >= 0))"));
+    assertThat(java, containsString("(((java.math.BigDecimal) arguments.get(\"COL8\")).compareTo(((java.math.BigDecimal) arguments.get(\"COL9\"))) >= 0)"));
   }
 
   @Test
@@ -765,7 +751,7 @@ public class SqlToJavaVisitorTest {
     final String java = sqlToJavaVisitor.process(compExp);
 
     // Then:
-    assertThat(java, containsString("(COL8.compareTo(COL9) < 0))"));
+    assertThat(java, containsString("(((java.math.BigDecimal) arguments.get(\"COL8\")).compareTo(((java.math.BigDecimal) arguments.get(\"COL9\"))) < 0)"));
   }
 
   @Test
@@ -781,7 +767,7 @@ public class SqlToJavaVisitorTest {
     final String java = sqlToJavaVisitor.process(compExp);
 
     // Then:
-    assertThat(java, containsString("(COL8.compareTo(COL9) <= 0))"));
+    assertThat(java, containsString("(((java.math.BigDecimal) arguments.get(\"COL8\")).compareTo(((java.math.BigDecimal) arguments.get(\"COL9\"))) <= 0)"));
   }
 
   @Test
@@ -797,7 +783,7 @@ public class SqlToJavaVisitorTest {
     final String java = sqlToJavaVisitor.process(compExp);
 
     // Then:
-    assertThat(java, containsString("(COL8.compareTo(COL9) != 0))"));
+    assertThat(java, containsString("(((java.math.BigDecimal) arguments.get(\"COL8\")).compareTo(((java.math.BigDecimal) arguments.get(\"COL9\"))) != 0))"));
   }
 
   @Test
@@ -813,7 +799,7 @@ public class SqlToJavaVisitorTest {
     final String java = sqlToJavaVisitor.process(compExp);
 
     // Then:
-    assertThat(java, containsString("(COL8.compareTo(BigDecimal.valueOf(COL3)) == 0))"));
+    assertThat(java, containsString("(((java.math.BigDecimal) arguments.get(\"COL8\")).compareTo(BigDecimal.valueOf(((java.lang.Double) arguments.get(\"COL3\")))) == 0)"));
   }
 
   @Test
@@ -829,7 +815,7 @@ public class SqlToJavaVisitorTest {
     final String java = sqlToJavaVisitor.process(compExp);
 
     // Then:
-    assertThat(java, containsString("(BigDecimal.valueOf(COL3).compareTo(COL8) == 0))"));
+    assertThat(java, containsString("(BigDecimal.valueOf(((java.lang.Double) arguments.get(\"COL3\"))).compareTo(((java.math.BigDecimal) arguments.get(\"COL8\"))) == 0)"));
   }
 
   @Test
@@ -845,7 +831,7 @@ public class SqlToJavaVisitorTest {
     final String java = sqlToJavaVisitor.process(binExp);
 
     // Then:
-    assertThat(java, is("(COL8.negate(new MathContext(2, RoundingMode.UNNECESSARY)))"));
+    assertThat(java, is("(((java.math.BigDecimal) arguments.get(\"COL8\")).negate(new MathContext(2, RoundingMode.UNNECESSARY)))"));
   }
 
   @Test
@@ -861,7 +847,7 @@ public class SqlToJavaVisitorTest {
     final String java = sqlToJavaVisitor.process(binExp);
 
     // Then:
-    assertThat(java, is("(COL8.plus(new MathContext(2, RoundingMode.UNNECESSARY)))"));
+    assertThat(java, is("(((java.math.BigDecimal) arguments.get(\"COL8\")).plus(new MathContext(2, RoundingMode.UNNECESSARY)))"));
   }
 
   @Test
@@ -877,7 +863,7 @@ public class SqlToJavaVisitorTest {
     final String java = sqlToJavaVisitor.process(compExp);
 
     // Then:
-    assertThat(java, containsString("(COL12.compareTo(COL12) < 0)"));
+    assertThat(java, containsString("(((java.sql.Time) arguments.get(\"COL12\")).compareTo(((java.sql.Time) arguments.get(\"COL12\"))) < 0)"));
   }
 
   @Test
@@ -893,7 +879,7 @@ public class SqlToJavaVisitorTest {
     final String java = sqlToJavaVisitor.process(compExp);
 
     // Then:
-    assertThat(java, containsString("(COL12.compareTo(SqlTimeTypes.parseTime(\"01:23:45\")) == 0)"));
+    assertThat(java, containsString("(((java.sql.Time) arguments.get(\"COL12\")).compareTo(SqlTimeTypes.parseTime(\"01:23:45\")) == 0)"));
   }
 
   @Test
@@ -937,7 +923,7 @@ public class SqlToJavaVisitorTest {
     final String java = sqlToJavaVisitor.process(compExp);
 
     // Then:
-    assertThat(java, containsString("(COL13.compareTo(COL13) < 0)"));
+    assertThat(java, containsString("(((java.sql.Date) arguments.get(\"COL13\")).compareTo(((java.sql.Date) arguments.get(\"COL13\"))) < 0)"));
   }
 
   @Test
@@ -953,7 +939,7 @@ public class SqlToJavaVisitorTest {
     final String java = sqlToJavaVisitor.process(compExp);
 
     // Then:
-    assertThat(java, containsString("(COL13.compareTo(SqlTimeTypes.parseDate(\"2021-06-23\")) == 0)"));
+    assertThat(java, containsString("(((java.sql.Date) arguments.get(\"COL13\")).compareTo(SqlTimeTypes.parseDate(\"2021-06-23\")) == 0)"));
   }
 
   @Test
@@ -969,7 +955,7 @@ public class SqlToJavaVisitorTest {
     final String java = sqlToJavaVisitor.process(compExp);
 
     // Then:
-    assertThat(java, containsString("(COL10.compareTo(COL10) < 0)"));
+    assertThat(java, containsString("(((java.sql.Timestamp) arguments.get(\"COL10\")).compareTo(((java.sql.Timestamp) arguments.get(\"COL10\"))) < 0)"));
   }
 
   @Test
@@ -985,7 +971,7 @@ public class SqlToJavaVisitorTest {
     final String java = sqlToJavaVisitor.process(compExp);
 
     // Then:
-    assertThat(java, containsString("(COL10.compareTo(SqlTimeTypes.parseTimestamp(\"2020-01-01T00:00:00\")) == 0)"));
+    assertThat(java, containsString("(((java.sql.Timestamp) arguments.get(\"COL10\")).compareTo(SqlTimeTypes.parseTimestamp(\"2020-01-01T00:00:00\")) == 0)"));
   }
 
   @Test
@@ -1001,7 +987,7 @@ public class SqlToJavaVisitorTest {
     final String java = sqlToJavaVisitor.process(compExp);
 
     // Then:
-    assertThat(java, containsString("(SqlTimeTypes.parseTimestamp(\"2020-01-01T00:00:00\").compareTo(COL10) >= 0)"));
+    assertThat(java, containsString("(SqlTimeTypes.parseTimestamp(\"2020-01-01T00:00:00\").compareTo(((java.sql.Timestamp) arguments.get(\"COL10\"))) >= 0)"));
   }
 
   @Test
@@ -1017,7 +1003,7 @@ public class SqlToJavaVisitorTest {
     final String java = sqlToJavaVisitor.process(compExp);
 
     // Then:
-    assertThat(java, containsString("(COL10.compareTo(COL13) > 0)"));
+    assertThat(java, containsString("(((java.sql.Timestamp) arguments.get(\"COL10\")).compareTo(((java.sql.Date) arguments.get(\"COL13\"))) > 0)"));
   }
 
   @Test
@@ -1033,7 +1019,7 @@ public class SqlToJavaVisitorTest {
     final String java = sqlToJavaVisitor.process(compExp);
 
     // Then:
-    assertThat(java, containsString("(COL14.compareTo(COL14) > 0)"));
+    assertThat(java, containsString("(((java.nio.ByteBuffer) arguments.get(\"COL14\")).compareTo(((java.nio.ByteBuffer) arguments.get(\"COL14\"))) > 0)"));
   }
 
   @Test
@@ -1099,7 +1085,7 @@ public class SqlToJavaVisitorTest {
     final String java = sqlToJavaVisitor.process(expression);
 
     // Then:
-    assertThat(java, is("InListEvaluator.matches(COL0,1L,2L)"));
+    assertThat(java, is("InListEvaluator.matches(((java.lang.Long) arguments.get(\"COL0\")),1L,2L)"));
   }
 
   @Test
@@ -1131,7 +1117,13 @@ public class SqlToJavaVisitorTest {
     // Then
     assertThat(
         javaExpression, equalTo(
-            "((String) TRANSFORM_0.evaluate(COL4, new Function() {\n @Override\n public Object apply(Object arg1) {\n   final Double x = (Double) arg1;\n   return ((String) ABS_1.evaluate(X));\n }\n}))"));
+            "((String) ((io.confluent.ksql.function.udf.Kudf) arguments.get(\"TRANSFORM_0\")).evaluate(((java.util.List) arguments.get(\"COL4\")), new Function() {\n" +
+            " @Override\n" +
+            " public Object apply(Object arg1) {\n" +
+            "   final Double x = (Double) arg1;\n" +
+            "   return ((String) ((io.confluent.ksql.function.udf.Kudf) arguments.get(\"ABS_1\")).evaluate(X));\n" +
+            " }\n" +
+            "}))"));
   }
 
   @Test
@@ -1168,7 +1160,7 @@ public class SqlToJavaVisitorTest {
     // Then
     assertThat(
         javaExpression, equalTo(
-            "((String) REDUCE_0.evaluate(COL4, COL3, new BiFunction() {\n" +
+            "((String) ((io.confluent.ksql.function.udf.Kudf) arguments.get(\"REDUCE_0\")).evaluate(((java.util.List) arguments.get(\"COL4\")), ((java.lang.Double) arguments.get(\"COL3\")), new BiFunction() {\n" +
                 " @Override\n" +
                 " public Object apply(Object arg1, Object arg2) {\n" +
                 "   final Double X = (Double) arg1;\n" +
@@ -1232,7 +1224,7 @@ public class SqlToJavaVisitorTest {
 
     // Then
     assertThat(
-        javaExpression, equalTo("((String) function_0.evaluate(COL4, COL1, new BiFunction() {\n"
+        javaExpression, equalTo("((String) ((io.confluent.ksql.function.udf.Kudf) arguments.get(\"function_0\")).evaluate(((java.util.List) arguments.get(\"COL4\")), ((java.lang.String) arguments.get(\"COL1\")), new BiFunction() {\n"
             + " @Override\n"
             + " public Object apply(Object arg1, Object arg2) {\n"
             + "   final Double X = (Double) arg1;\n"
@@ -1298,41 +1290,33 @@ public class SqlToJavaVisitorTest {
     // Then
     assertThat(
         javaExpression, equalTo(
-            "(((Double) nested_0.evaluate(COL4,  (new Supplier<java.lang.Double>() " +
-                    "{@Override public java.lang.Double get() { " +
-                    "try {  return ((Double)NullSafe.apply(0,new Function() {\n"
-                + " @Override\n"
-                + " public Object apply(Object arg1) {\n"
-                + "   final Integer val = (Integer) arg1;\n"
-                + "   return val.doubleValue();\n"
-                + " }\n"
-                + "})); } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    " +
-                    "\"Error processing DOUBLE\",    e instanceof InvocationTargetException? e.getCause() : e,    " +
-                    "row));  return (java.lang.Double) defaultValue; }}}).get(), new BiFunction() {\n"
-                + " @Override\n"
-                + " public Object apply(Object arg1, Object arg2) {\n"
-                + "   final Double A = (Double) arg1;\n"
-                + "   final Integer B = (Integer) arg2;\n"
-                + "   return (((Double) nested_1.evaluate(COL4,  (new Supplier<java.lang.Double>() " +
-                    "{@Override public java.lang.Double get() { try {  " +
-                    "return ((Double)NullSafe.apply(0,new Function() {\n"
-                + " @Override\n"
-                + " public Object apply(Object arg1) {\n"
-                + "   final Integer val = (Integer) arg1;\n"
-                + "   return val.doubleValue();\n"
-                + " }\n"
-                + "})); } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    " +
-                    "\"Error processing DOUBLE\",    e instanceof InvocationTargetException? e.getCause() : e,    " +
-                    "row));  return (java.lang.Double) defaultValue; }}}).get(), new BiFunction() {\n"
-                + " @Override\n"
-                + " public Object apply(Object arg1, Object arg2) {\n"
-                + "   final Double Q = (Double) arg1;\n"
-                + "   final Integer V = (Integer) arg2;\n"
-                + "   return (Q + V);\n"
-                + " }\n"
-                + "})) + B);\n"
-                + " }\n"
-                + "})) + 5)"));
+            "(((Double) ((io.confluent.ksql.function.udf.Kudf) arguments.get(\"nested_0\")).evaluate(((java.util.List) arguments.get(\"COL4\")),  (new Supplier<java.lang.Double>() {@Override public java.lang.Double get() { try {  return ((Double)NullSafe.apply(0,new Function() {\n" +
+            " @Override\n" +
+            " public Object apply(Object arg1) {\n" +
+            "   final Integer val = (Integer) arg1;\n" +
+            "   return val.doubleValue();\n" +
+            " }\n" +
+            "})); } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing DOUBLE\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return (java.lang.Double) defaultValue; }}}).get(), new BiFunction() {\n" +
+            " @Override\n" +
+            " public Object apply(Object arg1, Object arg2) {\n" +
+            "   final Double A = (Double) arg1;\n" +
+            "   final Integer B = (Integer) arg2;\n" +
+            "   return (((Double) ((io.confluent.ksql.function.udf.Kudf) arguments.get(\"nested_1\")).evaluate(((java.util.List) arguments.get(\"COL4\")),  (new Supplier<java.lang.Double>() {@Override public java.lang.Double get() { try {  return ((Double)NullSafe.apply(0,new Function() {\n" +
+            " @Override\n" +
+            " public Object apply(Object arg1) {\n" +
+            "   final Integer val = (Integer) arg1;\n" +
+            "   return val.doubleValue();\n" +
+            " }\n" +
+            "})); } catch (Exception e) {  logger.error(RecordProcessingError.recordProcessingError(    \"Error processing DOUBLE\",    e instanceof InvocationTargetException? e.getCause() : e,    row));  return (java.lang.Double) defaultValue; }}}).get(), new BiFunction() {\n" +
+            " @Override\n" +
+            " public Object apply(Object arg1, Object arg2) {\n" +
+            "   final Double Q = (Double) arg1;\n" +
+            "   final Integer V = (Integer) arg2;\n" +
+            "   return (Q + V);\n" +
+            " }\n" +
+            "})) + B);\n" +
+            " }\n" +
+            "})) + 5)"));
   }
 
   @Test
@@ -1354,6 +1338,41 @@ public class SqlToJavaVisitorTest {
   @Test
   public void shouldProcessTimeLiteral() {
     assertThat(sqlToJavaVisitor.process(new TimeLiteral(new Time(1000))), is("00:00:01"));
+  }
+
+  @Test
+  public void shouldHandleManyArguments() {
+    // Given:
+    final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder();
+    for (int i = 0; i < 500; i++) {
+      schemaBuilder.valueColumn(ColumnName.of("COL" + i), SqlTypes.STRING);
+    }
+    final LogicalSchema schema = schemaBuilder.build();
+
+    final AtomicInteger funCounter = new AtomicInteger();
+    final AtomicInteger structCounter = new AtomicInteger();
+    final SqlToJavaVisitor sqlToJavaVisitor = new SqlToJavaVisitor(
+            schema,
+            functionRegistry,
+            ref -> ref.text().replace(".", "_"),
+            name -> name.text() + "_" + funCounter.getAndIncrement(),
+            struct -> "schema" + structCounter.getAndIncrement(),
+            ksqlConfig
+    );
+
+    final List<Expression> expressions = new ArrayList<>();
+    for (int i = 0; i < 500 ; i++) {
+      expressions.add(new UnqualifiedColumnReferenceExp(ColumnName.of("COL" + i)));
+    }
+    final Expression expression = new CreateArrayExpression(expressions);
+
+    // When:
+    final String java = sqlToJavaVisitor.process(expression);
+
+    // Then:
+    final Map<String, Object> arguments = IntStream.range(0, 500).boxed().collect(Collectors.toMap(i -> "COL" + i, String::valueOf));
+    final Evaluator evaluator = CodeGenTestUtil.cookCode(java, List.class);
+    evaluator.evaluate(arguments);
   }
 
   private void givenUdf(

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/codegen/helpers/NullSafeTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/codegen/helpers/NullSafeTest.java
@@ -18,12 +18,12 @@ public class NullSafeTest {
 
     // When:
     final String javaCode = NullSafe
-        .generateApply("input", mapperCode, Long.class);
+        .generateApply("arguments.get(\"input\")", mapperCode, Long.class);
 
     // Then:
-    final Evaluator evaluator = CodeGenTestUtil.cookCode(javaCode, Long.class, "input", Long.class);
-    assertThat(evaluator.evaluate(10L), is(11L));
-    assertThat(evaluator.evaluate(null), is(nullValue()));
+    final Evaluator evaluator = CodeGenTestUtil.cookCode(javaCode, Long.class);
+    assertThat(evaluator.evaluate("input", 10L), is(11L));
+    assertThat(evaluator.evaluate("input", null), is(nullValue()));
   }
 
   @Test
@@ -34,11 +34,11 @@ public class NullSafeTest {
 
     // When:
     final String javaCode = NullSafe
-        .generateApplyOrDefault("input", mapperCode, "99L", Long.class);
+        .generateApplyOrDefault("arguments.get(\"input\")", mapperCode, "99L", Long.class);
 
     // Then:
-    final Evaluator evaluator = CodeGenTestUtil.cookCode(javaCode, Long.class, "input", Long.class);
-    assertThat(evaluator.evaluate(10L), is(11L));
-    assertThat(evaluator.evaluate(null), is(99L));
+    final Evaluator evaluator = CodeGenTestUtil.cookCode(javaCode, Long.class);
+    assertThat(evaluator.evaluate("input", 10L), is(11L));
+    assertThat(evaluator.evaluate("input", null), is(99L));
   }
 }

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
@@ -551,10 +551,9 @@ public class ExpressionTypeManagerTest {
     );
 
     // Then:
-    assertThat(e.getUnloggedMessage(), Matchers.containsString(
-        "Error processing expression: (A + B). " +
-            "Unsupported arithmetic types. DOUBLE STRING\n" +
-            "Statement: (A + B)"));
+    assertThat(e.getUnloggedMessage(), Matchers.containsString("Error processing expression: (A + B). Unsupported arithmetic types. DOUBLE STRING" +
+                                                               System.lineSeparator() +
+                                                               "Statement: (A + B)"));
     assertThat(e.getMessage(), Matchers.is(
         "Error processing expression."));
   }


### PR DESCRIPTION
### Description

Fixes #9353

When generating java from ksql, all arguments are passed as individual method arguments. The java compiler only allows up to 255 method arguments. After a ksql statement reaches a certain size, this limit is nolonger sufficient resulting in the following ClassFormatError:

`Exception in thread "main" java.lang.ClassFormatError: Too many arguments in method signature in class file SC
at java.base/java.lang.ClassLoader.defineClass1(Native Method)
at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
at org.codehaus.janino.ByteArrayClassLoader.findClass(ByteArrayClassLoader.java:74)
at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
at org.codehaus.janino.ClassBodyEvaluator.compileToClass(ClassBodyEvaluator.java:317)
at org.codehaus.janino.ScriptEvaluator.cook2(ScriptEvaluator.java:608)
at org.codehaus.janino.ScriptEvaluator.cook(ScriptEvaluator.java:597)
at org.codehaus.janino.ScriptEvaluator.cook(ScriptEvaluator.java:534)
at org.codehaus.janino.ScriptEvaluator.cook(ScriptEvaluator.java:503)
at org.codehaus.janino.SimpleCompiler.cook(SimpleCompiler.java:204)
at org.codehaus.commons.compiler.Cookable.cook(Cookable.java:80)
at org.codehaus.commons.compiler.Cookable.cook(Cookable.java:75)
at io.confluent.ksql.execution.codegen.CodeGenRunner.cook(CodeGenRunner.java:195)
...
`

This change puts all those arguments in one map. This map is then passed as one method argument.

### Testing done 
Unit tests have been changed to reflect the changes made in this PR.

A new test 'shouldHandleManyArguments' has been added to SqlToJavaVisitorTest.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

