### PR TITLE
MINOR: fix flaky test

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
@@ -283,7 +283,7 @@ public class ApiTest extends BaseApiTest {
     assertThat(queryResponse.rows, hasSize(DEFAULT_JSON_ROWS.size() - 1));
     validateError(ERROR_CODE_SERVER_ERROR, "Error in processing query. Check server logs for details.", queryResponse.error);
     assertThat(testEndpoints.getQueryPublishers(), hasSize(1));
-    assertThat(server.getQueryIDs().isEmpty(), is(true));
+    assertThatEventually(() -> server.getQueryIDs().isEmpty(), is(true));
   }
 
   @Test
@@ -543,7 +543,7 @@ public class ApiTest extends BaseApiTest {
     validateInsertStreamError(ERROR_CODE_SERVER_ERROR, "Error in processing inserts. Check server logs for details.",
         insertsResponse.error,
         (long) rows.size() - 1);
-    assertThat(testEndpoints.getInsertsSubscriber().isCompleted(), is(true));
+    assertThatEventually(() -> testEndpoints.getInsertsSubscriber().isCompleted(), is(true));
   }
 
   @Test


### PR DESCRIPTION
This test was failing on https://jenkins.confluent.io/job/confluentinc/job/ksql/job/6.2.x/2522/ (opened the PR against `6.0.x` that seems to have the same issue).

It's a classic race condition.

Note that the failing `TlsTest` is a sub-class of `ApiTest` is thus is fixed by this PR, too.