### PR TITLE
unpin jetty, get the version from common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,6 @@
         <skip.docker.test>true</skip.docker.test>
         <compile.warnings-flag>-Werror</compile.warnings-flag>
         <!-- Only used to provide login module implementation for tests -->
-        <jetty.version>9.4.51.v20230217</jetty.version>
         <git-commit-id-plugin.version>2.2.6</git-commit-id-plugin.version>
 
         <netty-tcnative-version>2.0.46.Final</netty-tcnative-version>


### PR DESCRIPTION
### Description 
Unpin jetty dependency version to use the version defined in common to address CVEs
