### PR TITLE
chore: disable pint-merge check on build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,5 +16,6 @@ common {
     maxDaysToKeep = 90
     extraBuildArgs = "-Dmaven.gitcommitid.nativegit=true"
     mavenBuildGoals = "clean install"
+    runMergeCheck = false
 }
 


### PR DESCRIPTION
### Description 
The build is failing due to the automated dependency-bump commits coming from older release branches. These commits would be skipped by actual merges, but they still cause merge-check failures.

Rather than updating pint right now, we'll just disable the check and see how it plays out.

### Testing done 
https://jenkins.confluent.io/job/confluentinc/job/ksql/job/master/12210/replay/diff

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

