### PR TITLE
Fix remove unnecessary complex regex

### DIFF
--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/CommandParser.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/CommandParser.java
@@ -47,7 +47,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public final class CommandParser {
-  private static final String QUOTED_STRING_OR_WHITESPACE = "('([^']*|(''))*')|\\s+";
   private static final Pattern SET_PROPERTY = Pattern.compile(
       "\\s*SET\\s+'((?:[^']*|(?:''))*)'\\s*=\\s*'((?:[^']*|(?:''))*)'\\s*;\\s*",
       Pattern.CASE_INSENSITIVE);
@@ -195,7 +194,7 @@ public final class CommandParser {
   */
   private static SqlCommand transformToSqlCommand(final String sql) {
     final List<String> tokens = Arrays
-        .stream(sql.toUpperCase().split(QUOTED_STRING_OR_WHITESPACE))
+        .stream(sql.toUpperCase().split("\\s+"))
         .filter(s -> !s.isEmpty())
         .collect(Collectors.toList());
     switch (getStatementType(tokens)) {


### PR DESCRIPTION
QUOTED_STRING_OR_WHITESPACE regex suffers from catastrophic backtracking. At the same time, the only method using this regex does not require extracting quoted strings that causes the backtracking issue.

This is a port of https://github.com/confluentinc/ksql/pull/9881 to 6.2.x.

### Testing done 

CI run - https://jenkins.confluent.io/job/Confluent%20Public%20Repo%20PR%20builder/job/ksql/job/PR-9883/1/

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
