### PR TITLE
chore: suppress RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT in SourceBuilderTest

### DIFF
--- a/findbugs/findbugs-exclude.xml
+++ b/findbugs/findbugs-exclude.xml
@@ -38,6 +38,10 @@ For a detailed description of findbugs bug categories, see http://findbugs.sourc
         <Class name="~io.confluent.ksql.version.metrics.KsqlVersionMetrics"/>
     </Match>
 
+    <Match>
+        <Class name="~io.confluent.ksql.execution.streams.SourceBuilderTest"/>
+    </Match>
+
     <!-- false positive in Java 11, see https://github.com/spotbugs/spotbugs/issues/756 -->
     <Match>
         <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
@@ -54,6 +58,9 @@ For a detailed description of findbugs bug categories, see http://findbugs.sourc
     </Match>
     <Match>
         <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_THROWABLE"/>
+    </Match>
+    <Match>
+        <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
     </Match>
 
     <!--


### PR DESCRIPTION
`Master` is broken currently due to `SourceBuilderTest` hitting a false positive spot bug https://github.com/spotbugs/spotbugs/issues/872 upon bumping these:
```
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>7.7.0-154</version>
+        <version>7.7.0-204</version>


 -        <io.confluent.schema-registry.version>7.7.0-53</io.confluent.schema-registry.version>
+        <io.confluent.schema-registry.version>7.7.0-80</io.confluent.schema-registry.version>
```
Repro: 
- On `master` run 
```
./mvnw clean install
-Dmaven.multiModuleProjectDirectory=<PATH_TO_KSQL>
 -U
 -T 100
 -Dmaven.gitcommitid.nativegit=true
 -DskipTests -DskipIntegrationTests
 -Dmaven.wagon.http.retryHandler.count=10
 -Pjenkins
 -Djava.io.tmpdir=/Volumes/RAMDisk
 --batch-mode
 --update-snapshots
```
or some useful subset. It will ✅ 
- Bump the versions and `./mvnw...` again. It will fail 🔴 
- Since the false positive bug was fixed in `4.8.0` ([changelog](https://github.com/spotbugs/spotbugs/releases/tag/4.8.0)) update `pom.xml`:
```
<plugin>
  <groupId>com.github.spotbugs</groupId>
  <artifactId>spotbugs-maven-plugin</artifactId>
  <version>${spotbugs.maven.plugin.version}</version>
  <dependencies>
    <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
    <dependency>
      <groupId>com.github.spotbugs</groupId>
      <artifactId>spotbugs</artifactId>
      <version>4.8.0</version>
    </dependency>
  </dependencies>
  <exclusions>
        <!-- Use a repackaged version of log4j with security patches instead-->
        <exclusion>
            <groupId>log4j</groupId>
            <artifactId>log4j</artifactId>
        </exclusion>
    </exclusions>
</plugin>
```
and then `./mvnw`. It will not his the original `RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT`. 

Solution:
Add an exclusion. I am choosing this over fixing forward because `4.8.0` is a minor version bump with new, more restrictive rules. Upgrading to `4.8.0` is fairly straightforward, but we are blocking a release. The new rules are:
- `CT_CONSTRUCTOR_THROW`
- `PLS_DO_NOT_REUSE-<JAVA-VARIABLE-NAME-OR-SOMETHING-LIKE-THAT>`


### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [x] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [x] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
