### PR TITLE
chore: upgrade guava to 32.0.1 on 7.0.x

### DIFF
--- a/ksqldb-engine-common/src/test/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercerTest.java
+++ b/ksqldb-engine-common/src/test/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercerTest.java
@@ -1295,9 +1295,13 @@ public class DefaultSqlValueCoercerTest {
         final SqlBaseType to
     ) {
       if (coercer == DefaultSqlValueCoercer.LAX) {
-        final boolean supported = LAX_ADDITIONAL
-            .getOrDefault(from, ImmutableSet.of())
-            .contains(to);
+        final ImmutableSet<SqlBaseType> sqlBaseTypes = LAX_ADDITIONAL
+            .getOrDefault(from, ImmutableSet.of());
+        // needed to avoid spotbugs warning with guava 32.0.1
+        if (sqlBaseTypes == null) {
+          return false;
+        }
+        final boolean supported = sqlBaseTypes.contains(to);
 
         if (supported) {
           return true;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Encode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/Encode.java
@@ -68,11 +68,12 @@ public class Encode {
 
     final String encodedString = inputEncoding.toLowerCase() + outputEncoding.toLowerCase();
 
-    if (ENCODER_MAP.get(encodedString) == null) {
+    final Encode.Encoder encoder = ENCODER_MAP.get(encodedString);
+    if (encoder == null) {
       throw new KsqlFunctionException("Supported input and output encodings are: "
                                   + "hex, utf8, ascii and base64");
     }
-    return ENCODER_MAP.get(encodedString).apply(str);
+    return encoder.apply(str);
   }
 
   interface Encoder {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
@@ -358,7 +358,12 @@ public class JoinNode extends PlanNode implements JoiningNode {
     }
 
     Joiner<?> getJoiner(final DataSourceType leftType, final DataSourceType rightType) {
-      return joinerMap.get(new Pair<>(leftType, rightType)).get();
+      final Supplier<Joiner<?>> joinerSupplier = joinerMap.get(new Pair<>(leftType, rightType));
+      if (joinerSupplier == null) {
+        throw new IllegalStateException("Invalid joiner supplier requested: left type: "
+            + leftType + ", right type: " + rightType);
+      }
+      return joinerSupplier.get();
     }
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
@@ -390,9 +390,10 @@ public class QueryMetadataImpl implements QueryMetadata {
       evict();
       return ImmutableList.copyOf(queue);
     }
-    
+
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     private void evict() {
-      while (queue.peek() != null) {
+      while (!queue.isEmpty()) {
         if (queue.peek().getTimestamp() > System.currentTimeMillis() - duration.toMillis()) {
           break;
         }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/json/JsonPathTokenizerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/json/JsonPathTokenizerTest.java
@@ -29,8 +29,7 @@ public class JsonPathTokenizerTest {
   @Test
   public void testJsonPathTokenizer() {
     final JsonPathTokenizer jsonPathTokenizer = new JsonPathTokenizer("$.logs[0].cloud.region");
-    final ImmutableList<String> tokens = ImmutableList.copyOf(jsonPathTokenizer);
-    final List<String> tokenList = tokens.asList();
+    final List<String> tokenList = ImmutableList.copyOf(jsonPathTokenizer);
     assertThat(tokenList.size(), is(equalTo(4)));
     assertThat(tokenList.get(0), is(equalTo("logs")));
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/helpers/CastEvaluator.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/helpers/CastEvaluator.java
@@ -45,6 +45,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.kafka.connect.data.Schema;
@@ -135,8 +136,8 @@ public final class CastEvaluator {
       return innerCode;
     }
 
-    return SUPPORTED
-        .getOrDefault(key(from.baseType(), to.baseType()), CastEvaluator::unsupportedCast)
+    return Optional.ofNullable(SUPPORTED.get(key(from.baseType(), to.baseType())))
+        .orElseThrow(() -> new UnsupportedCastException(from, to))
         .generateCode(innerCode, from, to, config);
   }
 
@@ -204,15 +205,6 @@ public final class CastEvaluator {
       final String function = LambdaUtil.toJavaCode("val", fromJavaType, lambdaBody);
       return NullSafe.generateApply(innerCode, function, toJavaType);
     };
-  }
-
-  private static String unsupportedCast(
-      final String innerCode,
-      final SqlType from,
-      final SqlType to,
-      final KsqlConfig config
-  ) {
-    throw new UnsupportedCastException(from, to);
   }
 
   private static String castToDecimal(

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/MaximumLagFilter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/MaximumLagFilter.java
@@ -59,7 +59,7 @@ public final class MaximumLagFilter implements RoutingFilter {
     final long allowedOffsetLag = routingOptions.getMaxOffsetLagAllowed();
     final Optional<LagInfoEntity> lagInfoEntity = lagByHost.get(hostInfo);
 
-    if (!lagInfoEntity.isPresent()) {
+    if (lagInfoEntity == null || !lagInfoEntity.isPresent()) {
       // If we don't have lag info, we'll be conservative and not include the host.  We have a
       // dual purpose, in both having HA and also having lag guarantees.  This ensures that we are
       // honoring the lag guarantees, and we'll try to minimize the window where lag isn't

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryConfigPlannerOptions.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryConfigPlannerOptions.java
@@ -20,6 +20,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.planner.QueryPlannerOptions;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Map;
+import java.util.Optional;
 
 public class PullQueryConfigPlannerOptions implements QueryPlannerOptions {
 
@@ -37,17 +38,15 @@ public class PullQueryConfigPlannerOptions implements QueryPlannerOptions {
 
   @Override
   public boolean getTableScansEnabled() {
-    if (configOverrides.containsKey(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED)) {
-      return (Boolean) configOverrides.get(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED);
-    }
-    return ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED);
+    return Optional.ofNullable(
+        (Boolean) configOverrides.get(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED)
+    ).orElse(ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED));
   }
 
   @Override
   public boolean getInterpreterEnabled() {
-    if (configOverrides.containsKey(KsqlConfig.KSQL_QUERY_PULL_INTERPRETER_ENABLED)) {
-      return (Boolean) configOverrides.get(KsqlConfig.KSQL_QUERY_PULL_INTERPRETER_ENABLED);
-    }
-    return ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_INTERPRETER_ENABLED);
+    return Optional.ofNullable(
+        (Boolean) configOverrides.get(KsqlConfig.KSQL_QUERY_PULL_INTERPRETER_ENABLED)
+    ).orElse(ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_INTERPRETER_ENABLED));
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryConfigRoutingOptions.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryConfigRoutingOptions.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -45,33 +46,29 @@ public class PullQueryConfigRoutingOptions implements RoutingOptions {
   }
 
   private long getLong() {
-    if (configOverrides.containsKey(KsqlConfig.KSQL_QUERY_PULL_MAX_ALLOWED_OFFSET_LAG_CONFIG)) {
-      return (Long) configOverrides.get(KsqlConfig.KSQL_QUERY_PULL_MAX_ALLOWED_OFFSET_LAG_CONFIG);
-    }
-    return ksqlConfig.getLong(KsqlConfig.KSQL_QUERY_PULL_MAX_ALLOWED_OFFSET_LAG_CONFIG);
+    return Optional.ofNullable(
+        (Long) configOverrides.get(KsqlConfig.KSQL_QUERY_PULL_MAX_ALLOWED_OFFSET_LAG_CONFIG)
+    ).orElse(ksqlConfig.getLong(KsqlConfig.KSQL_QUERY_PULL_MAX_ALLOWED_OFFSET_LAG_CONFIG));
   }
 
   private boolean getForwardedFlag() {
-    if (requestProperties.containsKey(KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_SKIP_FORWARDING)) {
-      return (Boolean) requestProperties.get(
-          KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_SKIP_FORWARDING);
-    }
-    return KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_SKIP_FORWARDING_DEFAULT;
+    return Optional.ofNullable(
+        (Boolean) requestProperties.get(KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_SKIP_FORWARDING)
+    ).orElse(KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_SKIP_FORWARDING_DEFAULT);
   }
 
   public boolean getIsDebugRequest() {
-    if (requestProperties.containsKey(KsqlRequestConfig.KSQL_DEBUG_REQUEST)) {
-      return (Boolean) requestProperties.get(KsqlRequestConfig.KSQL_DEBUG_REQUEST);
-    }
-    return KsqlRequestConfig.KSQL_DEBUG_REQUEST_DEFAULT;
+    return Optional.ofNullable(
+        (Boolean) requestProperties.get(KsqlRequestConfig.KSQL_DEBUG_REQUEST)
+    ).orElse(KsqlRequestConfig.KSQL_DEBUG_REQUEST_DEFAULT);
   }
 
   @Override
   public Set<Integer> getPartitions() {
     if (requestProperties.containsKey(KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_PARTITIONS)) {
       @SuppressWarnings("unchecked")
-      final List<String> partitions = (List<String>) requestProperties.get(
-          KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_PARTITIONS);
+      final List<String> partitions = Optional.ofNullable((List<String>) requestProperties.get(
+          KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_PARTITIONS)).orElse(Collections.emptyList());
       return partitions.stream()
           .map(partition -> {
             try {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
@@ -569,6 +569,10 @@ public class PullQueryRoutingFunctionalTest {
     ActiveStandbyEntity entity1 = clusterStatusResponse.getClusterStatus().get(testApp1.getHost())
         .getActiveStandbyPerQuery().get(queryId);
 
+    if (entity0 == null || entity1 == null) {
+      throw new AssertionError("Could not find active/standby entity!");
+    }
+
     // find active
     if (!entity0.getActiveStores().isEmpty() && !entity0.getActivePartitions().isEmpty()) {
       clusterFormation.setActive(testApp0);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/LagReportingAgentTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/LagReportingAgentTest.java
@@ -209,27 +209,37 @@ public class LagReportingAgentTest {
 
     // Then:
     ImmutableMap<KsqlHostInfoEntity, HostStoreLags> allLags = lagReportingAgent.getAllLags();
-    LagInfoEntity lag = allLags.get(HOST_ENTITY1).getStateStoreLags(QUERY_STORE_A)
+    LagInfoEntity lag = Optional.ofNullable(allLags.get(HOST_ENTITY1))
+        .orElseThrow(() -> new AssertionError("Lag could not be found"))
+        .getStateStoreLags(QUERY_STORE_A)
         .flatMap(s -> s.getLagByPartition(1)).get();
     assertEquals(M1_A1_CUR, lag.getCurrentOffsetPosition());
     assertEquals(M1_A1_END, lag.getEndOffsetPosition());
     assertEquals(M1_A1_LAG, lag.getOffsetLag());
-    lag = allLags.get(HOST_ENTITY1).getStateStoreLags(QUERY_STORE_A)
+    lag = Optional.ofNullable(allLags.get(HOST_ENTITY1))
+        .orElseThrow(() -> new AssertionError("Lag could not be found"))
+        .getStateStoreLags(QUERY_STORE_A)
         .flatMap(s -> s.getLagByPartition(3)).get();
     assertEquals(M1_A3_CUR, lag.getCurrentOffsetPosition());
     assertEquals(M1_A3_END, lag.getEndOffsetPosition());
     assertEquals(M1_A3_LAG, lag.getOffsetLag());
-    lag = allLags.get(HOST_ENTITY1).getStateStoreLags(QUERY_STORE_B)
+    lag = Optional.ofNullable(allLags.get(HOST_ENTITY1))
+        .orElseThrow(() -> new AssertionError("Lag could not be found"))
+        .getStateStoreLags(QUERY_STORE_B)
         .flatMap(s -> s.getLagByPartition(4)).get();
     assertEquals(M1_B4_CUR, lag.getCurrentOffsetPosition());
     assertEquals(M1_B4_END, lag.getEndOffsetPosition());
     assertEquals(M1_B4_LAG, lag.getOffsetLag());
-    lag = allLags.get(HOST_ENTITY2).getStateStoreLags(QUERY_STORE_A)
+    lag = Optional.ofNullable(allLags.get(HOST_ENTITY2))
+        .orElseThrow(() -> new AssertionError("Lag could not be found"))
+        .getStateStoreLags(QUERY_STORE_A)
         .flatMap(s -> s.getLagByPartition(1)).get();
     assertEquals(M2_A1_CUR, lag.getCurrentOffsetPosition());
     assertEquals(M2_A1_END, lag.getEndOffsetPosition());
     assertEquals(M2_A1_LAG, lag.getOffsetLag());
-    lag = allLags.get(HOST_ENTITY2).getStateStoreLags(QUERY_STORE_B)
+    lag = Optional.ofNullable(allLags.get(HOST_ENTITY2))
+        .orElseThrow(() -> new AssertionError("Lag could not be found"))
+        .getStateStoreLags(QUERY_STORE_B)
         .flatMap(s -> s.getLagByPartition(4)).get();
     assertEquals(M2_B4_CUR, lag.getCurrentOffsetPosition());
     assertEquals(M2_B4_END, lag.getEndOffsetPosition());

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/SchemaInfo.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/SchemaInfo.java
@@ -152,6 +152,7 @@ public class SchemaInfo {
   public String toTypeString() {
     // needs a map instead of switch because for some reason switch creates an
     // internal class with no annotations that messes up EntityTest
-    return TO_TYPE_STRING.getOrDefault(type, si -> si.type.name()).apply(this);
+    return Optional.ofNullable(TO_TYPE_STRING.getOrDefault(type, si -> si.type.name()))
+        .orElseThrow(NullPointerException::new).apply(this);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,6 @@
         <csv.version>1.4</csv.version>
         <commons.compress.version>1.21</commons.compress.version>
         <lang3.version>3.3.1</lang3.version>
-        <guava.version>30.1.1-jre</guava.version>
         <retrying.version>2.0.0</retrying.version>
         <inject.version>1</inject.version>
         <janino.version>3.0.7</janino.version>


### PR DESCRIPTION
### Description 
Upgrades guava to 32.0.1 due to GHSA-7g45-4rm6-3mm3. 
Fixes spotbugs failures due to the guava upgrade.

https://confluentinc.atlassian.net/browse/KSE-1714

### Testing done 
Build passing

