### PR TITLE
Bump netty tcnative version to 2.0.54.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <io.confluent.ksql.version>7.1.5-0</io.confluent.ksql.version>
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
         <mockito.version>3.8.0</mockito.version>
-        <netty-tcnative-version>2.0.46.Final</netty-tcnative-version>
+        <netty-tcnative-version>2.0.54.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`
              we might need to bump `tcnative`, too.


### PR DESCRIPTION
**Context**
packaging/7.1.x and 7.2.x [smoke tests](https://jenkins.confluent.io/job/confluentinc/job/packaging/job/7.1.x/570/execution/node/583/log/) are failing on error `Exception in thread "main" java.lang.NoClassDefFoundError: io/netty/internal/tcnative/CertificateCompressionAlgo`

Quick search of this issue gives me this slack convo, which indicates that tcnative version needs to be 2.0.50+ https://confluent.slack.com/archives/C209F54E8/p1667547233169589

**Changes:**
Update tcnative version to 2.0.54.Final. Checked netty versions and the tcnative version corresponding to the current netty-4.1.84.Final being used here should be [2.0.54.Final](https://github.com/netty/netty/blob/netty-4.1.84.Final/bom/pom.xml#L68)

To be pint merged through 7.2.x onwards
