### PR TITLE
fix: Fixes corruption in the output of pull queries with large responses

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonQueryStreamResponseWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonQueryStreamResponseWriter.java
@@ -76,7 +76,9 @@ public class JsonQueryStreamResponseWriter implements QueryStreamResponseWriter 
     if (keyValue.value() == null) {
       LOG.warn("Dropped tombstone. Not currently supported");
     } else {
-      writeBuffer(ServerUtils.serializeObject(keyValue.value().values()));
+      Buffer buff = ServerUtils.serializeObject(keyValue.value().values());
+      System.out.println("Returning data " + buff.toString());
+      writeBuffer(buff);
     }
     return this;
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonQueryStreamResponseWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonQueryStreamResponseWriter.java
@@ -76,9 +76,7 @@ public class JsonQueryStreamResponseWriter implements QueryStreamResponseWriter 
     if (keyValue.value() == null) {
       LOG.warn("Dropped tombstone. Not currently supported");
     } else {
-      Buffer buff = ServerUtils.serializeObject(keyValue.value().values());
-      System.out.println("Returning data " + buff.toString());
-      writeBuffer(buff);
+      writeBuffer(ServerUtils.serializeObject(keyValue.value().values()));
     }
     return this;
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriter.java
@@ -122,7 +122,6 @@ public class JsonStreamedRowResponseWriter implements QueryStreamResponseWriter 
       final KeyValueMetadata<List<?>, GenericRow> keyValueMetadata
   ) {
     final KeyValue<List<?>, GenericRow> keyValue = keyValueMetadata.getKeyValue();
-//    System.out.println("Alan: writeRow " + keyValue);
     final StreamedRow streamedRow;
     if (keyValue.value() == null) {
       Preconditions.checkState(tombstoneFactory.isPresent(),

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriter.java
@@ -54,8 +54,9 @@ import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Struct;
 
 public class JsonStreamedRowResponseWriter implements QueryStreamResponseWriter {
-
-  private static final int FLUSH_SIZE_BYTES = 50 * 1024;
+  // Make sure this is not too large or else we will overwhelm the response write buffer which
+  // appears to corrupt the output.
+  private static final int FLUSH_SIZE_BYTES = 5 * 1024;
   private static final ObjectMapper OBJECT_MAPPER = ApiJsonMapper.INSTANCE.get();
   static final long MAX_FLUSH_MS = 200;
 
@@ -121,6 +122,7 @@ public class JsonStreamedRowResponseWriter implements QueryStreamResponseWriter 
       final KeyValueMetadata<List<?>, GenericRow> keyValueMetadata
   ) {
     final KeyValue<List<?>, GenericRow> keyValue = keyValueMetadata.getKeyValue();
+//    System.out.println("Alan: writeRow " + keyValue);
     final StreamedRow streamedRow;
     if (keyValue.value() == null) {
       Preconditions.checkState(tombstoneFactory.isPresent(),

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriterTest.java
@@ -240,10 +240,10 @@ public class JsonStreamedRowResponseWriterTest {
 
     // Then:
     assertThat(stringBuilder.toString().split("\n").length, is(4001));
-    verify(response, times(4)).write((String) any());
+    verify(response, times(38)).write((String) any());
     verify(response, never()).write((Buffer) any());
-    verify(vertx, times(4)).setTimer(anyLong(), any());
-    verify(vertx, times(4)).cancelTimer(anyLong());
+    verify(vertx, times(38)).setTimer(anyLong(), any());
+    verify(vertx, times(38)).cancelTimer(anyLong());
   }
 
   @Test


### PR DESCRIPTION
### Description 
With 50k buffers for pull queries, writing to the http response could overwhelm the output buffer and seemingly corrupt the output.  Normally, this is managed by checking  `response.writeQueueFull()`, which it is in `QuerySubscriber`, and waiting until the write queue is no longer full.  This works when small amounts of data is written at a time, but not when the last row triggers a massive buffer to be written.  For that reason, I have made the buffer much smaller.  It should still have a nice performance benefit, and hopefully avoid triggering the corruption.

It's still a bit unclear to me why the output is corrupted -- it's possible that since Vertx is non-blocking framework, if the write buffer is near full, its only option is to top it off and discard the rest since you don't want to block until more can be written.  This should be verified at some point.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
