### PR TITLE
test: wait for successful assertion to avoid test failure due to race

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
@@ -331,7 +331,7 @@ public class ApiTest extends BaseApiTest {
     assertThat(queryResponse.rows, hasSize(DEFAULT_JSON_ROWS.size() - 1));
     validateError(ERROR_CODE_SERVER_ERROR, "java.lang.RuntimeException: Failure in processing", queryResponse.error);
     assertThat(testEndpoints.getPublishers(), hasSize(1));
-    assertThat(server.getQueryIDs().isEmpty(), is(true));
+    assertThatEventually(() -> server.getQueryIDs().isEmpty(), is(true));
   }
 
   @Test


### PR DESCRIPTION
### Description 
`ApiTest#shouldHandleErrorInProcessingQuery` test failed for no apparent reason. The assertion that was not satisfied reads a set of keys from a `ConcurrentHashMap` and verifies that that set is empty. The theory is that the assertion reads the set of keys before the key is concurrently removed from the hash map. This PR replaces the failing assertion with an assertion that retries the assertion for a certain amount of time before it fails.    

### Testing done 
Tested locally

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

