### PR TITLE
test: fix flaky pause/resume integration test

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PauseResumeIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PauseResumeIntegrationTest.java
@@ -28,7 +28,6 @@ import io.confluent.ksql.util.PageViewDataProvider.Batch;
 import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.KafkaMetric;
-import org.jetbrains.annotations.NotNull;
 import org.junit.*;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
@@ -127,7 +126,7 @@ public class PauseResumeIntegrationTest {
     RestIntegrationTestUtil.makeKsqlRequest(REST_APP, "PAUSE " + queryId + ";");
 
     assertThat(getPausedCount(), equalTo(1L));
-    assertThat(getFirstKsqlDbQueryState(), equalTo("PAUSED"));
+    assertThatEventually(this::getFirstKsqlDbQueryState, equalTo("PAUSED"));
 
     // Produce more records
     TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER2, KAFKA, JSON,


### PR DESCRIPTION
### Description 
Fixes flaky pause/resume integration test. The test pauses a query and then it verifies that the REST app has a paused query and that the metrics show the query as paused. The latter verification has failed sometimes because the metrics have not been updated before the verification was called. This PR repeatedly verifies the metrics and only fails after the metrics do not show the paused state after a certain period of time.    

### Testing done 
Before the fix, the test failed locally every 2-3 runs. With the fix the test run 50 times in a row without failure.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

