### PR TITLE
chore: change kafka dependencies to ce-kafka

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ClusterTerminationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ClusterTerminationTest.java
@@ -178,8 +178,8 @@ public class ClusterTerminationTest {
         is(true)
     );
 
-    // should only be the pageview topic left
-    assertThat(TEST_HARNESS.getKafkaCluster().getTopics().size(), is(1));
+    // should be the pageview and _confluent-command topic left
+    assertThat(TEST_HARNESS.getKafkaCluster().getTopics().size(), is(2));
 
     // Then:
     shouldReturn50303or50304WhenTerminating();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/TransientQueryResourceCleanerIntTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/TransientQueryResourceCleanerIntTest.java
@@ -75,10 +75,11 @@ public class TransientQueryResourceCleanerIntTest {
     private static final String USER_TABLE = USER_DATA_PROVIDER.sourceName();
 
     // Persistent Topics:
+    // _confluent-command, // This topic is created by ce-kafka for LicenseStore
     // _confluent-ksql-default__command_topic,
     // PAGEVIEW_TOPIC,
     // USER_TOPIC
-    private static final int numPersistentTopics = 3;
+    private static final int numPersistentTopics = 4;
 
     // Transient Topics:
     // _confluent-ksql-default_transient_transient_PV_[0-9]\d*_[0-9]\d*-KafkaTopic_Right-Reduce-changelog

--- a/ksqldb-test-util/pom.xml
+++ b/ksqldb-test-util/pom.xml
@@ -56,6 +56,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.confluent</groupId>
+      <artifactId>ce-sbk_${kafka.scala.version}</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka_${kafka.scala.version}</artifactId>
       <classifier>test</classifier>

--- a/ksqldb-test-util/pom.xml
+++ b/ksqldb-test-util/pom.xml
@@ -50,6 +50,13 @@
 
     <dependency>
       <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-server-common</artifactId>
+      <classifier>test</classifier>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
       <artifactId>kafka_${kafka.scala.version}</artifactId>
       <classifier>test</classifier>
       <scope>compile</scope>
@@ -66,12 +73,7 @@
       <classifier>test</classifier>
       <scope>compile</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-server-common</artifactId>
-      <classifier>test</classifier>
-      <scope>test</scope>
-    </dependency>
+
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>

--- a/ksqldb-test-util/pom.xml
+++ b/ksqldb-test-util/pom.xml
@@ -66,7 +66,12 @@
       <classifier>test</classifier>
       <scope>compile</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-server-common</artifactId>
+      <classifier>test</classifier>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -155,11 +155,59 @@
         <netty-codec-http2-version>4.1.86.Final</netty-codec-http2-version>
         <jersey-common>2.34</jersey-common>
         <multi-threaded-testing.forkCount>3</multi-threaded-testing.forkCount>
+        <kafka.version>${ce.kafka.version}</kafka.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
             <!-- Cross-submodule dependencies -->
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka_${kafka.scala.version}</artifactId>
+                <version>${kafka.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-streams</artifactId>
+                <version>${kafka.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-clients</artifactId>
+                <version>${kafka.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>connect-api</artifactId>
+                <version>${kafka.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>connect-runtime</artifactId>
+                <version>${kafka.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>connect-json</artifactId>
+                <version>${kafka.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>connect-file</artifactId>
+                <version>${kafka.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.apache.kafka</groupId>
@@ -171,6 +219,34 @@
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-streams-test-utils</artifactId>
                 <version>${kafka.version}</version>
+            </dependency>
+
+            <!-- Kafka's SSL utilities are used in tests. -->
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka_${kafka.scala.version}</artifactId>
+                <version>${kafka.version}</version>
+                <classifier>test</classifier>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-clients</artifactId>
+                <version>${kafka.version}</version>
+                <classifier>test</classifier>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,13 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-server-common</artifactId>
+                <version>${kafka.version}</version>
+                <classifier>test</classifier>
+                <scope>test</scope>
+            </dependency>
             <dependency>
                 <groupId>io.confluent.ksql</groupId>
                 <artifactId>ksqldb-common</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,14 @@
                 <classifier>test</classifier>
                 <scope>compile</scope>
             </dependency>
+
+            <dependency>
+                <groupId>io.confluent</groupId>
+                <artifactId>ce-sbk_${kafka.scala.version}</artifactId>
+                <version>${kafka.version}</version>
+                <scope>compile</scope>
+            </dependency>
+
             <dependency>
                 <groupId>io.confluent.ksql</groupId>
                 <artifactId>ksqldb-common</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
                 <artifactId>kafka-server-common</artifactId>
                 <version>${kafka.version}</version>
                 <classifier>test</classifier>
-                <scope>test</scope>
+                <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>io.confluent.ksql</groupId>
@@ -428,6 +428,12 @@
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-protobuf-converter</artifactId>
                 <version>${io.confluent.schema-registry.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.confluent</groupId>
+                <artifactId>broker-plugins</artifactId>
+                <version>${kafka.version}</version>
             </dependency>
 
             <!-- End Confluent dependencies -->
@@ -710,7 +716,10 @@
             <groupId>io.confluent</groupId>
             <artifactId>logredactor</artifactId>
         </dependency>
-
+            <dependency>
+                <groupId>io.confluent</groupId>
+                <artifactId>broker-plugins</artifactId>
+            </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -208,13 +208,6 @@
                 <artifactId>connect-file</artifactId>
                 <version>${kafka.version}</version>
             </dependency>
-
-            <dependency>
-                <groupId>org.apache.kafka</groupId>
-                <artifactId>kafka-streams</artifactId>
-                <version>${kafka.version}</version>
-            </dependency>
-
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-streams-test-utils</artifactId>


### PR DESCRIPTION
### Description 
Switch ksql dependency to ce-kafka for all kafka related dependencies (kafka-clients, kafka-streams, connect etc)

### Testing done 
* Existing tests.
* Manually build docker image and tested in ccloud
* Install with `./mvnw clean install -DversionFilter=true -Dspotbugs.skip  -DskipTests -Dcheckstyle.skip=True  -am -pl ksqldb-console-scripts,ksqldb-metastore,ksqldb-parser,ksqldb-rest-app,ksqldb-rocksdb-config-setter,ksqldb-version-metrics-client`
* Verified dependencies don't have `ccs` anywhere: 
```
hli@MacBook ~/projects/confluentinc/ksql$ ./mvnw dependency:tree | grep ccs
hli@MacBook ~/projects/confluentinc/ksql$
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

