### PR TITLE
fix: cast UnwrappedDeserializer's bytes argument

### DIFF
--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/unwrapped/UnwrappedDeserializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/unwrapped/UnwrappedDeserializerTest.java
@@ -38,7 +38,7 @@ public class UnwrappedDeserializerTest {
     deserializer = new UnwrappedDeserializer(inner);
 
     when(inner.deserialize(any(), any())).thenReturn(DESERIALIZED);
-    when(inner.deserialize(any(), any(), any())).thenReturn(DESERIALIZED);
+    when(inner.deserialize(any(), any(), (byte[]) any())).thenReturn(DESERIALIZED);
   }
 
   @Test
@@ -74,7 +74,7 @@ public class UnwrappedDeserializerTest {
   @Test
   public void shouldDeserializeNewStyleNulls() {
     // When:
-    final List<?> result = deserializer.deserialize(TOPIC, HEADERS, null);
+    final List<?> result = deserializer.deserialize(TOPIC, HEADERS, (byte[]) null);
 
     // Then:
     assertThat(result, is(nullValue()));


### PR DESCRIPTION

### Description 

This commit fixes "reference to deserialize is ambiguous" compilation error in UnwrappedDeserializerTest.


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
