### PR TITLE
fix: check status code and do not parse pull query error message

### DIFF
--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
@@ -517,7 +517,7 @@ public final class KsqlTarget {
         if (response.failed()) {
           vcf.completeExceptionally(response.cause());
         }
-        
+
         responseHandler.accept(response.result(), vcf);
       });
       httpClientRequest.exceptionHandler(vcf::completeExceptionally);

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
@@ -514,21 +514,11 @@ public final class KsqlTarget {
 
       final HttpClientRequest httpClientRequest = ar.result();
       httpClientRequest.response(response -> {
-        if (path.equals("/query")) {
-          if (response.failed()) {
-            vcf.completeExceptionally(response.cause());
-          }
-        } else {
-          if (response.failed()) {
-            vcf.completeExceptionally(response.cause());
-          }
+        if (response.failed()) {
+          vcf.completeExceptionally(response.cause());
         }
-
-        if (path.equals("/query")) {
-          responseHandler.accept(response.result(), vcf);
-        } else {
-          responseHandler.accept(response.result(), vcf);
-        }
+        
+        responseHandler.accept(response.result(), vcf);
       });
       httpClientRequest.exceptionHandler(vcf::completeExceptionally);
 


### PR DESCRIPTION
### Description 
https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java#L505 won't be true if status code isn't 200. As a result, the error message is parsed and json exception is thrown. See https://confluentinc.atlassian.net/browse/KSE-1778. 

This can reproduced by starting two local ksql nodes with configs:
```
listeners=http://0.0.0.0:8088

ksql.streams.state.dir=/tmp/1

ksql.streams.num.standby.replicas=1

ksql.heartbeat.enable=true
ksql.lag.reporting.enable=true
ksql.query.pull.enable.standby.reads=true

ksql.advertised.listener=http://localhost:8088
```
and 
```
listeners=http://0.0.0.0:8089

ksql.streams.state.dir=/tmp/2

ksql.streams.num.standby.replicas=1

ksql.heartbeat.enable=true
ksql.lag.reporting.enable=true
ksql.query.pull.enable.standby.reads=true

ksql.advertised.listener=http://localhost:8089
```

In this second node, always throw in https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java#L294-L295.

The fix is to check status code in response handler and if it's not 200, throw exception and fall back to local server to read from standby if possible.

### Testing done 
Manual testing
unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
