### PR TITLE
chore: upgrade guava to 32.0.1

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Encode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Encode.java
@@ -22,6 +22,7 @@ import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.util.KsqlConstants;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.Hex;
@@ -70,7 +71,9 @@ public class Encode {
       throw new KsqlFunctionException("Supported input and output encodings are: "
                                   + "hex, utf8, ascii and base64");
     }
-    return ENCODER_MAP.get(encodedString).apply(str);
+    return Optional.ofNullable(ENCODER_MAP.get(encodedString))
+        .orElseThrow(NullPointerException::new)
+        .apply(str);
   }
 
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
@@ -237,10 +237,11 @@ public class JoinNode extends PlanNode {
     Joiner<?> getJoiner(final DataSourceType leftType,
         final DataSourceType rightType) {
 
-      return joinerMap.getOrDefault(new Pair<>(leftType, rightType), () -> {
-        throw new KsqlException("Join between invalid operands requested: left type: "
-            + leftType + ", right type: " + rightType);
-      }).get();
+      return Optional.ofNullable(joinerMap.get(new Pair<>(leftType, rightType)))
+          .orElseThrow(
+              () -> new KsqlException("Join between invalid operands requested: left type: "
+                  + leftType + ", right type: " + rightType))
+          .get();
     }
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/json/JsonPathTokenizerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/json/JsonPathTokenizerTest.java
@@ -29,8 +29,7 @@ public class JsonPathTokenizerTest {
   @Test
   public void testJsonPathTokenizer() {
     final JsonPathTokenizer jsonPathTokenizer = new JsonPathTokenizer("$.logs[0].cloud.region");
-    final ImmutableList<String> tokens = ImmutableList.copyOf(jsonPathTokenizer);
-    final List<String> tokenList = tokens.asList();
+    final List<String> tokenList = ImmutableList.copyOf(jsonPathTokenizer);
     assertThat(tokenList.size(), is(equalTo(4)));
     assertThat(tokenList.get(0), is(equalTo("logs")));
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
@@ -97,6 +97,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -910,15 +911,12 @@ public class SqlToJavaVisitor {
         return new Pair<>(expr.getLeft(), sqlType);
       }
 
-      return CASTERS.getOrDefault(sqlType.baseType(), CastVisitor::unsupportedCast)
+      return Optional.ofNullable(
+          CASTERS.get(sqlType.baseType())
+          ).orElseThrow(
+              () -> new KsqlFunctionException("Cast of " + expr.getRight()
+                  + " to " + sqlType + " is not supported"))
           .cast(expr, sqlType);
-    }
-
-    private static Pair<String, SqlType> unsupportedCast(
-        final Pair<String, SqlType> expr, final SqlType returnType
-    ) {
-      throw new KsqlFunctionException("Cast of " + expr.getRight()
-            + " to " + returnType + " is not supported");
     }
 
     private static Pair<String, SqlType> castString(

--- a/ksqldb-functional-tests/pom.xml
+++ b/ksqldb-functional-tests/pom.xml
@@ -156,6 +156,14 @@
       <artifactId>protobuf-java-util</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+      <version>2.18.0</version>
+      <scope>compile</scope>
+    </dependency>
+
+
   </dependencies>
 
   <build>

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
@@ -399,6 +399,9 @@ public class PullQueryRoutingFunctionalTest {
     ActiveStandbyEntity entity1 = clusterStatusResponse.getClusterStatus().get(host1)
         .getActiveStandbyPerQuery().get(QUERY_ID);
 
+    if (entity0 == null || entity1 == null) {
+      throw new AssertionError("Could not find standby entity!");
+    }
     // find active
     if (!entity0.getActiveStores().isEmpty() && !entity0.getActivePartitions().isEmpty()) {
       clusterFormation.setActive(Pair.of(host0, restApp0));

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/LagReportingAgentTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/LagReportingAgentTest.java
@@ -209,27 +209,37 @@ public class LagReportingAgentTest {
 
     // Then:
     ImmutableMap<KsqlHostInfoEntity, HostStoreLags> allLags = lagReportingAgent.getAllLags();
-    LagInfoEntity lag = allLags.get(HOST_ENTITY1).getStateStoreLags(QUERY_STORE_A)
+    LagInfoEntity lag = Optional.ofNullable(allLags.get(HOST_ENTITY1))
+        .orElseThrow(() -> new AssertionError("Lag could not be found"))
+        .getStateStoreLags(QUERY_STORE_A)
         .flatMap(s -> s.getLagByPartition(1)).get();
     assertEquals(M1_A1_CUR, lag.getCurrentOffsetPosition());
     assertEquals(M1_A1_END, lag.getEndOffsetPosition());
     assertEquals(M1_A1_LAG, lag.getOffsetLag());
-    lag = allLags.get(HOST_ENTITY1).getStateStoreLags(QUERY_STORE_A)
+    lag = Optional.ofNullable(allLags.get(HOST_ENTITY1))
+        .orElseThrow(() -> new AssertionError("Lag could not be found"))
+        .getStateStoreLags(QUERY_STORE_A)
         .flatMap(s -> s.getLagByPartition(3)).get();
     assertEquals(M1_A3_CUR, lag.getCurrentOffsetPosition());
     assertEquals(M1_A3_END, lag.getEndOffsetPosition());
     assertEquals(M1_A3_LAG, lag.getOffsetLag());
-    lag = allLags.get(HOST_ENTITY1).getStateStoreLags(QUERY_STORE_B)
+    lag = Optional.ofNullable(allLags.get(HOST_ENTITY1))
+        .orElseThrow(() -> new AssertionError("Lag could not be found"))
+        .getStateStoreLags(QUERY_STORE_B)
         .flatMap(s -> s.getLagByPartition(4)).get();
     assertEquals(M1_B4_CUR, lag.getCurrentOffsetPosition());
     assertEquals(M1_B4_END, lag.getEndOffsetPosition());
     assertEquals(M1_B4_LAG, lag.getOffsetLag());
-    lag = allLags.get(HOST_ENTITY2).getStateStoreLags(QUERY_STORE_A)
+    lag = Optional.ofNullable(allLags.get(HOST_ENTITY2))
+        .orElseThrow(() -> new AssertionError("Lag could not be found"))
+        .getStateStoreLags(QUERY_STORE_A)
         .flatMap(s -> s.getLagByPartition(1)).get();
     assertEquals(M2_A1_CUR, lag.getCurrentOffsetPosition());
     assertEquals(M2_A1_END, lag.getEndOffsetPosition());
     assertEquals(M2_A1_LAG, lag.getOffsetLag());
-    lag = allLags.get(HOST_ENTITY2).getStateStoreLags(QUERY_STORE_B)
+    lag = Optional.ofNullable(allLags.get(HOST_ENTITY2))
+        .orElseThrow(() -> new AssertionError("Lag could not be found"))
+        .getStateStoreLags(QUERY_STORE_B)
         .flatMap(s -> s.getLagByPartition(4)).get();
     assertEquals(M2_B4_CUR, lag.getCurrentOffsetPosition());
     assertEquals(M2_B4_END, lag.getEndOffsetPosition());

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/SchemaInfo.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/SchemaInfo.java
@@ -110,6 +110,7 @@ public class SchemaInfo {
   public String toTypeString() {
     // needs a map instead of switch because for some reason switch creates an
     // internal class with no annotations that messes up EntityTest
-    return TO_TYPE_STRING.getOrDefault(type, si -> si.type.name()).apply(this);
+    return Optional.ofNullable(TO_TYPE_STRING.getOrDefault(type, si -> si.type.name()))
+        .orElseThrow(NullPointerException::new).apply(this);
   }
 }

--- a/ksqldb-udf/pom.xml
+++ b/ksqldb-udf/pom.xml
@@ -37,12 +37,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_annotations</artifactId>
-            <version>2.2.0</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,6 @@
         <commons.compress.version>1.21</commons.compress.version>
         <commons.codec.version>1.13</commons.codec.version>
         <lang3.version>3.3.1</lang3.version>
-        <guava.version>30.1.1-jre</guava.version>
         <retrying.version>2.0.0</retrying.version>
         <inject.version>1</inject.version>
         <janino.version>3.0.7</janino.version>


### PR DESCRIPTION
### Description 
The guava version used in ksql is affected by CVE-2023-2976.

This PR upgrades the guava dependency to 32.0.1.

Resolves https://confluentinc.atlassian.net/browse/KSE-1714

### Testing done 
Builds must pass.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
