### PR TITLE
fix: change assertions for flaky shouldExecutePrint

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
@@ -718,6 +718,14 @@ public class ApiIntegrationTest {
     }, is(1));
 
     PrintResponse printResponse = atomicReference.get();
+
+    assertThatEventually(() -> {
+      try {
+        return responseFuture.isDone();
+      } catch (Throwable t) {
+        return false;
+      }
+    }, is(true));
     assertThat(writeStream.isEnded(), is(true));
     assertThat(printResponse.rows.get(0), containsString(
         "key: {\"F1\":[\"a\"]}, value: {\"STR\":\"FOO\",\"LONG\":1,\"DEC\":1.11,\"BYTES_\":\"AQ==\",\"ARRAY\":[\"a\"],\"MAP\":{\"k1\":\"v1\"},\"STRUCT\":{\"F1\":2},\"COMPLEX\":{\"DECIMAL\":0.0,\"STRUCT\":{\"F1\":\"v0\",\"F2\":0},\"ARRAY_ARRAY\":[[\"foo\"]],\"ARRAY_STRUCT\":[{\"F1\":\"v0\"}],\"ARRAY_MAP\":[{\"k1\":0}],\"MAP_ARRAY\":{\"k\":[\"v0\"]},\"MAP_MAP\":{\"k\":{\"k\":0}},\"MAP_STRUCT\":{\"k\":{\"F1\":\"v0\"}}},\"TIMESTAMP\":1,\"DATE\":1,\"TIME\":0}, partition: 0"));


### PR DESCRIPTION
### Description 
Added one extra assertion to avoid flakiness. After some time I was able to replicate the behavior. 

Before the fix, after 82 runs, it failed once:
![image](https://user-images.githubusercontent.com/11739405/210581762-e74258b5-48bf-4e08-a406-cef35d07929f.png)

After the fix, it ran more than 200+ times without any noticeable delay:
![image](https://user-images.githubusercontent.com/11739405/210581500-7a70a858-e2ab-4630-b228-eff36bc51733.png)

My assumption is: we have an [endHandler for the response](https://github.com/confluentinc/ksql/blob/040e8d208d9760fb9cf9107d38619421371d9428/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QueryStreamHandler.java#L312), which closes the publisher. Due to parallelization, this was sometimes only called slightly after the response was already written to the stream/the assertion had been checked.

Fixes:
https://confluentinc.atlassian.net/browse/KSQL-9676
https://confluentinc.atlassian.net/jira/software/projects/KFS/boards/691?selectedIssue=KFS-449

### Testing done 
Unit testing.

### Reviewer checklist
- [x] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

