### PR TITLE
hotfix: fix command topic migration to produce byte array records to command topic

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicMigrationUtil.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicMigrationUtil.java
@@ -38,8 +38,9 @@ import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+// CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 public final class CommandTopicMigrationUtil {
-
+  // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
   private static final Logger log = LoggerFactory.getLogger(CommandTopicMigrationUtil.class);
   public static final CommandId MIGRATION_COMMAND_ID =
       new CommandId(CommandId.Type.CLUSTER, "migration", CommandId.Action.ALTER);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicMigrationUtil.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicMigrationUtil.java
@@ -27,8 +27,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
@@ -36,7 +34,6 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
-import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,7 +86,7 @@ public final class CommandTopicMigrationUtil {
         );
     oldBrokerConsumer.assign(Collections.singleton(topicPartition));
 
-    final List<ConsumerRecord<byte[], byte[]>> records = CommandTopic.getAllCommandsInCommandTopic(
+    final List<QueuedCommand> commands = CommandTopic.getAllCommandsInCommandTopic(
         oldBrokerConsumer,
         topicPartition,
         Optional.empty(),
@@ -98,20 +95,14 @@ public final class CommandTopicMigrationUtil {
     oldBrokerConsumer.close();
 
     // remove the incompatible command that was just written to the command topic
-    final List<ConsumerRecord<byte[], byte[]>> recordsToMigrate = new ArrayList<>();
-    for (ConsumerRecord<byte[], byte[]> record : records) {
-      final QueuedCommand command = new QueuedCommand(
-          record.key(),
-          record.value(),
-          Optional.empty(),
-          record.offset());
-
+    final List<QueuedCommand> commandsToMigrate = new ArrayList<>();
+    for (QueuedCommand command : commands) {
       final CommandId currentCommandId = command.getAndDeserializeCommandId();
       if (currentCommandId.equals(MIGRATION_COMMAND_ID)) {
         log.info("skipping migration command sent to old command "
             + "topic when migrating to new one");
       } else {
-        recordsToMigrate.add(record);
+        commandsToMigrate.add(command);
       }
     }
 
@@ -121,21 +112,21 @@ public final class CommandTopicMigrationUtil {
         ProducerConfig.TRANSACTIONAL_ID_CONFIG,
         config.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG) + "-migration-producer"
     );
-    try (Producer<byte[], byte[]> newBrokerProducer = new KafkaProducer<>(
+    try (Producer<CommandId, Command> newBrokerProducer = new KafkaProducer<>(
         newBrokerProducerConfigs,
-        new ByteArraySerializer(),
-        new ByteArraySerializer()
+        InternalTopicSerdes.serializer(),
+        InternalTopicSerdes.serializer()
     )) {
       newBrokerProducer.initTransactions();
       newBrokerProducer.beginTransaction();
 
       // re-create command topic
-      for (ConsumerRecord<byte[], byte[]> record : recordsToMigrate) {
-        final ProducerRecord<byte[], byte[]> producerRecord = new ProducerRecord<>(
+      for (QueuedCommand command : commandsToMigrate) {
+        final ProducerRecord<CommandId, Command> producerRecord = new ProducerRecord<>(
             commandTopic,
             0,
-            record.key(),
-            record.value());
+            command.getAndDeserializeCommandId(),
+            command.getAndDeserializeCommand(InternalTopicSerdes.deserializer(Command.class)));
         newBrokerProducer.send(producerRecord);
       }
       newBrokerProducer.commitTransaction();

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/QueuedCommand.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/QueuedCommand.java
@@ -55,13 +55,11 @@ public class QueuedCommand {
     this.offset = Objects.requireNonNull(offset, "offset");
   }
 
-  @VisibleForTesting
-  byte[] getCommandId() {
+  public byte[] getCommandId() {
     return Arrays.copyOf(commandId, commandId.length);
   }
 
-  @VisibleForTesting
-  byte[] getCommand() {
+  public byte[] getCommand() {
     return  Arrays.copyOf(command, command.length);
   }
 


### PR DESCRIPTION
### Description 
We need to recreate the command topic on the new broker with records as byte array. If we deserialize and then re-serialize records from the old command topic, we can inadvertently add new fields to the new records due to new fields that we introduce to the command object.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

