### PR TITLE
chore: return content type in header response for /query endpoint

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QueryStreamHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QueryStreamHandler.java
@@ -134,8 +134,11 @@ public class QueryStreamHandler implements Handler<RoutingContext> {
     if (DELIMITED_CONTENT_TYPE.equals(contentType)
         || (contentType == null && !queryCompatibilityMode)) {
       // Default
+      routingContext.response().putHeader("content-type", DELIMITED_CONTENT_TYPE);
       return new DelimitedQueryStreamResponseWriter(routingContext.response());
     } else if (KsqlMediaType.KSQL_V1_PROTOBUF.mediaType().equals(contentType)) {
+      routingContext.response().putHeader(
+          "content-type", KsqlMediaType.KSQL_V1_PROTOBUF.mediaType());
       return new JsonStreamedRowResponseWriter(
           routingContext.response(),
           queryPublisher,
@@ -149,6 +152,8 @@ public class QueryStreamHandler implements Handler<RoutingContext> {
     } else if (KsqlMediaType.KSQL_V1_JSON.mediaType().equals(contentType)
         || ((contentType == null || JSON_CONTENT_TYPE.equals(contentType)
         && queryCompatibilityMode))) {
+      routingContext.response().putHeader(
+          "content-type", KsqlMediaType.KSQL_V1_JSON.mediaType());
       return new JsonStreamedRowResponseWriter(
           routingContext.response(),
           queryPublisher,
@@ -159,6 +164,8 @@ public class QueryStreamHandler implements Handler<RoutingContext> {
           context,
           RowFormat.JSON);
     } else {
+      routingContext.response().putHeader(
+          "content-type", JSON_CONTENT_TYPE );
       return new JsonQueryStreamResponseWriter(routingContext.response());
     }
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QueryStreamHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QueryStreamHandler.java
@@ -56,6 +56,7 @@ public class QueryStreamHandler implements Handler<RoutingContext> {
 
   static final String DELIMITED_CONTENT_TYPE = "application/vnd.ksqlapi.delimited.v1";
   static final String JSON_CONTENT_TYPE = "application/json";
+  static final String CONTENT_TYPE = "content-type";
 
   private final Endpoints endpoints;
   private final ConnectionQueryManager connectionQueryManager;
@@ -134,11 +135,11 @@ public class QueryStreamHandler implements Handler<RoutingContext> {
     if (DELIMITED_CONTENT_TYPE.equals(contentType)
         || (contentType == null && !queryCompatibilityMode)) {
       // Default
-      routingContext.response().putHeader("content-type", DELIMITED_CONTENT_TYPE);
+      routingContext.response().putHeader(CONTENT_TYPE, DELIMITED_CONTENT_TYPE);
       return new DelimitedQueryStreamResponseWriter(routingContext.response());
     } else if (KsqlMediaType.KSQL_V1_PROTOBUF.mediaType().equals(contentType)) {
       routingContext.response().putHeader(
-          "content-type", KsqlMediaType.KSQL_V1_PROTOBUF.mediaType());
+          CONTENT_TYPE, KsqlMediaType.KSQL_V1_PROTOBUF.mediaType());
       return new JsonStreamedRowResponseWriter(
           routingContext.response(),
           queryPublisher,
@@ -153,7 +154,7 @@ public class QueryStreamHandler implements Handler<RoutingContext> {
         || ((contentType == null || JSON_CONTENT_TYPE.equals(contentType)
         && queryCompatibilityMode))) {
       routingContext.response().putHeader(
-          "content-type", KsqlMediaType.KSQL_V1_JSON.mediaType());
+          CONTENT_TYPE, KsqlMediaType.KSQL_V1_JSON.mediaType());
       return new JsonStreamedRowResponseWriter(
           routingContext.response(),
           queryPublisher,
@@ -164,8 +165,7 @@ public class QueryStreamHandler implements Handler<RoutingContext> {
           context,
           RowFormat.JSON);
     } else {
-      routingContext.response().putHeader(
-          "content-type", JSON_CONTENT_TYPE );
+      routingContext.response().putHeader(CONTENT_TYPE, JSON_CONTENT_TYPE);
       return new JsonQueryStreamResponseWriter(routingContext.response());
     }
   }


### PR DESCRIPTION
### Description 
Addresses issue https://github.com/confluentinc/ksql/issues/9282 for the \query endpoint. The migration flag is true by default so I only fixed it in `QueryStreamHandler`

```
 curl -v -X "POST" "http://localhost:8088/query"      -H "Accept: application/vnd.ksql.v1+protobuf"      -d $'{
  "ksql": "SELECT * FROM tab3;",
  "streamsProperties": {}
}'
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1:8088...
* Connected to localhost (127.0.0.1) port 8088 (#0)
> POST /query HTTP/1.1
> Host: localhost:8088
> User-Agent: curl/7.87.0
> Accept: application/vnd.ksql.v1+protobuf
> Content-Length: 62
> Content-Type: application/x-www-form-urlencoded
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Transfer-Encoding: chunked
< content-type: application/vnd.ksql.v1+protobuf
<
* Connection #0 to host localhost left intact
[{"header":{"queryId":"query_1680204531548","schema":"`ID` INTEGER KEY, `COUNT` INTEGER","protoSchema":"syntax = \"proto3\";\n\nmessage ConnectDefault1 {\n  int32 ID = 1;\n  int32 COUNT = 2;\n}\n"}}]
```

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

