### PR TITLE
chore: Fix testng test running.

### DIFF
--- a/ksqldb-api-reactive-streams-tck/pom.xml
+++ b/ksqldb-api-reactive-streams-tck/pom.xml
@@ -69,6 +69,17 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>${maven-surefire-plugin.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
### Description 
Adds the `surefire-testng` so that builds can find the testng tests in ksqldb-api-reactive-streams-tck` sub-module.

### Testing done 
Tested locally by running `/mvnw  clean install -pl ksqldb-api-reactive-streams-tck` and observing that the build did run the tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

