### PR TITLE
fix: change password-based configs to Type.PASSWORD

### DIFF
--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/MigrationConfig.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/MigrationConfig.java
@@ -78,7 +78,7 @@ public final class MigrationConfig extends AbstractConfig {
             "The username for the KSQL server"
         ).define(
             KSQL_BASIC_AUTH_PASSWORD,
-            Type.STRING,
+            Type.PASSWORD,
             null,
             Importance.MEDIUM,
             "The password for the KSQL server"
@@ -90,7 +90,7 @@ public final class MigrationConfig extends AbstractConfig {
             "The trust store path"
         ).define(
             SSL_TRUSTSTORE_PASSWORD,
-            Type.STRING,
+            Type.PASSWORD,
             null,
             Importance.MEDIUM,
             "The trust store password"
@@ -102,13 +102,13 @@ public final class MigrationConfig extends AbstractConfig {
             "The key store path"
         ).define(
             SSL_KEYSTORE_PASSWORD,
-            Type.STRING,
+            Type.PASSWORD,
             null,
             Importance.MEDIUM,
             "The key store password"
         ).define(
             SSL_KEY_PASSWORD,
-            Type.STRING,
+            Type.PASSWORD,
             null,
             Importance.MEDIUM,
             "The key password"


### PR DESCRIPTION
Sensitive parameters such as this should be defined with the `PASSWORD` type rather than a string

We should apply this fix to 6.2.x (when these configs were first introduced) and then pint merge it up to master, as well as porting it to any standalone release branches we plan to hotfix