### PR TITLE
Upgrade netty to 4.1.87.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,8 +151,8 @@
              Please check top level `pom.xml` at https://github.com/netty/netty
              for the netty version we bump to (ie, corresponding git tag),
              to find the correct `tcnative` version. -->
-        <netty.version>4.1.86.Final</netty.version>
-        <netty-codec-http2-version>4.1.86.Final</netty-codec-http2-version>
+        <netty.version>4.1.87.Final</netty.version>
+        <netty-codec-http2-version>4.1.87.Final</netty-codec-http2-version>
         <jersey-common>2.34</jersey-common>
         <multi-threaded-testing.forkCount>3</multi-threaded-testing.forkCount>
         <kafka.version>${ce.kafka.version}</kafka.version>


### PR DESCRIPTION
### Description 
```
java.lang.NoSuchMethodError: 'void io.netty.handler.ssl.SniHandler.<init>(io.netty.util.AsyncMapping, long)'
	at io.vertx.core.net.impl.VertxSniHandler.<init>(VertxSniHandler.java:33)
	at io.vertx.core.net.impl.SSLHelper.createSniHandler(SSLHelper.java:347)
	at io.vertx.core.net.impl.SSLHelper.createHandler(SSLHelper.java:352)
	at io.vertx.core.http.impl.HttpServerWorker.configurePipeline(HttpServerWorker.java:139)
	at io.vertx.core.http.impl.HttpServerWorker.handle(HttpServerWorker.java:132)
	at io.vertx.core.http.impl.HttpServerWorker.handle(HttpServerWorker.java:55)
	at io.vertx.core.net.impl.ServerChannelLoadBalancer.initChannel(ServerChannelLoadBalancer.java:61)
	at io.netty.channel.ChannelInitializer.initChannel(ChannelInitializer.java:129)
	at io.netty.channel.ChannelInitializer.handlerAdded(ChannelInitializer.java:112)
	at io.netty.channel.AbstractChannelHandlerContext.callHandlerAdded(AbstractChannelHandlerContext.java:1114)
	at io.netty.channel.DefaultChannelPipeline.callHandlerAdded0(DefaultChannelPipeline.java:609)
	at io.netty.channel.DefaultChannelPipeline.access$100(DefaultChannelPipeline.java:46)
	at io.netty.channel.DefaultChannelPipeline$PendingHandlerAddedTask.execute(DefaultChannelPipeline.java:1463)
	at io.netty.channel.DefaultChannelPipeline.callHandlerAddedForAllHandlers(DefaultChannelPipeline.java:1115)
	at io.netty.channel.DefaultChannelPipeline.invokeHandlerAddedIfNeeded(DefaultChannelPipeline.java:650)
	at io.netty.channel.AbstractChannel$AbstractUnsafe.register0(AbstractChannel.java:514)
	at io.netty.channel.AbstractChannel$AbstractUnsafe.access$200(AbstractChannel.java:429)
	at io.netty.channel.AbstractChannel$AbstractUnsafe$1.run(AbstractChannel.java:486)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)
```
The SNI handler constructor was introduced in all versions starting netty-4.1.87.Final. See the PR - https://github.com/netty/netty/commit/0bcc6c8a5d41535fe0f9f428dd53235b53c8d4e2 . This is mostly likely caused by bump to new vert.x version here - https://github.com/confluentinc/ksql/pull/9899

### Testing done 
Tests passing in Jenkins

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
