### PR TITLE
fix(ksqldb-client-api): fix describeConnector issued query

### DIFF
--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientImpl.java
@@ -476,7 +476,7 @@ public class ClientImpl implements Client {
     makePostRequest(
         KSQL_ENDPOINT,
         new JsonObject()
-            .put("ksql", "describe connector " + name + ";")
+            .put("ksql", String.format("describe connector \"%s\";", name))
             .put("sessionVariables", sessionVariables),
         cf,
         response -> handleSingleEntityResponse(

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
@@ -1568,6 +1568,7 @@ public class ClientTest extends BaseApiTest {
     final io.confluent.ksql.api.client.ConnectorDescription connector = javaClient.describeConnector("name").get();
 
     // Then:
+    assertThat(testEndpoints.getLastSql(), is("describe connector \"name\";"));
     assertThat(connector.state(), is("state"));
     assertThat(connector.className(), is("connectorClass"));
     assertThat(connector.type(), is(new ConnectorTypeImpl("SOURCE")));


### PR DESCRIPTION
This PR fixes issue #10150
Also, the unit test is made more strict to test for correct query

### Description 
The `ClientImpl.describeConnector` method does not add quotes around the connector name.
This fix adds the quotes.

### Testing done 
The unit test has been expanded to verify the issued query.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
