### PR TITLE
fix: Replace regex in CommandParser with a split by space

### DIFF
--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/CommandParser.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/CommandParser.java
@@ -48,7 +48,6 @@ import java.util.stream.Collectors;
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 public final class CommandParser {
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
-  private static final String QUOTED_STRING_OR_WHITESPACE = "('([^']*|(''))*')|\\s+";
   private static final KsqlParser KSQL_PARSER = new DefaultKsqlParser();
   private static final String SELECT = "SELECT";
   private static final String DESCRIBE = "DESCRIBE";
@@ -221,8 +220,7 @@ public final class CommandParser {
   /**
    * Validates that the sql statement represented by the list of input tokens
    * (keywords separated whitespace, or strings identified by single quotes)
-   * is not unsupported by the migrations tool. Assumes that tokens have already
-   * been upper-cased.
+   * is not unsupported by the migrations tool.
    *
    * @param sql components that make up the sql statement. Each component is
    *               either a keyword separated by whitespace or a string enclosed
@@ -230,7 +228,7 @@ public final class CommandParser {
    */
   private static void validateSupportedStatementType(final String sql) {
     final List<String> tokens = Arrays
-            .stream(sql.toUpperCase().split(QUOTED_STRING_OR_WHITESPACE))
+            .stream(sql.toUpperCase().split("\\s+"))
             .filter(s -> !s.isEmpty())
             .collect(Collectors.toList());
     if (tokens.size() > 0 && UNSUPPORTED_STATEMENTS.contains(tokens.get(0))) {

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/CommandParser.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/CommandParser.java
@@ -221,6 +221,11 @@ public final class CommandParser {
    * Validates that the sql statement represented by the list of input tokens
    * (keywords separated whitespace, or strings identified by single quotes)
    * is not unsupported by the migrations tool.
+   * <p>
+   * NOTE: this method is obsolete and should be replaced with type-checking after the parsing
+   * step. See https://github.com/confluentinc/ksql/pull/9881#discussion_r1174178200 for more
+   * details.
+   * </p>
    *
    * @param sql components that make up the sql statement. Each component is
    *               either a keyword separated by whitespace or a string enclosed


### PR DESCRIPTION
### Description 

`QUOTED_STRING_OR_WHITESPACE` regex suffers from catastrophic backtracking. At the same time, the only method using this regex does not require extracting quoted strings that causes the backtracking issue.

### Testing done 

https://jenkins.confluent.io/job/Confluent%20Public%20Repo%20PR%20builder/job/ksql/job/PR-9881/2/

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

