### PR TITLE
chore: Add exception into the error message when KafkaEmbedded fails to delete log dir

### DIFF
--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
@@ -141,7 +141,7 @@ class KafkaEmbedded {
     try {
       Files.delete(Paths.get(logDir()));
     } catch (final IOException e) {
-      log.error("Failed to delete log dir {}", logDir());
+      log.error("Failed to delete log dir {}", logDir(), e);
     }
     log.debug("Shutdown of embedded Kafka broker at {} completed (with ZK ensemble at {}) ...",
         brokerList(), zookeeperConnect());


### PR DESCRIPTION
### Description 
Right now there is no way to find out what happened when embedded Kafka cluster fails to delete the log directory. This commit adds the stacktrace into the log message.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

