### PR TITLE
fix: vert.x regression bug when doing high volume pull query

### DIFF
--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/BufferCopyStream.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/BufferCopyStream.java
@@ -24,13 +24,13 @@ public final class BufferCopyStream implements ReadStream<Buffer> {
 
   private final ReadStream<Buffer> source;
 
-  public BufferCopyStream(ReadStream<Buffer> source) {
+  public BufferCopyStream(final ReadStream<Buffer> source) {
     Objects.requireNonNull(source, "Source must be non-null");
     this.source = source;
   }
 
   @Override
-  public ReadStream<Buffer> handler(Handler<Buffer> handler) {
+  public ReadStream<Buffer> handler(final Handler<Buffer> handler) {
     if (handler == null) {
       source.handler(null);
     } else {
@@ -40,7 +40,7 @@ public final class BufferCopyStream implements ReadStream<Buffer> {
   }
 
   @Override
-  public ReadStream<Buffer> exceptionHandler(Handler<Throwable> handler) {
+  public ReadStream<Buffer> exceptionHandler(final Handler<Throwable> handler) {
     source.exceptionHandler(handler);
     return this;
   }
@@ -58,13 +58,13 @@ public final class BufferCopyStream implements ReadStream<Buffer> {
   }
 
   @Override
-  public ReadStream<Buffer> fetch(long amount) {
+  public ReadStream<Buffer> fetch(final long amount) {
     source.fetch(amount);
     return this;
   }
 
   @Override
-  public ReadStream<Buffer> endHandler(Handler<Void> endHandler) {
+  public ReadStream<Buffer> endHandler(final Handler<Void> endHandler) {
     source.endHandler(endHandler);
     return this;
   }

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/BufferCopyStream.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/BufferCopyStream.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.client;
+
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.streams.ReadStream;
+import java.util.Objects;
+
+public final class BufferCopyStream implements ReadStream<Buffer> {
+
+  private final ReadStream<Buffer> source;
+
+  public BufferCopyStream(ReadStream<Buffer> source) {
+    Objects.requireNonNull(source, "Source must be non-null");
+    this.source = source;
+  }
+
+  @Override
+  public ReadStream<Buffer> handler(Handler<Buffer> handler) {
+    if (handler == null) {
+      source.handler(null);
+    } else {
+      source.handler(event -> handler.handle(event.copy()));
+    }
+    return this;
+  }
+
+  @Override
+  public ReadStream<Buffer> exceptionHandler(Handler<Throwable> handler) {
+    source.exceptionHandler(handler);
+    return this;
+  }
+
+  @Override
+  public ReadStream<Buffer> pause() {
+    source.pause();
+    return this;
+  }
+
+  @Override
+  public ReadStream<Buffer> resume() {
+    source.resume();
+    return this;
+  }
+
+  @Override
+  public ReadStream<Buffer> fetch(long amount) {
+    source.fetch(amount);
+    return this;
+  }
+
+  @Override
+  public ReadStream<Buffer> endHandler(Handler<Void> endHandler) {
+    source.endHandler(endHandler);
+    return this;
+  }
+}

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
@@ -50,6 +50,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.parsetools.RecordParser;
+import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
 import java.util.Collections;
 import java.util.List;
@@ -348,11 +349,17 @@ public final class KsqlTarget {
       final WriteStream<T> chunkHandler,
       final CompletableFuture<Void> shouldCloseConnection
   ) {
+
     return executeSync(httpMethod, path, Optional.empty(), requestBody,
         resp -> responseSupplier.get(),
         (resp, vcf) -> {
-        final RecordParser recordParser =
-            RecordParser.newDelimited(delimiter, new BufferCopyStream(resp));
+        final ReadStream<Buffer> readStream;
+        if (resp.request().connection().isSsl()) {
+          readStream = new BufferCopyStream(resp);
+        } else {
+          readStream = resp;
+        }
+        final RecordParser recordParser = RecordParser.newDelimited(delimiter, readStream);
         final AtomicBoolean end = new AtomicBoolean(false);
 
         final WriteStream<Buffer> ws = new BufferMapWriteStream<>(chunkMapper, chunkHandler);

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
@@ -351,7 +351,8 @@ public final class KsqlTarget {
     return executeSync(httpMethod, path, Optional.empty(), requestBody,
         resp -> responseSupplier.get(),
         (resp, vcf) -> {
-        final RecordParser recordParser = RecordParser.newDelimited(delimiter, resp);
+        final RecordParser recordParser =
+            RecordParser.newDelimited(delimiter, new BufferCopyStream(resp));
         final AtomicBoolean end = new AtomicBoolean(false);
 
         final WriteStream<Buffer> ws = new BufferMapWriteStream<>(chunkMapper, chunkHandler);


### PR DESCRIPTION
### Description 

On chunked HTTP responses inside pull query handling logic for multi-node KSQL clusters, KSQL runs into a regression in upstream library Vert.x. Its record parser attempts to reuse the buffer from the HTTP response when aggregating chunks, however, when SSL is enabled, the buffers produced by the netty backend cannot be reused. This results in exceptions of the form

```java.lang.IndexOutOfBoundsException: writerIndex(1) + minWritableBytes(1) exceeds maxCapacity(1): UnpooledByteBufAllocator$InstrumentedUnpooledUnsafeDirectByteBuf(ridx: 0, widx: 1, cap: 1/1)```

Similar instances have been described here:
 - https://github.com/eclipse-vertx/vert.x/issues/3546 in vert.x 3.9.2 (fixed)
 - https://github.com/eclipse-vertx/vert.x/issues/4811 in vert.x 4.4.4 (not fixed)

To work around the bug, we create a `BufferCopyStream`, that does nothing but take the stream from the HTTP response object and call `Buffer.copy` on it.

### Testing done

The issue can be reproduced in a large table scan query on a multi-node cluster with SSL enabled for internode communication. The bug was reproduced this way, and the fix was validated to eliminate the bug in this setting.

### Reviewer checklist

- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
