### PR TITLE
fix: SandboxedSchemaRegistryClient does not impl. new registerWithResponse SR API

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/DefaultSchemaRegistryClient.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/DefaultSchemaRegistryClient.java
@@ -20,8 +20,12 @@ import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlSchemaRegistryNotConfiguredException;
+
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -65,6 +69,14 @@ public class DefaultSchemaRegistryClient implements SchemaRegistryClient {
 
   @Override
   public int register(final String s, final ParsedSchema parsedSchema, final int i, final int i1) {
+    throw configException;
+  }
+
+  @Override
+  public RegisterSchemaResponse registerWithResponse(
+    final String subject,
+    final ParsedSchema schema,
+    final boolean normalize) throws IOException, RestClientException {
     throw configException;
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
@@ -22,6 +22,7 @@ import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import java.io.IOException;
 import java.util.Collection;
@@ -94,6 +95,14 @@ final class SandboxedSchemaRegistryClient {
         final int version,
         final int id) {
       return -1; // swallow
+    }
+
+    @Override
+    public RegisterSchemaResponse registerWithResponse(
+        final String subject,
+        final ParsedSchema schema,
+        final boolean normalize) throws IOException, RestClientException {
+      return sandboxCacheClient.registerWithResponse(subject, schema, normalize);
     }
 
     @Deprecated


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

Ksql SR schema registration fails because `SandboxedSchemaRegistryClient` does not implement the new API `registerWithResponse`.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
