### PR TITLE
fix: concurrency bug when doing high volume pull query over java client

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/PullQueryWriteStream.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/PullQueryWriteStream.java
@@ -208,12 +208,8 @@ public class PullQueryWriteStream implements WriteStream<List<StreamedRow>>, Blo
 
     polled.handler.handle(new SucceededFuture<>(null, null));
 
-    if (monitor.enterIf(atHalfCapacity)) {
-      try {
-        drainHandler.forEach(h -> h.handle(null));
-      } finally {
-        monitor.leave();
-      }
+    if (isDone() || size() <= queueCapacity / 2) {
+      drainHandler.forEach(h -> h.handle(null));
     }
 
     return polled.row;

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
@@ -355,7 +355,7 @@ public final class KsqlTarget {
         // by `PullQueryWriteStream` via the drain handler of the pipe, and `RecordParser.handle`.
         // We may want to refactor PullQueryWriteStream to not call the drain handler from
         // another thread.
-        final RecordParser recordParser = SyncronizedRecordParser.newDelimited(delimiter, resp);
+        final RecordParser recordParser = SynchronizedRecordParser.newDelimited(delimiter, resp);
         final AtomicBoolean end = new AtomicBoolean(false);
 
         final WriteStream<Buffer> ws = new BufferMapWriteStream<>(chunkMapper, chunkHandler);

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/SynchronizedRecordParser.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/SynchronizedRecordParser.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.client;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Handler;
@@ -23,7 +24,7 @@ import io.vertx.core.parsetools.RecordParser;
 import io.vertx.core.streams.ReadStream;
 
 @SuppressWarnings("unused")
-public class SyncronizedRecordParser implements RecordParser {
+public class SynchronizedRecordParser implements RecordParser {
 
   private static class WrappedUpstream implements ReadStream<Buffer> {
 
@@ -76,7 +77,8 @@ public class SyncronizedRecordParser implements RecordParser {
   private final RecordParser delegate;
   private final ReadStream<Buffer> source;
 
-  public SyncronizedRecordParser(final RecordParser delegate, final ReadStream<Buffer> source) {
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  public SynchronizedRecordParser(final RecordParser delegate, final ReadStream<Buffer> source) {
     this.delegate = delegate;
     this.source = source;
   }
@@ -87,7 +89,7 @@ public class SyncronizedRecordParser implements RecordParser {
   }
 
   public static RecordParser newDelimited(final String delim, final ReadStream<Buffer> stream) {
-    return new SyncronizedRecordParser(
+    return new SynchronizedRecordParser(
         RecordParser.newDelimited(delim, new WrappedUpstream(stream)),
         stream
     );

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/SyncronizedRecordParser.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/SyncronizedRecordParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.rest.client;
 
 import io.vertx.codegen.annotations.Fluent;

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/SyncronizedRecordParser.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/SyncronizedRecordParser.java
@@ -1,0 +1,138 @@
+package io.confluent.ksql.rest.client;
+
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.parsetools.RecordParser;
+import io.vertx.core.streams.ReadStream;
+
+@SuppressWarnings("unused")
+public class SyncronizedRecordParser implements RecordParser {
+
+  private static class WrappedUpstream implements ReadStream<Buffer> {
+
+    private final ReadStream<Buffer> delegate;
+
+    WrappedUpstream(final ReadStream<Buffer> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public ReadStream<Buffer> exceptionHandler(@Nullable final Handler<Throwable> handler) {
+      return delegate.exceptionHandler(handler);
+    }
+
+    @Override
+    @Fluent
+    public ReadStream<Buffer> handler(@Nullable final Handler<Buffer> handler) {
+      return delegate.handler(bf -> {
+        synchronized (delegate) {
+          handler.handle(bf);
+        }
+      });
+    }
+
+    @Override
+    @Fluent
+    public ReadStream<Buffer> pause() {
+      return delegate.pause();
+    }
+
+    @Override
+    @Fluent
+    public ReadStream<Buffer> resume() {
+      return delegate.resume();
+    }
+
+    @Override
+    @Fluent
+    public ReadStream<Buffer> fetch(final long l) {
+      return delegate.fetch(l);
+    }
+
+    @Override
+    @Fluent
+    public ReadStream<Buffer> endHandler(@Nullable final Handler<Void> handler) {
+      return delegate.endHandler(handler);
+    }
+  }
+
+  private final RecordParser delegate;
+  private final ReadStream<Buffer> source;
+
+  public SyncronizedRecordParser(final RecordParser delegate, final ReadStream<Buffer> source) {
+    this.delegate = delegate;
+    this.source = source;
+  }
+
+  @Override
+  public void setOutput(final Handler<Buffer> handler) {
+    delegate.setOutput(handler);
+  }
+
+  public static RecordParser newDelimited(final String delim, final ReadStream<Buffer> stream) {
+    return new SyncronizedRecordParser(
+        RecordParser.newDelimited(delim, new WrappedUpstream(stream)),
+        stream
+    );
+  }
+
+  @Override
+  public void delimitedMode(final String s) {
+    delegate.delimitedMode(s);
+  }
+
+  @Override
+  public void delimitedMode(final Buffer buffer) {
+    delegate.delimitedMode(buffer);
+  }
+
+  @Override
+  public void fixedSizeMode(final int i) {
+    delegate.fixedSizeMode(i);
+  }
+
+  @Override
+  @Fluent
+  public RecordParser maxRecordSize(final int i) {
+    return delegate.maxRecordSize(i);
+  }
+
+  @Override
+  public void handle(final Buffer buffer) {
+    delegate.handle(buffer);
+  }
+
+  @Override
+  public RecordParser exceptionHandler(final Handler<Throwable> handler) {
+    return delegate.exceptionHandler(handler);
+  }
+
+  @Override
+  public RecordParser handler(final Handler<Buffer> handler) {
+    return delegate.handler(handler);
+  }
+
+  @Override
+  public RecordParser pause() {
+    return delegate.pause();
+  }
+
+  @Override
+  public RecordParser fetch(final long l) {
+    return delegate.fetch(l);
+  }
+
+  @Override
+  public RecordParser resume() {
+    synchronized (source) {
+      return delegate.resume();
+    }
+  }
+
+  @Override
+  public RecordParser endHandler(final Handler<Void> handler) {
+    return delegate.endHandler(handler);
+  }
+}


### PR DESCRIPTION
### Description 

Fix for a race inside vert.x’s `RecordParser`. Two threads are hitting `RecordParserImpl.handleParsing`, one is entering from upstream via `RecordParser.handle`, and one thread is coming from the downstream via `ReadStream.resume`. Once our `PullQueryWriteStream` is half empty, we call the drain handler, which calls `RecordParser.resume`, which synchronously starts parsing new records from the buffer. `RecordParser.handleParsing` is not thread-safe.

The cause is that the monitor inside `PullQueryWriteStream` is insufficient to protect from races inside the `RecordParser`. This fix uses a separate monitor (the object monitor of the HTTP response object) to prevent races inside the `RecordParser`. To implement the fix, we define a shim wrapper around `RecordParser`, which makes sure to acquire the monitor both on `handle` and on `resume`.

In the future, we may want to fix this by changing the way the drain handler is called.

### Testing done 

No behavior changes in existing integration tests. Tested locally.

### Reviewer checklist
- [x] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [x] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
