### PR TITLE
Upgrade netty to 4.1.86 #2

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/CorsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/CorsTest.java
@@ -58,7 +58,7 @@ public final class CorsTest {
   protected static final String DEFAULT_PULL_QUERY = "select * from foo where rowkey='1234';";
 
   private static final String URI = "/query-stream";
-  private static final String ORIGIN = "wibble.com";
+  private static final String ORIGIN = "http://wibble.com";
 
   private final Function<Map<String, String>, WebClient> clientSupplier;
   private final int successStatus;
@@ -135,7 +135,7 @@ public final class CorsTest {
   }
 
   public void shouldAcceptCorsRequestOriginExactMatchOneOfList() throws Exception {
-    shouldAcceptCorsRequest(ORIGIN, "foo.com,wibble.com");
+    shouldAcceptCorsRequest(ORIGIN, "foo.com," + ORIGIN);
   }
 
   public void shouldRejectCorsRequestOriginExactMatchOenOfList() throws Exception {

--- a/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientTest.java
+++ b/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientTest.java
@@ -539,7 +539,7 @@ public class KsqlClientTest {
     );
 
     // Then:
-    assertThat(e.getMessage(), containsString(
+    assertThat(e.getCause().getMessage(), containsString(
         "java.io.IOException: Keystore was tampered with, or password was incorrect"
     ));
   }
@@ -560,7 +560,7 @@ public class KsqlClientTest {
     );
 
     // Then:
-    assertThat(e.getMessage(), containsString(
+    assertThat(e.getCause().getMessage(), containsString(
         "java.io.IOException: Keystore was tampered with, or password was incorrect"
     ));
   }
@@ -788,6 +788,7 @@ public class KsqlClientTest {
     props.putAll(ClientTrustStore.trustStoreProps());
     props.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, password);
     createClient(props);
+    ksqlClient.target(serverUri).getServerInfo().get();
   }
 
   private void startServerWithTls() throws Exception {

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <wiremock.version>2.24.0</wiremock.version>
         <clearspring-analytics.version>2.9.5</clearspring-analytics.version>
         <icu.version>67.1</icu.version>
-        <vertx.version>4.3.2</vertx.version>
+        <vertx.version>4.3.7</vertx.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <skip.docker.build>true</skip.docker.build>
         <skip.docker.test>true</skip.docker.test>
@@ -151,8 +151,8 @@
              Please check top level `pom.xml` at https://github.com/netty/netty
              for the netty version we bump to (ie, corresponding git tag),
              to find the correct `tcnative` version. -->
-        <netty.version>4.1.78.Final</netty.version>
-        <netty-codec-http2-version>4.1.78.Final</netty-codec-http2-version>
+        <netty.version>4.1.86.Final</netty.version>
+        <netty-codec-http2-version>4.1.86.Final</netty-codec-http2-version>
         <jersey-common>2.34</jersey-common>
         <multi-threaded-testing.forkCount>3</multi-threaded-testing.forkCount>
     </properties>


### PR DESCRIPTION
### Description 
2nd attempt to upgrade netty to `4.1.86`. That also requires vertx upgrade to `4.3.7`.
The previous failed after merge by `KsqlClientTest` and had to be reverted.

Commits could be squashed after the review.

### Testing done 

Testing locally with `./mvnw verify -T 1.5C -Dcheckstyle.skip=true`; no new tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

