### PR TITLE
chore: make fetch remote host timeout configurable for test

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -702,6 +702,13 @@ public class KsqlConfig extends AbstractConfig {
       + "lifespan (if present) and the value of this config. If this config is set to 0, then "
       + "ksqlDB will not close websockets even if the token has an expiration time.";
 
+  public static final String KSQL_FETCH_REMOTE_HOSTS_TIMEOUT_SECONDS
+      = "ksql.fetch.remote.hosts.max.timeout.seconds";
+  public static final long KSQL_FETCH_REMOTE_HOSTS_TIMEOUT_SECONDS_DEFAULT = 10;
+  public static final String KSQL_FETCH_REMOTE_HOSTS_TIMEOUT_SECONDS_DOC
+      = "Configure how long the remote host executor will wait for in seconds "
+      + "when fetching all remote hosts.";
+
   private enum ConfigGeneration {
     LEGACY,
     CURRENT
@@ -1502,6 +1509,13 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_CLIENT_IP_PORT_CONFIGURATION_ENABLED_DEFAULT,
             Importance.LOW,
             KSQL_CLIENT_IP_PORT_CONFIGURATION_ENABLED_DOC
+        )
+        .define(
+            KSQL_FETCH_REMOTE_HOSTS_TIMEOUT_SECONDS,
+            Type.LONG,
+            KSQL_FETCH_REMOTE_HOSTS_TIMEOUT_SECONDS_DEFAULT,
+            Importance.LOW,
+            KSQL_FETCH_REMOTE_HOSTS_TIMEOUT_SECONDS_DOC
         )
         .withClientSslSupport();
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/RemoteHostExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/RemoteHostExecutor.java
@@ -28,7 +28,6 @@ import io.confluent.ksql.rest.server.ServerUtil;
 import io.confluent.ksql.rest.util.DiscoverRemoteHostsUtil;
 import io.confluent.ksql.services.SimpleKsqlClient;
 import io.confluent.ksql.statement.ConfiguredStatement;
-import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlRequestConfig;
 import io.confluent.ksql.util.Pair;
 import io.vertx.core.logging.Logger;
@@ -125,7 +124,9 @@ public final class RemoteHostExecutor {
           : futureResponses.entrySet()) {
         try {
           final RestResponse<KsqlEntityList> response =
-              e.getValue().get(getFetchRemoteHostsTimeout(), TimeUnit.SECONDS);
+              e.getValue().get(
+                  executionContext.getKsqlConfig().getLong(KSQL_FETCH_REMOTE_HOSTS_TIMEOUT_SECONDS),
+                  TimeUnit.SECONDS);
           if (response.isErroneous()) {
             LOG.warn("Error response from host. host: {}, cause: {}",
                 e.getKey(), response.getErrorMessage().getMessage());
@@ -144,16 +145,5 @@ public final class RemoteHostExecutor {
     } finally {
       executorService.shutdown();
     }
-  }
-
-  private long getFetchRemoteHostsTimeout(){
-    final Object timeout
-        = executionContext.getKsqlConfig().getLong(KSQL_FETCH_REMOTE_HOSTS_TIMEOUT_SECONDS);
-
-    if (timeout instanceof Long) {
-      return (long) timeout;
-    }
-
-    return KsqlConfig.KSQL_FETCH_REMOTE_HOSTS_TIMEOUT_SECONDS_DEFAULT;
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/RemoteHostExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/RemoteHostExecutor.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.rest.server.ServerUtil;
 import io.confluent.ksql.rest.util.DiscoverRemoteHostsUtil;
 import io.confluent.ksql.services.SimpleKsqlClient;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlRequestConfig;
 import io.confluent.ksql.util.Pair;
 import io.vertx.core.logging.Logger;
@@ -100,8 +101,6 @@ public final class RemoteHostExecutor {
   }
 
   public Pair<Map<HostInfo, KsqlEntity>, Set<HostInfo>> fetchAllRemoteResults() {
-    final long timeout =
-        executionContext.getKsqlConfig().getLong(KSQL_FETCH_REMOTE_HOSTS_TIMEOUT_SECONDS);
     final Set<HostInfo> remoteHosts = DiscoverRemoteHostsUtil.getRemoteHosts(
         executionContext.getPersistentQueries(),
         sessionProperties.getKsqlHostInfo()
@@ -126,7 +125,7 @@ public final class RemoteHostExecutor {
           : futureResponses.entrySet()) {
         try {
           final RestResponse<KsqlEntityList> response =
-              e.getValue().get(timeout, TimeUnit.SECONDS);
+              e.getValue().get(getFetchRemoteHostsTimeout(), TimeUnit.SECONDS);
           if (response.isErroneous()) {
             LOG.warn("Error response from host. host: {}, cause: {}",
                 e.getKey(), response.getErrorMessage().getMessage());
@@ -145,5 +144,16 @@ public final class RemoteHostExecutor {
     } finally {
       executorService.shutdown();
     }
+  }
+
+  private long getFetchRemoteHostsTimeout(){
+    final Object timeout
+        = executionContext.getKsqlConfig().getLong(KSQL_FETCH_REMOTE_HOSTS_TIMEOUT_SECONDS);
+
+    if (timeout instanceof Long) {
+      return (long) timeout;
+    }
+
+    return KsqlConfig.KSQL_FETCH_REMOTE_HOSTS_TIMEOUT_SECONDS_DEFAULT;
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/TerminateTransientQueryFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/TerminateTransientQueryFunctionalTest.java
@@ -27,6 +27,7 @@ import io.confluent.ksql.rest.entity.RunningQuery;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.rest.server.utils.TestUtils;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PageViewDataProvider;
 import java.util.List;
 import java.util.Optional;
@@ -65,12 +66,14 @@ public class TerminateTransientQueryFunctionalTest {
       .withStaticServiceContext(TEST_HARNESS::getServiceContext)
       .withProperty(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:" + INT_PORT0)
       .withProperty(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "http://localhost:" + INT_PORT0)
+      .withProperty(KsqlConfig.KSQL_FETCH_REMOTE_HOSTS_TIMEOUT_SECONDS, 20)
       .build();
   private static final TestKsqlRestApp REST_APP_1 = TestKsqlRestApp
       .builder(TEST_HARNESS::kafkaBootstrapServers)
       .withStaticServiceContext(TEST_HARNESS::getServiceContext)
       .withProperty(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:" + INT_PORT1)
       .withProperty(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "http://localhost:" + INT_PORT1)
+      .withProperty(KsqlConfig.KSQL_FETCH_REMOTE_HOSTS_TIMEOUT_SECONDS, 20)
       .build();
 
   @ClassRule

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/RemoteHostExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/RemoteHostExecutorTest.java
@@ -55,8 +55,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RemoteHostExecutorTest {
-//  @Mock
-//  public final KsqlEngine executionContext = mock(KsqlEngine.class);
   private final Set<HostInfo> hosts = Stream.of("otherhost:1234", "anotherhost:444")
       .map(HostInfo::buildFromEndpoint)
       .collect(Collectors.toSet());
@@ -79,8 +77,6 @@ public class RemoteHostExecutorTest {
   public void setup() throws MalformedURLException {
     when(sessionProperties.getInternalRequest()).thenReturn(false);
     when(sessionProperties.getLocalUrl()).thenReturn(new URL("https://address"));
-//    when(executionContext.getKsqlConfig()).thenReturn(ksqlConfig);
-//    when(ksqlConfig.getLong(anyString())).thenReturn(KsqlConfig.KSQL_FETCH_REMOTE_HOSTS_TIMEOUT_SECONDS_DEFAULT);
 
     augmenter = RemoteHostExecutor.create(
         (ConfiguredStatement<DescribeStreams>) engine.configure("describe streams;"),

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/RemoteHostExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/RemoteHostExecutorTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
-import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.parser.tree.DescribeStreams;
 import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.client.RestResponse;
@@ -37,6 +36,7 @@ import io.confluent.ksql.rest.server.TemporaryEngine;
 import io.confluent.ksql.rest.util.DiscoverRemoteHostsUtil;
 import io.confluent.ksql.services.SimpleKsqlClient;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.Pair;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -55,8 +55,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RemoteHostExecutorTest {
-  @Mock
-  public final KsqlEngine executionContext = mock(KsqlEngine.class);
+//  @Mock
+//  public final KsqlEngine executionContext = mock(KsqlEngine.class);
   private final Set<HostInfo> hosts = Stream.of("otherhost:1234", "anotherhost:444")
       .map(HostInfo::buildFromEndpoint)
       .collect(Collectors.toSet());
@@ -70,6 +70,8 @@ public class RemoteHostExecutorTest {
   private RestResponse<KsqlEntityList> response;
   @Mock
   private KsqlEntityList ksqlEntityList;
+  @Mock
+  private KsqlConfig ksqlConfig;
   private RemoteHostExecutor augmenter;
 
   @SuppressWarnings("unchecked")
@@ -77,13 +79,14 @@ public class RemoteHostExecutorTest {
   public void setup() throws MalformedURLException {
     when(sessionProperties.getInternalRequest()).thenReturn(false);
     when(sessionProperties.getLocalUrl()).thenReturn(new URL("https://address"));
+//    when(executionContext.getKsqlConfig()).thenReturn(ksqlConfig);
+//    when(ksqlConfig.getLong(anyString())).thenReturn(KsqlConfig.KSQL_FETCH_REMOTE_HOSTS_TIMEOUT_SECONDS_DEFAULT);
 
     augmenter = RemoteHostExecutor.create(
         (ConfiguredStatement<DescribeStreams>) engine.configure("describe streams;"),
         sessionProperties,
-        executionContext,
+        engine.getEngine(),
         ksqlClient);
-
   }
 
   @Test


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

`TerminateTransientQueryFunctionalTest` has been historically flaky, and the most recent fix was to improve the logging https://github.com/confluentinc/ksql/pull/9784.
`[2023-04-19 09:42:55,508] WARN Failed to retrieve info from host: HostInfo{host='localhost', port=1621}, statement: terminate transient_PAGEVIEW_KSTREAM_8865619672769769280;, cause: {} (io.confluent.ksql.rest.server.execution.RemoteHostExecutor:135) java.util.concurrent.TimeoutException
`
This new improved logging indicated the issue was with the timeout in RemoteHostExecutor, which has it configured to 10 seconds, so we bump this up 20 seconds in this PR.

Address feedback on https://github.com/confluentinc/ksql/pull/9890
### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
