### PR TITLE
fix: check for tombstone before forwarding to sink

### DIFF
--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SinkBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SinkBuilder.java
@@ -138,7 +138,7 @@ public final class SinkBuilder {
         @Override
         public KeyValue<K, GenericRow> transform(final K key, final GenericRow row) {
           try {
-            long timestamp;
+            final long timestamp;
             if (row == null) {
               timestamp = processorContext.currentStreamTimeMs();
             } else {

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SinkBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SinkBuilder.java
@@ -138,10 +138,16 @@ public final class SinkBuilder {
         @Override
         public KeyValue<K, GenericRow> transform(final K key, final GenericRow row) {
           try {
+            long timestamp;
+            if (row == null) {
+              timestamp = processorContext.currentStreamTimeMs();
+            } else {
+              timestamp = timestampExtractor.extract(key, row);
+            }
             processorContext.forward(
                 key,
                 row,
-                To.all().withTimestamp(timestampExtractor.extract(key, row))
+                To.all().withTimestamp(timestamp)
             );
           } catch (final Exception e) {
             processingLogger.error(RecordProcessingError


### PR DESCRIPTION
### Description 

Checks if the record is a tombstone before it is forwarded to the sink topic. 

Before this change, a tombstone record would cause a NullPointerException when ksql tries to extract the timestamp from the value since the value of a tombstone is null. The NullPointerException caused the following error log message:
"Error writing row with extracted timestamp: null","record":null,"cause":["java.lang.NullPointerException"]

If the record is a tombstone the stream time is used as the timestamp of the tombstone record.  

### Testing done 
Added a unit test.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

