### PR TITLE
[chore] pin parent version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>[7.6.0-0, 7.6.1-0)</version>
+        <version>7.6.0-139</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>


### PR DESCRIPTION
It looks like the last CP branch cut un-pinned the parent pom nanoversion. There is WIP to fix the tooling, so this is hopefully the last time a manual patch is needed.

`7.6.0-139` is the latest nanoversion of `common`, so it's the version we have been building against for the last three days.

I have confirmed from reading the Jenkins logs that this is the version we used in the last successful build: https://github.com/confluentinc/ksql/runs/15183266336
