### PR TITLE
restore PR -- fix: remove rc2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,7 @@
         <scala.version>2.13.2</scala.version>
         <apache.io.version>2.7</apache.io.version>
         <io.confluent.ksql.version>0.28.2</io.confluent.ksql.version>
+        <io.confluent.schema-registry.version>7.3.0-cc-docker-ksql.119-678</io.confluent.schema-registry.version>
         <netty-tcnative-version>2.0.46.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`
@@ -291,25 +292,25 @@
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-avro-converter</artifactId>
-                <version>7.3.0-cc-docker-ksql.119-678-rc2</version>
+                <version>${io.confluent.schema-registry.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-json-serializer</artifactId>
-                <version>7.3.0-cc-docker-ksql.119-678-rc2</version>
+                <version>${io.confluent.schema-registry.version}}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-avro-serializer</artifactId>
-                <version>7.3.0-cc-docker-ksql.119-678-rc2</version>
+                <version>${io.confluent.schema-registry.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-schema-registry-client</artifactId>
-                <version>7.3.0-cc-docker-ksql.119-678-rc2</version>
+                <version>${io.confluent.schema-registry.version}</version>
             </dependency>
 
             <dependency>
@@ -333,25 +334,25 @@
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-json-schema-provider</artifactId>
-                <version>7.3.0-cc-docker-ksql.119-678-rc2</version>
+                <version>${io.confluent.schema-registry.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-protobuf-provider</artifactId>
-                <version>7.3.0-cc-docker-ksql.119-678-rc2</version>
+                <version>${io.confluent.schema-registry.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-json-schema-converter</artifactId>
-                <version>7.3.0-cc-docker-ksql.119-678-rc2</version>
+                <version>${io.confluent.schema-registry.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-protobuf-converter</artifactId>
-                <version>7.3.0-cc-docker-ksql.119-678-rc2</version>
+                <version>${io.confluent.schema-registry.version}</version>
             </dependency>
 
             <!-- End Confluent dependencies -->


### PR DESCRIPTION
### Description 
- The release notes refer to `v0.28.2` Tag, and `0.28.2-ksqlDB` branch is a forward branch from `v0.28.2` Tag. however, it seems that a PR related to the dependency was lost in the `0.28.2-ksqlDB` branch comparing to `v0.28.2` Tag, so I wrote a PR to restore the deleted PR. 

### Testing done 
- not test.

### Reviewer checklist
- this PR are missed (https://github.com/confluentinc/ksql/commit/5fbc6e8a4409c3a6742ba9e7007cd51d309eb07c)
- `0.28.2-ksqldb` indicate this version `7.3.0-cc-docker-ksql.119-678-rc2` about schema-registry. but, `v0.28.2` Tag indicate `7.3.0-cc-docker-ksql.119-678` (https://github.com/confluentinc/ksql/blob/46ec707694a219a56241b315f5aa2ea313e83219/pom.xml#L306)

