### PR TITLE
docs: cherry-pick: clarify table functions support only stream sources (DOCS-19043)

### DIFF
--- a/docs/developer-guide/ksqldb-reference/table-functions.md
+++ b/docs/developer-guide/ksqldb-reference/table-functions.md
@@ -15,6 +15,9 @@ Table functions are analogous to the `FlatMap` operation commonly found in
 functional programming or stream processing frameworks such as
 {{ site.kstreams }}.
 
+!!! important
+    Table functions are supported only on stream sources. 
+
 Table functions are used in the SELECT clause of a query. They cause the query
 to output potentially more than one row for each input value.
 


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/9724.