### PR TITLE
Upgrade Antlr to 4.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <podam.version>6.0.2.RELEASE</podam.version>
         <airlift.version>0.29</airlift.version>
         <airline.version>2.6.0</airline.version>
-        <antlr.version>4.9.2</antlr.version>
+        <antlr.version>4.11.1</antlr.version>
         <commons-text.version>1.10.0</commons-text.version>
         <csv.version>1.4</csv.version>
         <commons.compress.version>1.21</commons.compress.version>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <podam.version>6.0.2.RELEASE</podam.version>
         <airlift.version>0.29</airlift.version>
         <airline.version>2.6.0</airline.version>
-        <antlr.version>4.11.1</antlr.version>
+        <antlr.version>4.13.1</antlr.version>
         <commons-text.version>1.10.0</commons-text.version>
         <csv.version>1.4</csv.version>
         <commons.compress.version>1.21</commons.compress.version>


### PR DESCRIPTION
### Description 
When trying to run Data Contract rules in ksql, ksql-server fails to start with the following exception.  This PR attempts to upgrade Antlr to 4.13.1 (the same version used by Schema Registry in master)
```
ANTLR Tool version 4.9.2 used for code generation does not match the current runtime version 4.11.1
ANTLR Runtime version 4.9.2 used for parser compilation does not match the current runtime version 4.11.1
Exception in thread "main" java.lang.ExceptionInInitializerError
        at io.confluent.ksql.util.ParserKeywordValidatorUtil.createFromVocabulary(ParserKeywordValidatorUtil.java:82)
        at io.confluent.ksql.util.ParserKeywordValidatorUtil.<clinit>(ParserKeywordValidatorUtil.java:53)
        at io.confluent.ksql.function.InternalFunctionRegistry.<init>(InternalFunctionRegistry.java:34)
        at io.confluent.ksql.rest.server.KsqlServerMain.loadFunctions(KsqlServerMain.java:127)
        at io.confluent.ksql.rest.server.KsqlServerMain.main(KsqlServerMain.java:80)
Caused by: java.lang.UnsupportedOperationException: java.io.InvalidClassException: org.antlr.v4.runtime.atn.ATN; Could not deserialize ATN with version 3 (expected 4).
        at org.antlr.v4.runtime.atn.ATNDeserializer.deserialize(ATNDeserializer.java:56)
        at org.antlr.v4.runtime.atn.ATNDeserializer.deserialize(ATNDeserializer.java:48)
        at io.confluent.ksql.parser.SqlBaseParser.<clinit>(SqlBaseParser.java:9575)
        ... 5 more
Caused by: java.io.InvalidClassException: org.antlr.v4.runtime.atn.ATN; Could not deserialize ATN with version 3 (expected 4).
        ... 8 more
```

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
