### PR TITLE
chore: remove testng dependency

### DIFF
--- a/ksqldb-api-reactive-streams-tck/pom.xml
+++ b/ksqldb-api-reactive-streams-tck/pom.xml
@@ -47,13 +47,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <version>6.11</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
     <build>


### PR DESCRIPTION
### Description 
The testng dependency is specified in module `ksqldb-api-reactive-streams-tck` but it is not used anywhere in the codebase.

### Testing done 
Successfully build `ksqldb-api-reactive-streams-tck` locally with `mvn -pl ksqldb-api-reactive-streams-tck clean verify`.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

