### PR TITLE
docs: Update docs build to use build.os config key (DOCS-25078)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,9 +2,6 @@
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required
-version: 2
-
 # Build documentation in the docs/ directory with Sphinx 
 #sphinx:
 #  configuration: docs/conf.py
@@ -16,8 +13,13 @@ mkdocs:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all
 
-# Optionally set the version of Python and requirements required to build your docs
+# Required
+version: 2
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.7"
+
 python:
- version: 3.7
  install:
    - requirements: docs/requirements.txt


### PR DESCRIPTION
Required by ReadThe Docs: [Use build.os instead of build.image on your configuration file](https://blog.readthedocs.com/use-build-os-config/).