### PR TITLE
docs: cherry-pick: millisecond format limit is 9 digits in PARSE_TIMESTAMP (DOCS-23668)

### DIFF
--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -1873,6 +1873,10 @@ for example:
 - "PDT"
 - "Europe/London"
 
+The timestamp format permits up to 9 digits in the millisecond field, for
+example, `yyyy-MM-dd HH:mm:ss.SSSSSSSSS`. If you provide more than 9 digits,
+the function fails to parse the timestamp.
+
 ---
 
 ### **`TIMEADD`**


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/9891.