### PR TITLE
chore: Upgrade jetty / vertx to address CVE-2023-44487

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,14 +131,14 @@
         <wiremock.version>2.24.0</wiremock.version>
         <clearspring-analytics.version>2.9.5</clearspring-analytics.version>
         <icu.version>67.1</icu.version>
-        <vertx.version>4.3.8</vertx.version>
+        <vertx.version>4.4.6</vertx.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <skip.docker.build>true</skip.docker.build>
         <skip.docker.test>true</skip.docker.test>
         <!-- Temporarily disabling this because it is causing failures in packaging but not CI builds. -->
         <!-- <compile.warnings-flag>-Werror</compile.warnings-flag> -->
         <!-- Only used to provide login module implementation for tests -->
-        <jetty.version>9.4.51.v20230217</jetty.version>
+        <jetty.version>9.4.53.v20231009</jetty.version>
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
         <apache.io.version>2.7</apache.io.version>
         <io.confluent.ksql.version>7.6.0-0</io.confluent.ksql.version>
@@ -603,6 +603,11 @@
              here -->
             <dependency>
                 <groupId>io.netty</groupId>
+                <artifactId>netty-all</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
                 <artifactId>netty-common</artifactId>
                 <version>${netty.version}</version>
             </dependency>
@@ -659,6 +664,11 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-dns</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-kqueue</artifactId>
                 <version>${netty.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Jetty / vertx was pulling in older versions of netty, which is exposed to CVE-2023-44487.

Upgrading vertx to `4.4.6`, and jetty to `9.4.53.v20231009`, which according to the following addresses the CVE:

1. https://github.com/jetty/jetty.project/releases/tag/jetty-9.4.53.v20231009
2. https://vertx.io/blog/eclipse-vert-x-4-4-6/

Did a `mvn dependency:tree | grep netty`, which shows that now all pulled in netty deps are on the target version `4.1.100.Final`.
