### PR TITLE
fix: complete transition to 7.5.x series

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.services;
 
+import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
@@ -59,6 +60,11 @@ final class SandboxedSchemaRegistryClient {
 
     private SandboxSchemaRegistryCache(final SchemaRegistryClient delegate) {
       this.srClient = delegate;
+    }
+
+    @Override
+    public Ticker ticker() {
+      throw new UnsupportedOperationException();
     }
 
     @Override

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatterTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Message;
@@ -1228,6 +1229,7 @@ public class RecordFormatterTest {
       props.put("schema.registry.url", "localhost:9092");
 
       final SchemaRegistryClient schemaRegistryClient = mock(SchemaRegistryClient.class);
+      when(schemaRegistryClient.ticker()).thenReturn(Ticker.systemTicker());
       return new KafkaAvroSerializer(schemaRegistryClient, props);
     }
 
@@ -1249,6 +1251,7 @@ public class RecordFormatterTest {
       props.put("schema.registry.url", "localhost:9092");
 
       final SchemaRegistryClient schemaRegistryClient = mock(SchemaRegistryClient.class);
+      when(schemaRegistryClient.ticker()).thenReturn(Ticker.systemTicker());
       return new KafkaProtobufSerializer<>(schemaRegistryClient, props);
     }
 
@@ -1257,6 +1260,7 @@ public class RecordFormatterTest {
       props.put("schema.registry.url", "localhost:9092");
 
       final SchemaRegistryClient schemaRegistryClient = mock(SchemaRegistryClient.class);
+      when(schemaRegistryClient.ticker()).thenReturn(Ticker.systemTicker());
       return new KafkaJsonSchemaSerializer<>(schemaRegistryClient, props);
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
         <apache.io.version>2.7</apache.io.version>
         <io.confluent.ksql.version>7.5.0-0</io.confluent.ksql.version>
-        <io.confluent.schema-registry.version>7.4.0-884</io.confluent.schema-registry.version>
+        <io.confluent.schema-registry.version>7.5.0-18</io.confluent.schema-registry.version>
         <netty-tcnative-version>2.0.54.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>[7.5.0-0, 7.5.1-0)</version>
+        <version>7.5.0-16</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>


### PR DESCRIPTION
### Description 
pinned-dependencies tooling is only partially completed, so CP branch cuts require some manual work. This commit bumps our SR dependency to the 7.5 series, pins the parent pom in the 7.5 series, and fixes a failing test related to the updated SR dependency.

### Testing done 
running the CI job is sufficient

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

