### PR TITLE
fix: do not continue processing records on permission errors in schema registry

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/errors/LogMetricAndContinueExceptionHandler.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/errors/LogMetricAndContinueExceptionHandler.java
@@ -61,7 +61,7 @@ public class LogMetricAndContinueExceptionHandler implements DeserializationExce
     return DeserializationHandlerResponse.CONTINUE;
   }
 
-  private OptionalLong recursiveFindErrorCode(Throwable throwable, int depthLeft) {
+  private OptionalLong recursiveFindErrorCode(final Throwable throwable, final int depthLeft) {
 
     // depthLeft is used just here to safeguard against infinite recursion in the case of
     // self-referencing exceptions

--- a/ksqldb-common/src/test/java/io/confluent/ksql/errors/LogMetricAndContinueExceptionHandlerTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/errors/LogMetricAndContinueExceptionHandlerTest.java
@@ -77,7 +77,7 @@ public class LogMetricAndContinueExceptionHandlerTest {
   }
 
   @Test
-  public void shouldTerminateForSelfReferencingExceptions() {
+  public void shouldReturnContinueForSelfReferencingExceptions() {
     assertThat(exceptionHandler.handle(context, record, new Exception() {
       @Override
       public synchronized Throwable getCause() {

--- a/ksqldb-common/src/test/java/io/confluent/ksql/errors/LogMetricAndContinueExceptionHandlerTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/errors/LogMetricAndContinueExceptionHandlerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.errors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.ksql.metrics.StreamsErrorCollector;
+import io.confluent.ksql.util.KsqlConfig;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.streams.errors.DeserializationExceptionHandler.DeserializationHandlerResponse;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LogMetricAndContinueExceptionHandlerTest {
+
+  private LogMetricAndContinueExceptionHandler exceptionHandler;
+
+  @Mock
+  private StreamsErrorCollector streamsErrorCollector;
+  @Mock
+  private ProcessorContext context;
+  @Mock
+  private ConsumerRecord<byte[], byte[]> record;
+
+  @Before
+  public void setUp() {
+    final Map<String, ?> configs = ImmutableMap.of(
+        KsqlConfig.KSQL_INTERNAL_STREAMS_ERROR_COLLECTOR_CONFIG, streamsErrorCollector);
+
+    exceptionHandler = new LogMetricAndContinueExceptionHandler();
+    exceptionHandler.configure(configs);
+  }
+
+  @Test
+  public void shouldCallErrorCollector() {
+    when(record.topic()).thenReturn("test");
+    exceptionHandler.handle(context, record, mock(Exception.class));
+    verify(streamsErrorCollector).recordError("test");
+  }
+
+  @Test
+  public void shouldReturnContinueForRegularExceptions() {
+    assertThat(exceptionHandler.handle(context, record, mock(Exception.class)),
+        equalTo(DeserializationHandlerResponse.CONTINUE));
+  }
+
+  @Test
+  public void shouldReturnFailForAuthorizationExceptions() {
+    assertThat(exceptionHandler.handle(context, record,
+            new Exception("", new RestClientException("", 403, 40301))),
+        equalTo(DeserializationHandlerResponse.FAIL));
+  }
+
+  @Test
+  public void shouldTerminateForSelfReferencingExceptions() {
+    assertThat(exceptionHandler.handle(context, record, new Exception() {
+      @Override
+      public synchronized Throwable getCause() {
+        return this;
+      }
+    }), equalTo(DeserializationHandlerResponse.CONTINUE));
+  }
+
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
@@ -447,7 +447,7 @@ public class QueryMetadataImpl implements QueryMetadata {
     listener.onResume(this);
   }
 
-  private QueryError.Type recursiveClassification(Throwable throwable, int depthLeft) {
+  private QueryError.Type recursiveClassification(final Throwable throwable, final int depthLeft) {
     // depthLeft is used just here to safeguard against infinite recursion in the case of
     // self-referencing exceptions
     if (throwable != null && depthLeft > 0) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
@@ -258,14 +258,11 @@ public class QueryMetadataTest {
       }
     };
 
-    // Given:
-    when(classifier.classify(eq(e))).thenReturn(Type.USER);
-
     // When:
     query.uncaughtHandler(new Exception("oops", e));
 
     // Then:
-    verify(listener).onError(same(query), argThat(q -> q.getType().equals(Type.USER)));
+    verify(listener).onError(same(query), argThat(q -> q.getType().equals(Type.UNKNOWN)));
   }
 
   @Test


### PR DESCRIPTION
### Description 

KSQL currently treats an exception due to missing permission on schema registry during deserialization as any other deserialization exception, and the default action for deserialization exception is log and continue.

The permission issue should stop KSQL from processing.

With this change:

 - We scan the exception in the `LogMetricAndContinueExceptionHandler` for a `RestClientException` (can have multiple levels of wrapping) to get the error code and check if we have to deal with an authorization error.
 - Return `FAIL` from the `deserializationExceptionHandler` for such exceptions.
 - The exception will fall through to `StreamsUncaughtExceptionHandler`. There, we make sure that the exception is classified as a `USER` error so that on-call is not alerted. The uncaught exception handler will restart the thread and retry processing records.

The `StreamThreads` for that query will end up in a loop that will restart the `StreamThread` and retry processing the next record. So we effectively get that the query is blocked until the permission error is resolved.

### Testing done 

Tested the change in a local setup connected to ccloud schema registry.

Unit tests included.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
