### PR TITLE
chore: add item for rollback compatibility into PR template (MINOR)

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -7,4 +7,4 @@ _Describe the testing strategy. Unit and integration tests are expected for any 
 ### Reviewer checklist
 - [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
 - [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
-
+- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.


### PR DESCRIPTION
### Description 

We used to bump the ksql command version on every release but that no longer makes sense as we switch to more frequent releases. Instead, we'll now leave it up to code contributors and reviewers to evaluate whether changes require bumping the command version, and to bump the version as part of those changes if so. This PR adds the relevant line item into the PR template.

### Testing done 

Non-functional change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

