### PR TITLE
chore: log whole exception not just message to avoid null error message

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/RemoteHostExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/RemoteHostExecutor.java
@@ -133,7 +133,7 @@ public final class RemoteHostExecutor {
           }
         } catch (final Exception cause) {
           LOG.warn("Failed to retrieve info from host: {}, statement: {}, cause: {}",
-              e.getKey(), statement.getMaskedStatementText(), cause.getMessage());
+              e.getKey(), statement.getMaskedStatementText(), cause);
           unresponsiveHosts.add(e.getKey());
         }
       }


### PR DESCRIPTION
### Description 
Currently when the flaky test `io.confluent.ksql.rest.integration.TerminateTransientQueryFunctionalTest.shouldTerminatePushQueryOnAnotherNode ` fails , we get the following unhelpful log line.

```
[2022-12-21 17:48:19,595] WARN Failed to retrieve info from host: HostInfo{host='localhost', port=1239}, statement: terminate transient_PAGEVIEW_KSTREAM_609054729411180441;, cause: null (io.confluent.ksql.rest.server.execution.RemoteHostExecutor:135)
[2022-12-21 17:48:19,599] INFO Processed unsuccessfully: KsqlRequest{configOverrides={}, requestProperties={}, commandSequenceNumber=Optional.empty} (26a2ed7f-da74-3a24-b1d5-20c11ce11610): TERMINATE query; (io.confluent.ksql.logging.query.QueryLogger:98)
```
And the “cause: null” isn’t very helpful. Hopefully next time it fails, we will have a better idea by logging the exception and its stacktrace instead of just getting the null caused by `e.getMessage`. See https://stackoverflow.com/a/8237111/14024129

### Testing done 
Log only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

