### PR TITLE
fix: show streams/tables should not return names in back tick

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionFactory.java
@@ -23,7 +23,6 @@ import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.rest.util.EntityUtil;
 import io.confluent.ksql.schema.utils.FormatOptions;
-import io.confluent.ksql.util.IdentifierUtil;
 import io.confluent.ksql.util.KsqlHostInfo;
 import java.util.List;
 import java.util.Optional;
@@ -87,7 +86,7 @@ public final class SourceDescriptionFactory {
         .map((stat) -> QueryHostStat.fromStat(stat, hostEntity));
 
     return new SourceDescription(
-        dataSource.getName().toString(FormatOptions.of(IdentifierUtil::needsQuotes)),
+        dataSource.getName().toString(FormatOptions.noEscape()),
         dataSource.getKsqlTopic().getKeyFormat().getWindowType(),
         readQueries,
         writeQueries,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -50,10 +50,8 @@ import io.confluent.ksql.rest.entity.SourceInfo.Table;
 import io.confluent.ksql.rest.entity.StreamsList;
 import io.confluent.ksql.rest.entity.TablesList;
 import io.confluent.ksql.rest.server.KsqlRestApplication;
-import io.confluent.ksql.schema.utils.FormatOptions;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
-import io.confluent.ksql.util.IdentifierUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlStatementException;
@@ -449,7 +447,7 @@ public final class ListSourceExecutor {
 
   private static Stream sourceSteam(final KsqlStream<?> dataSource) {
     return new Stream(
-        dataSource.getName().toString(FormatOptions.of(IdentifierUtil::needsQuotes)),
+        dataSource.getName().text(),
         dataSource.getKsqlTopic().getKafkaTopicName(),
         dataSource.getKsqlTopic().getKeyFormat().getFormat(),
         dataSource.getKsqlTopic().getValueFormat().getFormat(),
@@ -459,7 +457,7 @@ public final class ListSourceExecutor {
 
   private static Table sourceTable(final KsqlTable<?> dataSource) {
     return new Table(
-        dataSource.getName().toString(FormatOptions.of(IdentifierUtil::needsQuotes)),
+        dataSource.getName().text(),
         dataSource.getKsqlTopic().getKafkaTopicName(),
         dataSource.getKsqlTopic().getKeyFormat().getFormat(),
         dataSource.getKsqlTopic().getValueFormat().getFormat(),

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -496,19 +496,16 @@ public class TestKsqlRestApp extends ExternalResource {
       final KsqlRestClient client
   ) {
     final Set<String> sourcesDropped = new HashSet<>(streams.size() + tables.size());
-    Set<String> streamsNames = streams.stream().map(Identifiers::getIdentifierText).collect(
-        Collectors.toSet());
-    Iterables.concat(streamsNames, tables).forEach(source -> {
+    Iterables.concat(streams, tables).forEach(source -> {
       if (!sourcesDropped.contains(source)) {
         final Iterator<String> dropInOrder = getOrderedSourcesToDrop(source, client);
         dropInOrder.forEachRemaining(s -> {
-          if (streamsNames.contains(s)) {
+          if (streams.contains(s)) {
             dropStream(s, client);
           } else {
             dropTable(s, client);
           }
           sourcesDropped.add(s);
-
         });
       }
     });

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
@@ -193,7 +193,7 @@ public class DescribeConnectorExecutorTest {
     assertThat(description.getConnectorClass(), is(CONNECTOR_CLASS));
     assertThat(description.getStatus(), is(STATUS));
     assertThat(description.getSources().size(), is(1));
-    assertThat(description.getSources().get(0).getName(), is("`source`"));
+    assertThat(description.getSources().get(0).getName(), is("source"));
     assertThat(description.getSources().get(0).getTopic(), is(TOPIC));
     assertThat(description.getTopics().size(), is(1));
     assertThat(description.getTopics().get(0), is(TOPIC));

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
@@ -104,7 +104,7 @@ public class ListSourceExecutorTest {
   @Test
   public void shouldShowStreams() {
     // Given:
-    final KsqlStream<?> stream1 = engine.givenSource(DataSourceType.KSTREAM, "STREAM1");
+    final KsqlStream<?> stream1 = engine.givenSource(DataSourceType.KSTREAM, "stream1");
     final KsqlStream<?> stream2 = engine.givenSource(DataSourceType.KSTREAM, "stream2");
     engine.givenSource(DataSourceType.KTABLE, "table");
 
@@ -120,14 +120,14 @@ public class ListSourceExecutorTest {
     // Then:
     assertThat(descriptionList.getStreams(), containsInAnyOrder(
         new SourceInfo.Stream(
-            stream1.getName().toString(FormatOptions.of(IdentifierUtil::needsQuotes)),
+            stream1.getName().toString(FormatOptions.noEscape()),
             stream1.getKafkaTopicName(),
             stream1.getKsqlTopic().getKeyFormat().getFormat(),
             stream1.getKsqlTopic().getValueFormat().getFormat(),
             stream1.getKsqlTopic().getKeyFormat().isWindowed()
         ),
         new SourceInfo.Stream(
-            stream2.getName().toString(FormatOptions.of(IdentifierUtil::needsQuotes)),
+            stream2.getName().toString(FormatOptions.noEscape()),
             stream2.getKafkaTopicName(),
             stream2.getKsqlTopic().getKeyFormat().getFormat(),
             stream2.getKsqlTopic().getValueFormat().getFormat(),
@@ -223,7 +223,7 @@ public class ListSourceExecutorTest {
   @Test
   public void shouldShowTables() {
     // Given:
-    final KsqlTable<?> table1 = engine.givenSource(DataSourceType.KTABLE, "TABLE1");
+    final KsqlTable<?> table1 = engine.givenSource(DataSourceType.KTABLE, "table1");
     final KsqlTable<?> table2 = engine.givenSource(DataSourceType.KTABLE, "table2");
     engine.givenSource(DataSourceType.KSTREAM, "stream");
 
@@ -239,14 +239,14 @@ public class ListSourceExecutorTest {
     // Then:
     assertThat(descriptionList.getTables(), containsInAnyOrder(
         new SourceInfo.Table(
-            table1.getName().toString(FormatOptions.of(IdentifierUtil::needsQuotes)),
+            table1.getName().toString(FormatOptions.noEscape()),
             table1.getKsqlTopic().getKafkaTopicName(),
             table2.getKsqlTopic().getKeyFormat().getFormat(),
             table1.getKsqlTopic().getValueFormat().getFormat(),
             table1.getKsqlTopic().getKeyFormat().isWindowed()
         ),
         new SourceInfo.Table(
-            table2.getName().toString(FormatOptions.of(IdentifierUtil::needsQuotes)),
+            table2.getName().toString(FormatOptions.noEscape()),
             table2.getKsqlTopic().getKafkaTopicName(),
             table2.getKsqlTopic().getKeyFormat().getFormat(),
             table2.getKsqlTopic().getValueFormat().getFormat(),


### PR DESCRIPTION
solves issue #9730 
### Description 
Currently, the command `show streams/tables`, lists the names of sources that have been originally creates using double quotes wrapped in back ticks, while the expected behaviour is that all source names are listed as they are not wrapped within any other character.

### Testing done 
Unit tests
Manual testing
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

