### PR TITLE
Bump io.confluent.schema-registry.version to 7.6.0-0 after bumping ksql version to 7.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
         <apache.io.version>2.7</apache.io.version>
         <io.confluent.ksql.version>7.6.0-0</io.confluent.ksql.version>
-        <io.confluent.schema-registry.version>7.5.0-811</io.confluent.schema-registry.version>
+        <io.confluent.schema-registry.version>7.6.0-0</io.confluent.schema-registry.version>
         <netty-tcnative-version>2.0.54.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`


### PR DESCRIPTION
On master, `io.confluent.ksql.version` is `7.6.0-0`, but `io.confluent.schema-registry.version` is `7.5.0-811`
which supposedly causes packaging build [failure](https://jenkins.confluent.io/view/Packaging%20Snapshot/job/confluentinc/job/packaging/job/master/3518/execution/node/323/log/).
