### PR TITLE
Use https for repository

### DIFF
--- a/docs/developer-guide/ksqldb-clients/java-client.md
+++ b/docs/developer-guide/ksqldb-clients/java-client.md
@@ -110,7 +110,7 @@ Start by creating a `pom.xml` for your Java application:
 
 !!! note
       If you’re using ksqlDB for Confluent Platform (CP), use the CP-specific modules
-      from [http://packages.confluent.io/maven/](http://packages.confluent.io/maven/)
+      from [https://packages.confluent.io/maven/](https://packages.confluent.io/maven/)
       by replacing the repositories in the example POM above with a repository with this
       URL instead. Also update `ksqldb.version` to be a CP version, such as `{{ site.cprelease }}`, instead.
 


### PR DESCRIPTION

### Description 
Since Maven 3.8.1, non-ssl maven repositories are blocked. We need to use https here.

### Testing done 
manually executed the steps

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
