### PR TITLE
fix: catch TopicAuthorizationExceptions when getting topic config

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -420,7 +420,9 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
           .filter(e -> includeDefaults || !e.isDefault())
           .collect(Collectors.toMap(ConfigEntry::name, ConfigEntry::value));
     } catch (final TopicAuthorizationException e) {
-      throw new KsqlTopicAuthorizationException(AclOperation.DESCRIBE_CONFIGS, e.unauthorizedTopics());
+      throw new KsqlTopicAuthorizationException(
+          AclOperation.DESCRIBE_CONFIGS,
+          e.unauthorizedTopics());
     } catch (final Exception e) {
       throw new KafkaResponseGetFailedException(
           "Failed to get config for Kafka Topic " + topicName, e);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -419,6 +419,8 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
           .filter(e -> e.value() != null)
           .filter(e -> includeDefaults || !e.isDefault())
           .collect(Collectors.toMap(ConfigEntry::name, ConfigEntry::value));
+    } catch (final TopicAuthorizationException e) {
+      throw new KsqlTopicAuthorizationException(AclOperation.DESCRIBE, e.unauthorizedTopics());
     } catch (final Exception e) {
       throw new KafkaResponseGetFailedException(
           "Failed to get config for Kafka Topic " + topicName, e);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -420,7 +420,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
           .filter(e -> includeDefaults || !e.isDefault())
           .collect(Collectors.toMap(ConfigEntry::name, ConfigEntry::value));
     } catch (final TopicAuthorizationException e) {
-      throw new KsqlTopicAuthorizationException(AclOperation.DESCRIBE, e.unauthorizedTopics());
+      throw new KsqlTopicAuthorizationException(AclOperation.DESCRIBE_CONFIGS, e.unauthorizedTopics());
     } catch (final Exception e) {
       throw new KafkaResponseGetFailedException(
           "Failed to get config for Kafka Topic " + topicName, e);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
@@ -734,7 +734,7 @@ public class KafkaTopicClientImplTest {
 
     // Then:
     assertThat(e.getMessage(), containsString(
-        "Authorization denied to Describe on topic(s): [" + topicName + "]"));
+        "Authorization denied to Describe_configs on topic(s): [" + topicName + "]"));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
@@ -720,6 +720,24 @@ public class KafkaTopicClientImplTest {
   }
 
   @Test
+  public void shouldThrowKsqlTopicAuthorizationExceptionFromGetTopicConfig() {
+    // Given:
+    final String topicName = "foobar";
+    when(adminClient.describeConfigs(ImmutableList.of(topicResource(topicName))))
+        .thenAnswer(describeConfigsResult(new TopicAuthorizationException(ImmutableSet.of(topicName))));
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlTopicAuthorizationException.class,
+        () -> kafkaTopicClient.getTopicConfig(topicName)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString(
+        "Authorization denied to Describe on topic(s): [" + topicName + "]"));
+  }
+
+  @Test
   public void shouldSetTopicCleanupPolicyToCompact() {
     // Given:
     final Map<String, String> configs = ImmutableMap.of(


### PR DESCRIPTION
### Description 
Catches TopicAuthorizationException in KafkaTopicClient#getTopicConfig and transforms it to KsqlTopicAuthorizationException.

### Testing done 
Unit testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

