### PR TITLE
fix: migrations tool without basic auth works again

### DIFF
--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientOptionsImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientOptionsImpl.java
@@ -138,7 +138,8 @@ public class ClientOptionsImpl implements ClientOptions {
 
   @Override
   public ClientOptions setBasicAuthCredentials(final String username, final String password) {
-    this.useBasicAuth = username != null || password != null;
+    this.useBasicAuth = !(username == null || username.isEmpty())
+        || !(password == null || password.isEmpty());
     this.basicAuthUsername = username;
     this.basicAuthPassword = password;
     return this;

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/MigrationConfig.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/MigrationConfig.java
@@ -73,49 +73,49 @@ public final class MigrationConfig extends AbstractConfig {
         ).define(
             KSQL_BASIC_AUTH_USERNAME,
             Type.STRING,
-            null,
+            "",
             Importance.MEDIUM,
             "The username for the KSQL server"
         ).define(
             KSQL_BASIC_AUTH_PASSWORD,
             Type.PASSWORD,
-            null,
+            "",
             Importance.MEDIUM,
             "The password for the KSQL server"
         ).define(
             SSL_TRUSTSTORE_LOCATION,
             Type.STRING,
-            null,
+            "",
             Importance.MEDIUM,
             "The trust store path"
         ).define(
             SSL_TRUSTSTORE_PASSWORD,
             Type.PASSWORD,
-            null,
+            "",
             Importance.MEDIUM,
             "The trust store password"
         ).define(
             SSL_KEYSTORE_LOCATION,
             Type.STRING,
-            null,
+            "",
             Importance.MEDIUM,
             "The key store path"
         ).define(
             SSL_KEYSTORE_PASSWORD,
             Type.PASSWORD,
-            null,
+            "",
             Importance.MEDIUM,
             "The key store password"
         ).define(
             SSL_KEY_PASSWORD,
             Type.PASSWORD,
-            null,
+            "",
             Importance.MEDIUM,
             "The key password"
         ).define(
             SSL_KEY_ALIAS,
             Type.STRING,
-            null,
+            "",
             Importance.MEDIUM,
             "The key alias"
         ).define(

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommand.java
@@ -34,6 +34,7 @@ import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
+import org.apache.kafka.common.config.types.Password;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -193,7 +194,7 @@ public class NewMigrationCommand extends BaseCommand {
       builder.append("\n# ");
       builder.append(cfg);
       builder.append("=");
-      builder.append(value == null ? "" : value);
+      builder.append((value == null || value instanceof Password) ? "" : value);
     }
   }
 }

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsUtil.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsUtil.java
@@ -103,7 +103,7 @@ public final class MigrationsUtil {
         .setHost(url.getHost())
         .setPort(url.getPort());
 
-    if (username != null || password != null) {
+    if (!Strings.isNullOrEmpty(username) || !Strings.isNullOrEmpty(password)) {
       options.setBasicAuthCredentials(username, password);
     }
 


### PR DESCRIPTION
### Description 

Ever since https://github.com/confluentinc/ksql/pull/9717, the ksql-migrations tool doesn't work without basic auth because an NPE is hit as soon as the tool needs to interact with the ksql server because the default basic auth password is null, and the previous change calls `.value()` on it.

This PR fixes the bug by changing the password config defaults (and related non-password configs for consistency) from null to empty string instead. 

### Testing done 

The earlier regression wasn't caught by our integration testing because the integration tests only run with basic auth enabled. I updated the test locally to run without basic auth and saw the regression was fixed.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

