### PR TITLE
chore: bump SR version

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
@@ -22,6 +22,7 @@ import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import java.io.IOException;
 import java.util.Collection;
@@ -68,6 +69,11 @@ final class SandboxedSchemaRegistryClient {
     }
 
     @Override
+    public String tenant() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Optional<ParsedSchema> parseSchema(
         final String schemaType,
         final String schemaString,
@@ -94,6 +100,14 @@ final class SandboxedSchemaRegistryClient {
         final int version,
         final int id) {
       return -1; // swallow
+    }
+
+    @Override
+    public RegisterSchemaResponse registerWithResponse(
+        final String subject,
+        final ParsedSchema schema,
+        final boolean normalize) {
+      throw new UnsupportedOperationException();
     }
 
     @Deprecated

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
         <apache.io.version>2.7</apache.io.version>
         <io.confluent.ksql.version>7.6.0-0</io.confluent.ksql.version>
-        <io.confluent.schema-registry.version>7.6.0-26</io.confluent.schema-registry.version>
+        <io.confluent.schema-registry.version>7.6.0-51</io.confluent.schema-registry.version>
         <netty-tcnative-version>2.0.54.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`


### PR DESCRIPTION
Current master is blocked by not being able to bump SR version
