### PR TITLE
chore: upgrade testng to 7.7.0

### DIFF
--- a/ksqldb-api-reactive-streams-tck/pom.xml
+++ b/ksqldb-api-reactive-streams-tck/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>6.11</version>
+            <version>7.7.0</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
### Description 
testng needs to be upgraded to 7.7.0 due to a CVE. See https://github.com/confluentinc/ksql/security/dependabot/24

### Testing done 
Successfully build with `mvn -pl ksqldb-api-reactive-streams-tck clean verify`.
Command `mvn dependency:tree -Dincludes=org.testng:testng | grep -C 5 testng` only shows the upgraded version.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

