### PR TITLE
fix: Makes SslClientAuthFunctionalTest work with both java 8 and 11

### DIFF
--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslClientAuthFunctionalTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslClientAuthFunctionalTest.java
@@ -19,6 +19,7 @@ import static io.confluent.ksql.serde.FormatFactory.JSON;
 import static io.confluent.ksql.serde.FormatFactory.KAFKA;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static java.util.Collections.emptyMap;
+import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -44,6 +45,8 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLHandshakeException;
+
+import io.netty.handler.codec.http.websocketx.WebSocketHandshakeException;
 import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.common.config.SslConfigs;
 import org.junit.Before;
@@ -112,7 +115,10 @@ public class SslClientAuthFunctionalTest {
 
     // Then:
     assertThat(e.getCause(), (is(instanceOf(ExecutionException.class))));
-    assertThat(e.getCause(), (hasCause(is(instanceOf(SSLHandshakeException.class)))));
+    // Make this compatible with both java 8 and 11.
+    assertThat(e.getCause(), anyOf(
+            hasCause(hasCause(is(instanceOf(SSLHandshakeException.class)))),
+            hasCause(is(instanceOf(SSLHandshakeException.class)))));
   }
 
   @Test
@@ -133,10 +139,16 @@ public class SslClientAuthFunctionalTest {
     givenClientConfiguredWithoutCertificate();
 
     // When:
-    assertThrows(
-        SSLHandshakeException.class,
-        () -> WebsocketUtils.makeWsRequest(JSON_KSQL_REQUEST, clientProps, REST_APP)
+    final Exception e = assertThrows(
+            Exception.class,
+            () -> WebsocketUtils.makeWsRequest(JSON_KSQL_REQUEST, clientProps, REST_APP)
     );
+    assertThat(e, anyOf(is(instanceOf(RuntimeException.class)),
+            is(instanceOf(SSLHandshakeException.class))));
+    if (e instanceof RuntimeException) {
+      assertThat(e.getCause(), is(instanceOf(ExecutionException.class)));
+      assertThat(e.getCause(), hasCause(instanceOf(WebSocketHandshakeException.class)));
+    }
   }
 
   @Test


### PR DESCRIPTION
### Description 

Cherry pick of #10156

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
