### PR TITLE
chore: fix tests for updated Schema Registry client internals

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatterTest.java
@@ -28,17 +28,16 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Message;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.connect.protobuf.ProtobufData;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.json.JsonSchema;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
@@ -1228,9 +1227,7 @@ public class RecordFormatterTest {
       final Map<String, String> props = new HashMap<>();
       props.put("schema.registry.url", "localhost:9092");
 
-      final SchemaRegistryClient schemaRegistryClient = mock(SchemaRegistryClient.class);
-      when(schemaRegistryClient.ticker()).thenReturn(Ticker.systemTicker());
-      return new KafkaAvroSerializer(schemaRegistryClient, props);
+      return new KafkaAvroSerializer(new MockSchemaRegistryClient(), props);
     }
 
     private static Message protobufRecord() {
@@ -1250,18 +1247,14 @@ public class RecordFormatterTest {
       final Map<String, String> props = new HashMap<>();
       props.put("schema.registry.url", "localhost:9092");
 
-      final SchemaRegistryClient schemaRegistryClient = mock(SchemaRegistryClient.class);
-      when(schemaRegistryClient.ticker()).thenReturn(Ticker.systemTicker());
-      return new KafkaProtobufSerializer<>(schemaRegistryClient, props);
+      return new KafkaProtobufSerializer<>(new MockSchemaRegistryClient(), props);
     }
 
     private static Serializer<Object> jsonSrSerializer() {
       final Map<String, String> props = new HashMap<>();
       props.put("schema.registry.url", "localhost:9092");
 
-      final SchemaRegistryClient schemaRegistryClient = mock(SchemaRegistryClient.class);
-      when(schemaRegistryClient.ticker()).thenReturn(Ticker.systemTicker());
-      return new KafkaJsonSchemaSerializer<>(schemaRegistryClient, props);
+      return new KafkaJsonSchemaSerializer<>(new MockSchemaRegistryClient(), props);
     }
   }
 

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSchemaDeserializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSchemaDeserializerTest.java
@@ -3,14 +3,11 @@ package io.confluent.ksql.serde.json;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.serde.connect.ConnectKsqlSchemaTranslator;
 import io.confluent.ksql.util.KsqlConfig;
@@ -85,8 +82,8 @@ public class KsqlJsonSchemaDeserializerTest {
   public void before() throws Exception {
     schema = (new JsonSchemaTranslator()).fromConnectSchema(ORDER_SCHEMA.schema());
 
-    schemaRegistryClient = mock(SchemaRegistryClient.class);
-    when(schemaRegistryClient.getSchemaBySubjectAndId(anyString(), anyInt())).thenReturn(schema);
+    schemaRegistryClient = new MockSchemaRegistryClient();
+    schemaRegistryClient.register(SOME_TOPIC, schema);
 
     final KsqlJsonSerdeFactory jsonSerdeFactory =
         new KsqlJsonSerdeFactory(new JsonSchemaProperties(ImmutableMap.of()));

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
         <apache.io.version>2.7</apache.io.version>
         <io.confluent.ksql.version>7.6.0-0</io.confluent.ksql.version>
-        <io.confluent.schema-registry.version>7.6.0-0</io.confluent.schema-registry.version>
+        <io.confluent.schema-registry.version>7.6.0-26</io.confluent.schema-registry.version>
         <netty-tcnative-version>2.0.54.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`


### PR DESCRIPTION
### Description 

Some unit tests are failing in the build after https://github.com/confluentinc/schema-registry/pull/2674 was merged, due to improper usage of mock SR clients on the ksql side. We should be using the provided `MockSchemaRegistryClient` implementation rather than `Mockito.mock(SchemaRegistryClient.class)` since the methods which need to be mocked when using the latter are implementation details of SR which are subject to change.

The specific failure in this case is that a new internal method added to the `SchemaRegistryClient` usage is resulting in an NPE in our unit tests because the unit tests do not provide mocked implementations for this new method. Here's an example failure from `KsqlJsonSchemaDeserializerTest.shouldDeserializeJsonObjectCorrectly`:
```
Error serializing message to topic: bob. Converting Kafka Connect data to byte[] failed due to serialization error of topic bob: 
Hint: You probably forgot to add VALUE_SCHEMA_ID when creating the source.
	at io.confluent.ksql.serde.connect.KsqlConnectSerializer.serialize(KsqlConnectSerializer.java:56)
	at io.confluent.ksql.serde.tls.ThreadLocalSerializer.serialize(ThreadLocalSerializer.java:37)
	at io.confluent.ksql.serde.json.KsqlJsonSchemaDeserializerTest.shouldDeserializeJsonObjectCorrectly(KsqlJsonSchemaDeserializerTest.java:109)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.mockito.internal.runners.DefaultInternalRunner$1$1.evaluate(DefaultInternalRunner.java:55)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.mockito.internal.runners.DefaultInternalRunner$1.run(DefaultInternalRunner.java:100)
	at org.mockito.internal.runners.DefaultInternalRunner.run(DefaultInternalRunner.java:107)
	at org.mockito.internal.runners.StrictRunner.run(StrictRunner.java:41)
	at org.mockito.junit.MockitoJUnitRunner.run(MockitoJUnitRunner.java:163)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
	at org.junit.vintage.engine.execution.RunnerExecutor.execute(RunnerExecutor.java:42)
	at org.junit.vintage.engine.VintageTestEngine.executeAllChildren(VintageTestEngine.java:80)
	at org.junit.vintage.engine.VintageTestEngine.execute(VintageTestEngine.java:72)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:107)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
	at org.apache.maven.surefire.junitplatform.LazyLauncher.execute(LazyLauncher.java:55)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:223)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:175)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:139)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:456)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:169)
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:595)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:581)
Caused by: org.apache.kafka.connect.errors.DataException: Converting Kafka Connect data to byte[] failed due to serialization error of topic bob: 
	at io.confluent.connect.json.JsonSchemaConverter.fromConnectData(JsonSchemaConverter.java:106)
	at io.confluent.connect.json.JsonSchemaConverter.fromConnectData(JsonSchemaConverter.java:87)
	at io.confluent.ksql.serde.connect.KsqlConnectSerializer.serialize(KsqlConnectSerializer.java:53)
	... 49 more
Caused by: org.apache.kafka.common.errors.SerializationException: Error serializing JSON message
	at io.confluent.kafka.serializers.json.AbstractKafkaJsonSchemaSerializer.serializeImpl(AbstractKafkaJsonSchemaSerializer.java:166)
	at io.confluent.connect.json.JsonSchemaConverter$Serializer.serialize(JsonSchemaConverter.java:175)
	at io.confluent.connect.json.JsonSchemaConverter.fromConnectData(JsonSchemaConverter.java:98)
	... 51 more
Caused by: java.lang.NullPointerException
	at io.confluent.kafka.schemaregistry.client.rest.entities.Schema.<init>(Schema.java:169)
	at io.confluent.kafka.serializers.AbstractKafkaSchemaSerDe.registerWithResponse(AbstractKafkaSchemaSerDe.java:507)
	at io.confluent.kafka.serializers.json.AbstractKafkaJsonSchemaSerializer.serializeImpl(AbstractKafkaJsonSchemaSerializer.java:126)
	... 53 more
```

This PR fixes the failing tests by updating our mock SR client usage to `MockSchemaRegistryClient`. 

This PR also contains an additional fix for the SR dependency version: it was set to `7.6.0-0` in this [PR](https://github.com/confluentinc/ksql/pull/9969) which is a mistake -- setting the version to a `-0` nanoversion means that Jenkins no longer automatically bumps the version as new nanoversions are released (here's an [example](https://github.com/confluentinc/ksql/commit/d02ab8b4ec24a6754e6adac2b9a76bf91ec3ac26) of where this previously happened), which means ksql development locally will not match what's seen in Jenkins, since Jenkins continually recompiles the latest schema-registry whereas ksql developers typically do not. 

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
