### PR TITLE
fix: SR client dep manual bump and test fix

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
@@ -280,5 +280,10 @@ final class SandboxedSchemaRegistryClient {
     public void reset() {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public void close() {
+      throw new UnsupportedOperationException();
+    }
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedSchemaRegistryClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedSchemaRegistryClientTest.java
@@ -98,7 +98,7 @@ public final class SandboxedSchemaRegistryClientTest {
     @Test
     public void shouldThrowOnUnsupportedOperation() {
       assertThrows(
-          UnsupportedOperationException.class, // thrown from .get() when the future completes exceptionally
+          UnsupportedOperationException.class,
           () -> testCase.invokeMethod(sandboxedSchemaRegistryClient)
       );
     }

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
         <apache.io.version>2.7</apache.io.version>
         <io.confluent.ksql.version>7.6.0-0</io.confluent.ksql.version>
-        <io.confluent.schema-registry.version>7.6.0-73</io.confluent.schema-registry.version>
+        <io.confluent.schema-registry.version>7.6.0-92</io.confluent.schema-registry.version>
         <netty-tcnative-version>2.0.54.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`


### PR DESCRIPTION
The SR client added a new method with broke our sandboxing tests. The auto version bump failed so manually doing it now 

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
