### PR TITLE
Revert "chore: switch to pinned nanoversion strategy (#9193)"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,6 @@ common {
     downStreamRepos = downStreams
     downStreamValidate = false
     nanoVersion = true
-    pinnedNanoVersions = true
     maxBuildsToKeep = 99
     maxDaysToKeep = 90
     extraBuildArgs = "-Dmaven.gitcommitid.nativegit=true"

--- a/ksqldb-common/pom.xml
+++ b/ksqldb-common/pom.xml
@@ -42,6 +42,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-avro-converter</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
         </dependency>
 
         <dependency>

--- a/ksqldb-examples/pom.xml
+++ b/ksqldb-examples/pom.xml
@@ -45,6 +45,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-avro-converter</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
         </dependency>
 
         <!-- Required for running tests -->

--- a/ksqldb-rest-app/pom.xml
+++ b/ksqldb-rest-app/pom.xml
@@ -71,6 +71,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-json-serializer</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
         </dependency>
 
         <dependency>

--- a/ksqldb-serde/pom.xml
+++ b/ksqldb-serde/pom.xml
@@ -43,6 +43,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-registry-client</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
         </dependency>
 
         <dependency>
@@ -54,31 +55,37 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-avro-converter</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-protobuf-provider</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-json-schema-provider</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-protobuf-converter</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-json-schema-converter</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
         </dependency>
 
         <!-- Required for running tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
         <apache.io.version>2.7</apache.io.version>
         <io.confluent.ksql.version>7.5.0-0</io.confluent.ksql.version>
-        <io.confluent.schema-registry.version>7.5.0-847</io.confluent.schema-registry.version>
+        <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
         <netty-tcnative-version>2.0.54.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`


### PR DESCRIPTION
This reverts commit https://github.com/confluentinc/ksql/commit/577029425c4ae4288fa527488acf1ef4820aade2

CP release tooling doesn't know how to deal with pinned dependencies, reverting these changes for 7.5.x so that we can get a clean RC cut for upcoming CP 7.5 release

Only intended for 7.5.x for now, will pint merge -strategy ours to resolve the conflict

(Note: This is similar to https://github.com/confluentinc/ksql/pull/9815 PR for 7.4.x)