### PR TITLE
test: close TopologyTestDrivers in between QTTs (MINOR)

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -162,20 +162,23 @@ public class TestExecutor implements Closeable {
     this.topicInfoCache = new TopicInfoCache(ksqlEngine, serviceContext.getSchemaRegistryClient());
   }
 
+  // CHECKSTYLE_RULES.OFF: CyclomaticComplexity
   public void buildAndExecuteQuery(
       final TestCase testCase,
       final TestExecutionListener listener
   )  {
+    // CHECKSTYLE_RULES.ON: CyclomaticComplexity
     topicInfoCache.clear();
 
     final KsqlConfig ksqlConfig = testCase.applyPersistedProperties(new KsqlConfig(config));
 
+    List<TopologyTestDriverContainer> topologyTestDrivers = null;
     try {
       System.setProperty(RuntimeBuildContext.KSQL_TEST_TRACK_SERDE_TOPICS, "true");
 
       maybeRegisterTopicSchemas(testCase.getTopics());
 
-      final List<TopologyTestDriverContainer> topologyTestDrivers = topologyBuilder
+      topologyTestDrivers = topologyBuilder
           .buildStreamsTopologyTestDrivers(
               testCase,
               serviceContext,
@@ -274,6 +277,11 @@ public class TestExecutor implements Closeable {
       assertThat(e, isThrowable(expectedExceptionMatcher.get()));
     } finally {
       System.clearProperty(RuntimeBuildContext.KSQL_TEST_TRACK_SERDE_TOPICS);
+      if (topologyTestDrivers != null) {
+        for (final TopologyTestDriverContainer topologyTestDriverContainer : topologyTestDrivers) {
+          topologyTestDriverContainer.close();
+        }
+      }
     }
   }
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TopologyTestDriverContainer.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TopologyTestDriverContainer.java
@@ -106,4 +106,8 @@ public final class TopologyTestDriverContainer {
   public Set<String> getSourceTopicNames() {
     return sourceTopics.keySet();
   }
+
+  public void close() {
+    topologyTestDriver.close();
+  }
 }


### PR DESCRIPTION
### Description 

The code for running query translation tests doesn't call close() on the TopologyTestDriver instances it creates, which means thousands of them accumulate until the entire suite of QTTs is finished running. This PR calls close on the TopologyTestDrivers after each individual test case is run, in order to prevent accumulation of resources (e.g., tens of thousands of file descriptors) while the test suite is running.

### Testing done 

Verified that open file descriptors no longer accumulate while the QTT suite is running.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

