### PR TITLE
feat: Alternative representations for nullable protobuf fields (backport)

### DIFF
--- a/docs/developer-guide/ksqldb-reference/create-stream-as-select.md
+++ b/docs/developer-guide/ksqldb-reference/create-stream-as-select.md
@@ -189,6 +189,15 @@ table.
 You can't use the `KEY_FORMAT` property with the `FORMAT` property in the
 same `CREATE STREAM AS SELECT` statement.
 
+### KEY_PROTOBUF_NULLABLE_REPRESENTATION
+
+In the default configuration, primitive fields in protobuf do not distinguish `null` from the
+default values (such as zero, empty string). To enable the use of a protobuf schema that can make
+this distinction, set `KEY_PROTOBUF_NULLABLE_REPRESENTATION` to either `OPTIONAL` or `WRAPPER`.
+The schema will be used to serialize keys for the stream created by this `CREATE` statement.
+For more details, see the corresponding section in the
+[Serialization Formats](/reference/serialization#protobuf) documentation.
+
 ### KEY_SCHEMA_ID
 
 The schema ID of the key schema in {{ site.sr }}.
@@ -296,6 +305,15 @@ table.
 
 You can't use the `VALUE_FORMAT` property with the `FORMAT` property in the
 same `CREATE STREAM AS SELECT` statement.
+
+### VALUE_PROTOBUF_NULLABLE_REPRESENTATION
+
+In the default configuration, primitive fields in protobuf do not distinguish `null` from the
+default values (such as zero, empty string). To enable the use of a protobuf schema that can make
+this distinction, set `VALUE_PROTOBUF_NULLABLE_REPRESENTATION` to either `OPTIONAL` or `WRAPPER`.
+The schema will be used to serialize values for the stream created by this `CREATE` statement.
+For more details, see the corresponding section in the
+[Serialization Formats](/reference/serialization#protobuf) documentation.
 
 ### VALUE_SCHEMA_ID
 

--- a/docs/developer-guide/ksqldb-reference/create-stream.md
+++ b/docs/developer-guide/ksqldb-reference/create-stream.md
@@ -192,6 +192,15 @@ If the default is also not set, the statement is rejected as invalid.
 You can't use the `KEY_FORMAT` property with the `FORMAT` property in the
 same `CREATE STREAM` statement.
 
+### KEY_PROTOBUF_NULLABLE_REPRESENTATION
+
+In the default configuration, primitive fields in protobuf do not distinguish `null` from the
+default values (such as zero, empty string). To enable the use of a protobuf schema that can make
+this distinction, set `KEY_PROTOBUF_NULLABLE_REPRESENTATION` to either `OPTIONAL` or `WRAPPER`.
+The schema will be used to serialize keys for the stream created by this `CREATE` statement.
+For more details, see the corresponding section in the
+[Serialization Formats](/reference/serialization#protobuf) documentation.
+
 ### KEY_SCHEMA_ID
 
 The schema ID of the key schema in {{ site.sr }}.
@@ -273,6 +282,15 @@ If the default is also not set, the statement is rejected as invalid.
 
 You can't use the `VALUE_FORMAT` property with the `FORMAT` property in the
 same CREATE STREAM statement.
+
+### VALUE_PROTOBUF_NULLABLE_REPRESENTATION
+
+In the default configuration, primitive fields in protobuf do not distinguish `null` from the
+default values (such as zero, empty string). To enable the use of a protobuf schema that can make
+this distinction, set `VALUE_PROTOBUF_NULLABLE_REPRESENTATION` to either `OPTIONAL` or `WRAPPER`.
+The schema will be used to serialize values for the stream created by this `CREATE` statement.
+For more details, see the corresponding section in the
+[Serialization Formats](/reference/serialization#protobuf) documentation.
 
 ### VALUE_SCHEMA_ID
 

--- a/docs/developer-guide/ksqldb-reference/create-table-as-select.md
+++ b/docs/developer-guide/ksqldb-reference/create-table-as-select.md
@@ -165,6 +165,15 @@ table.
 You can't use the `KEY_FORMAT` property with the `FORMAT` property in the
 same `CREATE TABLE AS SELECT` statement.
 
+### KEY_PROTOBUF_NULLABLE_REPRESENTATION
+
+In the default configuration, primitive fields in protobuf do not distinguish `null` from the
+default values (such as zero, empty string). To enable the use of a protobuf schema that can make
+this distinction, set `KEY_PROTOBUF_NULLABLE_REPRESENTATION` to either `OPTIONAL` or `WRAPPER`.
+The schema will be used to serialize keys for the table created by this `CREATE` statement.
+For more details, see the corresponding section in the
+[Serialization Formats](/reference/serialization#protobuf) documentation.
+
 ### KEY_SCHEMA_ID
 
 The schema ID of the key schema in {{ site.sr }}.
@@ -284,6 +293,15 @@ If the default is also not set, the statement is rejected as invalid.
 
 You can't use the `VALUE_FORMAT` property with the `FORMAT` property in the
 same `CREATE TABLE AS SELECT` statement.
+
+### VALUE_PROTOBUF_NULLABLE_REPRESENTATION
+
+In the default configuration, primitive fields in protobuf do not distinguish `null` from the
+default values (such as zero, empty string). To enable the use of a protobuf schema that can make
+this distinction, set `VALUE_PROTOBUF_NULLABLE_REPRESENTATION` to either `OPTIONAL` or `WRAPPER`.
+The schema will be used to serialize values for the table created by this `CREATE` statement.
+For more details, see the corresponding section in the
+[Serialization Formats](/reference/serialization#protobuf) documentation.
 
 ### VALUE_SCHEMA_ID
 

--- a/docs/developer-guide/ksqldb-reference/create-table.md
+++ b/docs/developer-guide/ksqldb-reference/create-table.md
@@ -204,6 +204,15 @@ If the default is also not set, the statement is rejected as invalid.
 You can't use the `KEY_FORMAT` property with the `FORMAT` property in the
 same `CREATE TABLE` statement.
 
+### KEY_PROTOBUF_NULLABLE_REPRESENTATION
+
+In the default configuration, primitive fields in protobuf do not distinguish `null` from the
+default values (such as zero, empty string). To enable the use of a protobuf schema that can make
+this distinction, set `KEY_PROTOBUF_NULLABLE_REPRESENTATION` to either `OPTIONAL` or `WRAPPER`.
+The schema will be used to serialize keys for the table created by this `CREATE` statement.
+For more details, see the corresponding section in the
+[Serialization Formats](/reference/serialization#protobuf) documentation.
+
 ### KEY_SCHEMA_ID
 
 The schema ID of the key schema in {{ site.sr }}.
@@ -276,6 +285,15 @@ If the default is also not set, the statement is rejected as invalid.
 
 You can't use the `VALUE_FORMAT` property with the `FORMAT` property in the
 same `CREATE TABLE` statement.
+
+### VALUE_PROTOBUF_NULLABLE_REPRESENTATION
+
+In the default configuration, primitive fields in protobuf do not distinguish `null` from the
+default values (such as zero, empty string). To enable the use of a protobuf schema that can make
+this distinction, set `VALUE_PROTOBUF_NULLABLE_REPRESENTATION` to either `OPTIONAL` or `WRAPPER`.
+The schema will be used to serialize values for the table created by this `CREATE` statement.
+For more details, see the corresponding section in the
+[Serialization Formats](/reference/serialization#protobuf) documentation.
 
 ### VALUE_SCHEMA_ID
 

--- a/docs/reference/serialization.md
+++ b/docs/reference/serialization.md
@@ -506,6 +506,22 @@ have the concept of a `null` value, so the conversion between PROTOBUF and Java
 - **Message field:** the field is not set. Its exact value is language-dependent.
   See the generated code guide for details.
 
+To enable alternative representations for `null` values in protobuf, protobuf-specific properties
+can be passed to `CREATE` statements. For example, the following `CREATE` statement will
+create a protobuf schema that wraps all primitive types into the corresponding standard wrappers 
+(e.g. `google.protobuf.StringValue` for `string`). 
+
+```sql
+CREATE STREAM USERS (ID STRING KEY, i INTEGER, s STRING) WITH (VALUE_FORMAT='PROTOBUF', VALUE_PROTOBUF_NULLABLE_REPRESENTATION='WRAPPER');
+```
+
+This way, `null` can be distinguished from default values. Similarly, when 
+`VALUE_PROTOBUF_NULLABLE_REPRESENTATION` is set to `OPTIONAL`, all fields in protobuf will be
+declared optional, also allowing `null` primitive fields to be distinguished from default values. 
+
+The same property values can be used with the `KEY_PROTOBUF_NULLABLE_REPRESENTATION` property to
+customize the protobuf serialization of the key.
+
 Single field (un)wrapping
 -------------------------
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CommonCreateConfigs.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CommonCreateConfigs.java
@@ -47,6 +47,15 @@ public final class CommonCreateConfigs {
   public static final String KEY_FORMAT_PROPERTY = "KEY_FORMAT";
   public static final String FORMAT_PROPERTY = "FORMAT";
   public static final String WRAP_SINGLE_VALUE = "WRAP_SINGLE_VALUE";
+  public static final String KEY_PROTOBUF_NULLABLE_REPRESENTATION =
+      "KEY_PROTOBUF_NULLABLE_REPRESENTATION";
+  public static final String VALUE_PROTOBUF_NULLABLE_REPRESENTATION =
+      "VALUE_PROTOBUF_NULLABLE_REPRESENTATION";
+
+  public enum ProtobufNullableConfigValues {
+    OPTIONAL,
+    WRAPPER
+  }
 
   public static final String VALUE_DELIMITER_PROPERTY = "VALUE_DELIMITER";
   public static final String KEY_DELIMITER_PROPERTY = "KEY_DELIMITER";
@@ -133,6 +142,32 @@ public final class CommonCreateConfigs {
                 + "only a single field.  If set to true, KSQL expects the field to have been "
                 + "serialized as a named field within a record. If set to false, KSQL expects the "
                 + "field to have been serialized as an anonymous value."
+        )
+        .define(
+            KEY_PROTOBUF_NULLABLE_REPRESENTATION,
+            ConfigDef.Type.STRING,
+            null,
+            ConfigValidators.enumValues(ProtobufNullableConfigValues.class),
+            Importance.LOW,
+            "If supplied, protobuf schema generation will use fields that distinguish "
+                + "null from default values for primitive values. The value `"
+                + ProtobufNullableConfigValues.OPTIONAL.name()
+                + "` will enable using the `optional` on all fields, whereas `"
+                + ProtobufNullableConfigValues.WRAPPER.name()
+                + "` will use wrappers for all primitive value fields, including strings."
+        )
+        .define(
+            VALUE_PROTOBUF_NULLABLE_REPRESENTATION,
+            ConfigDef.Type.STRING,
+            null,
+            ConfigValidators.enumValues(ProtobufNullableConfigValues.class),
+            Importance.LOW,
+            "If supplied, protobuf schema generation will use fields that distinguish "
+                + "null from default values for primitive values. The value `"
+                + ProtobufNullableConfigValues.OPTIONAL.name()
+                + "` will enable using the `optional` on all fields, whereas `"
+                + ProtobufNullableConfigValues.WRAPPER.name()
+                + "` will use wrappers for all primitive value fields, including strings."
         )
         .define(
             VALUE_AVRO_SCHEMA_FULL_NAME,

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/AssertExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/AssertExecutor.java
@@ -90,7 +90,8 @@ public final class AssertExecutor {
           ),
           "key format properties",
           CommonCreateConfigs.KEY_DELIMITER_PROPERTY,
-          CommonCreateConfigs.KEY_SCHEMA_FULL_NAME
+          CommonCreateConfigs.KEY_SCHEMA_FULL_NAME,
+          CommonCreateConfigs.KEY_PROTOBUF_NULLABLE_REPRESENTATION
       )).add(new SourceProperty(
           ds -> ds.getKsqlTopic().getValueFormat().getFormatInfo().getFormat(),
           (cs, cfg) -> cs.getProperties().getValueFormat().map(FormatInfo::getFormat)
@@ -107,7 +108,8 @@ public final class AssertExecutor {
           "value format properties",
           CommonCreateConfigs.VALUE_AVRO_SCHEMA_FULL_NAME,
           CommonCreateConfigs.VALUE_SCHEMA_FULL_NAME,
-          CommonCreateConfigs.VALUE_DELIMITER_PROPERTY
+          CommonCreateConfigs.VALUE_DELIMITER_PROPERTY,
+          CommonCreateConfigs.VALUE_PROTOBUF_NULLABLE_REPRESENTATION
       )).add(new SourceProperty(
           ds -> ds.getKsqlTopic().getValueFormat().getFormatInfo().getProperties()
               .get(CommonCreateConfigs.VALUE_SCHEMA_ID),

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/ConnectSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/ConnectSerdeSupplier.java
@@ -63,6 +63,13 @@ public abstract class ConnectSerdeSupplier<T extends ParsedSchema>
 
   protected abstract Schema fromParsedSchema(T schema);
 
+  protected void configureConverter(final Converter c, final boolean isKey) {
+    c.configure(
+        ImmutableMap.of(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "foo"),
+        isKey
+    );
+  }
+
   private final class SpecSerializer implements Serializer<Object> {
 
     private final SchemaRegistryClient srClient;
@@ -72,10 +79,7 @@ public abstract class ConnectSerdeSupplier<T extends ParsedSchema>
     SpecSerializer(final SchemaRegistryClient srClient, final boolean isKey) {
       this.srClient = Objects.requireNonNull(srClient, "srClient");
       this.converter = converterFactory.apply(srClient);
-      converter.configure(
-          ImmutableMap.of(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "foo"),
-          isKey
-      );
+      configureConverter(converter, isKey);
       this.isKey = isKey;
     }
 
@@ -111,10 +115,7 @@ public abstract class ConnectSerdeSupplier<T extends ParsedSchema>
 
     SpecDeserializer(final SchemaRegistryClient srClient, final boolean isKey) {
       this.converter = converterFactory.apply(srClient);
-      converter.configure(
-          ImmutableMap.of(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "foo"),
-          isKey
-      );
+      configureConverter(converter, isKey);
     }
 
     @Override

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/protobuf/ValueSpecProtobufSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/protobuf/ValueSpecProtobufSerdeSupplier.java
@@ -15,24 +15,48 @@
 
 package io.confluent.ksql.test.serde.protobuf;
 
+import static io.confluent.connect.protobuf.ProtobufDataConfig.OPTIONAL_FOR_NULLABLES_CONFIG;
+import static io.confluent.connect.protobuf.ProtobufDataConfig.WRAPPER_FOR_NULLABLES_CONFIG;
+
+import com.google.common.collect.ImmutableMap;
 import io.confluent.connect.protobuf.ProtobufConverter;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.ksql.serde.protobuf.ProtobufProperties;
 import io.confluent.ksql.serde.protobuf.ProtobufSchemaTranslator;
 import io.confluent.ksql.test.serde.ConnectSerdeSupplier;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.storage.Converter;
 
 public class ValueSpecProtobufSerdeSupplier extends ConnectSerdeSupplier<ProtobufSchema> {
 
   private final ProtobufSchemaTranslator schemaTranslator;
 
+  private final ImmutableMap<String, Boolean> converterConfig;
+
   public ValueSpecProtobufSerdeSupplier(final ProtobufProperties protobufProperties) {
     super(ProtobufConverter::new);
     this.schemaTranslator = new ProtobufSchemaTranslator(protobufProperties);
+    this.converterConfig = ImmutableMap.of(
+        OPTIONAL_FOR_NULLABLES_CONFIG, protobufProperties.isNullableAsOptional(),
+        WRAPPER_FOR_NULLABLES_CONFIG, protobufProperties.isNullableAsWrapper()
+    );
   }
 
   @Override
   protected Schema fromParsedSchema(final ProtobufSchema schema) {
     return schemaTranslator.toConnectSchema(schema);
   }
+
+  @Override
+  protected void configureConverter(final Converter c, final boolean isKey) {
+    c.configure(
+        ImmutableMap.<String, Object>builder()
+            .putAll(converterConfig)
+            .put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "foo")
+            .build(),
+        isKey
+    );
+  }
+
 }

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_protobuf_primitives_with_null/7.4.0_1668008700948/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_protobuf_primitives_with_null/7.4.0_1668008700948/plan.json
@@ -1,0 +1,214 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (K STRING KEY, I INTEGER, L BIGINT, D DOUBLE, B BOOLEAN, S STRING) WITH (KAFKA_TOPIC='input', KEY_FORMAT='KAFKA', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE, `B` BOOLEAN, `S` STRING",
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : {
+            "unwrapPrimitives" : "true"
+          }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE, `B` BOOLEAN, `S` STRING",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : {
+            "unwrapPrimitives" : "true"
+          }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : {
+                  "unwrapPrimitives" : "true"
+                }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE, `B` BOOLEAN, `S` STRING",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "I AS I", "L AS L", "D AS D", "B AS B", "S AS S" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : {
+              "unwrapPrimitives" : "true"
+            }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.websocket.connection.max.timeout.ms" : "3600000",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "true",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.json_sr.converter.deserializer.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_protobuf_primitives_with_null/7.4.0_1668008700948/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_protobuf_primitives_with_null/7.4.0_1668008700948/spec.json
@@ -1,0 +1,142 @@
+{
+  "version" : "7.4.0",
+  "timestamp" : 1668008700948,
+  "path" : "query-validation-tests/protobuf.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE, `B` BOOLEAN, `S` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF",
+        "properties" : {
+          "unwrapPrimitives" : "true"
+        }
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE, `B` BOOLEAN, `S` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF",
+        "properties" : {
+          "unwrapPrimitives" : "true"
+        }
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "protobuf primitives with null",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : null,
+        "l" : 0,
+        "d" : null,
+        "b" : false,
+        "s" : null
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 0,
+        "l" : null,
+        "d" : 0.0,
+        "b" : null,
+        "s" : ""
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "i" : 0,
+        "l" : 0,
+        "d" : 0.0,
+        "b" : false,
+        "s" : ""
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "i" : 0,
+        "l" : 0,
+        "d" : 0.0,
+        "b" : false,
+        "s" : ""
+      }
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "valueSchema" : "syntax = \"proto3\";\n\nmessage ConnectDefault1 {\n  int32 I = 1;\n  int64 L = 2;\n  double D = 3;\n  bool B = 4;\n  string S = 5;\n}\n",
+      "valueFormat" : "PROTOBUF",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (K STRING KEY, i INTEGER, l BIGINT, d DOUBLE, b BOOLEAN, s STRING) WITH (kafka_topic='input', value_format='PROTOBUF');", "CREATE STREAM OUTPUT as SELECT * FROM input;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE, `B` BOOLEAN, `S` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE, `B` BOOLEAN, `S` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : {
+              "unwrapPrimitives" : "true"
+            }
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nmessage ConnectDefault1 {\n  int32 I = 1;\n  int64 L = 2;\n  double D = 3;\n  bool B = 4;\n  string S = 5;\n}\n"
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : {
+              "unwrapPrimitives" : "true"
+            }
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nmessage ConnectDefault1 {\n  int32 I = 1;\n  int64 L = 2;\n  double D = 3;\n  bool B = 4;\n  string S = 5;\n}\n"
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_protobuf_primitives_with_null/7.4.0_1668008700948/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_protobuf_primitives_with_null/7.4.0_1668008700948/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_protobuf_primitives_with_null_and_nullable_as_optional/7.4.0_1668008701004/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_protobuf_primitives_with_null_and_nullable_as_optional/7.4.0_1668008701004/plan.json
@@ -1,0 +1,218 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (K STRING KEY, I INTEGER, L BIGINT, D DOUBLE, B BOOLEAN, S STRING) WITH (KAFKA_TOPIC='input', KEY_FORMAT='KAFKA', VALUE_FORMAT='PROTOBUF', VALUE_PROTOBUF_NULLABLE_REPRESENTATION='OPTIONAL');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE, `B` BOOLEAN, `S` STRING",
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : {
+            "unwrapPrimitives" : "true",
+            "nullableRepresentation" : "optional"
+          }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT WITH (VALUE_FORMAT='PROTOBUF', VALUE_PROTOBUF_NULLABLE_REPRESENTATION='OPTIONAL') AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE, `B` BOOLEAN, `S` STRING",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : {
+            "unwrapPrimitives" : "true",
+            "nullableRepresentation" : "optional"
+          }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : {
+                  "unwrapPrimitives" : "true",
+                  "nullableRepresentation" : "optional"
+                }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE, `B` BOOLEAN, `S` STRING",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "I AS I", "L AS L", "D AS D", "B AS B", "S AS S" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : {
+              "unwrapPrimitives" : "true",
+              "nullableRepresentation" : "optional"
+            }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.websocket.connection.max.timeout.ms" : "3600000",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "true",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.json_sr.converter.deserializer.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_protobuf_primitives_with_null_and_nullable_as_optional/7.4.0_1668008701004/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_protobuf_primitives_with_null_and_nullable_as_optional/7.4.0_1668008701004/spec.json
@@ -1,0 +1,146 @@
+{
+  "version" : "7.4.0",
+  "timestamp" : 1668008701004,
+  "path" : "query-validation-tests/protobuf.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE, `B` BOOLEAN, `S` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF",
+        "properties" : {
+          "unwrapPrimitives" : "true",
+          "nullableRepresentation" : "optional"
+        }
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE, `B` BOOLEAN, `S` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF",
+        "properties" : {
+          "unwrapPrimitives" : "true",
+          "nullableRepresentation" : "optional"
+        }
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "protobuf primitives with null and nullable as optional",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : null,
+        "l" : 0,
+        "d" : null,
+        "b" : false,
+        "s" : null
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 0,
+        "l" : null,
+        "d" : 0.0,
+        "b" : null,
+        "s" : ""
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "i" : null,
+        "l" : 0,
+        "d" : null,
+        "b" : false,
+        "s" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "i" : 0,
+        "l" : null,
+        "d" : 0.0,
+        "b" : null,
+        "s" : ""
+      }
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "valueSchema" : "syntax = \"proto3\";\n\nmessage ConnectDefault1 {\n  optional int32 I = 1 [deprecated = false];\n  optional int64 L = 2 [deprecated = false];\n  optional double D = 3 [deprecated = false];\n  optional bool B = 4 [deprecated = false];\n  optional string S = 5 [deprecated = false];\n}\n",
+      "valueFormat" : "PROTOBUF",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (K STRING KEY, i INTEGER, l BIGINT, d DOUBLE, b BOOLEAN, s STRING) WITH (kafka_topic='input', value_format='PROTOBUF', value_protobuf_nullable_representation='OPTIONAL');", "CREATE STREAM OUTPUT WITH (value_format='PROTOBUF', value_protobuf_nullable_representation='OPTIONAL') as SELECT * FROM input;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE, `B` BOOLEAN, `S` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE, `B` BOOLEAN, `S` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : {
+              "unwrapPrimitives" : "true",
+              "nullableRepresentation" : "optional"
+            }
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nmessage ConnectDefault1 {\n  optional int32 I = 1 [deprecated = false];\n  optional int64 L = 2 [deprecated = false];\n  optional double D = 3 [deprecated = false];\n  optional bool B = 4 [deprecated = false];\n  optional string S = 5 [deprecated = false];\n}\n"
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : {
+              "unwrapPrimitives" : "true",
+              "nullableRepresentation" : "optional"
+            }
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nmessage ConnectDefault1 {\n  optional int32 I = 1 [deprecated = false];\n  optional int64 L = 2 [deprecated = false];\n  optional double D = 3 [deprecated = false];\n  optional bool B = 4 [deprecated = false];\n  optional string S = 5 [deprecated = false];\n}\n"
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_protobuf_primitives_with_null_and_nullable_as_optional/7.4.0_1668008701004/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_protobuf_primitives_with_null_and_nullable_as_optional/7.4.0_1668008701004/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_protobuf_primitives_with_null_and_nullable_as_wrapper/7.4.0_1668008701047/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_protobuf_primitives_with_null_and_nullable_as_wrapper/7.4.0_1668008701047/plan.json
@@ -1,0 +1,218 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (K STRING KEY, I INTEGER, L BIGINT, D DOUBLE, B BOOLEAN, S STRING) WITH (KAFKA_TOPIC='input', KEY_FORMAT='KAFKA', VALUE_FORMAT='PROTOBUF', VALUE_PROTOBUF_NULLABLE_REPRESENTATION='WRAPPER');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE, `B` BOOLEAN, `S` STRING",
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : {
+            "unwrapPrimitives" : "true",
+            "nullableRepresentation" : "wrapper"
+          }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT WITH (VALUE_FORMAT='PROTOBUF', VALUE_PROTOBUF_NULLABLE_REPRESENTATION='WRAPPER') AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE, `B` BOOLEAN, `S` STRING",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : {
+            "unwrapPrimitives" : "true",
+            "nullableRepresentation" : "wrapper"
+          }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : {
+                  "unwrapPrimitives" : "true",
+                  "nullableRepresentation" : "wrapper"
+                }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE, `B` BOOLEAN, `S` STRING",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "I AS I", "L AS L", "D AS D", "B AS B", "S AS S" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : {
+              "unwrapPrimitives" : "true",
+              "nullableRepresentation" : "wrapper"
+            }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.websocket.connection.max.timeout.ms" : "3600000",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "true",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.json_sr.converter.deserializer.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_protobuf_primitives_with_null_and_nullable_as_wrapper/7.4.0_1668008701047/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_protobuf_primitives_with_null_and_nullable_as_wrapper/7.4.0_1668008701047/spec.json
@@ -1,0 +1,146 @@
+{
+  "version" : "7.4.0",
+  "timestamp" : 1668008701047,
+  "path" : "query-validation-tests/protobuf.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE, `B` BOOLEAN, `S` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF",
+        "properties" : {
+          "unwrapPrimitives" : "true",
+          "nullableRepresentation" : "wrapper"
+        }
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE, `B` BOOLEAN, `S` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF",
+        "properties" : {
+          "unwrapPrimitives" : "true",
+          "nullableRepresentation" : "wrapper"
+        }
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "protobuf primitives with null and nullable as wrapper",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : null,
+        "l" : 0,
+        "d" : null,
+        "b" : false,
+        "s" : null
+      }
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "i" : 0,
+        "l" : null,
+        "d" : 0.0,
+        "b" : null,
+        "s" : ""
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "i" : null,
+        "l" : 0,
+        "d" : null,
+        "b" : false,
+        "s" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "i" : 0,
+        "l" : null,
+        "d" : 0.0,
+        "b" : null,
+        "s" : ""
+      }
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/protobuf/wrappers.proto\";\n\nmessage ConnectDefault1 {\n  google.protobuf.Int32Value I = 1;\n  google.protobuf.Int64Value L = 2;\n  google.protobuf.DoubleValue D = 3;\n  google.protobuf.BoolValue B = 4;\n  google.protobuf.StringValue S = 5;\n}\n",
+      "valueFormat" : "PROTOBUF",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (K STRING KEY, i INTEGER, l BIGINT, d DOUBLE, b BOOLEAN, s STRING) WITH (kafka_topic='input', value_format='PROTOBUF', value_protobuf_nullable_representation='WRAPPER');", "CREATE STREAM OUTPUT WITH (value_format='PROTOBUF', value_protobuf_nullable_representation='WRAPPER') as SELECT * FROM input;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE, `B` BOOLEAN, `S` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `I` INTEGER, `L` BIGINT, `D` DOUBLE, `B` BOOLEAN, `S` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : {
+              "unwrapPrimitives" : "true",
+              "nullableRepresentation" : "wrapper"
+            }
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/protobuf/wrappers.proto\";\n\nmessage ConnectDefault1 {\n  google.protobuf.Int32Value I = 1;\n  google.protobuf.Int64Value L = 2;\n  google.protobuf.DoubleValue D = 3;\n  google.protobuf.BoolValue B = 4;\n  google.protobuf.StringValue S = 5;\n}\n"
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : {
+              "unwrapPrimitives" : "true",
+              "nullableRepresentation" : "wrapper"
+            }
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/protobuf/wrappers.proto\";\n\nmessage ConnectDefault1 {\n  google.protobuf.Int32Value I = 1;\n  google.protobuf.Int64Value L = 2;\n  google.protobuf.DoubleValue D = 3;\n  google.protobuf.BoolValue B = 4;\n  google.protobuf.StringValue S = 5;\n}\n"
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_protobuf_primitives_with_null_and_nullable_as_wrapper/7.4.0_1668008701047/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_protobuf_primitives_with_null_and_nullable_as_wrapper/7.4.0_1668008701047/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/protobuf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/protobuf.json
@@ -80,6 +80,111 @@
       "outputs": [{"topic": "OUTPUT", "value": {"I": 1, "L": 1, "D": 1.2, "B": true, "S": "foo"}}]
     },
     {
+      "name": "protobuf primitives with null",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, i INTEGER, l BIGINT, d DOUBLE, b BOOLEAN, s STRING) WITH (kafka_topic='input', value_format='PROTOBUF');",
+        "CREATE STREAM OUTPUT as SELECT * FROM input;"
+      ],
+      "inputs": [
+        {"topic": "input", "value": {"i": null, "l": 0, "d": null, "b": false, "s": null}},
+        {"topic": "input", "value": {"i": 0, "l": null, "d": 0.0, "b": null, "s": ""}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"i": 0, "l": 0, "d": 0.0, "b": false, "s": ""}},
+        {"topic": "OUTPUT", "value": {"i": 0, "l": 0, "d": 0.0, "b": false, "s": ""}}
+      ],
+      "post": {
+        "topics": {
+          "topics": [
+            {
+              "name": "input",
+              "keyFormat": {"format": "KAFKA"},
+              "partitions": 4,
+              "valueFormat": {"format": "PROTOBUF", "properties": {"unwrapPrimitives": "true"}},
+              "valueSchema": "syntax = \"proto3\";\n\nmessage ConnectDefault1 {\n  int32 I = 1;\n  int64 L = 2;\n  double D = 3;\n  bool B = 4;\n  string S = 5;\n}\n"
+            },
+            {
+              "name": "OUTPUT",
+              "keyFormat": {"format": "KAFKA"},
+              "partitions": 4,
+              "valueFormat": {"format": "PROTOBUF", "properties": {"unwrapPrimitives": "true"}},
+              "valueSchema": "syntax = \"proto3\";\n\nmessage ConnectDefault1 {\n  int32 I = 1;\n  int64 L = 2;\n  double D = 3;\n  bool B = 4;\n  string S = 5;\n}\n"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "protobuf primitives with null and nullable as optional",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, i INTEGER, l BIGINT, d DOUBLE, b BOOLEAN, s STRING) WITH (kafka_topic='input', value_format='PROTOBUF', value_protobuf_nullable_representation='OPTIONAL');",
+        "CREATE STREAM OUTPUT WITH (value_format='PROTOBUF', value_protobuf_nullable_representation='OPTIONAL') as SELECT * FROM input;"
+      ],
+      "inputs": [
+        {"topic": "input", "value": {"i": null, "l": 0, "d": null, "b": false, "s": null}},
+        {"topic": "input", "value": {"i": 0, "l": null, "d": 0.0, "b": null, "s": ""}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"i": null, "l": 0, "d": null, "b": false, "s": null}},
+        {"topic": "OUTPUT", "value": {"i": 0, "l": null, "d": 0.0, "b": null, "s": ""}}
+      ],
+      "post": {
+        "topics": {
+          "topics": [
+            {
+              "name": "input",
+              "keyFormat": {"format": "KAFKA"},
+              "partitions": 4,
+              "valueFormat": {"format": "PROTOBUF", "properties": {"unwrapPrimitives": "true", "nullableRepresentation": "optional"}},
+              "valueSchema": "syntax = \"proto3\";\n\nmessage ConnectDefault1 {\n  optional int32 I = 1 [deprecated = false];\n  optional int64 L = 2 [deprecated = false];\n  optional double D = 3 [deprecated = false];\n  optional bool B = 4 [deprecated = false];\n  optional string S = 5 [deprecated = false];\n}\n"
+            },
+            {
+              "name": "OUTPUT",
+              "keyFormat": {"format": "KAFKA"},
+              "partitions": 4,
+              "valueFormat": {"format": "PROTOBUF", "properties": {"unwrapPrimitives": "true", "nullableRepresentation": "optional"}},
+              "valueSchema": "syntax = \"proto3\";\n\nmessage ConnectDefault1 {\n  optional int32 I = 1 [deprecated = false];\n  optional int64 L = 2 [deprecated = false];\n  optional double D = 3 [deprecated = false];\n  optional bool B = 4 [deprecated = false];\n  optional string S = 5 [deprecated = false];\n}\n"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "protobuf primitives with null and nullable as wrapper",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, i INTEGER, l BIGINT, d DOUBLE, b BOOLEAN, s STRING) WITH (kafka_topic='input', value_format='PROTOBUF', value_protobuf_nullable_representation='WRAPPER');",
+        "CREATE STREAM OUTPUT WITH (value_format='PROTOBUF', value_protobuf_nullable_representation='WRAPPER') as SELECT * FROM input;"
+      ],
+      "inputs": [
+        {"topic": "input", "value": {"i": null, "l": 0, "d": null, "b": false, "s": null}},
+        {"topic": "input", "value": {"i": 0, "l": null, "d": 0.0, "b": null, "s": ""}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"i": null, "l": 0, "d": null, "b": false, "s": null}},
+        {"topic": "OUTPUT", "value": {"i": 0, "l": null, "d": 0.0, "b": null, "s": ""}}
+      ],
+      "post": {
+        "topics": {
+          "topics": [
+            {
+              "name": "input",
+              "keyFormat": {"format": "KAFKA"},
+              "partitions": 4,
+              "valueFormat": {"format": "PROTOBUF", "properties": {"unwrapPrimitives": "true", "nullableRepresentation": "wrapper"}},
+              "valueSchema": "syntax = \"proto3\";\n\nimport \"google/protobuf/wrappers.proto\";\n\nmessage ConnectDefault1 {\n  google.protobuf.Int32Value I = 1;\n  google.protobuf.Int64Value L = 2;\n  google.protobuf.DoubleValue D = 3;\n  google.protobuf.BoolValue B = 4;\n  google.protobuf.StringValue S = 5;\n}\n"
+            },
+            {
+              "name": "OUTPUT",
+              "keyFormat": {"format": "KAFKA"},
+              "partitions": 4,
+              "valueFormat": {"format": "PROTOBUF", "properties": {"unwrapPrimitives": "true", "nullableRepresentation": "wrapper"}},
+              "valueSchema": "syntax = \"proto3\";\n\nimport \"google/protobuf/wrappers.proto\";\n\nmessage ConnectDefault1 {\n  google.protobuf.Int32Value I = 1;\n  google.protobuf.Int64Value L = 2;\n  google.protobuf.DoubleValue D = 3;\n  google.protobuf.BoolValue B = 4;\n  google.protobuf.StringValue S = 5;\n}\n"
+            }
+          ]
+        }
+      }
+    },
+    {
       "name": "protobuf containers",
       "statements": [
         "CREATE STREAM INPUT (astr ARRAY<STRING>, mstr MAP<STRING, STRING>) WITH (kafka_topic='input', value_format='PROTOBUF');",

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
@@ -30,6 +30,7 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.ColumnReferenceParser;
 import io.confluent.ksql.parser.DurationParser;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
+import io.confluent.ksql.properties.with.CommonCreateConfigs.ProtobufNullableConfigValues;
 import io.confluent.ksql.properties.with.CreateConfigs;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeFeature;
@@ -190,8 +191,38 @@ public final class CreateSourceProperties {
       builder.put(DelimitedFormat.DELIMITER, delimiter);
     }
 
-    if (ProtobufFormat.NAME.equalsIgnoreCase(keyFormat) && unwrapProtobufPrimitives) {
-      builder.put(ProtobufProperties.UNWRAP_PRIMITIVES, ProtobufProperties.UNWRAP);
+    if (ProtobufFormat.NAME.equalsIgnoreCase(keyFormat)) {
+
+      if (unwrapProtobufPrimitives) {
+        builder.put(ProtobufProperties.UNWRAP_PRIMITIVES, ProtobufProperties.UNWRAP);
+      }
+
+      final String nullableRep = props.getString(
+          CommonCreateConfigs.KEY_PROTOBUF_NULLABLE_REPRESENTATION);
+      if (nullableRep != null) {
+        switch (ProtobufNullableConfigValues.valueOf(nullableRep)) {
+          case WRAPPER:
+            builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
+                ProtobufProperties.NULLABLE_AS_WRAPPER);
+            break;
+          case OPTIONAL:
+            builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
+                ProtobufProperties.NULLABLE_AS_OPTIONAL);
+            break;
+          default:
+            throw new RuntimeException(String.format(
+                "Unexpected nullable representation %s. This indicates an implementation error.",
+                nullableRep));
+        }
+      }
+
+    } else {
+      // Reject protobuf options for non-protobuf formats
+      if (props.getString(CommonCreateConfigs.KEY_PROTOBUF_NULLABLE_REPRESENTATION) != null) {
+        throw new KsqlException(
+            String.format("Property %s can only be enabled with protobuf format",
+                CommonCreateConfigs.KEY_PROTOBUF_NULLABLE_REPRESENTATION));
+      }
     }
 
     final Optional<Integer> keySchemaId = getKeySchemaId();
@@ -227,8 +258,38 @@ public final class CreateSourceProperties {
       builder.put(DelimitedFormat.DELIMITER, delimiter);
     }
 
-    if (ProtobufFormat.NAME.equalsIgnoreCase(valueFormat) && unwrapProtobufPrimitives) {
-      builder.put(ProtobufProperties.UNWRAP_PRIMITIVES, ProtobufProperties.UNWRAP);
+    if (ProtobufFormat.NAME.equalsIgnoreCase(valueFormat)) {
+
+      if (unwrapProtobufPrimitives) {
+        builder.put(ProtobufProperties.UNWRAP_PRIMITIVES, ProtobufProperties.UNWRAP);
+      }
+
+      final String nullableRep = props.getString(
+          CommonCreateConfigs.VALUE_PROTOBUF_NULLABLE_REPRESENTATION);
+      if (nullableRep != null) {
+        switch (ProtobufNullableConfigValues.valueOf(nullableRep)) {
+          case WRAPPER:
+            builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
+                ProtobufProperties.NULLABLE_AS_WRAPPER);
+            break;
+          case OPTIONAL:
+            builder.put(ProtobufProperties.NULLABLE_REPRESENTATION,
+                ProtobufProperties.NULLABLE_AS_OPTIONAL);
+            break;
+          default:
+            throw new RuntimeException(String.format(
+                "Unexpected nullable representation %s. This indicates an implementation error.",
+                nullableRep));
+        }
+      }
+
+    } else {
+      // Reject protobuf options for non-protobuf formats
+      if (props.getString(CommonCreateConfigs.VALUE_PROTOBUF_NULLABLE_REPRESENTATION) != null) {
+        throw new KsqlException(
+            String.format("Property %s can only be enabled with protobuf format",
+                CommonCreateConfigs.VALUE_PROTOBUF_NULLABLE_REPRESENTATION));
+      }
     }
 
     final Optional<Integer> valueSchemaId = getValueSchemaId();

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
@@ -19,15 +19,18 @@ import static com.google.common.collect.ImmutableMap.of;
 import static io.confluent.ksql.parser.properties.with.CreateSourceAsProperties.from;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.FORMAT_PROPERTY;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.KEY_FORMAT_PROPERTY;
+import static io.confluent.ksql.properties.with.CommonCreateConfigs.KEY_PROTOBUF_NULLABLE_REPRESENTATION;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.KEY_SCHEMA_FULL_NAME;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.KEY_SCHEMA_ID;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.TIMESTAMP_FORMAT_PROPERTY;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_AVRO_SCHEMA_FULL_NAME;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_FORMAT_PROPERTY;
+import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_PROTOBUF_NULLABLE_REPRESENTATION;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_SCHEMA_FULL_NAME;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_SCHEMA_ID;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
@@ -43,6 +46,7 @@ import io.confluent.ksql.execution.expression.tree.Literal;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
+import io.confluent.ksql.properties.with.CommonCreateConfigs.ProtobufNullableConfigValues;
 import io.confluent.ksql.properties.with.CreateConfigs;
 import io.confluent.ksql.serde.SerdeFeature;
 import io.confluent.ksql.serde.SerdeFeatures;
@@ -476,5 +480,122 @@ public class CreateSourceAsPropertiesTest {
 
     // Then:
     assertThat(e.getMessage(), containsString("Invalid config variable(s) in the WITH clause: SOURCED_BY_CONNECTOR"));
+  }
+
+  @Test
+  public void shouldGetProtobufKeyFormatPropertiesWithNullableAsWrapper() {
+    // Given:
+    final CreateSourceAsProperties props = CreateSourceAsProperties
+        .from(ImmutableMap.of(
+            FORMAT_PROPERTY, new StringLiteral("PROTOBUF"),
+            KEY_PROTOBUF_NULLABLE_REPRESENTATION, new StringLiteral(
+                ProtobufNullableConfigValues.WRAPPER.name())
+        ));
+
+    // When / Then:
+    assertThat(props.getKeyFormatProperties("foo", "PROTOBUF"),
+        hasEntry(ProtobufProperties.NULLABLE_REPRESENTATION,
+            ProtobufProperties.NULLABLE_AS_WRAPPER));
+  }
+
+  @Test
+  public void shouldGetProtobufKeyFormatPropertiesWithNullableAsOptional() {
+    // Given:
+    final CreateSourceAsProperties props = CreateSourceAsProperties
+        .from(ImmutableMap.of(
+            FORMAT_PROPERTY, new StringLiteral("PROTOBUF"),
+            KEY_PROTOBUF_NULLABLE_REPRESENTATION, new StringLiteral(
+                ProtobufNullableConfigValues.OPTIONAL.name())));
+
+    // When / Then:
+    assertThat(props.getKeyFormatProperties("foo", "PROTOBUF"),
+        hasEntry(ProtobufProperties.NULLABLE_REPRESENTATION,
+            ProtobufProperties.NULLABLE_AS_OPTIONAL));
+  }
+
+  @Test
+  public void shouldGetProtobufKeyFormatPropertiesWithoutNullableRepresentation() {
+    // Given:
+    final CreateSourceAsProperties props = CreateSourceAsProperties
+        .from(ImmutableMap.of(FORMAT_PROPERTY, new StringLiteral("PROTOBUF")));
+
+    // When / Then:
+    assertThat(props.getKeyFormatProperties("foo", "PROTOBUF"),
+        not(hasKey(ProtobufProperties.NULLABLE_REPRESENTATION)));
+  }
+
+  @Test
+  public void shouldGetProtobufValueFormatPropertiesWithNullableAsWrapper() {
+    // Given:
+
+    final CreateSourceAsProperties props = CreateSourceAsProperties
+        .from(ImmutableMap.of(
+            FORMAT_PROPERTY, new StringLiteral("PROTOBUF"),
+            VALUE_PROTOBUF_NULLABLE_REPRESENTATION, new StringLiteral(
+                ProtobufNullableConfigValues.WRAPPER.name())));
+
+    // When / Then:
+    assertThat(props.getValueFormatProperties("PROTOBUF"),
+        hasEntry(ProtobufProperties.NULLABLE_REPRESENTATION,
+            ProtobufProperties.NULLABLE_AS_WRAPPER));
+  }
+
+  @Test
+  public void shouldGetProtobufValueFormatPropertiesWithNullableAsOptional() {
+    // Given:
+
+    final CreateSourceAsProperties props = CreateSourceAsProperties
+        .from(ImmutableMap.of(
+            FORMAT_PROPERTY, new StringLiteral("PROTOBUF"),
+            VALUE_PROTOBUF_NULLABLE_REPRESENTATION, new StringLiteral(
+                ProtobufNullableConfigValues.OPTIONAL.name())));
+
+    // When / Then:
+    assertThat(props.getValueFormatProperties("PROTOBUF"),
+        hasEntry(ProtobufProperties.NULLABLE_REPRESENTATION,
+            ProtobufProperties.NULLABLE_AS_OPTIONAL));
+  }
+
+  @Test
+  public void shouldGetProtobufValueFormatPropertiesWithoutNullableRepresentation() {
+    // Given:
+    final CreateSourceAsProperties props = CreateSourceAsProperties
+        .from(ImmutableMap.of(FORMAT_PROPERTY, new StringLiteral("PROTOBUF")));
+
+    // When / Then:
+    assertThat(props.getValueFormatProperties("PROTOBUF"),
+        not(hasKey(ProtobufProperties.NULLABLE_REPRESENTATION)));
+  }
+
+  @Test
+  public void shouldFailWhenProtobufPropertiesAreUsedOnOtherKeyFormats() {
+    // Given:
+    final CreateSourceAsProperties props = CreateSourceAsProperties
+        .from(ImmutableMap.of(
+            FORMAT_PROPERTY, new StringLiteral("JSON"),
+            KEY_PROTOBUF_NULLABLE_REPRESENTATION, new StringLiteral(
+                ProtobufNullableConfigValues.OPTIONAL.name())));
+
+    // When / Then:
+    final Exception e = assertThrows(KsqlException.class,
+        () -> props.getKeyFormatProperties("", "JSON"));
+    assertThat(e.getMessage(), is(equalTo(
+        "Property KEY_PROTOBUF_NULLABLE_REPRESENTATION can only be enabled with protobuf format")));
+  }
+
+  @Test
+  public void shouldFailWhenProtobufPropertiesAreUsedOnOtherValueFormats() {
+    // Given:
+    final CreateSourceAsProperties props = CreateSourceAsProperties
+        .from(ImmutableMap.of(
+            FORMAT_PROPERTY, new StringLiteral("JSON"),
+            VALUE_PROTOBUF_NULLABLE_REPRESENTATION, new StringLiteral(
+                ProtobufNullableConfigValues.OPTIONAL.name())));
+
+    // When / Then:
+    final Exception e = assertThrows(KsqlException.class,
+        () -> props.getValueFormatProperties("JSON"));
+    assertThat(e.getMessage(), is(equalTo(
+        "Property VALUE_PROTOBUF_NULLABLE_REPRESENTATION can only be enabled with protobuf format")));
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourcePropertiesTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourcePropertiesTest.java
@@ -20,17 +20,20 @@ import static io.confluent.ksql.parser.properties.with.CreateSourceAsProperties.
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.FORMAT_PROPERTY;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.KAFKA_TOPIC_NAME_PROPERTY;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.KEY_FORMAT_PROPERTY;
+import static io.confluent.ksql.properties.with.CommonCreateConfigs.KEY_PROTOBUF_NULLABLE_REPRESENTATION;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.KEY_SCHEMA_FULL_NAME;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.KEY_SCHEMA_ID;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.TIMESTAMP_FORMAT_PROPERTY;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_AVRO_SCHEMA_FULL_NAME;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_FORMAT_PROPERTY;
+import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_PROTOBUF_NULLABLE_REPRESENTATION;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_SCHEMA_FULL_NAME;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_SCHEMA_ID;
 import static io.confluent.ksql.properties.with.CreateConfigs.WINDOW_SIZE_PROPERTY;
 import static io.confluent.ksql.properties.with.CreateConfigs.WINDOW_TYPE_PROPERTY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
@@ -49,6 +52,7 @@ import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
+import io.confluent.ksql.properties.with.CommonCreateConfigs.ProtobufNullableConfigValues;
 import io.confluent.ksql.properties.with.CreateConfigs;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeFeature;
@@ -779,5 +783,140 @@ public class CreateSourcePropertiesTest {
     assertThat(props.getValueFormat().get().getFormat(), is("PROTOBUF"));
     assertThat(props.getValueFormat().get().getProperties(),
         not(hasKey(ProtobufProperties.UNWRAP_PRIMITIVES)));
+  }
+
+  @Test
+  public void shouldGetProtobufKeyFormatPropertiesWithNullableAsWrapper() {
+    // Given:
+    final CreateSourceProperties props = CreateSourceProperties
+        .from(ImmutableMap.<String, Literal>builder()
+            .putAll(MINIMUM_VALID_PROPS)
+            .put(FORMAT_PROPERTY, new StringLiteral("PROTOBUF"))
+            .put(KEY_PROTOBUF_NULLABLE_REPRESENTATION, new StringLiteral(
+                ProtobufNullableConfigValues.WRAPPER.name()))
+            .build());
+
+    // When / Then:
+    assertThat(props.getKeyFormat(SourceName.of("foo")).get().getFormat(), is("PROTOBUF"));
+    assertThat(props.getKeyFormat(
+            SourceName.of("foo")).get().getProperties(),
+        hasEntry(ProtobufProperties.NULLABLE_REPRESENTATION,
+            ProtobufProperties.NULLABLE_AS_WRAPPER));
+  }
+
+  @Test
+  public void shouldGetProtobufKeyFormatPropertiesWithNullableAsOptional() {
+    // Given:
+    final CreateSourceProperties props = CreateSourceProperties
+        .from(ImmutableMap.<String, Literal>builder()
+            .putAll(MINIMUM_VALID_PROPS)
+            .put(FORMAT_PROPERTY, new StringLiteral("PROTOBUF"))
+            .put(KEY_PROTOBUF_NULLABLE_REPRESENTATION, new StringLiteral(
+                ProtobufNullableConfigValues.OPTIONAL.name()))
+            .build());
+
+    // When / Then:
+    assertThat(props.getKeyFormat(SourceName.of("foo")).get().getFormat(), is("PROTOBUF"));
+    assertThat(props.getKeyFormat(
+            SourceName.of("foo")).get().getProperties(),
+        hasEntry(ProtobufProperties.NULLABLE_REPRESENTATION,
+            ProtobufProperties.NULLABLE_AS_OPTIONAL));
+  }
+
+  @Test
+  public void shouldGetProtobufKeyFormatPropertiesWithoutNullableRepresentation() {
+    // Given:
+    final CreateSourceProperties props = CreateSourceProperties
+        .from(ImmutableMap.<String, Literal>builder()
+            .putAll(MINIMUM_VALID_PROPS)
+            .put(FORMAT_PROPERTY, new StringLiteral("PROTOBUF"))
+            .build());
+
+    // When / Then:
+    assertThat(props.getKeyFormat(SourceName.of("foo")).get().getFormat(), is("PROTOBUF"));
+    assertThat(props.getKeyFormat(
+            SourceName.of("foo")).get().getProperties(),
+        not(hasKey(ProtobufProperties.NULLABLE_REPRESENTATION)));
+  }
+
+  @Test
+  public void shouldGetProtobufValueFormatPropertiesWithNullableAsWrapper() {
+    // Given:
+    final CreateSourceProperties props = CreateSourceProperties
+        .from(ImmutableMap.<String, Literal>builder()
+            .putAll(MINIMUM_VALID_PROPS)
+            .put(FORMAT_PROPERTY, new StringLiteral("PROTOBUF"))
+            .put(VALUE_PROTOBUF_NULLABLE_REPRESENTATION, new StringLiteral(
+                ProtobufNullableConfigValues.WRAPPER.name()))
+            .build());
+
+    // When / Then:
+    assertThat(props.getValueFormat().get().getFormat(), is("PROTOBUF"));
+    assertThat(props.getValueFormat().get().getProperties(),
+        hasEntry(ProtobufProperties.NULLABLE_REPRESENTATION,
+            ProtobufProperties.NULLABLE_AS_WRAPPER));
+  }
+
+  @Test
+  public void shouldGetProtobufValueFormatPropertiesWithNullableAsOptional() {
+    // Given:
+    final CreateSourceProperties props = CreateSourceProperties
+        .from(ImmutableMap.<String, Literal>builder()
+            .putAll(MINIMUM_VALID_PROPS)
+            .put(FORMAT_PROPERTY, new StringLiteral("PROTOBUF"))
+            .put(VALUE_PROTOBUF_NULLABLE_REPRESENTATION, new StringLiteral(
+                ProtobufNullableConfigValues.OPTIONAL.name()))
+            .build());
+
+    // When / Then:
+    assertThat(props.getValueFormat().get().getFormat(), is("PROTOBUF"));
+    assertThat(props.getValueFormat().get().getProperties(),
+        hasEntry(ProtobufProperties.NULLABLE_REPRESENTATION,
+            ProtobufProperties.NULLABLE_AS_OPTIONAL));
+  }
+
+  @Test
+  public void shouldGetProtobufValueFormatPropertiesWithoutNullableRepresentation() {
+    // Given:
+    final CreateSourceProperties props = CreateSourceProperties
+        .from(ImmutableMap.<String, Literal>builder()
+            .putAll(MINIMUM_VALID_PROPS)
+            .put(FORMAT_PROPERTY, new StringLiteral("PROTOBUF"))
+            .build());
+
+    // When / Then:
+    assertThat(props.getValueFormat().get().getFormat(), is("PROTOBUF"));
+    assertThat(props.getValueFormat().get().getProperties(),
+        not(hasKey(ProtobufProperties.NULLABLE_REPRESENTATION)));
+  }
+
+  @Test
+  public void shouldFailWhenProtobufPropertiesAreUsedOnOtherKeyFormats() {
+    // Given:
+    final CreateSourceAsProperties props = CreateSourceAsProperties.from(
+        ImmutableMap.of(FORMAT_PROPERTY, new StringLiteral("JSON"),
+            KEY_PROTOBUF_NULLABLE_REPRESENTATION,
+            new StringLiteral(ProtobufNullableConfigValues.OPTIONAL.name())));
+
+    // When / Then:
+    final Exception e = assertThrows(KsqlException.class,
+        () -> props.getKeyFormatProperties("", "JSON"));
+    assertThat(e.getMessage(), is(equalTo(
+        "Property KEY_PROTOBUF_NULLABLE_REPRESENTATION can only be enabled with protobuf format")));
+  }
+
+  @Test
+  public void shouldFailWhenProtobufPropertiesAreUsedOnOtherValueFormats() {
+    // Given:
+    final CreateSourceAsProperties props = CreateSourceAsProperties.from(
+        ImmutableMap.of(FORMAT_PROPERTY, new StringLiteral("JSON"),
+            VALUE_PROTOBUF_NULLABLE_REPRESENTATION,
+            new StringLiteral(ProtobufNullableConfigValues.OPTIONAL.name())));
+
+    // When / Then:
+    final Exception e = assertThrows(KsqlException.class,
+        () -> props.getValueFormatProperties("JSON"));
+    assertThat(e.getMessage(), is(equalTo(
+        "Property VALUE_PROTOBUF_NULLABLE_REPRESENTATION can only be enabled with protobuf format")));
   }
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufProperties.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufProperties.java
@@ -27,10 +27,15 @@ public class ProtobufProperties extends ConnectProperties {
   public static final String UNWRAP = "true";
   private static final String WRAP = "false";
 
+  public static final String NULLABLE_REPRESENTATION = "nullableRepresentation";
+  public static final String NULLABLE_AS_OPTIONAL = "optional";
+  public static final String NULLABLE_AS_WRAPPER = "wrapper";
+
   static final ImmutableSet<String> SUPPORTED_PROPERTIES = ImmutableSet.of(
       FULL_SCHEMA_NAME,
       SCHEMA_ID,
       UNWRAP_PRIMITIVES,
+      NULLABLE_REPRESENTATION,
       SUBJECT_NAME
   );
 
@@ -56,6 +61,18 @@ public class ProtobufProperties extends ConnectProperties {
 
   public boolean getUnwrapPrimitives() {
     return UNWRAP.equalsIgnoreCase(properties.getOrDefault(UNWRAP_PRIMITIVES, WRAP));
+  }
+
+  public boolean isNullableAsOptional() {
+    return NULLABLE_AS_OPTIONAL.equals(getNullableRepresentation());
+  }
+
+  public boolean isNullableAsWrapper() {
+    return NULLABLE_AS_WRAPPER.equals(getNullableRepresentation());
+  }
+
+  private String getNullableRepresentation() {
+    return properties.getOrDefault(NULLABLE_REPRESENTATION, null);
   }
 
   public ProtobufProperties withFullSchemaName(final String name) {

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSchemaTranslator.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSchemaTranslator.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.serde.protobuf;
 
+import static io.confluent.connect.protobuf.ProtobufDataConfig.OPTIONAL_FOR_NULLABLES_CONFIG;
+import static io.confluent.connect.protobuf.ProtobufDataConfig.WRAPPER_FOR_NULLABLES_CONFIG;
 import static io.confluent.connect.protobuf.ProtobufDataConfig.WRAPPER_FOR_RAW_PRIMITIVES_CONFIG;
 
 import com.google.common.base.Strings;
@@ -47,6 +49,8 @@ public class ProtobufSchemaTranslator implements ConnectSchemaTranslator {
 
     this.baseConfigs = ImmutableMap.of(
         WRAPPER_FOR_RAW_PRIMITIVES_CONFIG, properties.getUnwrapPrimitives(),
+        OPTIONAL_FOR_NULLABLES_CONFIG, properties.isNullableAsOptional(),
+        WRAPPER_FOR_NULLABLES_CONFIG, properties.isNullableAsWrapper(),
 
         // This flag is needed so that the schema translation in toConnectRow() adds the
         // package name information to the row schema

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSerdeFactory.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSerdeFactory.java
@@ -247,10 +247,11 @@ final class ProtobufSerdeFactory implements SerdeFactory {
       protobufConfig.put(AbstractKafkaSchemaSerDeConfig.ID_COMPATIBILITY_STRICT, false);
     }
 
-    protobufConfig.put(
-        ProtobufDataConfig.WRAPPER_FOR_RAW_PRIMITIVES_CONFIG,
-        properties.getUnwrapPrimitives()
-    );
+    protobufConfig.putAll(ImmutableMap.of(
+        ProtobufDataConfig.WRAPPER_FOR_RAW_PRIMITIVES_CONFIG, properties.getUnwrapPrimitives(),
+        ProtobufDataConfig.OPTIONAL_FOR_NULLABLES_CONFIG, properties.isNullableAsOptional(),
+        ProtobufDataConfig.WRAPPER_FOR_NULLABLES_CONFIG, properties.isNullableAsWrapper()
+    ));
 
     final ProtobufConverter converter = new ProtobufConverter(schemaRegistryClient);
     converter.configure(protobufConfig, isKey);

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/ProtobufPropertiesTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/ProtobufPropertiesTest.java
@@ -80,6 +80,40 @@ public class ProtobufPropertiesTest {
   }
 
   @Test
+  public void shouldGetDefaultNullableRepresentation() {
+    // Given:
+    final ProtobufProperties properties = new ProtobufProperties(ImmutableMap.of());
+
+    // When/Then:
+    assertThat(properties.isNullableAsWrapper(), is(false));
+    assertThat(properties.isNullableAsOptional(), is(false));
+  }
+
+  @Test
+  public void shouldGetNullableAsOptional() {
+    // Given:
+    final ProtobufProperties properties = new ProtobufProperties(ImmutableMap.of(
+        ProtobufProperties.NULLABLE_REPRESENTATION, ProtobufProperties.NULLABLE_AS_OPTIONAL
+    ));
+
+    // When/Then:
+    assertThat(properties.isNullableAsWrapper(), is(false));
+    assertThat(properties.isNullableAsOptional(), is(true));
+  }
+
+  @Test
+  public void shouldGetNullableAsWrapper() {
+    // Given:
+    final ProtobufProperties properties = new ProtobufProperties(ImmutableMap.of(
+        ProtobufProperties.NULLABLE_REPRESENTATION, ProtobufProperties.NULLABLE_AS_WRAPPER
+    ));
+
+    // When/Then:
+    assertThat(properties.isNullableAsWrapper(), is(true));
+    assertThat(properties.isNullableAsOptional(), is(false));
+  }
+
+  @Test
   public void shouldThrowWithUnsupportedProperty() {
     // When:
     final Exception e = assertThrows(KsqlException.class,


### PR DESCRIPTION
The protobuf support in schema registry by default represents an
optional field (corresponding in KSQL to a nullable SQL column) by
a singular protobuf field. For primitive types, singular protobuf
fields cannot distinguish default values (such as 0 for int32 and
"" for string) from `null`.

This change introduces a new option for KSQL `CREATE` statements
that can enable two alternative representations of nullable fields.
One is to use nullable protobuf wrappers
(e.g. using `google.protobuf.StringValue` for strings), the other
is to use the `optional` keyword. Both options will allow KSQL and
downstream consumers to clearly distinguish between default values
and `null`.

New unit tests are added to cover that the properties are
propagated from the `CREATE` statement to the `Serde`
implementation. We use query translation tests to test
end-to-end testcases.
