### PR TITLE
chore: Backport Use QueryLogger any time we log a query

### DIFF
--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlRequest.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlRequest.java
@@ -152,7 +152,6 @@ public class KsqlRequest {
     return "KsqlRequest{"
         + "configOverrides=" + configOverrides
         + ", requestProperties=" + requestProperties
-        + ", sessionVariables=" + sessionVariables
         + ", commandSequenceNumber=" + commandSequenceNumber
         + '}';
   }


### PR DESCRIPTION
This fix was spread over several commits, so I'm squashing it into one backportable chunk. Most of it is a no-op on 7.3.

chore: Use QueryLogger any time we log a query (#9681)

* fix: use QueryLogger for logging queries

* anonymize processed queries

* logging for unparsable queries

* anonymized query handling logs

* anonymized received queries

* anonymized streaming query

* checkstyle

* prevent exception from querylogger

* don't include statement text in exception message

* don't include statement text in exception messages

* fix tests

* fix tests

* fix tests

* checkstyle

* checkstyle

* fix parser test

* fix tests

* checkstyle

* restore ability to print errors in CLI

* checkstyle

* checkstyle

* fix error code

* One more fix for RestoreCommandsCompactor

* Fix style bug

Co-authored-by: Alan Sheinberg <asheinberg@confluent.io>

chore: Use QueryLogger to log queries, part 2 (#9695)

chore: use QueryLogger to log queries, part 3 (#9706)

Follow-up to #9695

chore: Use QueryLogger to log queries, part 4 (#9707)

chore: Use QueryLogger any time we log a query (#9705)

chore: Use QueryLogger to log queries, part 5 (#9722)

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

