### PR TITLE
docs: Fix the release for JSON_ITEMS

### DIFF
--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -1170,7 +1170,7 @@ JSON_RECORDS('abc') => NULL
 ```
 ### `JSON_ITEMS`
 
-```sql title="Since: 0.28.0"
+```sql title="Since: 0.29.0"
 JSON_ITEMS(json_string) => Array<String>
 ```
 


### PR DESCRIPTION
`JSON_ITEMS` will be available for users in the [0.29.0 release](https://github.com/confluentinc/ksql/commit/c62c2d24fb0ee687b3824941464c368a8f0a74d2). However, the docs claim that the function is available since 0.28.0 which confuses our users - https://github.com/confluentinc/ksql/issues/9786#issuecomment-1436362671.

This PR changes `JSON_ITEMS` release to 0.29.0.

