### PR TITLE
chore: switch schema registry dependency to use version range

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
@@ -68,6 +68,11 @@ final class SandboxedSchemaRegistryClient {
     }
 
     @Override
+    public String tenant() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Optional<ParsedSchema> parseSchema(
         final String schemaType,
         final String schemaString,

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
         <apache.io.version>2.7</apache.io.version>
         <io.confluent.ksql.version>7.6.0-0</io.confluent.ksql.version>
-        <io.confluent.schema-registry.version>7.6.0-26</io.confluent.schema-registry.version>
+        <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
         <netty-tcnative-version>2.0.54.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`


### PR DESCRIPTION
### Description 

Previously, setting the schema registry dependency version to a specific nanoversion resulted in the dependency being auto-bumped as new nanoversions were created ([example](https://github.com/confluentinc/ksql/commit/d02ab8b4ec24a6754e6adac2b9a76bf91ec3ac26)) but this is no longer happening. Interestingly, the common dependency was recently switched from a specific nanoversion back to a version range ([link](https://github.com/confluentinc/ksql/commit/fb5923a5d7f31d656ec885671e07fd2382948f75#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L32)), which could be related to why the SR dep is no longer being auto-bumped. This PR switches the SR dep back to using a version range as well, as it'd be good to keep the two in sync ([example](https://github.com/confluentinc/ksql/pull/9815/files)). 

As part doing so, I had to add the new `tenant()` method ([link](https://github.com/confluentinc/schema-registry/commit/f1fdcd52b49fdc1100082c72107f503fd17eda22)) to the `SandboxedSchemaRegistryClient` in order to get `SandboxedSchemaRegistryClientTest#shouldThrowOnUnsupportedOperation()` to pass, as this test verifies that all methods in the `SchemaRegistryClient` interface are either explicitly supported or unsupported by the sandbox.

### Testing done 

N/A

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
