### PR TITLE
fix: Set timeout for pull query forwarded requsts to 20s

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -360,6 +360,13 @@ public class KsqlConfig extends AbstractConfig {
           = "Enables the use of LIMIT clause in pull queries";
   public static final boolean KSQL_QUERY_PULL_LIMIT_CLAUSE_ENABLED_DEFAULT = true;
 
+  public static final String KSQL_QUERY_PULL_FORWARDING_TIMEOUT_MS_CONFIG
+      = "ksql.query.pull.forwarding.timeout.ms";
+  public static final String KSQL_QUERY_PULL_FORWARDING_TIMEOUT_MS_DOC
+      = "Pull query forwarding timeout in milliseconds";
+  public static final long KSQL_QUERY_PULL_FORWARDING_TIMEOUT_MS_DEFAULT =
+      15000L;
+
   public static final String KSQL_QUERY_PUSH_V2_ENABLED
       = "ksql.query.push.v2.enabled";
   public static final String KSQL_QUERY_PUSH_V2_ENABLED_DOC =
@@ -1210,6 +1217,13 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_QUERY_PULL_LIMIT_CLAUSE_ENABLED_DEFAULT,
             Importance.LOW,
             KSQL_QUERY_PULL_LIMIT_CLAUSE_ENABLED_DOC
+        )
+        .define(
+            KSQL_QUERY_PULL_FORWARDING_TIMEOUT_MS_CONFIG,
+            Type.LONG,
+            KSQL_QUERY_PULL_FORWARDING_TIMEOUT_MS_DEFAULT,
+            Importance.LOW,
+            KSQL_QUERY_PULL_FORWARDING_TIMEOUT_MS_DOC
         )
         .define(
             KSQL_QUERY_PUSH_V2_ENABLED,

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -365,7 +365,7 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_QUERY_PULL_FORWARDING_TIMEOUT_MS_DOC
       = "Pull query forwarding timeout in milliseconds";
   public static final long KSQL_QUERY_PULL_FORWARDING_TIMEOUT_MS_DEFAULT =
-      15000L;
+      20000L;
 
   public static final String KSQL_QUERY_PUSH_V2_ENABLED
       = "ksql.query.push.v2.enabled";

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
@@ -97,7 +97,7 @@ public final class RestServiceContextFactory {
         kafkaClientSupplier,
         srClientFactory,
         () -> connectClientFactory.get(authHeader, requestHeaders, userPrincipal),
-        () -> new DefaultKsqlClient(authHeader, sharedClient)
+        () -> new DefaultKsqlClient(authHeader, sharedClient, ksqlConfig)
     );
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -680,9 +680,10 @@ public class TestKsqlRestApp extends ExternalResource {
     }
 
     public Builder withNetworkDisruptorInternalKsqlClient(NetworkState networkState) {
-      internalSimpleKsqlClientFactory = (authHeader, ksqlClient) ->
+      internalSimpleKsqlClientFactory = (authHeader, additionalProps, ksqlClient) ->
           new NetworkDisruptorClient(
-              TestDefaultKsqlClientFactory.instance(authHeader, ksqlClient), networkState);
+              TestDefaultKsqlClientFactory.instance(authHeader, additionalProps, ksqlClient),
+              networkState);
       return this;
     }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/services/TestDefaultKsqlClientFactory.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/services/TestDefaultKsqlClientFactory.java
@@ -2,6 +2,7 @@ package io.confluent.ksql.rest.server.services;
 
 import io.confluent.ksql.rest.client.KsqlClient;
 import io.confluent.ksql.services.SimpleKsqlClient;
+import io.confluent.ksql.util.KsqlConfig;
 import io.vertx.core.net.SocketAddress;
 import java.util.Map;
 import java.util.Optional;
@@ -27,9 +28,10 @@ public class TestDefaultKsqlClientFactory {
   // With auth and a shared client
   public static SimpleKsqlClient instance(
       final Optional<String> authHeader,
+      final Map<String, Object> clientProps,
       final KsqlClient sharedClient
   ) {
-    return new DefaultKsqlClient(authHeader, sharedClient);
+    return new DefaultKsqlClient(authHeader, sharedClient, new KsqlConfig(clientProps));
   }
 
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/services/TestRestServiceContextFactory.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/services/TestRestServiceContextFactory.java
@@ -10,15 +10,18 @@ import io.confluent.ksql.services.ServiceContextFactory;
 import io.confluent.ksql.services.SimpleKsqlClient;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import org.apache.kafka.common.security.ssl.DefaultSslEngineFactory;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
 
 public class TestRestServiceContextFactory {
 
   public interface InternalSimpleKsqlClientFactory {
-    SimpleKsqlClient create(Optional<String> authHeader, KsqlClient ksqlClient);
+    SimpleKsqlClient create(Optional<String> authHeader, Map<String, Object> clientProps,
+        KsqlClient ksqlClient);
   }
 
   public static DefaultServiceContextFactory createDefault(
@@ -55,7 +58,7 @@ public class TestRestServiceContextFactory {
               Optional.empty(),
               false,
               CONNECT_REQUEST_TIMEOUT_DEFAULT),
-          () -> ksqlClientFactory.create(authHeader, sharedClient)
+          () -> ksqlClientFactory.create(authHeader, ksqlConfig.originals(), sharedClient)
       );
     };
 

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlClient.java
@@ -28,6 +28,7 @@ import io.vertx.core.VertxException;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.RequestOptions;
 import io.vertx.core.net.JksOptions;
 import io.vertx.core.net.SocketAddress;
 import java.net.URI;
@@ -132,7 +133,7 @@ public final class KsqlClient implements AutoCloseable {
     final HttpClient client = isUriTls ? httpTlsClient : httpNonTlsClient;
     return new KsqlTarget(client,
         socketAddressFactory.apply(server.getPort(), server.getHost()), localProperties,
-        basicAuthHeader, server.getHost(), additionalHeaders);
+        basicAuthHeader, server.getHost(), additionalHeaders, RequestOptions.DEFAULT_TIMEOUT);
   }
 
   public KsqlTarget targetHttp2(final URI server) {
@@ -141,7 +142,7 @@ public final class KsqlClient implements AutoCloseable {
         () -> new IllegalStateException("Must provide http2 options to use targetHttp2"));
     return new KsqlTarget(client,
         socketAddressFactory.apply(server.getPort(), server.getHost()), localProperties,
-        basicAuthHeader, server.getHost(), Collections.emptyMap());
+        basicAuthHeader, server.getHost(), Collections.emptyMap(), RequestOptions.DEFAULT_TIMEOUT);
   }
 
   @VisibleForTesting

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
@@ -88,6 +88,7 @@ public final class KsqlTarget {
   private final Optional<String> authHeader;
   private final String host;
   private final Map<String, String> additionalHeaders;
+  private final long timeout;
 
   /**
    * Create a KsqlTarget containing all of the connection information required to make a request
@@ -103,7 +104,8 @@ public final class KsqlTarget {
       final LocalProperties localProperties,
       final Optional<String> authHeader,
       final String host,
-      final Map<String, String> additionalHeaders
+      final Map<String, String> additionalHeaders,
+      final long timeout
   ) {
     this.httpClient = requireNonNull(httpClient, "httpClient");
     this.socketAddress = requireNonNull(socketAddress, "socketAddress");
@@ -111,17 +113,24 @@ public final class KsqlTarget {
     this.authHeader = requireNonNull(authHeader, "authHeader");
     this.host = host;
     this.additionalHeaders = requireNonNull(additionalHeaders, "additionalHeaders");
+    this.timeout = timeout;
   }
 
   public KsqlTarget authorizationHeader(final String authHeader) {
     return new KsqlTarget(httpClient, socketAddress, localProperties,
-        Optional.of(authHeader), host, additionalHeaders);
+        Optional.of(authHeader), host, additionalHeaders, timeout);
   }
 
   public KsqlTarget properties(final Map<String, ?> properties) {
     return new KsqlTarget(httpClient, socketAddress,
         new LocalProperties(properties),
-        authHeader, host, additionalHeaders);
+        authHeader, host, additionalHeaders, timeout);
+  }
+
+  public KsqlTarget timeout(final long timeout) {
+    return new KsqlTarget(httpClient, socketAddress,
+        localProperties,
+        authHeader, host, additionalHeaders, timeout);
   }
 
   public RestResponse<ServerInfo> getServerInfo() {
@@ -475,6 +484,7 @@ public final class KsqlTarget {
     options.setPort(socketAddress.port());
     options.setHost(host);
     options.setURI(path);
+    options.setTimeout(timeout);
 
     httpClient.request(options, ar -> {
       if (ar.failed()) {


### PR DESCRIPTION
### Description 
Sets a timeout for pull query requests which are forwarded to 20s by default, though allows it to be set by the client.

### Testing done 
Unit tests, plus was able to test manually.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

