### PR TITLE
fix: implement default method for schema registry client

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
@@ -22,6 +22,7 @@ import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import java.io.IOException;
 import java.util.Collection;
@@ -73,6 +74,13 @@ final class SandboxedSchemaRegistryClient {
         final String schemaString,
         final List<SchemaReference> references) {
       throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RegisterSchemaResponse registerWithResponse(
+        final String subject, final ParsedSchema schema, final boolean normalize)
+        throws IOException, RestClientException {
+      return sandboxCacheClient.registerWithResponse(subject, schema, normalize);
     }
 
     @Override

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedSchemaRegistryClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedSchemaRegistryClientTest.java
@@ -64,6 +64,7 @@ public final class SandboxedSchemaRegistryClientTest {
           .ignore("register", String.class, Schema.class, int.class, int.class)
           .ignore("register", String.class, ParsedSchema.class, int.class, int.class)
           .ignore("getLatestSchemaMetadata", String.class)
+          .ignore("registerWithResponse", String.class, ParsedSchema.class, boolean.class)
           .ignore("getSchemaBySubjectAndId", String.class, int.class)
           .ignore("testCompatibility", String.class, Schema.class)
           .ignore("testCompatibility", String.class, ParsedSchema.class)

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/serde/json/ValueSpecJsonSchemaSerdeSupplierTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/serde/json/ValueSpecJsonSchemaSerdeSupplierTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
@@ -13,15 +14,20 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ValueSpecJsonSchemaSerdeSupplierTest {
-  @Mock
+
   private SchemaRegistryClient srClient;
+
+  @Before
+  public void setUp() {
+    srClient = new MockSchemaRegistryClient();
+  }
 
   @Test
   public void shouldSerializeAndDeserializeDecimalsWithOutStrippingTrailingZeros() throws RestClientException, IOException {
@@ -30,33 +36,29 @@ public class ValueSpecJsonSchemaSerdeSupplierTest {
 
     final Serializer<Object> serializer = srSerde.getSerializer(srClient, false);
     final Deserializer<Object> deserializer = srSerde.getDeserializer(srClient, false);
-
-    when(srClient.getLatestSchemaMetadata("t-value"))
-        .thenReturn(new SchemaMetadata(0, 1, ""));
-    when(srClient.getSchemaBySubjectAndId("t-value", 0))
-        .thenReturn(new JsonSchema("{\n" +
-            "  \"properties\": {\n" +
-            "    \"B\": {\n" +
-            "      \"connect.index\": 0,\n" +
-            "      \"oneOf\": [\n" +
-            "        {\n" +
-            "          \"type\": \"null\"\n" +
-            "        },\n" +
-            "        {\n" +
-            "          \"connect.parameters\": {\n" +
-            "            \"connect.decimal.precision\": \"3\",\n" +
-            "            \"scale\": \"1\"\n" +
-            "          },\n" +
-            "          \"connect.type\": \"bytes\",\n" +
-            "          \"connect.version\": 1,\n" +
-            "          \"title\": \"org.apache.kafka.connect.data.Decimal\",\n" +
-            "          \"type\": \"number\"\n" +
-            "        }\n" +
-            "      ]\n" +
-            "    }\n" +
-            "  },\n" +
-            "  \"type\": \"object\"\n" +
-            "}"));
+    srClient.register("t-value", new JsonSchema("{\n" +
+        "  \"properties\": {\n" +
+        "    \"B\": {\n" +
+        "      \"connect.index\": 0,\n" +
+        "      \"oneOf\": [\n" +
+        "        {\n" +
+        "          \"type\": \"null\"\n" +
+        "        },\n" +
+        "        {\n" +
+        "          \"connect.parameters\": {\n" +
+        "            \"connect.decimal.precision\": \"3\",\n" +
+        "            \"scale\": \"1\"\n" +
+        "          },\n" +
+        "          \"connect.type\": \"bytes\",\n" +
+        "          \"connect.version\": 1,\n" +
+        "          \"title\": \"org.apache.kafka.connect.data.Decimal\",\n" +
+        "          \"type\": \"number\"\n" +
+        "        }\n" +
+        "      ]\n" +
+        "    }\n" +
+        "  },\n" +
+        "  \"type\": \"object\"\n" +
+        "}"));
 
     // When:
     final byte[] bytes = serializer.serialize("t",

--- a/pom.xml
+++ b/pom.xml
@@ -151,9 +151,9 @@
              Please check top level `pom.xml` at https://github.com/netty/netty
              for the netty version we bump to (ie, corresponding git tag),
              to find the correct `tcnative` version. -->
-        <netty.version>4.1.87.Final</netty.version>
-        <netty-codec-http2-version>4.1.87.Final</netty-codec-http2-version>
-        <jersey-common>2.34</jersey-common>
+        <netty.version>4.1.89.Final</netty.version>
+        <netty-codec-http2-version>4.1.89.Final</netty-codec-http2-version>
+        <jersey-common>2.91</jersey-common>
         <multi-threaded-testing.forkCount>3</multi-threaded-testing.forkCount>
         <kafka.version>${ce.kafka.version}</kafka.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
              to find the correct `tcnative` version. -->
         <netty.version>4.1.89.Final</netty.version>
         <netty-codec-http2-version>4.1.89.Final</netty-codec-http2-version>
-        <jersey-common>2.91</jersey-common>
+        <jersey-common>2.39.1</jersey-common>
         <multi-threaded-testing.forkCount>3</multi-threaded-testing.forkCount>
         <kafka.version>${ce.kafka.version}</kafka.version>
     </properties>


### PR DESCRIPTION
### Description 

See https://github.com/confluentinc/ksql/pull/10000. https://github.com/confluentinc/schema-registry/pull/2674 introduced a new default method `registerWithResponse` which throws exception by default. `SandboxedSchemaRegistryClient.java` should implement it. Otherwise `io.confluent.ksql.rest.server.InsertionIntegrationTest.shouldSupportEvolvingSchemasOnInsert` and `KsqlResourceFunctionalTest.shouldInsertIntoValuesForAvroTopic` fail.

### Testing done 
`io.confluent.ksql.rest.server.InsertionIntegrationTest.shouldSupportEvolvingSchemasOnInsert` and `KsqlResourceFunctionalTest.shouldInsertIntoValuesForAvroTopic` pass after the fix.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
