### PR TITLE
fix: force the number of standby to always be zero for transient queries

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -201,6 +201,9 @@ final class QueryBuilder {
         config.getConfig(true),
         processingLogContext
     );
+
+    streamsProperties.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 0);
+
     final Object buildResult = buildQueryImplementation(physicalPlan, runtimeBuildContext);
     final TransientQueryQueue queue =
         buildTransientQueryQueue(buildResult, limit, excludeTombstones, endOffsets);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
@@ -288,6 +288,7 @@ public class QueryBuilderTest {
     verify(kafkaStreamsBuilder).build(any(), propertyCaptor.capture());
     assertThat(queryMetadata.getStreamsProperties(), equalTo(propertyCaptor.getValue()));
     assertThat(queryMetadata.getStreamsProperties().get(InternalConfig.TOPIC_PREFIX_ALTERNATIVE), nullValue());
+    assertThat(queryMetadata.getStreamsProperties().get(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG), equalTo(0));
   }
 
   @Test


### PR DESCRIPTION
to prevent the transient queries from creating standby replicas when they shouldn't I force the number to be set to zero before the stream is made

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
