### PR TITLE
SSEO-3393 - Add metatag for Zendesk search crawler

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -3,4 +3,5 @@
 {% block extrahead %}
   <meta class="swiftype" name="site-id" data-type="integer" content="4" />
   <meta class="swiftype" name="docs-boost" data-type="integer" content="6" />
+  <meta name='zd-site-verification' content='30d1zoyi0fpyh1acggoi58' />
 {% endblock %}


### PR DESCRIPTION
[SSEO-3393](https://confluentinc.atlassian.net/browse/SSEO-3393)

In order to make content from [ksqlDB Docs](https://docs.ksqldb.io) searchable via Zendesk Federated Search in Support Portal ([support.confluent.io](https://support.confluent.io/hc)), we need to add a HTML meta tag to this website.

Zendesk's search crawler uses this tag for domain verification each time it runs and more info about the crawler setup can be found in [support.zendesk.com/hc/en-us/articles/4593564000410](https://support.zendesk.com/hc/en-us/articles/4593564000410).


[SSEO-3393]: https://confluentinc.atlassian.net/browse/SSEO-3393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ