### PR TITLE
chore: remove cc-docker-ksql from downstream CP 7.4 release builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ common {
     dockerPush = false
     dockerScan = false
     dockerImageClean = false
-    downStreamRepos = ["confluent-security-plugins", "confluent-cloud-plugins", "cc-docker-ksql"]
+    downStreamRepos = ["confluent-security-plugins", "confluent-cloud-plugins"]
     downStreamValidate = false
     nanoVersion = true
     pinnedNanoVersions = true


### PR DESCRIPTION
The docker build isn't part of CP.

See also: https://github.com/confluentinc/ksql/pull/9468

