### PR TITLE
fix: do not scan the whole classpath

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UserFunctionLoader.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UserFunctionLoader.java
@@ -133,7 +133,8 @@ public class UserFunctionLoader {
   private ClassGraph.ClasspathElementFilter ksqlEngineFilter(final ClassLoader loader) {
     // if we are loading from the parent classloader then restrict the name space to only
     // jars/dirs containing "ksql-engine". This is so we don't end up scanning every jar
-    return name -> parentClassLoader != loader || name.contains("ksqldb-engine");
+    return name -> parentClassLoader != loader || name.contains("ksqldb-rest-app")
+        || name.contains("ksqldb-engine");
   }
 
   public static UserFunctionLoader newInstance(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UserFunctionLoader.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UserFunctionLoader.java
@@ -133,8 +133,7 @@ public class UserFunctionLoader {
   private ClassGraph.ClasspathElementFilter ksqlEngineFilter(final ClassLoader loader) {
     // if we are loading from the parent classloader then restrict the name space to only
     // jars/dirs containing "ksql-engine". This is so we don't end up scanning every jar
-    //return name -> parentClassLoader != loader || name.contains("ksqldb-engine");
-    return name -> true;
+    return name -> parentClassLoader != loader || name.contains("ksqldb-engine");
   }
 
   public static UserFunctionLoader newInstance(


### PR DESCRIPTION
We scanned the whole classpath for UDF functions, while we should only scan the UDF directory and the ksql-engine jar.

This is a regression introduced in Scalable push queries end to end #7661.
