### PR TITLE
test: update QTT for KIP-904 and KAFKA-7499

### DIFF
--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/average-udaf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/average-udaf.json
@@ -106,8 +106,6 @@
         {"topic": "OUTPUT", "key": "a", "value": {"AVG": 1.0}},
         {"topic": "OUTPUT", "key": "a", "value": {"AVG": 1.5}},
         {"topic": "OUTPUT", "key": "a", "value": {"AVG": 2.0}},
-        {"topic": "OUTPUT", "key": "a", "value": {"AVG": 2.0}},
-        {"topic": "OUTPUT", "key": "a", "value": {"AVG": 2.0}},
         {"topic": "OUTPUT", "key": "a", "value": {"AVG": 3.0}}
       ]
     }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/collect-list.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/collect-list.json
@@ -305,10 +305,8 @@
       ],
       "outputs": [
         {"topic": "S2", "key": 0, "value": {"COLLECTED": [0]}},
-        {"topic": "S2", "key": 0, "value": {"COLLECTED": []}},
         {"topic": "S2", "key": 0, "value": {"COLLECTED": [100]}},
         {"topic": "S2", "key": 100, "value": {"COLLECTED": [500]}},
-        {"topic": "S2", "key": 100, "value": {"COLLECTED": []}},
         {"topic": "S2", "key": 100, "value": {"COLLECTED": [100]}}
       ]
     },
@@ -327,10 +325,8 @@
       ],
       "outputs": [
         {"topic": "S2", "key": 0, "value": {"COLLECTED": [2147483648]}},
-        {"topic": "S2", "key": 0, "value": {"COLLECTED": []}},
         {"topic": "S2", "key": 0, "value": {"COLLECTED": [100]}},
         {"topic": "S2", "key": 100, "value": {"COLLECTED": [500]}},
-        {"topic": "S2", "key": 100, "value": {"COLLECTED": []}},
         {"topic": "S2", "key": 100, "value": {"COLLECTED": [100]}}
       ]
     },
@@ -349,10 +345,8 @@
       ],
       "outputs": [
         {"topic": "S2", "key": 0,"value": {"COLLECTED": [5.4]}},
-        {"topic": "S2", "key": 0,"value": {"COLLECTED": []}},
         {"topic": "S2", "key": 0,"value": {"COLLECTED": [100.1]}},
         {"topic": "S2", "key": 100,"value": {"COLLECTED": [500.9]}},
-        {"topic": "S2", "key": 100,"value": {"COLLECTED": []}},
         {"topic": "S2", "key": 100,"value": {"COLLECTED": [300.8]}}
       ]
     },
@@ -373,11 +367,8 @@
       "outputs": [
         {"topic": "S2", "key": 0,"value": {"COLLECTED": ["foo"]}},
         {"topic": "S2", "key": 100,"value": {"COLLECTED": ["baz"]}},
-        {"topic": "S2", "key": 0,"value": {"COLLECTED": []}},
         {"topic": "S2", "key": 0,"value": {"COLLECTED": ["bar"]}},
-        {"topic": "S2", "key": 100,"value": {"COLLECTED": []}},
         {"topic": "S2", "key": 100,"value": {"COLLECTED": ["baz"]}},
-        {"topic": "S2", "key": 100,"value": {"COLLECTED": []}},
         {"topic": "S2", "key": 100,"value": {"COLLECTED": ["foo"]}}
       ]
     },
@@ -395,9 +386,7 @@
       ],
       "outputs": [
         {"topic": "S2", "key": 0,"value": {"COLLECTED":[true]}},
-        {"topic": "S2", "key": 0,"value": {"COLLECTED":[]}},
         {"topic": "S2", "key": 0,"value": {"COLLECTED":[false]}},
-        {"topic": "S2", "key": 0,"value": {"COLLECTED":[]}},
         {"topic": "S2", "key": 0,"value": {"COLLECTED":[true]}}
       ]
     },
@@ -415,9 +404,7 @@
       ],
       "outputs": [
         {"topic": "S2", "key": 0, "value": {"COLLECTED":[10]}},
-        {"topic": "S2", "key": 0, "value": {"COLLECTED":[]}},
         {"topic": "S2", "key": 0, "value": {"COLLECTED":[20]}},
-        {"topic": "S2", "key": 0, "value": {"COLLECTED":[]}},
         {"topic": "S2", "key": 0, "value": {"COLLECTED":[30]}}
       ]
     },
@@ -435,9 +422,7 @@
       ],
       "outputs": [
         {"topic": "S2", "key": 0, "value": {"COLLECTED":[10]}},
-        {"topic": "S2", "key": 0, "value": {"COLLECTED":[]}},
         {"topic": "S2", "key": 0, "value": {"COLLECTED":[20]}},
-        {"topic": "S2", "key": 0, "value": {"COLLECTED":[]}},
         {"topic": "S2", "key": 0, "value": {"COLLECTED":[30]}}
       ]
     },
@@ -455,9 +440,7 @@
       ],
       "outputs": [
         {"topic": "S2", "key": 0, "value": {"COLLECTED":[10]}},
-        {"topic": "S2", "key": 0, "value": {"COLLECTED":[]}},
         {"topic": "S2", "key": 0, "value": {"COLLECTED":[20]}},
-        {"topic": "S2", "key": 0, "value": {"COLLECTED":[]}},
         {"topic": "S2", "key": 0, "value": {"COLLECTED":[30]}}
       ]
     },
@@ -474,7 +457,6 @@
       ],
       "outputs": [
         {"topic": "S2", "key": 0, "value": {"COLLECTED":["YQ=="]}},
-        {"topic": "S2", "key": 0, "value": {"COLLECTED":[]}},
         {"topic": "S2", "key": 0, "value": {"COLLECTED":["Yg=="]}}
       ]
     },

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/correlation-udaf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/correlation-udaf.json
@@ -106,7 +106,6 @@
         {"topic": "OUTPUT", "key": "a", "value": {"CORRELATION": "NaN"}},
         {"topic": "OUTPUT", "key": "a", "value": {"CORRELATION": 1.0}},
         {"topic": "OUTPUT", "key": "a", "value": {"CORRELATION": "NaN"}},
-        {"topic": "OUTPUT", "key": "a", "value": {"CORRELATION": "NaN"}},
         {"topic": "OUTPUT", "key": "a", "value": {"CORRELATION": -0.7205766921228921}}
       ]
     }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/elements.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/elements.json
@@ -1328,7 +1328,7 @@
       "outputs": [{"topic": "OUTPUT", "key": 42, "value": {"c1": 4}}],
       "expectedException": {
         "type": "org.apache.kafka.streams.errors.StreamsException",
-        "message": "Error serializing message to topic: OUTPUT. Missing default value for required Avro field: [c2]. This field appears in Avro schema in Schema Registry\nHint: You probably forgot to add VALUE_SCHEMA_ID when creating the source."
+        "message": "Unable to serialize record. ProducerRecord(topic=[OUTPUT], partition=[null], timestamp=[0]"
       }
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
@@ -1579,9 +1579,7 @@
       ],
       "outputs": [
         {"topic": "OUTPUT", "key": 2, "value": "20"},
-        {"topic": "OUTPUT", "key": 2, "value": "0"},
         {"topic": "OUTPUT", "key": 2, "value": "40"},
-        {"topic": "OUTPUT", "key": 2, "value": "0"},
         {"topic": "OUTPUT", "key": 2, "value": "60"},
         {"topic": "OUTPUT", "key": 2, "value": "0"}
       ]
@@ -1846,7 +1844,6 @@
         {"topic": "OUTPUT", "key": 1, "value": "2"},
         {"topic": "OUTPUT", "key": 1, "value": "3"},
         {"topic": "OUTPUT", "key": 1, "value": "2"},
-        {"topic": "OUTPUT", "key": 1, "value": "1"},
         {"topic": "OUTPUT", "key": 1, "value": "2"}
       ]
     },
@@ -2527,13 +2524,9 @@
       "outputs": [
         {"topic": "OUTPUT", "key": 0,"value": {"SUM": 100}},
         {"topic": "OUTPUT", "key": 1,"value": {"SUM": 101}},
-        {"topic": "OUTPUT", "key": 0,"value": null},
         {"topic": "OUTPUT", "key": 0,"value": {"SUM": 105}},
-        {"topic": "OUTPUT", "key": 1,"value": null},
         {"topic": "OUTPUT", "key": 1,"value": {"SUM": 111}},
-        {"topic": "OUTPUT", "key": 0,"value": null},
         {"topic": "OUTPUT", "key": 0,"value": {"SUM": 120}},
-        {"topic": "OUTPUT", "key": 0,"value": null},
         {"topic": "OUTPUT", "key": 0,"value": {"SUM": 100}}
       ]
     },

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/sum.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/sum.json
@@ -41,13 +41,9 @@
       "outputs": [
         {"topic": "OUTPUT", "key": 0,"value": {"SUM": 0}},
         {"topic": "OUTPUT", "key": 1,"value": {"SUM": 0}},
-        {"topic": "OUTPUT", "key": 0,"value": {"SUM": 0}},
         {"topic": "OUTPUT", "key": 0,"value": {"SUM": 5}},
-        {"topic": "OUTPUT", "key": 1,"value": {"SUM": 0}},
         {"topic": "OUTPUT", "key": 1,"value": {"SUM": 10}},
-        {"topic": "OUTPUT", "key": 0,"value": {"SUM": 0}},
         {"topic": "OUTPUT", "key": 0,"value": {"SUM": 20}},
-        {"topic": "OUTPUT", "key": 0,"value": {"SUM": 0}},
         {"topic": "OUTPUT", "key": 0,"value": {"SUM": 0}}
       ]
     },


### PR DESCRIPTION
### Description 

Some QTTs are failing now that [KIP-904](https://cwiki.apache.org/confluence/display/KAFKA/KIP-904%3A+Kafka+Streams+-+Guarantee+subtractor+is+called+before+adder+if+key+has+not+changed) has been merged because KIP-904 results in table aggregates for the same key being processed as a single update, rather than two (removal followed by addition). This PR updates the failing tests to reflect the new behavior.

This PR also contains another test update for KAFKA-7499 ([PR](https://github.com/apache/kafka/pull/13477)). The test in `elements.json` checked for a specific error message, but that error is now nested inside another one as a result of the linked PR. This PR updates the expected message to be the new outer message instead; we could also remove the test entirely if that's preferable since it's no longer checking for a message generated by ksql. 

### Testing done 

Test-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
