### PR TITLE
chore: Backport Use QueryLogger any time we log a query

### DIFF
--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
@@ -294,7 +294,7 @@ public class ClientTest extends BaseApiTest {
   @Test
   public void shouldHandleErrorResponseFromStreamQuery() {
     // Given
-    ParseFailedException pfe = new ParseFailedException("invalid query blah");
+    ParseFailedException pfe = new ParseFailedException("invalid query blah", "bad query text");
     testEndpoints.setCreateQueryPublisherException(pfe);
 
     // When
@@ -504,7 +504,7 @@ public class ClientTest extends BaseApiTest {
   @Test
   public void shouldHandleErrorResponseFromExecuteQuery() {
     // Given
-    ParseFailedException pfe = new ParseFailedException("invalid query blah");
+    ParseFailedException pfe = new ParseFailedException("invalid query blah", "bad query text");
     testEndpoints.setCreateQueryPublisherException(pfe);
 
     // When

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -1233,11 +1233,13 @@ public class CliTest {
 
     // Then:
     final String out = terminal.getOutputString();
-    final String expected = "Statement: create stream if not exist s1(id int) "
-        + "with (kafka_topic='s1', value_format='json', partitions=1);\n"
-        + "Caused by: line 2:22: no viable alternative at input 'create stream if not";
+    final String expected = "line 2:22: " +
+        "no viable alternative at input 'create stream if not exist'\n" +
+        "Statement: create stream if not exist s1(id int) with " +
+        "(kafka_topic='s1', value_format='json', partitions=1);\n" +
+        "Caused by: line 2:22: Syntax error at line 2:22\n";
     assertThat(error_code, is(-1));
-    assertThat(out, containsString(expected));
+    assertThat(out, is(expected));
     assertThat(out, not(containsString("drop stream if exists")));
   }
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/ErrorMessageUtil.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/ErrorMessageUtil.java
@@ -71,7 +71,13 @@ public final class ErrorMessageUtil {
       return "Could not connect to the server. "
           + "Please check the server details are correct and that the server is running.";
     } else {
-      return e.getMessage() == null ? e.toString() : e.getMessage();
+      final String message;
+      if (e instanceof KsqlStatementException) {
+        message = ((KsqlStatementException) e).getUnloggedMessage();
+      } else {
+        message = e.getMessage();
+      }
+      return message == null ? e.toString() : message;
     }
   }
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlStatementException.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlStatementException.java
@@ -17,22 +17,140 @@ package io.confluent.ksql.util;
 
 public class KsqlStatementException extends KsqlException {
 
+  /**
+   * KsqlStatementException is used to track any exception that contains sql text.
+   * When we catch this exception in the API layer and need to map it to a response
+   * code, we need to know whether the exception was caused by a bad statement,
+   * another kind of bad request, or a generic server error. This Problem enum
+   * captures those causes.
+   */
+  public enum Problem {
+    STATEMENT,
+    REQUEST,
+    OTHER;
+  }
+
+  /**
+   * The SQL text corresponding to this error. Will not be logged. May be returned to the user.
+   */
   private final String sqlStatement;
+
+  /**
+   * Categorization of the error. See {@link Problem}.
+   */
+  private final Problem problem;
+
+  /**
+   * The text of the original message field the exception was created with.
+   */
   private final String rawMessage;
 
+  /**
+   * Extended exception message, which can contain sensitive
+   * information because it will never be logged. May be returned to the user.
+   */
+  private final String unloggedDetails;
+
+  /**
+   * Text of the original extended exception message, which can contain sensitive
+   * information because it will never be logged. May be returned to the user.
+   */
+  private final String rawUnloggedDetails;
+
   public KsqlStatementException(final String message, final String sqlStatement) {
-    super(buildMessage(message, sqlStatement));
+    super(message);
     this.rawMessage = message == null ? "" : message;
     this.sqlStatement = sqlStatement == null ? "" : sqlStatement;
+    this.problem = Problem.STATEMENT;
+    this.rawUnloggedDetails = this.rawMessage;
+    this.unloggedDetails = buildMessage(message, sqlStatement);
+  }
+
+  public KsqlStatementException(final String message,
+                                final String unloggedDetails,
+                                final String sqlStatement) {
+    super(message);
+    this.rawMessage = message == null ? "" : message;
+    this.sqlStatement = sqlStatement == null ? "" : sqlStatement;
+    this.problem = Problem.STATEMENT;
+    this.rawUnloggedDetails = unloggedDetails;
+    this.unloggedDetails = buildMessage(unloggedDetails, sqlStatement);
+  }
+
+  public KsqlStatementException(final String message,
+                                final String sqlStatement,
+                                final Problem problem) {
+    super(message);
+    this.rawMessage = message == null ? "" : message;
+    this.sqlStatement = sqlStatement == null ? "" : sqlStatement;
+    this.problem = problem;
+    this.rawUnloggedDetails = rawMessage;
+    this.unloggedDetails = null;
+  }
+
+  public KsqlStatementException(final String message,
+                                final String unloggedDetails,
+                                final String sqlStatement,
+                                final Problem problem) {
+    super(message);
+    this.rawMessage = message == null ? "" : message;
+    this.sqlStatement = sqlStatement == null ? "" : sqlStatement;
+    this.problem = problem;
+    this.rawUnloggedDetails = unloggedDetails;
+    this.unloggedDetails = buildMessage(unloggedDetails, sqlStatement);
   }
 
   public KsqlStatementException(
       final String message,
       final String sqlStatement,
       final Throwable cause) {
-    super(buildMessage(message, sqlStatement), cause);
+    super(message, cause);
     this.rawMessage = message == null ? "" : message;
     this.sqlStatement = sqlStatement == null ? "" : sqlStatement;
+    this.problem = Problem.STATEMENT;
+    this.rawUnloggedDetails = this.rawMessage;
+    this.unloggedDetails = null;
+  }
+
+  public KsqlStatementException(
+      final String message,
+      final String unloggedDetails,
+      final String sqlStatement,
+      final Throwable cause) {
+    super(message, cause);
+    this.rawMessage = message == null ? "" : message;
+    this.sqlStatement = sqlStatement == null ? "" : sqlStatement;
+    this.rawUnloggedDetails = unloggedDetails;
+    this.unloggedDetails = buildMessage(unloggedDetails, sqlStatement);
+    this.problem = Problem.STATEMENT;
+  }
+
+  public KsqlStatementException(
+      final String message,
+      final String sqlStatement,
+      final Problem problem,
+      final Throwable cause) {
+    super(message, cause);
+    this.rawMessage = message == null ? "" : message;
+    this.sqlStatement = sqlStatement == null ? "" : sqlStatement;
+    this.problem = problem;
+    this.rawUnloggedDetails = this.rawMessage;
+    this.unloggedDetails = null;
+  }
+
+  public KsqlStatementException(
+      final String message,
+      final String unloggedDetails,
+      final String sqlStatement,
+      final Problem problem,
+      final Throwable cause) {
+    super(message, cause);
+    this.rawMessage = message == null ? "" : message;
+    this.sqlStatement = sqlStatement == null ? "" : sqlStatement;
+    this.problem = problem;
+    this.rawUnloggedDetails = unloggedDetails;
+    this.unloggedDetails =
+        problem == Problem.OTHER ? unloggedDetails : buildMessage(unloggedDetails, sqlStatement);
   }
 
   public String getSqlStatement() {
@@ -41,6 +159,18 @@ public class KsqlStatementException extends KsqlException {
 
   public String getRawMessage() {
     return rawMessage;
+  }
+
+  public Problem getProblem() {
+    return problem;
+  }
+
+  public String getUnloggedMessage() {
+    return unloggedDetails == null ? getMessage() : unloggedDetails;
+  }
+
+  public String getRawUnloggedDetails() {
+    return rawUnloggedDetails;
   }
 
   private static String buildMessage(final String message, final String sqlStatement) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/FilterTypeValidator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/FilterTypeValidator.java
@@ -53,9 +53,15 @@ public final class FilterTypeValidator {
   public void validateFilterExpression(final Expression exp) {
     final SqlType type = getExpressionReturnType(exp);
     if (!SqlTypes.BOOLEAN.equals(type)) {
-      throw new KsqlException("Type error in " + filterType.name() + " expression: "
+      throw new KsqlStatementException(
+          "Type error in " + filterType.name() + " expression: "
+          + "Should evaluate to boolean but is"
+          + " (" + type.toString(FormatOptions.none()) + ") instead.",
+          "Type error in " + filterType.name() + " expression: "
           + "Should evaluate to boolean but is " + exp.toString()
-          + " (" + type.toString(FormatOptions.none()) + ") instead.");
+          + " (" + type.toString(FormatOptions.none()) + ") instead.",
+          exp.toString()
+      );
     }
   }
 
@@ -71,9 +77,18 @@ public final class FilterTypeValidator {
 
     try {
       return expressionTypeManager.getExpressionSqlType(magicTimestampRewrite);
+    } catch (KsqlStatementException e) {
+      throw new KsqlStatementException(
+          "Error in " + filterType.name() + " expression",
+          "Error in " + filterType.name() + " expression: " + e.getUnloggedMessage(),
+          exp.toString()
+      );
     } catch (KsqlException e) {
-      throw new KsqlStatementException("Error in " + filterType.name() + " expression: "
-          + e.getMessage(), exp.toString());
+      throw new KsqlStatementException(
+          "Error in " + filterType.name() + " expression",
+          "Error in " + filterType.name() + " expression: " + e.getMessage(),
+          exp.toString()
+      );
     }
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -17,10 +17,8 @@ package io.confluent.ksql.engine;
 
 import static io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.KsqlExecutionContext.ExecuteResult;
 import io.confluent.ksql.analyzer.ImmutableAnalysis;
@@ -52,6 +50,7 @@ import io.confluent.ksql.execution.streams.RoutingOptions;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.internal.PullQueryExecutorMetrics;
 import io.confluent.ksql.internal.ScalablePushQueryMetrics;
+import io.confluent.ksql.logging.query.QueryLogger;
 import io.confluent.ksql.logicalplanner.LogicalPlan;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.MetaStoreImpl;
@@ -118,10 +117,8 @@ import io.confluent.ksql.util.QueryMask;
 import io.confluent.ksql.util.ScalablePushQueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import io.vertx.core.Context;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -312,39 +309,27 @@ final class EngineExecutor {
         ));
       }
 
-      final String stmtLower = statement.getMaskedStatementText().toLowerCase(Locale.ROOT);
-      final String messageLower = e.getMessage().toLowerCase(Locale.ROOT);
-      final String stackLower = Throwables.getStackTraceAsString(e).toLowerCase(Locale.ROOT);
-
-      // do not include the statement text in the default logs as it may contain sensitive
-      // information - the exception which is returned to the user below will contain
-      // the contents of the query
-      if (messageLower.contains(stmtLower) || stackLower.contains(stmtLower)) {
-        final StackTraceElement loc = Iterables
-            .getLast(Throwables.getCausalChain(e))
-            .getStackTrace()[0];
-        LOG.error("Failure to execute pull query {} {}, not logging the error message since it "
-            + "contains the query string, which may contain sensitive information. If you "
-            + "see this LOG message, please submit a GitHub ticket and we will scrub "
-            + "the statement text from the error at {}",
-            routingOptions.debugString(),
-            queryPlannerOptions.debugString(),
-            loc);
-      } else {
-        LOG.error("Failure to execute pull query. {} {}",
-            routingOptions.debugString(),
-            queryPlannerOptions.debugString(),
-            e);
-      }
-      LOG.debug("Failed pull query text {}, {}", statement.getMaskedStatementText(), e);
-
-      throw new KsqlStatementException(
-          e.getMessage() == null
-              ? "Server Error" + Arrays.toString(e.getStackTrace())
-              : e.getMessage(),
+      QueryLogger.error(
+          "Failure to execute pull query",
           statement.getMaskedStatementText(),
           e
       );
+      if (e instanceof KsqlStatementException) {
+        throw new KsqlStatementException(
+            e.getMessage() == null ? "Server Error" : e.getMessage(),
+            ((KsqlStatementException) e).getUnloggedMessage(),
+            statement.getMaskedStatementText(),
+            e
+        );
+      } else {
+        throw new KsqlStatementException(
+            e.getMessage() == null
+                ? "Server Error"
+                : e.getMessage(),
+            statement.getMaskedStatementText(),
+            e
+        );
+      }
     }
   }
 
@@ -425,39 +410,30 @@ final class EngineExecutor {
         ));
       }
 
-      final String stmtLower = statement.getMaskedStatementText().toLowerCase(Locale.ROOT);
-      final String messageLower = e.getMessage().toLowerCase(Locale.ROOT);
-      final String stackLower = Throwables.getStackTraceAsString(e).toLowerCase(Locale.ROOT);
-
-      // do not include the statement text in the default logs as it may contain sensitive
-      // information - the exception which is returned to the user below will contain
-      // the contents of the query
-      if (messageLower.contains(stmtLower) || stackLower.contains(stmtLower)) {
-        final StackTraceElement loc = Iterables
-                .getLast(Throwables.getCausalChain(e))
-                .getStackTrace()[0];
-        LOG.error("Failure to execute push query V2 {} {}, not logging the error message since it "
-                        + "contains the query string, which may contain sensitive information."
-                        + " If you see this LOG message, please submit a GitHub ticket and"
-                        + " we will scrub the statement text from the error at {}",
-                pushRoutingOptions.debugString(),
-                queryPlannerOptions.debugString(),
-                loc);
-      } else {
-        LOG.error("Failure to execute push query V2. {} {}",
-                pushRoutingOptions.debugString(),
-                queryPlannerOptions.debugString(),
-                e);
-      }
-      LOG.debug("Failed push query V2 text {}, {}", statement.getMaskedStatementText(), e);
-
-      throw new KsqlStatementException(
-              e.getMessage() == null
-                      ? "Server Error" + Arrays.toString(e.getStackTrace())
-                      : e.getMessage(),
-              statement.getMaskedStatementText(),
-              e
+      QueryLogger.error(
+          "Failure to execute push query V2. "
+              + pushRoutingOptions.debugString() + " "
+              + queryPlannerOptions.debugString(),
+          statement.getMaskedStatementText(),
+          e
       );
+
+      if (e instanceof KsqlStatementException) {
+        throw new KsqlStatementException(
+            e.getMessage() == null ? "Server Error" : e.getMessage(),
+            ((KsqlStatementException) e).getUnloggedMessage(),
+            statement.getMaskedStatementText(),
+            e
+        );
+      } else {
+        throw new KsqlStatementException(
+            e.getMessage() == null
+                ? "Server Error"
+                : e.getMessage(),
+            statement.getMaskedStatementText(),
+            e
+        );
+      }
     }
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -316,6 +316,7 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
       // add the statement text to the KsqlException
       throw new KsqlStatementException(
           e.getMessage(),
+          e.getMessage(),
           plan.getPlan().getStatementText(),
           e.getCause()
       );

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjector.java
@@ -184,9 +184,18 @@ public class SchemaRegisterInjector implements Injector {
               .getDdlCommand()
               .get();
     } catch (final Exception e) {
-      throw new KsqlStatementException(
-          "Could not determine output schema for query due to error: "
-              + e.getMessage(), cas.getMaskedStatementText(), e);
+      if (e instanceof KsqlStatementException) {
+        throw new KsqlStatementException(
+            e.getMessage() == null ? "Server Error" : e.getMessage(),
+            ((KsqlStatementException) e).getUnloggedMessage(),
+            ((KsqlStatementException) e).getSqlStatement(),
+            e
+        );
+      } else {
+        throw new KsqlStatementException(
+            "Could not determine output schema for query due to error: "
+                + e.getMessage(), cas.getMaskedStatementText(), e);
+      }
     }
 
     final SchemaAndId rawKeySchema = (SchemaAndId) cas.getSessionConfig().getOverrides()

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/DirectiveParser.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/DirectiveParser.java
@@ -37,7 +37,6 @@ public final class DirectiveParser {
     if (!matcher.find()) {
       throw new ParsingException(
           "Expected directive matching pattern " + DIRECTIVE_REGEX + " but got " + comment,
-          null,
           loc.getLineNumber(),
           loc.getColumnNumber()
       );

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/SqlTestReader.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/SqlTestReader.java
@@ -65,7 +65,7 @@ public final class SqlTestReader implements Iterator<TestStatement> {
         final String message,
         final RecognitionException e
     ) {
-      throw new ParsingException(message, e, line, charPositionInLine);
+      throw new ParsingException(message, line, charPositionInLine);
     }
   };
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/exceptions/KsqlExpectedException.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/exceptions/KsqlExpectedException.java
@@ -22,7 +22,9 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.List;
+import org.hamcrest.Description;
 import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
 import org.junit.internal.matchers.ThrowableMessageMatcher;
 
 @SuppressFBWarnings("NM_CLASS_NOT_EXCEPTION")
@@ -46,11 +48,39 @@ public class KsqlExpectedException {
   }
 
   public void expectMessage(final Matcher<String> matcher) {
-    matchers.add(ThrowableMessageMatcher.hasMessage(matcher));
+    matchers.add(new KsqlExceptionMatcher<>(ThrowableMessageMatcher.hasMessage(matcher),
+        KsqlStatementExceptionMessageMatcher.hasMessage(matcher)));
   }
 
   @SuppressWarnings("unchecked")
   public Matcher<Throwable> build() {
     return allOf((List)new ArrayList<>(matchers));
+  }
+
+  private static class KsqlExceptionMatcher<T extends Throwable> extends TypeSafeMatcher<T> {
+    private final Matcher<T> matcher1;
+    private final Matcher<T> matcher2;
+
+    KsqlExceptionMatcher(final Matcher<T> matcher1, final Matcher<T> matcher2) {
+      this.matcher1 = matcher1;
+      this.matcher2 = matcher2;
+    }
+
+    public void describeTo(final Description description) {
+      description.appendText("CompoundMatchers:");
+      description.appendDescriptionOf(this.matcher1);
+      description.appendDescriptionOf(this.matcher2);
+    }
+
+    protected boolean matchesSafely(final T item) {
+      return this.matcher1.matches(item) || this.matcher2.matches(item);
+    }
+
+    protected void describeMismatchSafely(final T item, final Description description) {
+      description.appendText("message ");
+      this.matcher1.describeMismatch(item.getMessage(), description);
+      this.matcher2.describeMismatch(item.getMessage(), description);
+
+    }
   }
 }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/exceptions/KsqlStatementExceptionMessageMatcher.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/exceptions/KsqlStatementExceptionMessageMatcher.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.tools.exceptions;
+
+import io.confluent.ksql.util.KsqlStatementException;
+import org.hamcrest.Description;
+import org.hamcrest.Factory;
+import org.hamcrest.Matcher;
+import org.junit.internal.matchers.ThrowableMessageMatcher;
+
+public class KsqlStatementExceptionMessageMatcher<T extends KsqlStatementException>
+    extends ThrowableMessageMatcher<T> {
+  private final Matcher<String> matcher;
+
+  public KsqlStatementExceptionMessageMatcher(final Matcher<String> matcher) {
+    super(matcher);
+    this.matcher = matcher;
+  }
+
+  @Override
+  protected boolean matchesSafely(final T item) {
+    return this.matcher.matches(item.getRawUnloggedDetails())
+        || this.matcher.matches(item.getUnloggedMessage());
+  }
+
+  @Override
+  protected void describeMismatchSafely(final T item, final Description description) {
+    description.appendText("unloggedmessage ");
+    this.matcher.describeMismatch(item.getRawUnloggedDetails(), description);
+  }
+
+  @Factory
+  public static <T extends Throwable> Matcher<T> hasMessage(final Matcher<String> matcher) {
+    return new KsqlStatementExceptionMessageMatcher(matcher);
+  }
+}

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/EndToEndEngineTestUtil.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/EndToEndEngineTestUtil.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Maps;
 import io.confluent.connect.avro.AvroData;
+import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.test.tools.TestCase;
 import io.confluent.ksql.test.tools.TestExecutionListener;
 import io.confluent.ksql.test.tools.TestExecutor;
@@ -30,6 +31,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import io.confluent.ksql.util.KsqlStatementException;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericData.Record;
 
@@ -40,6 +43,14 @@ final class EndToEndEngineTestUtil {
   static void shouldBuildAndExecuteQuery(final TestCase testCase) {
     try (final TestExecutor testExecutor = TestExecutor.create(true, Optional.empty())) {
       testExecutor.buildAndExecuteQuery(testCase, TestExecutionListener.noOp());
+    } catch (KsqlStatementException e) {
+      throw new AssertionError(e.getUnloggedMessage()
+          + System.lineSeparator()
+          + "failed test: " + testCase.getName()
+          + System.lineSeparator()
+          + "in " + testCase.getTestLocation(),
+          e
+      );
     } catch (final AssertionError | Exception e) {
       throw new AssertionError(e.getMessage()
           + System.lineSeparator()

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/parser/SqlTestReaderTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/parser/SqlTestReaderTest.java
@@ -181,7 +181,7 @@ public class SqlTestReaderTest {
     final ParsingException parsingException = assertThrows(ParsingException.class, reader::next);
 
     // Then:
-    assertThat(parsingException.getMessage(), is("line 1:8: no viable alternative at input 'CREATE foo'"));
+    assertThat(parsingException.getUnloggedDetails(), containsString("line 1:8: no viable alternative at input 'CREATE foo'"));
   }
 
   @Test

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-streams.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-streams.json
@@ -37,7 +37,7 @@
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "line 1:24: mismatched input 'BY' expecting {';', 'EMIT', 'WHERE', 'WINDOW', 'GROUP', 'HAVING', 'LIMIT', 'PARTITION'}\nStatement: SELECT * FROM S1 ORDER BY MYKEY DESC;\nCaused by: line 1:24: mismatched input 'BY' expecting {';', 'EMIT', 'WHERE',\n\t'WINDOW', 'GROUP', 'HAVING', 'LIMIT', 'PARTITION'}\nCaused by: org.antlr.v4.runtime.InputMismatchException",
+        "message": "line 1:24: mismatched input 'BY' expecting {';', 'EMIT', 'WHERE', 'WINDOW', 'GROUP', 'HAVING', 'LIMIT', 'PARTITION'}\nStatement: SELECT * FROM S1 ORDER BY MYKEY DESC;\nCaused by: line 1:24: Syntax error at line 1:24",
         "status": 400
       }
     },

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/ColumnReferenceParser.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/ColumnReferenceParser.java
@@ -61,7 +61,11 @@ public final class ColumnReferenceParser {
       return resolve((QualifiedColumnReferenceContext) primaryExpression).getColumnName();
     }
 
-    throw new ParseFailedException("Cannot parse text that is not column reference: " + text);
+    throw new ParseFailedException(
+        "Cannot parse text that is not column reference.",
+        "Cannot parse text that is not column reference: " + text,
+        text
+    );
   }
 
   static UnqualifiedColumnReferenceExp resolve(final ColumnReferenceContext context) {

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/GrammarParseUtil.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/GrammarParseUtil.java
@@ -36,7 +36,11 @@ final class GrammarParseUtil {
         final String message,
         final RecognitionException e
     ) {
-      throw new ParsingException(message, e, line, charPositionInLine);
+      throw new ParsingException(
+          message,
+          line,
+          charPositionInLine
+      );
     }
   };
 

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/ParsingException.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/ParsingException.java
@@ -18,18 +18,17 @@ package io.confluent.ksql.parser;
 import static java.lang.String.format;
 
 import java.util.Optional;
-import org.antlr.v4.runtime.RecognitionException;
 
 public class ParsingException
     extends RuntimeException {
 
   private final int line;
   private final int charPositionInLine;
+  private final String unloggedDetails;
 
   public ParsingException(final String message, final Optional<NodeLocation> nodeLocation) {
     this(
         message,
-        null,
         nodeLocation.map(NodeLocation::getLineNumber).orElse(1),
         nodeLocation.map(NodeLocation::getColumnNumber).orElse(0)
     );
@@ -37,12 +36,11 @@ public class ParsingException
 
   public ParsingException(
       final String message,
-      final RecognitionException cause,
       final int line,
       final int charPositionInLine
   ) {
-    super(message, cause);
-
+    super("Syntax error at line " + line + ":" + (charPositionInLine + 1));
+    this.unloggedDetails = message;
     this.line = line;
     this.charPositionInLine = charPositionInLine;
   }
@@ -62,5 +60,9 @@ public class ParsingException
   @Override
   public String getMessage() {
     return format("line %s:%s: %s", getLineNumber(), getColumnNumber(), getErrorMessage());
+  }
+
+  public String getUnloggedDetails() {
+    return format("line %s:%s: %s", getLineNumber(), getColumnNumber(), unloggedDetails);
   }
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SyntaxErrorValidator.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SyntaxErrorValidator.java
@@ -134,9 +134,9 @@ public class SyntaxErrorValidator extends BaseErrorListener {
       final String newMessage =
           "\"" + tokenName + "\" is a reserved keyword and it can't be used as an identifier."
               + " You can use it as an identifier by escaping it as \'" + tokenName + "\' ";
-      throw new ParsingException(newMessage, e, line, charPositionInLine);
+      throw new ParsingException(newMessage, line, charPositionInLine);
     } else {
-      throw new ParsingException(message, e, line, charPositionInLine);
+      throw new ParsingException(message, line, charPositionInLine);
     }
   }
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/VariableSubstitutor.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/VariableSubstitutor.java
@@ -174,6 +174,9 @@ public final class VariableSubstitutor {
         throw new ParseFailedException(
             "Illegal argument at " + location.map(NodeLocation::toString).orElse("?")
                 + ". Identifier names cannot start with '@' and may only contain alphanumeric "
+                + "values and '_'.",
+            "Illegal argument at " + location.map(NodeLocation::toString).orElse("?")
+                + ". Identifier names cannot start with '@' and may only contain alphanumeric "
                 + "values and '_'. Got: '" + value + "'",
             statementText);
       }
@@ -199,6 +202,7 @@ public final class VariableSubstitutor {
       }
 
       throw new ParseFailedException(
+          "Illegal argument at " + location.map(NodeLocation::toString).orElse("?") + ".",
           "Illegal argument at " + location.map(NodeLocation::toString).orElse("?")
               + ". Got: '" + value + "'",
           statementText);

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/exception/ParseFailedException.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/exception/ParseFailedException.java
@@ -19,12 +19,14 @@ import io.confluent.ksql.util.KsqlStatementException;
 
 public class ParseFailedException extends KsqlStatementException {
 
-  public ParseFailedException(final String message) {
-    super(message, "");
-  }
-
   public ParseFailedException(final String message, final String sqlStatement) {
     super(message, sqlStatement);
+  }
+
+  public ParseFailedException(final String message,
+                              final String unloggedDetails,
+                              final String sqlStatement) {
+    super(message, unloggedDetails, sqlStatement);
   }
 
   public ParseFailedException(
@@ -32,5 +34,13 @@ public class ParseFailedException extends KsqlStatementException {
       final String sqlStatement,
       final Throwable cause) {
     super(message, sqlStatement, cause);
+  }
+
+  public ParseFailedException(
+      final String message,
+      final String unloggedDetails,
+      final String sqlStatement,
+      final Throwable cause) {
+    super(message, unloggedDetails, sqlStatement, cause);
   }
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStream.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStream.java
@@ -22,6 +22,7 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.NodeLocation;
 import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
+import java.util.Objects;
 import java.util.Optional;
 
 @Immutable
@@ -107,13 +108,22 @@ public class CreateStream extends CreateSource implements ExecutableDdlStatement
 
     wrongKey.ifPresent(col -> {
       final String loc = NodeLocation.asPrefix(col.getLocation());
+      final String fullMessage = loc + "Column " + col.getName() + " is a 'PRIMARY KEY' column: "
+          + "please use 'KEY' for streams."
+          + System.lineSeparator()
+          + "Tables have PRIMARY KEYs, which are unique and NON NULL."
+          + System.lineSeparator()
+          + "Streams have KEYs, which have no uniqueness or NON NULL constraints.";
+      final String sanitizedMessage = loc + "Column is a 'PRIMARY KEY' column: "
+          + "please use 'KEY' for streams."
+          + System.lineSeparator()
+          + "Tables have PRIMARY KEYs, which are unique and NON NULL."
+          + System.lineSeparator()
+          + "Streams have KEYs, which have no uniqueness or NON NULL constraints.";
       throw new ParseFailedException(
-          loc + "Column " + col.getName() + " is a 'PRIMARY KEY' column: "
-              + "please use 'KEY' for streams."
-              + System.lineSeparator()
-              + "Tables have PRIMARY KEYs, which are unique and NON NULL."
-              + System.lineSeparator()
-              + "Streams have KEYs, which have no uniqueness or NON NULL constraints."
+          sanitizedMessage,
+          fullMessage,
+          Objects.toString(col.getName())
       );
     });
   }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTable.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTable.java
@@ -22,6 +22,7 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.NodeLocation;
 import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
+import java.util.Objects;
 import java.util.Optional;
 
 @Immutable
@@ -106,13 +107,22 @@ public class CreateTable extends CreateSource implements ExecutableDdlStatement 
 
     wrongKey.ifPresent(col -> {
       final String loc = NodeLocation.asPrefix(col.getLocation());
+      final String fullMessage = loc + "Column " + col.getName() + " is a 'KEY' column: "
+          + "please use 'PRIMARY KEY' for tables."
+          + System.lineSeparator()
+          + "Tables have PRIMARY KEYs, which are unique and NON NULL."
+          + System.lineSeparator()
+          + "Streams have KEYs, which have no uniqueness or NON NULL constraints.";
+      final String sanitizedMessage = loc + "Column is a 'KEY' column: "
+          + "please use 'PRIMARY KEY' for tables."
+          + System.lineSeparator()
+          + "Tables have PRIMARY KEYs, which are unique and NON NULL."
+          + System.lineSeparator()
+          + "Streams have KEYs, which have no uniqueness or NON NULL constraints.";
       throw new ParseFailedException(
-          loc + "Column " + col.getName() + " is a 'KEY' column: "
-              + "please use 'PRIMARY KEY' for tables."
-              + System.lineSeparator()
-              + "Tables have PRIMARY KEYs, which are unique and NON NULL."
-              + System.lineSeparator()
-              + "Streams have KEYs, which have no uniqueness or NON NULL constraints."
+          sanitizedMessage,
+          fullMessage,
+          Objects.toString(col.getName())
       );
     });
   }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/schema/ksql/SqlTypeParser.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/schema/ksql/SqlTypeParser.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.schema.ksql.types.SqlPrimitiveType;
 import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.ParserUtil;
 import java.util.Objects;
 import java.util.Optional;
@@ -56,7 +57,13 @@ public final class SqlTypeParser {
       final TypeContext typeContext = parseTypeContext(schema);
       return getType(typeContext);
     } catch (final ParsingException e) {
-      throw new KsqlException("Failed to parse: " + schema, e);
+      throw new KsqlStatementException(
+          "Failed to parse schema",
+          "Failed to parse: " + schema,
+          schema,
+          KsqlStatementException.Problem.STATEMENT,
+          e
+      );
     }
   }
 

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
@@ -71,10 +71,14 @@ public final class ParserUtil {
   public static SourceName getSourceName(final SourceNameContext sourceName) {
     final String text = getIdentifierText(sourceName.identifier());
     if (!VALID_SOURCE_NAMES.matcher(text).matches()) {
+      final String baseMessage = "Illegal argument at "
+          + getLocation(sourceName).map(NodeLocation::toString).orElse("?")
+          + ". Source names may only contain alphanumeric values, '_' or '-'.";
       throw new ParseFailedException(
-          "Illegal argument at " + getLocation(sourceName).map(NodeLocation::toString).orElse("?")
-              + ". Source names may only contain alphanumeric values, '_' or '-'. Got: '"
-              + text + "'");
+          baseMessage,
+          baseMessage + " Got: '" + text + "'",
+          text
+      );
     }
     return SourceName.of(text);
   }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
@@ -395,13 +395,20 @@ public class AstBuilderTest {
   @Test
   public void shouldNotBuildLambdaFunctionNotLastArguments() {
     // Given:
-    final Exception e = assertThrows(
+    final ParseFailedException e = assertThrows(
         ParseFailedException.class,
         () -> givenQuery("SELECT TRANSFORM_ARRAY(X => X + 5, Col4) FROM TEST1;")
     );
 
     // Then:
-    assertThat(e.getMessage(), containsString("mismatched input '=>' expecting {',', ')'}"));
+    assertThat(
+        e.getUnloggedMessage(),
+        containsString("line 1:26: mismatched input '=>' expecting {',', ')'}\n" +
+            "Statement: SELECT TRANSFORM_ARRAY(X => X + 5, Col4) FROM TEST1;"));
+    assertThat(
+        e.getMessage(),
+        containsString("line 1:26: Syntax error at line 1:26")
+    );
   }
 
   @Test

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -441,7 +441,7 @@ public class KsqlParserTest {
   @Test
   public void shouldThrowOnNonAlphanumericSourceName() {
     // When:
-    final Exception e = assertThrows(
+    final ParseFailedException e = assertThrows(
         ParseFailedException.class,
         () -> KsqlParserTestUtil.buildSingleAst(
             "CREATE STREAM `foo!bar` WITH (kafka_topic='foo', value_format='AVRO');",
@@ -449,8 +449,10 @@ public class KsqlParserTest {
     );
 
     // Then:
-    assertThat(e.getMessage(), containsString(
+    assertThat(e.getUnloggedMessage(), containsString(
         "Got: 'foo!bar'"));
+    assertThat(e.getMessage(), containsString("Illegal argument at Line: 1, Col: 15. Source names may only contain alphanumeric values, '_' or '-'."));
+    assertThat(e.getSqlStatement(), containsString("foo!bar"));
   }
 
   @Test
@@ -592,8 +594,12 @@ public class KsqlParserTest {
       KsqlParserTestUtil.buildSingleAst(simpleQuery, metaStore);
       fail(format("Expected query: %s to fail", simpleQuery));
     } catch (final ParseFailedException e) {
-      final String errorMessage = e.getMessage();
+      final String errorMessage = e.getUnloggedMessage();
       Assert.assertTrue(errorMessage.toLowerCase().contains(("line 1:1: mismatched input 'SELLECT'" + " expecting").toLowerCase()));
+      assertThat(
+          e.getMessage(),
+          containsString("line 1:1: Syntax error at line 1:1")
+      );
     }
   }
 
@@ -1192,13 +1198,14 @@ public class KsqlParserTest {
     final String simpleQuery = "SELECT ONLY, COLUMNS;";
 
     // When:
-    final Exception e = assertThrows(
+    final ParseFailedException e = assertThrows(
         ParseFailedException.class,
         () -> KsqlParserTestUtil.buildSingleAst(simpleQuery, metaStore)
     );
 
     // Then:
-    assertThat(e.getMessage(), containsString("line 1:21: extraneous input ';' expecting {',', 'FROM'}"));
+    assertThat(e.getUnloggedMessage(), containsString("line 1:21: extraneous input ';' expecting {',', 'FROM'}"));
+    assertThat(e.getMessage(), containsString("line 1:21: Syntax error at line 1:21"));
   }
 
   @Test
@@ -1207,13 +1214,14 @@ public class KsqlParserTest {
     final String simpleQuery = "SELECT A B C FROM address;";
 
     // When:
-    final Exception e = assertThrows(
+    final ParseFailedException e = assertThrows(
         ParseFailedException.class,
         () -> KsqlParserTestUtil.buildSingleAst(simpleQuery, metaStore)
     );
 
     // Then:
-    assertThat(e.getMessage(), containsString("line 1:12: extraneous input 'C' expecting"));
+    assertThat(e.getUnloggedMessage(), containsString("line 1:12: extraneous input 'C' expecting"));
+    assertThat(e.getMessage(), containsString("line 1:12: Syntax error at line 1:12"));
   }
 
   @Test
@@ -1223,13 +1231,14 @@ public class KsqlParserTest {
             "  WITH (kafka_topic='ords', value_format='json');";
 
     // When:
-    final Exception e = assertThrows(
+    final ParseFailedException e = assertThrows(
             ParseFailedException.class,
             () -> KsqlParserTestUtil.buildSingleAst(simpleQuery, metaStore)
     );
 
     // Then:
-    assertThat(e.getMessage(), containsString("\"size\" is a reserved keyword and it can't be used as an identifier"));
+    assertThat(e.getUnloggedMessage(), containsString("\"size\" is a reserved keyword and it can't be used as an identifier"));
+    assertThat(e.getMessage(), containsString("line 1:35: Syntax error at line 1:35"));
   }
 
   @Test
@@ -1239,13 +1248,18 @@ public class KsqlParserTest {
             "  WITH (kafka_topic='ords', value_format='json');";
 
     // When:
-    final Exception e = assertThrows(
+    final ParseFailedException e = assertThrows(
             ParseFailedException.class,
             () -> KsqlParserTestUtil.buildSingleAst(simpleQuery, metaStore)
     );
 
     // Then:
-    assertThat(e.getMessage(), containsString("\"Load\" is a reserved keyword and it can't be used as an identifier"));
+    assertThat(e.getUnloggedMessage(), containsString("line 1:23: " +
+        "\"Load\" is a reserved keyword and it can't be used as an identifier. " +
+        "You can use it as an identifier by escaping it as 'Load' \n" +
+        "Statement: CREATE STREAM ORDERS (Load VARCHAR, size INTEGER)"));
+    assertThat(e.getMessage(), containsString("line 1:23: Syntax error at line 1:23"));
+    assertThat(e.getSqlStatement(), containsString("CREATE STREAM ORDERS (Load VARCHAR, size INTEGER)"));
   }
 
   @Test
@@ -1266,13 +1280,14 @@ public class KsqlParserTest {
     final String simpleQuery = "SELECT * FROM address, itemid;";
 
     // When:
-    final Exception e = assertThrows(
+    final ParseFailedException e = assertThrows(
         ParseFailedException.class,
         () -> KsqlParserTestUtil.buildSingleAst(simpleQuery, metaStore)
     );
 
     // Then:
-    assertThat(e.getMessage(), containsString("line 1:22: mismatched input ',' expecting"));
+    assertThat(e.getUnloggedMessage(), containsString("line 1:22: mismatched input ',' expecting"));
+    assertThat(e.getMessage(), containsString("line 1:22: Syntax error at line 1:22"));
   }
 
   @Test
@@ -1493,8 +1508,6 @@ public class KsqlParserTest {
     assertThat(preparedStatement.getUnMaskedStatementText(), is(query));
     assertThat(preparedStatement.toString(), is(masked));
   }
-
-
 
   private Literal parseDouble(final String literalText) {
     final PreparedStatement<Query> query = KsqlParserTestUtil

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SyntaxErrorValidatorTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SyntaxErrorValidatorTest.java
@@ -52,14 +52,16 @@ public class SyntaxErrorValidatorTest {
     final RecognitionException exception = null;
 
     // When
-    final Exception e = assertThrows(
+    final ParsingException e = assertThrows(
         ParsingException.class,
         () -> callSyntaxError(errorMessage, exception)
     );
 
     // Then:
-    assertThat(e.getMessage(),
+    assertThat(e.getUnloggedDetails(),
         containsString("mismatched input 'topic' expecting IDENTIFIER"));
+    assertThat(e.getMessage(),
+        containsString("line 0:1: Syntax error at line 0:1"));
   }
 
   @Test
@@ -69,14 +71,15 @@ public class SyntaxErrorValidatorTest {
     final RecognitionException exception = givenException(null, getToken("topic"));
 
     // When
-    final Exception e = assertThrows(
+    final ParsingException e = assertThrows(
         ParsingException.class,
         () -> callSyntaxError(errorMessage, exception)
     );
 
     // Then:
-    assertThat(e.getMessage(),
+    assertThat(e.getUnloggedDetails(),
         containsString("mismatched input 'topic' expecting IDENTIFIER"));
+    assertThat(e.getMessage(), containsString("line 0:1: Syntax error at line 0:1"));
   }
 
   @Test
@@ -87,14 +90,15 @@ public class SyntaxErrorValidatorTest {
         givenException(mock(VariableNameContext.class), getToken("1"));
 
     // When
-    final Exception e = assertThrows(
+    final ParsingException e = assertThrows(
         ParsingException.class,
         () -> callSyntaxError(errorMessage, exception)
     );
 
     // Then:
-    assertThat(e.getMessage(),
+    assertThat(e.getUnloggedDetails(),
         containsString("mismatched input '1' expecting IDENTIFIER"));
+    assertThat(e.getMessage(), containsString("line 0:1: Syntax error at line 0:1"));
   }
 
   @Test
@@ -105,14 +109,16 @@ public class SyntaxErrorValidatorTest {
         givenException(mock(CreateStreamContext.class), getToken("size"));
 
     // When:
-    final Exception e = assertThrows(
+    final ParsingException e = assertThrows(
         ParsingException.class,
         () -> callSyntaxError(errorMessage, exception)
     );
 
     // Then:
-    assertThat(e.getMessage(),
+    assertThat(e.getUnloggedDetails(),
         containsString("\"size\" is a reserved keyword and it can't be used as an identifier"));
+    assertThat(e.getMessage(),
+        containsString("line 0:1: Syntax error at line 0:1"));
   }
 
   private void callSyntaxError(final String errorMessage, final RecognitionException exception) {

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/VariableSubstitutorTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/VariableSubstitutorTest.java
@@ -128,13 +128,13 @@ public class VariableSubstitutorTest {
 
     final List<Pair<String, String>> statements = Arrays.asList(
         // DESCRIBE
-        Pair.of("DESCRIBE ${identifier};", "Got: 'EXTENDED _id_'"),
-        Pair.of("DESCRIBE ${quotedIdentifier};", "Got: 'EXTENDED \"_id_\"'"),
-        Pair.of("DESCRIBE ${backQuotedIdentifier};", "Got: 'EXTENDED `_id_`'"),
-        Pair.of("DESCRIBE ${singleQuoteIdentifier};", "Got: 'EXTENDED '_id_''"),
-        Pair.of("DESCRIBE ${quotedIdentifier2};", "Got: '\"EXTENDED _id_\"'"),
-        Pair.of("DESCRIBE ${backQuotedIdentifier2};", "Got: '`EXTENDED _id_`'"),
-        Pair.of("DESCRIBE ${singleQuoteIdentifier2};", "Got: ''EXTENDED _id_''")
+        Pair.of("DESCRIBE ${identifier};", "Illegal argument"),
+        Pair.of("DESCRIBE ${quotedIdentifier};", "Illegal argument"),
+        Pair.of("DESCRIBE ${backQuotedIdentifier};", "Illegal argument"),
+        Pair.of("DESCRIBE ${singleQuoteIdentifier};", "Illegal argument"),
+        Pair.of("DESCRIBE ${quotedIdentifier2};", "Illegal argument"),
+        Pair.of("DESCRIBE ${backQuotedIdentifier2};", "Illegal argument"),
+        Pair.of("DESCRIBE ${singleQuoteIdentifier2};", "Illegal argument")
     );
 
     assertThrowOnInvalidVariables(statements, variablesMap);
@@ -221,19 +221,19 @@ public class VariableSubstitutorTest {
     final List<Pair<String, String>> statements = Arrays.asList(
         // INSERT
         Pair.of("INSERT INTO ${injectSchema} VALUES (1);",
-            "Got: 's1 (id, name)'"),
+            "Identifier names cannot start"),
         Pair.of("INSERT INTO s1 VALUES (${injectValues});",
-            "Got: '1, 5'"),
+            "Illegal argument"),
 
         // SELECT
         Pair.of("SELECT * FROM ${injectWhere};",
-            "Got: 's1 WHERE id = 1'"),
+            "Identifier names cannot start"),
         Pair.of("SELECT * FROM s1 WHERE id = ${injectExpression};",
-            "5 and id != 5"),
+            "Illegal argument"),
 
         // CREATE
         Pair.of("CREATE STREAM ${injectSchema} WITH (kafka_topic='t1');",
-            "Got: 's1 (id, name)'")
+            "Identifier names cannot start")
     );
 
     // When/Then

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateStreamTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateStreamTest.java
@@ -117,9 +117,15 @@ public class CreateStreamTest {
 
     // Then:
     assertThat(e.getMessage(),
+        containsString("Line: 2, Col: 4: Column is a 'PRIMARY KEY' column: "
+            + "please use 'KEY' for streams.\n"
+            + "Tables have PRIMARY KEYs, which are unique and NON NULL.\n"
+            + "Streams have KEYs, which have no uniqueness or NON NULL constraints."));
+    assertThat(e.getUnloggedMessage(),
         containsString("Line: 2, Col: 4: Column `PK` is a 'PRIMARY KEY' column: "
             + "please use 'KEY' for streams.\n"
             + "Tables have PRIMARY KEYs, which are unique and NON NULL.\n"
             + "Streams have KEYs, which have no uniqueness or NON NULL constraints."));
+    assertThat(e.getSqlStatement(), containsString("PK"));
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateTableTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateTableTest.java
@@ -116,9 +116,15 @@ public class CreateTableTest {
     );
 
     // Then:
-    assertThat(e.getMessage(), containsString("Line: 2, Col: 4: Column `K` is a 'KEY' column: "
+    assertThat(e.getUnloggedMessage(), containsString(
+        "Line: 2, Col: 4: Column `K` is a 'KEY' column: "
         + "please use 'PRIMARY KEY' for tables.\n"
         + "Tables have PRIMARY KEYs, which are unique and NON NULL.\n"
         + "Streams have KEYs, which have no uniqueness or NON NULL constraints."));
+    assertThat(e.getMessage(), containsString("Line: 2, Col: 4: Column is a 'KEY' column: "
+        + "please use 'PRIMARY KEY' for tables.\n"
+        + "Tables have PRIMARY KEYs, which are unique and NON NULL.\n"
+        + "Streams have KEYs, which have no uniqueness or NON NULL constraints."));
+    assertThat(e.getSqlStatement(), containsString("K"));
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/util/ParserUtilTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/util/ParserUtilTest.java
@@ -54,13 +54,14 @@ public class ParserUtilTest {
     when(decimalLiteralContext.getText()).thenReturn("NaN");
 
     // When:
-    final Exception e = assertThrows(
+    final ParsingException e = assertThrows(
         ParsingException.class,
         () -> ParserUtil.parseDecimalLiteral(decimalLiteralContext)
     );
 
     // Then:
-    assertThat(e.getMessage(), containsString("line 1:4: Invalid numeric literal: NaN"));
+    assertThat(e.getUnloggedDetails(), containsString("line 1:4: Invalid numeric literal: NaN"));
+    assertThat(e.getMessage(), containsString("line 1:4: Syntax error at line 1:4"));
   }
 
   @Test
@@ -69,13 +70,14 @@ public class ParserUtilTest {
     when(floatLiteralContext.getText()).thenReturn("NaN");
 
     // When:
-    final Exception e = assertThrows(
+    final ParsingException e = assertThrows(
         ParsingException.class,
         () -> ParserUtil.parseFloatLiteral(floatLiteralContext)
     );
 
     // Then:
-    assertThat(e.getMessage(), containsString("line 1:4: Not a number: NaN"));
+    assertThat(e.getUnloggedDetails(), containsString("line 1:4: Not a number: NaN"));
+    assertThat(e.getMessage(), containsString("line 1:4: Syntax error at line 1:4"));
   }
 
   @Test
@@ -84,13 +86,14 @@ public class ParserUtilTest {
     when(decimalLiteralContext.getText()).thenReturn("What?");
 
     // When:
-    final Exception e = assertThrows(
+    final ParsingException e = assertThrows(
         ParsingException.class,
         () -> ParserUtil.parseDecimalLiteral(decimalLiteralContext)
     );
 
     // Then:
-    assertThat(e.getMessage(), containsString("line 1:4: Invalid numeric literal: What?"));
+    assertThat(e.getUnloggedDetails(), containsString("line 1:4: Invalid numeric literal: What?"));
+    assertThat(e.getMessage(), containsString("line 1:4: Syntax error at line 1:4"));
   }
 
   @Test
@@ -99,13 +102,14 @@ public class ParserUtilTest {
     when(floatLiteralContext.getText()).thenReturn("1.7976931348623159E308");
 
     // When:
-    final Exception e = assertThrows(
+    final ParsingException e = assertThrows(
         ParsingException.class,
         () -> ParserUtil.parseFloatLiteral(floatLiteralContext)
     );
 
     // Then:
-    assertThat(e.getMessage(), containsString("line 1:4: Number overflows DOUBLE: 1.7976931348623159E308"));
+    assertThat(e.getUnloggedDetails(), containsString("line 1:4: Number overflows DOUBLE: 1.7976931348623159E308"));
+    assertThat(e.getMessage(), containsString("line 1:4: Syntax error at line 1:4"));
   }
 
   private static void mockLocation(final ParserRuleContext ctx, final int line, final int col) {

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/schema/ksql/SqlTypeParserTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/schema/ksql/SqlTypeParserTest.java
@@ -11,6 +11,7 @@ import io.confluent.ksql.metastore.TypeRegistry;
 import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.KsqlStatementException;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
@@ -181,18 +182,21 @@ public class SqlTypeParserTest {
     final String schemaString = "STRUCT<foo VARCHAR,>";
 
     // When:
-    final KsqlException e = assertThrows(
-        KsqlException.class,
+    final KsqlStatementException e = assertThrows(
+        KsqlStatementException.class,
         () -> parser.parse(schemaString)
     );
 
     // Then:
     System.out.println(e.getMessage());
-    assertThat(e.getMessage(), containsString(
-        "Failed to parse: STRUCT<foo VARCHAR,>"
+    assertThat(e.getUnloggedMessage(), is(
+        "Failed to parse: STRUCT<foo VARCHAR,>\nStatement: STRUCT<foo VARCHAR,>"
     ));
-    assertThat(e.getCause().getMessage(), containsString(
-        "line 1:20: mismatched input '>'"
+    assertThat(e.getMessage(), is(
+        "Failed to parse schema"
+    ));
+    assertThat(e.getCause().getMessage(), is(
+        "line 1:20: Syntax error at line 1:20"
     ));
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/FailureHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/FailureHandler.java
@@ -38,12 +38,17 @@ public class FailureHandler implements Handler<RoutingContext> {
 
   @Override
   public void handle(final RoutingContext routingContext) {
-    log.error(String.format("Failed to handle request %d %s", routingContext.statusCode(),
-        routingContext.request().path()),
-        routingContext.failure());
-
     final int statusCode = routingContext.statusCode();
     final Throwable failure = routingContext.failure();
+    // Don't log the failure, since it may contain sensitive information meant for the user.
+    log.error(
+        String.format(
+            "Failed to handle request %d %s",
+            routingContext.statusCode(),
+            routingContext.request().path()
+        )
+    );
+
 
     if (failure != null) {
       if (failure instanceof KsqlApiException) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerUtils.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerUtils.java
@@ -114,9 +114,14 @@ public final class ServerUtils {
       final Throwable actual = t.getCause();
       log.error(logMsg, actual);
       if (actual instanceof KsqlStatementException) {
-        routingContext.fail(BAD_REQUEST.code(),
-            new KsqlApiException(actual.getMessage(), ERROR_CODE_BAD_STATEMENT,
-                ((KsqlStatementException) actual).getSqlStatement()));
+        routingContext.fail(
+            BAD_REQUEST.code(),
+            new KsqlApiException(
+                ((KsqlStatementException) actual).getUnloggedMessage(),
+                ERROR_CODE_BAD_STATEMENT,
+                ((KsqlStatementException) actual).getSqlStatement()
+            )
+        );
         return null;
       } else if (actual instanceof KsqlApiException) {
         routingContext.fail(BAD_REQUEST.code(), actual);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicBackupImpl.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicBackupImpl.java
@@ -137,14 +137,14 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
   public void writeRecord(final ConsumerRecord<byte[], byte[]> record) {
     if (corruptionDetected) {
       throw new CommandTopicCorruptionException(
-          "Failed to write record due to out of sync command topic and backup file: " + record);
+          "Failed to write record due to out of sync command topic and backup file. "
+              + String.format("partition=%d, offset=%d", record.partition(), record.offset()));
     }
 
     if (record.key() == null || record.value() == null) {
       LOG.warn(String.format("Can't backup a command topic record with a null key/value:"
-              + " key=%s, value=%s, partition=%d, offset=%d",
-          record.key(), record.value(), record.partition(), record.offset()));
-
+              + " partition=%d, offset=%d",
+          record.partition(), record.offset()));
       return;
     }
 
@@ -155,7 +155,8 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
       } else {
         corruptionDetected = true;
         throw new CommandTopicCorruptionException(
-            "Failed to write record due to out of sync command topic and backup file: " + record);
+            "Failed to write record due to out of sync command topic and backup file. "
+                + String.format("partition=%d, offset=%d", record.partition(), record.offset()));
       }
     } else if (latestReplay.size() > 0) {
       // clear latest replay from memory

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandStore.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandStore.java
@@ -25,8 +25,8 @@ import io.confluent.ksql.rest.server.CommandTopicBackupNoOp;
 import io.confluent.ksql.rest.util.CommandTopicBackupUtil;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlServerException;
+import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.QueryMask;
 import java.io.Closeable;
 import java.time.Duration;
@@ -225,12 +225,14 @@ public class CommandStore implements CommandQueue, Closeable {
       return new QueuedCommandStatus(recordMetadata.offset(), statusFuture);
     } catch (final Exception e) {
       commandStatusMap.remove(commandId);
-      throw new KsqlException(
+      throw new KsqlStatementException(
+          "Could not write the statement into the command topic.",
           String.format(
-              "Could not write the statement '%s' into the "
-                  + "command topic"
-                  + ".", QueryMask.getMaskedStatement(command.getStatement())
+              "Could not write the statement '%s' into the command topic.",
+              QueryMask.getMaskedStatement(command.getStatement())
           ),
+          QueryMask.getMaskedStatement(command.getStatement()),
+          KsqlStatementException.Problem.OTHER,
           e
       );
     }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/RestoreCommandsCompactor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/RestoreCommandsCompactor.java
@@ -19,6 +19,7 @@ import io.confluent.ksql.engine.KsqlPlan;
 import io.confluent.ksql.execution.ddl.commands.CreateSourceCommand;
 import io.confluent.ksql.execution.ddl.commands.DdlCommand;
 import io.confluent.ksql.execution.ddl.commands.DropSourceCommand;
+import io.confluent.ksql.logging.query.QueryLogger;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.tree.TerminateQuery;
 import io.confluent.ksql.query.QueryId;
@@ -152,10 +153,11 @@ public final class RestoreCommandsCompactor {
               // hitting a known bug that wrote IF NOT EXISTS statements to the command topic.
               // See https://github.com/confluentinc/ksql/issues/8173
               if (createAsIfNotExistsBugDetection.contains(sourceName)) {
-                LOG.warn("A known bug is found while restoring the command topic. The restoring "
+                QueryLogger.warn(
+                    "A known bug is found while restoring the command topic. The restoring "
                     + "process will continue, but the query of the affected stream or table won't "
                     + "be executed until https://github.com/confluentinc/ksql/issues/8173 "
-                    + "is fixed. Invalid statement is: " + command.getStatement());
+                    + "is fixed.", command.getStatement());
               }
             }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/query/QueryExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/query/QueryExecutor.java
@@ -398,7 +398,7 @@ public class QueryExecutor {
 
     localCommands.ifPresent(lc -> lc.write(query));
 
-    log.info("Streaming query '{}'", statement.getMaskedStatementText());
+    QueryLogger.info("Streaming query", statement.getMaskedStatementText());
     return QueryMetadataHolder.of(query);
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -277,7 +277,7 @@ public class KsqlResource implements KsqlConfigurable {
     // Set masked sql statement if request is not from OldApiUtils.handleOldApiRequest
     ApiServerUtils.setMaskedSqlIfNeeded(request);
 
-    LOG.info("Received: " + request);
+    QueryLogger.info("Received: " + request.toStringWithoutQuery(), request.getMaskedKsql());
     throwIfNotConfigured();
 
     activenessRegistrar.updateLastRequestTime();
@@ -330,24 +330,53 @@ public class KsqlResource implements KsqlConfigurable {
           )
       );
 
-      LOG.info("Processed successfully: " + request);
+      QueryLogger.info(
+          "Processed successfully: " + request.toStringWithoutQuery(),
+          request.getMaskedKsql()
+      );
       addCommandRunnerWarning(
           entities,
           commandRunnerWarning);
       return EndpointResponse.ok(entities);
     } catch (final KsqlRestException e) {
-      LOG.info("Processed unsuccessfully: " + request + ", reason: ", e);
+      QueryLogger.info(
+          "Processed unsuccessfully: " + request.toStringWithoutQuery(),
+          request.getMaskedKsql(),
+          e
+      );
       throw e;
     } catch (final KsqlStatementException e) {
-      LOG.info("Processed unsuccessfully: " + request + ", reason: ", e);
-      return Errors.badStatement(e.getRawMessage(), e.getSqlStatement());
+      QueryLogger.info(
+          "Processed unsuccessfully: " + request.toStringWithoutQuery(),
+          request.getMaskedKsql(),
+          e
+      );
+      final EndpointResponse response;
+      if (e.getProblem() == KsqlStatementException.Problem.STATEMENT) {
+        response = Errors.badStatement(e.getRawUnloggedDetails(), e.getSqlStatement());
+      } else if (e.getProblem() == KsqlStatementException.Problem.OTHER) {
+        response = Errors.serverErrorForStatement(e, e.getSqlStatement());
+      } else {
+        response = Errors.badRequest(e);
+      }
+      return errorHandler.generateResponse(e, response);
     } catch (final KsqlException e) {
-      LOG.info("Processed unsuccessfully: " + request + ", reason: ", e);
+      QueryLogger.info(
+          "Processed unsuccessfully: " + request.toStringWithoutQuery(),
+          request.getMaskedKsql(),
+          e
+      );
       return errorHandler.generateResponse(e, Errors.badRequest(e));
     } catch (final Exception e) {
-      LOG.info("Processed unsuccessfully: " + request + ", reason: ", e);
+      QueryLogger.info(
+          "Processed unsuccessfully: " + request.toStringWithoutQuery(),
+          request.getMaskedKsql(),
+          e
+      );
       return errorHandler.generateResponse(
-          e, Errors.serverErrorForStatement(e, request.getMaskedKsql()));
+          e,
+          Errors.serverErrorForStatement(e, request.getMaskedKsql())
+      );
     }
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryStreamWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryStreamWriter.java
@@ -35,7 +35,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -95,7 +94,7 @@ public class PullQueryStreamWriter implements StreamingOutput {
     } catch (Exception e) {
       throw new KsqlStatementException(
           e.getMessage() == null
-              ? "Server Error" + Arrays.toString(e.getStackTrace())
+              ? "Server Error"
               : e.getMessage(),
           statement.getMaskedStatementText(),
           e

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/QueryCapacityUtil.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/QueryCapacityUtil.java
@@ -18,7 +18,7 @@ package io.confluent.ksql.rest.util;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.KsqlStatementException;
 
 public final class QueryCapacityUtil {
   private QueryCapacityUtil() {
@@ -36,18 +36,32 @@ public final class QueryCapacityUtil {
       final KsqlConfig ksqlConfig,
       final String statementStr
   ) {
-    throw new KsqlException(
-        String.format(
-            "Not executing statement(s) '%s' as it would cause the number "
-                + "of active, persistent queries to exceed the configured limit. "
-                + "Use the TERMINATE command to terminate existing queries, "
-                + "or increase the '%s' setting via the 'ksql-server.properties' file. "
-                + "Current persistent query count: %d. Configured limit: %d.",
-            statementStr,
-            KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG,
-            executionContext.getPersistentQueries().size(),
-            getQueryLimit(ksqlConfig)
-        )
+    final String sanitizedMessage = String.format(
+        "Not executing statement(s) as it would cause the number "
+            + "of active, persistent queries to exceed the configured limit. "
+            + "Use the TERMINATE command to terminate existing queries, "
+            + "or increase the '%s' setting via the 'ksql-server.properties' file. "
+            + "Current persistent query count: %d. Configured limit: %d.",
+        KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG,
+        executionContext.getPersistentQueries().size(),
+        getQueryLimit(ksqlConfig)
+    );
+    final String unloggedMessage = String.format(
+        "Not executing statement(s) '%s' as it would cause the number "
+            + "of active, persistent queries to exceed the configured limit. "
+            + "Use the TERMINATE command to terminate existing queries, "
+            + "or increase the '%s' setting via the 'ksql-server.properties' file. "
+            + "Current persistent query count: %d. Configured limit: %d.",
+        statementStr,
+        KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG,
+        executionContext.getPersistentQueries().size(),
+        getQueryLimit(ksqlConfig)
+    );
+    throw new KsqlStatementException(
+        sanitizedMessage,
+        unloggedMessage,
+        statementStr,
+        KsqlStatementException.Problem.REQUEST
     );
   }
 
@@ -67,18 +81,31 @@ public final class QueryCapacityUtil {
           final KsqlRestConfig ksqlRestConfig,
           final String statementStr
   ) {
-    throw new KsqlException(
-            String.format(
-                    "Not executing statement(s) '%s' as it would cause the number "
-                            + "of active, push queries to exceed the configured limit. "
-                            + "Terminate existing PUSH queries, "
-                            + "or increase the '%s' setting via the 'ksql-server.properties' file. "
-                            + "Current push query count: %d. Configured limit: %d.",
-                    statementStr,
-                    KsqlRestConfig.MAX_PUSH_QUERIES,
-                    getNumLivePushQueries(executionContext),
-                    getPushQueryLimit(ksqlRestConfig)
-            )
+    final String sanitizedMessage = String.format(
+        "Not executing statement(s) as it would cause the number "
+            + "of active, push queries to exceed the configured limit. "
+            + "Terminate existing PUSH queries, "
+            + "or increase the '%s' setting via the 'ksql-server.properties' file. "
+            + "Current push query count: %d. Configured limit: %d.",
+        KsqlRestConfig.MAX_PUSH_QUERIES,
+        getNumLivePushQueries(executionContext),
+        getPushQueryLimit(ksqlRestConfig)
+    );
+    final String unloggedMessage = String.format(
+        "Not executing statement(s) '%s' as it would cause the number "
+            + "of active, push queries to exceed the configured limit. "
+            + "Terminate existing PUSH queries, "
+            + "or increase the '%s' setting via the 'ksql-server.properties' file. "
+            + "Current push query count: %d. Configured limit: %d.",
+        statementStr,
+        KsqlRestConfig.MAX_PUSH_QUERIES,
+        getNumLivePushQueries(executionContext),
+        getPushQueryLimit(ksqlRestConfig)
+    );
+    throw new KsqlStatementException(
+        sanitizedMessage,
+        unloggedMessage,
+        statementStr
     );
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
@@ -841,7 +841,7 @@ public class ApiTest extends BaseApiTest {
   private void shouldRejectInvalidQuery(final String query) throws Exception {
 
     // Given
-    ParseFailedException pfe = new ParseFailedException("invalid query blah");
+    ParseFailedException pfe = new ParseFailedException("invalid query blah", "bad query text");
     testEndpoints.setCreateQueryPublisherException(pfe);
     JsonObject requestBody = new JsonObject().put("sql", query);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicBackupImplTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicBackupImplTest.java
@@ -174,7 +174,6 @@ public class CommandTopicBackupImplTest {
     commandTopicBackup.initialize();
     final ConsumerRecord<byte[], byte[]> record = mock(ConsumerRecord.class);
     when(record.key()).thenReturn(null);
-    when(record.value()).thenReturn(new byte[]{});
 
     // When
     commandTopicBackup.writeRecord(record);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandStoreTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandStoreTest.java
@@ -181,7 +181,7 @@ public class CommandStoreTest {
     );
 
     assertThat(e.getMessage(), containsString(
-        "Could not write the statement 'test-statement' into the command topic."
+        "Could not write the statement into the command topic."
     ));
 
     // When:

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/VariableExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/VariableExecutorTest.java
@@ -174,14 +174,15 @@ public class VariableExecutorTest {
 
     for (final String invalidValue : invalidValues) {
       // When:
-      final Exception e = assertThrows(
+      final ParseFailedException e = assertThrows(
           ParseFailedException.class,
           () -> executeDefineVariable(String.format("DEFINE var1=%s;", invalidValue))
       );
 
       // Then:
-      assertThat(e.getMessage(), containsString(
+      assertThat(e.getUnloggedMessage(), containsString(
           String.format("mismatched input '%s'", invalidValue)));
+      assertThat(e.getMessage(), containsString("line 1:13: Syntax error at line 1:13"));
     }
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/query/QueryExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/query/QueryExecutorTest.java
@@ -220,9 +220,7 @@ public class QueryExecutorTest {
     final String errorMsg =
         "Pull queries are disabled. See https://cnfl.io/queries for more info.\n"
         + "Add EMIT CHANGES if you intended to issue a push query.\n"
-        + "Please set ksql.pull.queries.enable=true to enable this feature.\n"
-        + "\n"
-        + "Statement: SELECT * FROM test_stream WHERE ROWKEY='null';";
+        + "Please set ksql.pull.queries.enable=true to enable this feature.\n";
     assertThat(e.getMessage(), is(errorMsg));
   }
 

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlRequest.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlRequest.java
@@ -148,6 +148,14 @@ public class KsqlRequest {
         + '}';
   }
 
+  public String toStringWithoutQuery() {
+    return "KsqlRequest{"
+        + "configOverrides=" + configOverrides
+        + ", requestProperties=" + requestProperties
+        + ", commandSequenceNumber=" + commandSequenceNumber
+        + '}';
+  }
+
   /**
    * Converts all Class references values to their canonical String value.
    * </p>


### PR DESCRIPTION
chore: Use QueryLogger any time we log a query (#9681)

* fix: use QueryLogger for logging queries

* anonymize processed queries

* logging for unparsable queries

* anonymized query handling logs

* anonymized received queries

* anonymized streaming query

* checkstyle

* prevent exception from querylogger

* don't include statement text in exception message

* don't include statement text in exception messages

* fix tests

* fix tests

* fix tests

* checkstyle

* checkstyle

* fix parser test

* fix tests

* checkstyle

* restore ability to print errors in CLI

* checkstyle

* checkstyle

* fix error code

* One more fix for RestoreCommandsCompactor

* Fix style bug

Co-authored-by: Alan Sheinberg <asheinberg@confluent.io>

chore: Use QueryLogger to log queries, part 2 (#9695)

chore: use QueryLogger to log queries, part 3 (#9706)

Follow-up to #9695

chore: Use QueryLogger to log queries, part 4 (#9707)

chore: Use QueryLogger any time we log a query (#9705)

chore: Use QueryLogger to log queries, part 5 (#9722)

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

