### PR TITLE
[hotfix] fix 7.5.x KsqlAvroSerializerTest error

### DIFF
--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroSerializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroSerializerTest.java
@@ -215,7 +215,7 @@ public class KsqlAvroSerializerTest {
       parseAvroSchema("{\"type\": \"string\"}");
 
   private static final org.apache.avro.Schema BOOLEAN_ARRAY_AVRO_SCHEMA =
-      parseAvroSchema("{\"type\": \"array\", \"items\": [\"null\", \"boolean\"]}]");
+      parseAvroSchema("{\"type\": \"array\", \"items\": [\"null\", \"boolean\"]}");
 
   private static final org.apache.avro.Schema REQUIRED_KEY_MAP_AVRO_SCHEMA =
       parseAvroSchema("{\"type\": \"map\", \"values\": [\"null\", \"int\"],"


### PR DESCRIPTION
### Description 

- Branch 7.5.x fails due to [KsqlAvroSerializerTest](https://jenkins.confluent.io/job/confluentinc/job/ksql/job/7.5.x/487/console) error. 
- Similar issue was found for branch 6.0.x and was fixed by https://github.com/confluentinc/ksql/pull/10110
- This PR fixes the same issue for branch 7.5.x

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
