### PR TITLE
chore: [1/N][client_ip]add port to principle

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/DefaultKsqlPrincipal.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/DefaultKsqlPrincipal.java
@@ -78,7 +78,7 @@ public class DefaultKsqlPrincipal implements KsqlPrincipal {
    * IP address and port are populated from the request context, and subsequently passed
    * throughout the engine.
    */
-  public DefaultKsqlPrincipal withIpAddressAndPort(final String ipAddress, int port) {
+  public DefaultKsqlPrincipal withIpAddressAndPort(final String ipAddress, final int port) {
     return new DefaultKsqlPrincipal(principal, ipAddress, port);
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/DefaultKsqlPrincipal.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/DefaultKsqlPrincipal.java
@@ -29,14 +29,17 @@ public class DefaultKsqlPrincipal implements KsqlPrincipal {
 
   private final Principal principal;
   private final String ipAddress;
+  private final int port;
 
   public DefaultKsqlPrincipal(final Principal principal) {
-    this(principal, "");
+    this(principal, "", 0);
   }
 
-  protected DefaultKsqlPrincipal(final Principal principal, final String ipAddress) {
+  protected DefaultKsqlPrincipal(final Principal principal,
+      final String ipAddress, final int port) {
     this.principal = Objects.requireNonNull(principal, "principal");
     this.ipAddress = Objects.requireNonNull(ipAddress, "ipAddress");
+    this.port = port;
   }
 
   @Override
@@ -66,11 +69,16 @@ public class DefaultKsqlPrincipal implements KsqlPrincipal {
     return ipAddress;
   }
 
+  @Override
+  public int getPort() {
+    return port;
+  }
+
   /**
-   * IP address is populated from the request context, and subsequently passed
+   * IP address and port are populated from the request context, and subsequently passed
    * throughout the engine.
    */
-  public DefaultKsqlPrincipal withIpAddress(final String ipAddress) {
-    return new DefaultKsqlPrincipal(principal, ipAddress);
+  public DefaultKsqlPrincipal withIpAddressAndPort(final String ipAddress, int port) {
+    return new DefaultKsqlPrincipal(principal, ipAddress, port);
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlPrincipal.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlPrincipal.java
@@ -48,4 +48,11 @@ public interface KsqlPrincipal extends Principal {
   default String getIpAddress() {
     return "";
   }
+
+  /**
+   * Returns the user's port number, as set by the ksqlDB server's request context.
+   */
+  default int getPort() {
+    return 0;
+  }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/security/DefaultKsqlPrincipalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/security/DefaultKsqlPrincipalTest.java
@@ -71,4 +71,11 @@ public class DefaultKsqlPrincipalTest {
     assertThat(wrappedKsqlPrincipal.getOriginalPrincipal(), is(ksqlPrincipal));
     assertThat(wrappedOtherPrincipal.getOriginalPrincipal(), is(otherPrincipal));
   }
+
+  @Test
+  public void shouldReturnIpAndPort() {
+    final KsqlPrincipal principal = wrappedKsqlPrincipal.withIpAddressAndPort("127.0.0.1", 1234);
+    assertThat(principal.getPort(), is(1234));
+    assertThat(principal.getIpAddress(), is("127.0.0.1"));
+  }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/DefaultApiSecurityContext.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/DefaultApiSecurityContext.java
@@ -45,9 +45,11 @@ public final class DefaultApiSecurityContext implements ApiSecurityContext {
 
     final List<Entry<String, String>> requestHeaders = routingContext.request().headers().entries();
     final String ipAddress = routingContext.request().remoteAddress().host();
+    final int port = routingContext.request().remoteAddress().port();
+
     return new DefaultApiSecurityContext(
         apiUser != null
-            ? apiUser.getPrincipal().withIpAddress(ipAddress == null ? "" : ipAddress)
+            ? apiUser.getPrincipal().withIpAddressAndPort(ipAddress == null ? "" : ipAddress, port)
             : null,
         authToken,
         requestHeaders);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/JaasPrincipal.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/JaasPrincipal.java
@@ -37,11 +37,12 @@ public class JaasPrincipal extends DefaultKsqlPrincipal {
   private final String token;
 
   public JaasPrincipal(final String name, final String password) {
-    this(name, password, "");
+    this(name, password, "", 0);
   }
 
-  private JaasPrincipal(final String name, final String password, final String ipAddress) {
-    super(new BasicJaasPrincipal(name), ipAddress);
+  private JaasPrincipal(final String name, final String password,
+      final String ipAddress, int port) {
+    super(new BasicJaasPrincipal(name), ipAddress, port);
 
     this.name = Objects.requireNonNull(name, "name");
     this.password = Objects.requireNonNull(password, "password");
@@ -67,8 +68,8 @@ public class JaasPrincipal extends DefaultKsqlPrincipal {
    * IP address is set from the routing context.
    */
   @Override
-  public DefaultKsqlPrincipal withIpAddress(final String ipAddress) {
-    return new JaasPrincipal(name, password, ipAddress);
+  public DefaultKsqlPrincipal withIpAddressAndPort(final String ipAddress, int port) {
+    return new JaasPrincipal(name, password, ipAddress, port);
   }
 
   private static String createToken(final String name, final String secret) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/JaasPrincipal.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/JaasPrincipal.java
@@ -41,7 +41,7 @@ public class JaasPrincipal extends DefaultKsqlPrincipal {
   }
 
   private JaasPrincipal(final String name, final String password,
-      final String ipAddress, int port) {
+      final String ipAddress, final int port) {
     super(new BasicJaasPrincipal(name), ipAddress, port);
 
     this.name = Objects.requireNonNull(name, "name");
@@ -68,7 +68,7 @@ public class JaasPrincipal extends DefaultKsqlPrincipal {
    * IP address is set from the routing context.
    */
   @Override
-  public DefaultKsqlPrincipal withIpAddressAndPort(final String ipAddress, int port) {
+  public DefaultKsqlPrincipal withIpAddressAndPort(final String ipAddress, final int port) {
     return new JaasPrincipal(name, password, ipAddress, port);
   }
 


### PR DESCRIPTION
### Description 
Add port number to principle as well since it's needed to populate client port config `confluent.proxy.protocol.client.port` in addition to ip config `confluent.proxy.protocol.client.address`.

### Testing done 
Unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

