### PR TITLE
[hotfix] fix the 7.5.x avro schemas format issue

### DIFF
--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroSerializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroSerializerTest.java
@@ -232,8 +232,7 @@ public class KsqlAvroSerializerTest {
           + "{\"name\":\"key\",\"type\":[\"null\",\"string\"],\"default\":null},"
           + "{\"name\":\"value\",\"type\":[\"null\",\"int\"],\"default\":null}],"
           + "\"connect.internal.type\":\"MapEntry\"},"
-          + "\"connect.name\":\"io.confluent.ksql.avro_schemas.KsqlDataSourceSchema\"}"
-          + "}");
+          + "\"connect.name\":\"io.confluent.ksql.avro_schemas.KsqlDataSourceSchema\"}");
 
   private static final org.apache.avro.Schema DECIMAL_SCHEMA =
       parseAvroSchema(


### PR DESCRIPTION
### Description 

- Build of branch 7.5.x fails: https://jenkins.confluent.io/job/confluentinc/job/ksql/job/7.5.x/459/console

- The local test shows that this is due to a format issue of avro schema:

```
Caused by: org.apache.avro.SchemaParseException: dangling content after end of schema: }
	at org.apache.avro.Schema$Parser.parse(Schema.java:1484)
	at org.apache.avro.Schema$Parser.parse(Schema.java:1458)
	at io.confluent.ksql.serde.avro.KsqlAvroSerializerTest.parseAvroSchema(KsqlAvroSerializerTest.java:1534)
	at io.confluent.ksql.serde.avro.KsqlAvroSerializerTest.<clinit>(KsqlAvroSerializerTest.java:225)
```

- This PR fixes this format issue and pass the test.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
