### PR TITLE
[KSQL-11372] Log pull query bandwidth rate in bytes

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/SlidingWindowRateLimiter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/SlidingWindowRateLimiter.java
@@ -130,8 +130,8 @@ public class SlidingWindowRateLimiter {
       this.numBytesInWindow -= responseSizesLog.poll().right;
     }
     if (this.numBytesInWindow > throttleLimit) {
-      LOG.warn("Hit bandwidth rate limit of " + throttleLimit + "MB with use of "
-          + numBytesInWindow + "MB");
+      LOG.warn("Hit bandwidth rate limit of " + throttleLimit + "B with use of "
+          + numBytesInWindow + "B");
       rejectSensor.record();
       throw new KsqlApiException("Host is at bandwidth rate limit for "
           + ksqlQueryType.toString().toLowerCase() + " queries.",


### PR DESCRIPTION
### Description 
Fix logging for pull query bandwidth limit which reports results in MB instead of B
```
Hit bandwidth rate limit of 199229440MB with use of 279042475MB

```
### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
