### PR TITLE
chore: fix broken test

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryCleanupService.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryCleanupService.java
@@ -27,8 +27,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.log4j.Logger;
 
 /**
  * {@code QueryCleanupService} helps cleanup external resources from queries
@@ -42,7 +41,7 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("UnstableApiUsage")
 public class QueryCleanupService extends AbstractExecutionThreadService {
 
-  private static final Logger LOG = LoggerFactory.getLogger(QueryCleanupService.class);
+  private static final Logger LOG = Logger.getLogger(QueryCleanupService.class);
   private static final Runnable SHUTDOWN_SENTINEL = () -> { };
 
   private final BlockingQueue<Runnable> cleanupTasks;
@@ -118,13 +117,13 @@ public class QueryCleanupService extends AbstractExecutionThreadService {
         final File directory = new File(String.valueOf(pathName.normalize()));
         if (directory.exists()) {
           FileUtils.deleteDirectory(directory);
-          LOG.warn("Deleted local state store for non-existing query {}. "
+          LOG.warn(String.format("Deleted local state store for non-existing query %s. "
                   + "This is not expected and was likely due to a "
                   + "race condition when the query was dropped before.",
-              appId);
+              appId));
         }
       } catch (Exception e) {
-        LOG.error("Error cleaning up state directory {}\n. {}", appId, e);
+        LOG.error(String.format("Error cleaning up state directory %s.", appId), e);
       }
       tryRun(
           () -> SchemaRegistryUtil.cleanupInternalTopicSchemas(
@@ -146,7 +145,7 @@ public class QueryCleanupService extends AbstractExecutionThreadService {
       try {
         runnable.run();
       } catch (final Exception e) {
-        LOG.warn("Failed to cleanup {} for {}", resource, appId, e);
+        LOG.warn(String.format("Failed to cleanup %s for %s", resource, appId), e);
       }
     }
 


### PR DESCRIPTION
Not sure why, but `io.confluent.ksql.rest.util.PersistentQueryCleanupImplTest.shouldDeleteExtraStateStores` started to fail recently (cf https://jenkins.confluent.io/job/confluentinc/job/ksql/job/7.0.x/2171/testReport/junit/io.confluent.ksql.rest.util/PersistentQueryCleanupImplTest/shouldDeleteExtraStateStores/):
```
java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
	at io.confluent.ksql.rest.util.PersistentQueryCleanupImplTest.shouldDeleteExtraStateStores(PersistentQueryCleanupImplTest.java:86)
```

Capturing the log output did not work any longer. Updating how we create the logger in `QueryCleanupService` fixes the issue