### PR TITLE
chore: revert testng dependency to 6.11 on older branches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@
 def channel = "${env.BRANCH_NAME}".contains('master') ? '#ksqldb-quality-oncall' : '#ksqldb-warn'
 
 common {
+    nodeLabel = 'docker-debian-jdk8'
     slackChannel = channel
     timeoutHours = 4
     upstreamProjects = 'confluentinc/schema-registry'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,6 @@
 def channel = "${env.BRANCH_NAME}".contains('master') ? '#ksqldb-quality-oncall' : '#ksqldb-warn'
 
 common {
-    nodeLabel = 'docker-openjdk11'
     slackChannel = channel
     timeoutHours = 4
     upstreamProjects = 'confluentinc/schema-registry'

--- a/ksqldb-api-reactive-streams-tck/pom.xml
+++ b/ksqldb-api-reactive-streams-tck/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.7.0</version>
+            <version>6.11</version>
             <scope>test</scope>
         </dependency>
 
@@ -68,17 +68,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-testng</artifactId>
-                        <version>${maven-surefire-plugin.version}</version>
-                    </dependency>
-                </dependencies>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
### Description 

Reverts https://github.com/confluentinc/ksql/pull/9801 and corresponding follow-up changes https://github.com/confluentinc/ksql/pull/9807 and https://github.com/confluentinc/ksql/pull/9805 on older branches since these older branches are not set up to run with Java 11 (there are various test failures due to discrepancies between Java 8 and 11). This revert will only be merged forward through 7.1.x, as newer branches are already Java 11 compatible. 

### Testing done 


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

