### PR TITLE
feat: add MD5 hash UDF

### DIFF
--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -1389,6 +1389,17 @@ MASK_RIGHT("My Test $123", 4) => "My Test -nnn"
 
 ---
 
+### **`MD5`**
+
+```sql title="Since: 0.29.0"
+MD5('hash me')
+MD5(col1)
+```
+
+Returns the hex-encoded MD5 hash of the given `STRING`.
+
+---
+
 ### **`REPLACE`**
 
 ```sql title="Since: 0.6.0"

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/MD5.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/MD5.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.string;
+
+import io.confluent.ksql.function.FunctionCategory;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import io.confluent.ksql.util.KsqlConstants;
+import org.apache.commons.codec.digest.DigestUtils;
+
+@UdfDescription(
+    name = "md5",
+    category = FunctionCategory.STRING,
+    author = KsqlConstants.CONFLUENT_AUTHOR,
+    description = "Computes the hex-encoded md5 hash of the given string"
+)
+public class MD5 {
+
+  @Udf(description = "Returns the hex-encoded md5 hash of the input string")
+  public String md5(
+      @UdfParameter(description = "The input string") final String s
+  ) {
+    if (s == null) {
+      return null;
+    }
+    return DigestUtils.md5Hex(s);
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/MD5Test.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/MD5Test.java
@@ -52,7 +52,6 @@ public class MD5Test {
     // Now generate random input strings and compare results to DigestUtils
     for (int i = 0; i < 1000; i++) {
       String uuid = UUID.randomUUID().toString();
-      DigestUtils.md5Hex(uuid);
       assertThat(udf.md5(uuid), is(DigestUtils.md5Hex(uuid)));
     }
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/MD5Test.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/MD5Test.java
@@ -14,8 +14,15 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class MD5Test {
 
@@ -28,12 +35,26 @@ public class MD5Test {
 
   @Test
   public void shouldReturnNullForNull() {
-
+    assertThat(udf.md5(null), is(nullValue()));
   }
 
   @Test
   public void shouldReturnHexString() {
+    assertThat(udf.md5("one"), is("f97c5d29941bfb1b2fdab0874906ab82"));
+    assertThat(udf.md5("two"), is("b8a9f715dbb64fd5c56e7783c6820a61"));
+    assertThat(udf.md5("three"), is("35d6d33467aae9a2e3dccb4b6b027878"));
+    assertThat(udf.md5(""), is("d41d8cd98f00b204e9800998ecf8427e"));
+    assertThat(udf.md5(" "), is("7215ee9c7d9dc229d2921a40e899ec5f"));
 
+    // Sanity check some strange Unicode characters
+    assertThat(udf.md5("★☀☺"), is("670884f26d7be1298886c2e9d7c248a4"));
+
+    // Now generate random input strings and compare results to DigestUtils
+    for (int i = 0; i < 1000; i++) {
+      String uuid = UUID.randomUUID().toString();
+      DigestUtils.md5Hex(uuid);
+      assertThat(udf.md5(uuid), is(DigestUtils.md5Hex(uuid)));
+    }
   }
 }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/MD5Test.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/MD5Test.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package io.confluent.ksql.function.udf.string;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class MD5Test {
+
+  private MD5 udf;
+
+  @Before
+  public void setUp() {
+    udf = new MD5();
+  }
+
+  @Test
+  public void shouldReturnNullForNull() {
+
+  }
+
+  @Test
+  public void shouldReturnHexString() {
+
+  }
+}
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/md5_-_md5_to_hex_string/7.4.0_1681850900031/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/md5_-_md5_to_hex_string/7.4.0_1681850900031/plan.json
@@ -1,0 +1,210 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID STRING KEY, STR STRING) WITH (FORMAT='JSON', KAFKA_TOPIC='test_topic');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` STRING KEY, `STR` STRING",
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "keyFeatures" : [ "UNWRAP_SINGLES" ]
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  MD5(INPUT.STR) MD5\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `MD5` STRING",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        },
+        "keyFeatures" : [ "UNWRAP_SINGLES" ]
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              },
+              "keyFeatures" : [ "UNWRAP_SINGLES" ]
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`ID` STRING KEY, `STR` STRING",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "MD5(STR) AS MD5" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          },
+          "keyFeatures" : [ "UNWRAP_SINGLES" ]
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.websocket.connection.max.timeout.ms" : "3600000",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "true",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.json_sr.converter.deserializer.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/md5_-_md5_to_hex_string/7.4.0_1681850900031/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/md5_-_md5_to_hex_string/7.4.0_1681850900031/spec.json
@@ -1,0 +1,103 @@
+{
+  "version" : "7.4.0",
+  "timestamp" : 1681850900031,
+  "path" : "query-validation-tests/md5.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` STRING KEY, `STR` STRING",
+      "keyFormat" : {
+        "format" : "JSON",
+        "features" : [ "UNWRAP_SINGLES" ]
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` STRING KEY, `MD5` STRING",
+      "keyFormat" : {
+        "format" : "JSON",
+        "features" : [ "UNWRAP_SINGLES" ]
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "md5 to hex string",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "r1",
+      "value" : {
+        "str" : "r1"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "r1",
+      "value" : {
+        "MD5" : "7c92cf1eee8d99cc85f8355a3d6e4b86"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ "UNWRAP_SINGLES" ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID STRING KEY, STR STRING) WITH (kafka_topic='test_topic', format='JSON');", "CREATE STREAM OUTPUT AS SELECT ID, MD5(STR) AS MD5 FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `STR` STRING",
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ "UNWRAP_SINGLES" ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `MD5` STRING",
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ "UNWRAP_SINGLES" ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "JSON",
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "JSON",
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/md5_-_md5_to_hex_string/7.4.0_1681850900031/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/md5_-_md5_to_hex_string/7.4.0_1681850900031/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/md5.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/md5.json
@@ -1,0 +1,20 @@
+{
+  "comments": [
+    "Tests covering the use of the MD5() function."
+  ],
+  "tests": [
+    {
+      "name": "md5 to hex string",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, STR STRING) WITH (kafka_topic='test_topic', format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT ID, MD5(STR) AS MD5 FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "r1", "value": {"str": "r1"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "r1", "value": {"MD5": "7c92cf1eee8d99cc85f8355a3d6e4b86"}}
+      ]
+    }
+  ]
+}

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/md5.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/md5.json
@@ -10,10 +10,22 @@
         "CREATE STREAM OUTPUT AS SELECT ID, MD5(STR) AS MD5 FROM INPUT;"
       ],
       "inputs": [
-        {"topic": "test_topic", "key": "r1", "value": {"str": "r1"}}
+        {"topic": "test_topic", "key": "r1", "value": {"str": "r1"}},
+        {"topic": "test_topic", "key": "r2", "value": {"str": "r2"}},
+        {"topic": "test_topic", "key": "r3", "value": {"str": "r3"}},
+        {"topic": "test_topic", "key": "r3", "value": {"str": null}},
+        {"topic": "test_topic", "key": "r3", "value": {"str": ""}},
+        {"topic": "test_topic", "key": "r3", "value": {"str": " "}},
+        {"topic": "test_topic", "key": "r3", "value": {"str": "  "}}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": "r1", "value": {"MD5": "7c92cf1eee8d99cc85f8355a3d6e4b86"}}
+        {"topic": "OUTPUT", "key": "r1", "value": {"MD5": "7c92cf1eee8d99cc85f8355a3d6e4b86"}},
+        {"topic": "OUTPUT", "key": "r2", "value": {"MD5": "d279186428a75016b17e4df5ea43d080"}},
+        {"topic": "OUTPUT", "key": "r3", "value": {"MD5": "9d3e622df914d8de7f747b7b8b143c52"}},
+        {"topic": "OUTPUT", "key": "r3", "value": {"MD5": null}},
+        {"topic": "OUTPUT", "key": "r3", "value": {"MD5": "d41d8cd98f00b204e9800998ecf8427e"}},
+        {"topic": "OUTPUT", "key": "r3", "value": {"MD5": "7215ee9c7d9dc229d2921a40e899ec5f"}},
+        {"topic": "OUTPUT", "key": "r3", "value": {"MD5": "23b58def11b45727d3351702515f86af"}}
       ]
     }
   ]


### PR DESCRIPTION
### Description 
Adds a new `MD5` UDF that takes a string as input and outputs the hex-encoded MD5 hash of the string. 

### Testing done 
- [x] Unit tests
- [x] Functional tests
- [x] Historical query plan

### Reviewer checklist
- [x] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

