### PR TITLE
Migration: Jenkins -> Semaphore

### DIFF
--- a/.semaphore/project.yml
+++ b/.semaphore/project.yml
@@ -1,0 +1,43 @@
+# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
+# template and configurations in service.yml.
+# Modifications in this file will be overwritten by generated content in the nightly run.
+# For more information, please refer to the page:
+# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
+apiVersion: v1alpha
+kind: Project
+metadata:
+  name: ksql
+  description: ""
+spec:
+  visibility: private
+  repository:
+    url: git@github.com:confluentinc/ksql.git
+    run_on:
+    - branches
+    - pull_requests
+    pipeline_file: .semaphore/semaphore.yml
+    integration_type: github_app
+    status:
+      pipeline_files:
+      - path: .semaphore/semaphore.yml
+        level: pipeline
+    whitelist:
+      branches:
+      - master
+      - main
+      - /^\d+\.\d+\.x$/
+      - /^gh-readonly-queue.*/
+  custom_permissions: true
+  debug_permissions:
+  - empty
+  - default_branch
+  - non_default_branch
+  - pull_request
+  - forked_pull_request
+  - tag
+  attach_permissions:
+  - default_branch
+  - non_default_branch
+  - pull_request
+  - forked_pull_request
+  - tag

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,89 @@
+# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
+# template and configurations in service.yml.
+# Any modifications made to ths file will be overwritten by the generated content in nightly runs.
+# For more information, please refer to the page:
+# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
+version: v1.0
+name: build-test-release
+agent:
+  machine:
+    type: s1-prod-ubuntu20-04-amd64-1
+
+fail_fast:
+  cancel:
+    when: "true"
+
+execution_time_limit:
+  hours: 1
+
+queue:
+  - when: "branch != 'master' and branch !~ '[0-9]+\\.[0-9]+\\.x'"
+    processing: parallel
+
+global_job_config:
+  prologue:
+    commands:
+      - checkout
+      - . set-cp-java-version
+      - . cache-maven restore
+
+blocks:
+  - name: Test
+    dependencies: []
+    run:
+      # don't run the tests on non-functional changes...
+      when: "change_in('/', {exclude: ['/.deployed-versions/', '.github/']})"
+    task:
+      jobs:
+        - name: Test
+          commands:
+            - . ci-tools ci-update-version
+            - mvn -Dmaven.gitcommitid.nativegit=true -DskipTests -DskipIntegrationTests -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress clean install
+            - . cache-maven store
+      epilogue:
+        always:
+          commands:
+            - . publish-test-results
+            - artifact push workflow target/test-results
+
+  - name: Release
+    dependencies: ["Test"]
+    run:
+      when: "branch = 'master' or branch =~ '[0-9]+\\.[0-9]+\\.x'"
+    task:
+      jobs:
+        - name: Release
+          commands:
+            - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+            - git fetch --unshallow || true
+            - . ci-tools ci-update-version
+            - . ci-tools ci-push-tag
+            - mvn -Ddocker.skip=true -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode -Pjenkins -DaltDeploymentRepository=confluent-codeartifact-internal::default::https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/
+              -DrepositoryId=confluent-codeartifact-internal deploy -DskipTests
+
+
+after_pipeline:
+  task:
+    agent:
+      machine:
+        type: s1-prod-ubuntu20-04-arm64-0
+    jobs:
+      - name: Metrics
+        commands:
+          - emit-ci-metrics -p -a test-results
+      - name: Publish Test Results
+        commands:
+          - test-results gen-pipeline-report
+      - name: SonarQube
+        commands:
+          - checkout
+          - sem-version java 11
+          - emit-sonarqube-data -a test-results
+      - name: Trigger downstream projects
+        commands:
+          - >-
+            if [[ -z "$SEMAPHORE_GIT_PR_BRANCH" ]] && [[ "$SEMAPHORE_PIPELINE_RESULT" == "passed" ]]; then
+              sem-trigger -p confluent-security-plugins -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
+              sem-trigger -p confluent-cloud-plugins -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
+              sem-trigger -p cc-docker-ksql -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
+            fi

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -58,7 +58,7 @@ blocks:
             - git fetch --unshallow || true
             - . ci-tools ci-update-version
             - . ci-tools ci-push-tag
-            - mvn -Ddocker.skip=true -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode -Pjenkins -DaltDeploymentRepository=confluent-codeartifact-internal::default::https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/
+            - mvn -Ddocker.skip=true -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode -DaltDeploymentRepository=confluent-codeartifact-internal::default::https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/
               -DrepositoryId=confluent-codeartifact-internal deploy -DskipTests
 
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,5 @@ common {
     extraBuildArgs = "-Dmaven.gitcommitid.nativegit=true -DskipTests -DskipIntegrationTests"
     mavenBuildGoals = "clean install"
     runMergeCheck = false
-    mvnSkipDeploy = true
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,5 +24,6 @@ common {
     extraBuildArgs = "-Dmaven.gitcommitid.nativegit=true -DskipTests -DskipIntegrationTests"
     mavenBuildGoals = "clean install"
     runMergeCheck = false
+    mvnSkipDeploy = true
 }
 

--- a/service.yml
+++ b/service.yml
@@ -1,5 +1,6 @@
 name: ksql
 lang: unknown
+lang_version: unknown
 codeowners:
   enable: true
 semaphore:

--- a/service.yml
+++ b/service.yml
@@ -9,3 +9,5 @@ semaphore:
   extra_deploy_args: '-Ddocker.skip=true'
   extra_build_args: "-Dmaven.gitcommitid.nativegit=true -DskipTests -DskipIntegrationTests"
   maven_build_goals: "clean install"
+git:
+  enable: true

--- a/service.yml
+++ b/service.yml
@@ -6,6 +6,7 @@ codeowners:
 semaphore:
   enable: true
   pipeline_type: cp
+  nano_version: true
   downstream_projects: ["confluent-security-plugins", "confluent-cloud-plugins", "cc-docker-ksql"]
   extra_deploy_args: '-Ddocker.skip=true'
   extra_build_args: "-Dmaven.gitcommitid.nativegit=true -DskipTests -DskipIntegrationTests"

--- a/service.yml
+++ b/service.yml
@@ -11,5 +11,6 @@ semaphore:
   extra_deploy_args: '-Ddocker.skip=true'
   extra_build_args: "-Dmaven.gitcommitid.nativegit=true -DskipTests -DskipIntegrationTests"
   maven_build_goals: "clean install"
+  run_merge_check: false
 git:
   enable: true

--- a/service.yml
+++ b/service.yml
@@ -1,0 +1,11 @@
+name: ksql
+lang: unknown
+codeowners:
+  enable: true
+semaphore:
+  enable: true
+  pipeline_type: cp
+  downstream_projects: ["confluent-security-plugins", "confluent-cloud-plugins", "cc-docker-ksql"]
+  extra_deploy_args: '-Ddocker.skip=true'
+  extra_build_args: "-Dmaven.gitcommitid.nativegit=true -DskipTests -DskipIntegrationTests"
+  maven_build_goals: "clean install"


### PR DESCRIPTION
### Action required after merging
If these changes should be on older .x branches as well, apply them to the oldest .x branch, then [pint merge](https://jenkins.confluent.io/job/tools-autotasks/job/tools-autotasks/job/apply-pint-merge/build?delay=0sec) them all the way up to master. Then you can close this PR.

### Changes
1) Deletes the Jenkinsfile.
2) Adds the service-bot config (service.yml) and semaphore files generated by service-bot

### Why are we migrating?
[Read the background and motivation](https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/3033867557/CI+System+Migration+Jenkins-+Semaphore#Background-and-Motivation)  
Please merge this PR ASAP because we plan on shutting down Jenkins by the end of the year.