### PR TITLE
chore: Upgrade netty to 4.1.100.Final for CVE-2023-44487

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,15 +143,15 @@
         <apache.io.version>2.7</apache.io.version>
         <io.confluent.ksql.version>7.6.0-0</io.confluent.ksql.version>
         <io.confluent.schema-registry.version>7.6.0-150</io.confluent.schema-registry.version>
-        <netty-tcnative-version>2.0.54.Final</netty-tcnative-version>
+        <netty-tcnative-version>2.0.61.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`
              we might need to bump `tcnative`, too.
              Please check top level `pom.xml` at https://github.com/netty/netty
              for the netty version we bump to (ie, corresponding git tag),
              to find the correct `tcnative` version. -->
-        <netty.version>4.1.89.Final</netty.version>
-        <netty-codec-http2-version>4.1.89.Final</netty-codec-http2-version>
+        <netty.version>4.1.100.Final</netty.version>
+        <netty-codec-http2-version>4.1.100.Final</netty-codec-http2-version>
         <jersey-common>2.39.1</jersey-common>
         <multi-threaded-testing.forkCount>3</multi-threaded-testing.forkCount>
         <kafka.version>${ce.kafka.version}</kafka.version>


### PR DESCRIPTION
This PR upgrades netty to `4.1.00.Final` and `netty-tcnative-version` to `2.0.61.Final` to address https://nvd.nist.gov/vuln/detail/CVE-2023-44487.

`4.1.100.Final` address the vulnerability according to https://netty.io/news/2023/10/10/4-1-100-Final.html.