### PR TITLE
tests: change_expection_check

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedSchemaRegistryClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedSchemaRegistryClientTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.services;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -36,6 +37,8 @@ import io.confluent.ksql.test.util.TestMethods;
 import io.confluent.ksql.test.util.TestMethods.TestCase;
 import java.util.Collection;
 import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+
 import org.apache.avro.Schema;
 import org.apache.hc.core5.http.HttpStatus;
 import org.junit.Before;
@@ -93,9 +96,12 @@ public final class SandboxedSchemaRegistryClientTest {
           mock(SchemaRegistryClient.class));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void shouldThrowOnUnsupportedOperation() throws Throwable {
-      testCase.invokeMethod(sandboxedSchemaRegistryClient);
+    @Test
+    public void shouldThrowOnUnsupportedOperation() {
+      assertThrows(
+          UnsupportedOperationException.class, // thrown from .get() when the future completes exceptionally
+          () -> testCase.invokeMethod(sandboxedSchemaRegistryClient)
+      );
     }
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedSchemaRegistryClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedSchemaRegistryClientTest.java
@@ -37,7 +37,6 @@ import io.confluent.ksql.test.util.TestMethods;
 import io.confluent.ksql.test.util.TestMethods.TestCase;
 import java.util.Collection;
 import java.util.Objects;
-import java.util.concurrent.ExecutionException;
 
 import org.apache.avro.Schema;
 import org.apache.hc.core5.http.HttpStatus;


### PR DESCRIPTION
Hoping that updating how the exception is checked will get it to stop failing on Jenkins when it passes just fine locally

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
