### PR TITLE
chore: fix tests for updated Schema Registry client internals (#9982)

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatterTest.java
@@ -28,17 +28,16 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Message;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.connect.protobuf.ProtobufData;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.json.JsonSchema;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
@@ -1228,9 +1227,7 @@ public class RecordFormatterTest {
       final Map<String, String> props = new HashMap<>();
       props.put("schema.registry.url", "localhost:9092");
 
-      final SchemaRegistryClient schemaRegistryClient = mock(SchemaRegistryClient.class);
-      when(schemaRegistryClient.ticker()).thenReturn(Ticker.systemTicker());
-      return new KafkaAvroSerializer(schemaRegistryClient, props);
+      return new KafkaAvroSerializer(new MockSchemaRegistryClient(), props);
     }
 
     private static Message protobufRecord() {
@@ -1250,18 +1247,14 @@ public class RecordFormatterTest {
       final Map<String, String> props = new HashMap<>();
       props.put("schema.registry.url", "localhost:9092");
 
-      final SchemaRegistryClient schemaRegistryClient = mock(SchemaRegistryClient.class);
-      when(schemaRegistryClient.ticker()).thenReturn(Ticker.systemTicker());
-      return new KafkaProtobufSerializer<>(schemaRegistryClient, props);
+      return new KafkaProtobufSerializer<>(new MockSchemaRegistryClient(), props);
     }
 
     private static Serializer<Object> jsonSrSerializer() {
       final Map<String, String> props = new HashMap<>();
       props.put("schema.registry.url", "localhost:9092");
 
-      final SchemaRegistryClient schemaRegistryClient = mock(SchemaRegistryClient.class);
-      when(schemaRegistryClient.ticker()).thenReturn(Ticker.systemTicker());
-      return new KafkaJsonSchemaSerializer<>(schemaRegistryClient, props);
+      return new KafkaJsonSchemaSerializer<>(new MockSchemaRegistryClient(), props);
     }
   }
 

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSchemaDeserializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSchemaDeserializerTest.java
@@ -3,14 +3,11 @@ package io.confluent.ksql.serde.json;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.serde.connect.ConnectKsqlSchemaTranslator;
 import io.confluent.ksql.util.KsqlConfig;
@@ -85,8 +82,8 @@ public class KsqlJsonSchemaDeserializerTest {
   public void before() throws Exception {
     schema = (new JsonSchemaTranslator()).fromConnectSchema(ORDER_SCHEMA.schema());
 
-    schemaRegistryClient = mock(SchemaRegistryClient.class);
-    when(schemaRegistryClient.getSchemaBySubjectAndId(anyString(), anyInt())).thenReturn(schema);
+    schemaRegistryClient = new MockSchemaRegistryClient();
+    schemaRegistryClient.register(SOME_TOPIC, schema);
 
     final KsqlJsonSerdeFactory jsonSerdeFactory =
         new KsqlJsonSerdeFactory(new JsonSchemaProperties(ImmutableMap.of()));


### PR DESCRIPTION
This PR cherrypicked the commit [here](https://github.com/confluentinc/ksql/commit/1c8979460c0704320a8145f0d1db6a49b22d17c1) in order to backporting fixes to 7.4.x so that the unit tests pass.
