### PR TITLE
fix: remove duplicate definition

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
@@ -109,13 +109,6 @@ final class SandboxedSchemaRegistryClient {
       return -1; // swallow
     }
 
-    @Override
-    public RegisterSchemaResponse registerWithResponse(
-        final String subject, final ParsedSchema schema, final boolean normalize)
-        throws IOException, RestClientException {
-      return sandboxCacheClient.registerWithResponse(subject, schema, normalize);
-    }
-
     @Deprecated
     @Override
     public Schema getById(final int id) {


### PR DESCRIPTION
### Description 
Remove duplicate definition of `registerWithResponse`

### Testing done 
Existing unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
