### PR TITLE
chore: bump up fetch all remote hosts timeout

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/RemoteHostExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/RemoteHostExecutor.java
@@ -45,7 +45,7 @@ import org.apache.kafka.streams.state.HostInfo;
 
 
 public final class RemoteHostExecutor {
-  private static final int TIMEOUT_SECONDS = 10;
+  private static final int TIMEOUT_SECONDS = 20;
   private static final Logger LOG = LoggerFactory.getLogger(RemoteHostExecutor.class);
 
   private final ConfiguredStatement<?> statement;


### PR DESCRIPTION
`TerminateTransientQueryFunctionalTest` has been historically flaky, and the most recent fix was to improve the logging https://github.com/confluentinc/ksql/pull/9784.
`[2023-04-19 09:42:55,508] WARN Failed to retrieve info from host: HostInfo{host='localhost', port=1621}, statement: terminate transient_PAGEVIEW_KSTREAM_8865619672769769280;, cause: {} (io.confluent.ksql.rest.server.execution.RemoteHostExecutor:135)
java.util.concurrent.TimeoutException`

 This new improved logging indicated the issue was with the timeout in `RemoteHostExecutor`, which has it configured to 10 seconds, so we bump this up 20 seconds in this PR.

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
