### PR TITLE
fix: Avoid calling context.fail() twice

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/AuthenticationPluginHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/AuthenticationPluginHandler.java
@@ -63,8 +63,11 @@ public class AuthenticationPluginHandler implements Handler<RoutingContext> {
         routingContext.next();
       }
     }).exceptionally(t -> {
-      // An internal error occurred
-      routingContext.fail(t);
+      // Avoid calling context.fail() twice
+      if (!routingContext.failed()) {
+        // An internal error occurred
+        routingContext.fail(t);
+      }
       return null;
     });
   }


### PR DESCRIPTION
### Description 
Avoid calling `context.fail()` twice as currently its possible for both the plugin and the plugin handler to do so.

### Testing done 
Existing tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

