### PR TITLE
[KSE-1612] Upgrade netty to 4.1.86

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <wiremock.version>2.24.0</wiremock.version>
         <clearspring-analytics.version>2.9.5</clearspring-analytics.version>
         <icu.version>67.1</icu.version>
-        <vertx.version>4.3.2</vertx.version>
+        <vertx.version>4.3.7</vertx.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <skip.docker.build>true</skip.docker.build>
         <skip.docker.test>true</skip.docker.test>
@@ -151,8 +151,8 @@
              Please check top level `pom.xml` at https://github.com/netty/netty
              for the netty version we bump to (ie, corresponding git tag),
              to find the correct `tcnative` version. -->
-        <netty.version>4.1.78.Final</netty.version>
-        <netty-codec-http2-version>4.1.78.Final</netty-codec-http2-version>
+        <netty.version>4.1.86.Final</netty.version>
+        <netty-codec-http2-version>4.1.86.Final</netty-codec-http2-version>
         <jersey-common>2.34</jersey-common>
         <multi-threaded-testing.forkCount>3</multi-threaded-testing.forkCount>
     </properties>


### PR DESCRIPTION
This fixes CVE-2022-41881 and, potentially, CVE-2022-41915 vulnerabilities.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

