### PR TITLE
chore: set Mockito to  5.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,7 @@
         <io.confluent.ksql.version>7.7.0-0</io.confluent.ksql.version>
         <!-- We need to bump this version manually after each version bump on `master`: next bump should be 8.0.0-0 -->
         <io.confluent.schema-registry.version>7.7.0-53</io.confluent.schema-registry.version>
+        <mockito.version>5.2.0</mockito.version>
         <netty-tcnative-version>2.0.61.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`


### PR DESCRIPTION
### Description 
CP packaging (master) failed while building ksqldb:
```
[ERROR] Medium: Return value of org.apache.kafka.streams.kstream.Consumed.withOffsetResetPolicy(Topology$AutoOffsetReset) ignored, but method has no side effect [io.confluent.ksql.execution.streams.SourceBuilderV1Test] At SourceBuilderV1Test.java:[line 329] RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT
```

`cycloneDX`'s `bom.json` reveals that we are pulling in mockito 4.7.1 which is quite old. Mockito has also been known for `RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT` false positives documented [here](https://github.com/spotbugs/spotbugs/issues/872)

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
