### PR TITLE
Only trigger downstream docker build for master branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,10 @@
 
 def channel = "${env.BRANCH_NAME}".contains('master') ? '#ksqldb-quality-oncall' : '#ksqldb-warn'
 
+def downStreams = "${env.BRANCH_NAME}".contains('master') ? 
+    ["confluent-security-plugins", "confluent-cloud-plugins", "cc-docker-ksql"] :
+    ["confluent-security-plugins", "confluent-cloud-plugins"]
+
 common {
     nodeLabel = 'docker-debian-jdk11'
     slackChannel = channel
@@ -11,7 +15,7 @@ common {
     dockerPush = false
     dockerScan = false
     dockerImageClean = false
-    downStreamRepos = ["confluent-security-plugins", "confluent-cloud-plugins", "cc-docker-ksql"]
+    downStreamRepos = downStreams
     downStreamValidate = false
     nanoVersion = true
     pinnedNanoVersions = true


### PR DESCRIPTION
Try to fix `ERROR: No item named confluentinc/cc-docker-ksql/7.4.x found` build issue
by only triggering docker build for master branch of ksql.

This change should NOT affect ksql `master`, but should fix building `7.4.x` branch when merged.