### PR TITLE
fix: make SR dependency optional

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
@@ -283,22 +283,18 @@ public class KsqlServerMain {
 
   private static void validateSrUrl(
       final FipsValidator fipsValidator, final KsqlRestConfig restConfig) {
-    if (!restConfig.originals()
+    if (restConfig.originals()
         .containsKey(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY)) {
-      final String errorMsg = "The Ksql schema registry url property "
-          + "('ksql.schema.registry.url') is not specified.";
-      log.error(errorMsg);
-      throw new SecurityException(errorMsg);
-    }
-    try {
-      fipsValidator.validateRestProtocol(determineProtocol(
-          restConfig.originals().get(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY).toString()));
-    } catch (final Exception e) {
-      final String errorMsg = e.getMessage()
-          + "\nInvalid rest protocol for "
-          + KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY;
-      log.error(errorMsg);
-      throw new SecurityException(errorMsg);
+      try {
+        fipsValidator.validateRestProtocol(determineProtocol(
+            restConfig.originals().get(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY).toString()));
+      } catch (final Exception e) {
+        final String errorMsg = e.getMessage()
+            + "\nInvalid rest protocol for "
+            + KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY;
+        log.error(errorMsg);
+        throw new SecurityException(errorMsg);
+      }
     }
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlServerMainTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlServerMainTest.java
@@ -423,34 +423,6 @@ public class KsqlServerMainTest {
   }
 
   @Test
-  public void shouldFailOnNullSRUrl() {
-    // Given:
-    final KsqlConfig config = configWith(ImmutableMap.of(
-        ConfluentConfigs.ENABLE_FIPS_CONFIG, true,
-        CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SASL_SSL.name
-    ));
-    final KsqlRestConfig restConfig = new KsqlRestConfig(ImmutableMap.<String, Object>builder()
-        .put(KsqlRestConfig.SSL_CIPHER_SUITES_CONFIG,
-            Collections.singletonList("TLS_RSA_WITH_AES_256_CCM"))
-        .put(KsqlConfig.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "https")
-        .build()
-    );
-
-    // When:
-    final Exception e = assertThrows(
-        SecurityException.class,
-        () -> KsqlServerMain.validateFips(config, restConfig)
-    );
-
-    // Then:
-    assertThat(e.getMessage(), containsString(
-        "The Ksql schema registry url property "
-            + "('"
-            + KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY
-            + "') is not specified."));
-  }
-
-  @Test
   public void shouldFailOnInvalidSRUrl() {
     // Given:
     final KsqlConfig config = configWith(ImmutableMap.of(
@@ -490,7 +462,6 @@ public class KsqlServerMainTest {
         .put(KsqlRestConfig.SSL_CIPHER_SUITES_CONFIG,
             Collections.singletonList("TLS_RSA_WITH_AES_256_CCM"))
         .put(KsqlConfig.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "https")
-        .put(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY, "https://foo:8080")
         .build()
     );
 
@@ -519,7 +490,6 @@ public class KsqlServerMainTest {
         .put(KsqlRestConfig.SSL_CIPHER_SUITES_CONFIG,
             Collections.singletonList("TLS_RSA_WITH_AES_256_CCM"))
         .put(KsqlConfig.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "https")
-        .put(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY, "https://foo:8080")
         .put(KsqlRestConfig.LISTENERS_CONFIG,
             Collections.singletonList("https://bar:8080"))
         .put(KsqlRestConfig.PROXY_PROTOCOL_LISTENERS_CONFIG,
@@ -552,7 +522,6 @@ public class KsqlServerMainTest {
         .put(KsqlRestConfig.SSL_CIPHER_SUITES_CONFIG,
             Collections.singletonList("TLS_RSA_WITH_AES_256_CCM"))
         .put(KsqlConfig.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "https")
-        .put(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY, "https://foo:8080")
         .put(KsqlRestConfig.LISTENERS_CONFIG,
             Collections.singletonList("https://bar:8080"))
         .put(KsqlRestConfig.INTERNAL_LISTENER_CONFIG, "http://baz:8080")
@@ -584,7 +553,6 @@ public class KsqlServerMainTest {
         .put(KsqlRestConfig.SSL_CIPHER_SUITES_CONFIG,
             Collections.singletonList("TLS_RSA_WITH_AES_256_CCM"))
         .put(KsqlConfig.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "https")
-        .put(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY, "https://foo:8080")
         .put(KsqlRestConfig.LISTENERS_CONFIG,
             Collections.singletonList("https://bar:8080"))
         .put(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "http://baz:8080")


### PR DESCRIPTION
KSE-1781
Make SR dependency optional in FIPS mode.
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
