### PR TITLE
feat: ksql-test-runner tool returns exit code "1" on test failure

### DIFF
--- a/docs/how-to-guides/test-an-app.md
+++ b/docs/how-to-guides/test-an-app.md
@@ -14,7 +14,7 @@ keywords: testing, qa, quality assurance, test runner
 
 ## Context
 
-ksqlDB ships with a command line tool to to test KSQL statements automatically.
+ksqlDB ships with a command line tool to test KSQL statements automatically.
 It doesn't require an active {{ site.aktm }} or ksqlDB cluster.
 
 ## In action

--- a/docs/how-to-guides/test-an-app.md
+++ b/docs/how-to-guides/test-an-app.md
@@ -186,6 +186,8 @@ Expected record does not match actual.
 file:///path/to/failing/test/file.sql:18
 ```
 
+The tool will return an exit code of `1` if any test fails and `0` if all tests pass.
+
 ### Kafka cluster
 
 `run-ksql-test` doesn't use a real Kafka cluster. Instead, it simulates

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/KsqlTestingTool.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/KsqlTestingTool.java
@@ -53,14 +53,17 @@ public final class KsqlTestingTool {
       }
       if (testOptions.getStatementsFile() != null
           && testOptions.getOutputFile() != null) {
-        runWithTripleFiles(
+        final int resultCode = runWithTripleFiles(
             testOptions.getStatementsFile(),
             testOptions.getInputFile(),
             testOptions.getOutputFile(),
             testOptions.getExtensionDir());
+
+        System.exit(resultCode);
       }
     } catch (final Exception e) {
       System.err.println("Invalid arguments: " + e.getMessage());
+      System.exit(1);
     }
   }
 
@@ -83,7 +86,7 @@ public final class KsqlTestingTool {
   }
 
 
-  static void runWithTripleFiles(
+  static int runWithTripleFiles(
       final String statementFile,
       final String inputFile,
       final String outputFile,
@@ -129,12 +132,12 @@ public final class KsqlTestingTool {
         .buildTests(testCaseNode, location.getTestPath(), name -> location)
         .get(0);
 
-    executeTestCase(
+    return executeTestCase(
         testCase,
         TestExecutor.create(true, extensionDir));
   }
 
-  static void executeTestCase(
+  static int executeTestCase(
       final TestCase testCase,
       final TestExecutor testExecutor
   ) {
@@ -143,8 +146,11 @@ public final class KsqlTestingTool {
       System.out.println("\t >>> Test passed!");
     } catch (final Exception | AssertionError e) {
       System.err.println("\t>>>>> Test failed: " + e.getMessage());
+      return 1;
     } finally {
       testExecutor.close();
     }
+
+    return 0;
   }
 }

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/KsqlTestingToolTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/KsqlTestingToolTest.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.test.tools;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -116,7 +117,7 @@ public class KsqlTestingToolTest {
   @Test
   public void shouldFailWithIncorrectTest() throws Exception {
     // When:
-    KsqlTestingTool.runWithTripleFiles(
+    final int code = KsqlTestingTool.runWithTripleFiles(
         INCORRECT_TESTS_FOLDER + "/expected_mismatch/statements.sql",
         INCORRECT_TESTS_FOLDER + "/expected_mismatch/input.json",
         INCORRECT_TESTS_FOLDER + "/expected_mismatch/output.json",
@@ -125,6 +126,7 @@ public class KsqlTestingToolTest {
     // Then:
     assertThat(errContent.toString(UTF_8),
         containsString("Test failed: Topic 'S1', message 0: Expected <\"1001\", \"101\"> with timestamp=0 and headers=[] but was <101, \"101\"> with timestamp=0 and headers=[]\n"));
+    assertEquals(1, code);
   }
 
   @Test
@@ -199,7 +201,7 @@ public class KsqlTestingToolTest {
   @Test
   public void shouldPropagateInsertValuesExecutorError() throws Exception {
     // When:
-    KsqlTestingTool.runWithTripleFiles(
+    final int code = KsqlTestingTool.runWithTripleFiles(
         "src/test/resources/test-runner/incorrect/insert_values/statements.sql",
         null,
         "src/test/resources/test-runner/incorrect/insert_values/output.json",
@@ -208,6 +210,7 @@ public class KsqlTestingToolTest {
     // Then:
     assertThat(errContent.toString(UTF_8),
         containsString("Test failed: Failed to insert values into 'TEST'."));
+    assertEquals(1, code);
   }
 
   @Test
@@ -233,7 +236,7 @@ public class KsqlTestingToolTest {
       final Optional<String> extensionDir
   ) throws Exception {
     // When:
-    KsqlTestingTool.runWithTripleFiles(statementsFilePath, inputFilePath, outputFilePath,
+    final int code = KsqlTestingTool.runWithTripleFiles(statementsFilePath, inputFilePath, outputFilePath,
         extensionDir);
 
     // Then:
@@ -242,6 +245,7 @@ public class KsqlTestingToolTest {
         + errContent.toString(UTF_8);
 
     assertThat(reason, outContent.toString(UTF_8), containsString("Test passed!"));
+    assertEquals(0, code);
   }
 
   private void runTestCaseAndAssertPassed(
@@ -249,7 +253,7 @@ public class KsqlTestingToolTest {
       final String outputFilePath
   ) throws Exception {
     // When:
-    KsqlTestingTool.runWithTripleFiles(statementsFilePath, null, outputFilePath,
+    final int code = KsqlTestingTool.runWithTripleFiles(statementsFilePath, null, outputFilePath,
         Optional.empty());
 
     // Then:
@@ -258,5 +262,6 @@ public class KsqlTestingToolTest {
         + errContent.toString(UTF_8);
 
     assertThat(reason, outContent.toString(UTF_8), containsString("Test passed!"));
+    assertEquals(0, code);
   }
 }


### PR DESCRIPTION
### Description 
Fixes #4665 

Current behavior is the ksql-test-runner exits with only a "0" exit code regardless if it encounters an error while executing or if any tests fail that it is running. This prevents use in a CI/CD deployment pipeline. The change I submit here will let ksql-test-runner return exit code "1" if any test failure or errors are encountered and a "0" exit code if all tests completed successfully.

### Testing done 
I have included modifications to existing unit tests that verify the ksql test runner does return a "0" exit code on successful executions and a "1" exit code on any test failures or errors encountered while attempting to run the ksql tests.

![unknown](https://user-images.githubusercontent.com/38697249/206269910-cc1f3499-42ff-483c-8cba-aba242c5c5d1.png)

![unknown](https://user-images.githubusercontent.com/38697249/206270049-cfd8471c-79bb-4b9b-be41-c33a86ee8b27.png)

![image](https://user-images.githubusercontent.com/38697249/206270464-ab460b00-4827-437a-a12b-8431594a239e.png)


I have also executed the KsqlTestingTool.java class from my IDE with parameters to a ksql test I wrote and validated the program returns the expected result codes for both a successful test and a failed test.

I also ran the unit tests locally before and after my changes.

![image](https://user-images.githubusercontent.com/38697249/206259860-b24f7cc3-07b6-4bfe-ac2d-65a2a7eb88b0.png)

### Reviewer checklist
- [X] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [X] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

