### PR TITLE
docs: cherry-pick: fix link to 0.28.2 blog post (DOCS-23732)

### DIFF
--- a/docs/operate-and-deploy/changelog.md
+++ b/docs/operate-and-deploy/changelog.md
@@ -9,7 +9,7 @@ keywords: ksqldb, changelog
 Version 0.28.2
 --------------
 
-- [Announcing ksqlDB 0.28.2](https://www.confluent.io/blog/announcing-ksqldb-0-28-2-and-improvements-in-confluent-cloud/)
+- [Announcing ksqlDB 0.28.2](https://www.confluent.io/blog/announcing-ksqldb-0-28-2-and-improvements-to-ksqldb-in-confluent-cloud/)
 - [ksqlDB v0.28.2 changelog](https://github.com/confluentinc/ksql/blob/master/CHANGELOG.md#0282-2022-08-02)
 
 Version 0.27.1


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/9896.