### PR TITLE
chore: use jenkins/common instead of jenkins/dockerfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,14 +1,20 @@
 #!/usr/bin/env groovy
 
-def channel = "${env.BRANCH_NAME}".contains('master') ? '#ksql-alerts' : '#ksqldb-warn'
+def channel = "${env.BRANCH_NAME}".contains('master') ? '#ksqldb-quality-oncall' : '#ksqldb-warn'
 
-dockerfile {
+common {
+    nodeLabel = 'docker-openjdk11'
     slackChannel = channel
+    timeoutHours = 4
     upstreamProjects = 'confluentinc/schema-registry'
     extraDeployArgs = '-Ddocker.skip=true'
     dockerPush = false
     dockerScan = false
     dockerImageClean = false
     disableConcurrentBuilds = true
+    downStreamValidate = false
+    maxBuildsToKeep = 99
+    maxDaysToKeep = 90
+    extraBuildArgs = "-Dmaven.gitcommitid.nativegit=true"
 }
 


### PR DESCRIPTION
### Description 
jenkins/dockerfile uses Java 8 to build ksql. With the recent upgrade of testng to 7.7.0 (https://github.com/confluentinc/ksql/commit/096155ee27aa7772dc5b2fdf56cb29cdf8ccc5ca) Java 11 is required. jenkins/common is able to use Java 11.

### Testing done 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

