### PR TITLE
chore: Only trigger downstream docker build for master branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,10 @@
 
 def channel = "${env.BRANCH_NAME}".contains('master') ? '#ksqldb-quality-oncall' : '#ksqldb-warn'
 
+def downStreams = "${env.BRANCH_NAME}".contains('master') ? 
+    ["confluent-security-plugins", "confluent-cloud-plugins", "cc-docker-ksql"] :
+    ["confluent-security-plugins", "confluent-cloud-plugins"]
+
 common {
     nodeLabel = 'docker-debian-jdk11'
     slackChannel = channel
@@ -11,7 +15,7 @@ common {
     dockerPush = false
     dockerScan = false
     dockerImageClean = false
-    downStreamRepos = ["confluent-security-plugins", "confluent-cloud-plugins", "cc-docker-ksql"]
+    downStreamRepos = downStreams
     downStreamValidate = false
     nanoVersion = true
     maxBuildsToKeep = 99


### PR DESCRIPTION
Changes from #9870 ported to 7.4.x.

I realized that commits are not back-ported, but rather older branches are merged into newer ones.
So I plan to merge this PR into 7.4.x and then pint-merge into master.