### PR TITLE
Remove downstream repos in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ common {
     dockerPush = false
     dockerScan = false
     dockerImageClean = false
-    downStreamRepos = ["confluent-security-plugins", "confluent-cloud-plugins"]
+    // downStreamRepos = ["confluent-security-plugins", "confluent-cloud-plugins"]
     downStreamValidate = false
     nanoVersion = true
     maxBuildsToKeep = 99


### PR DESCRIPTION
### Description 
This PR removes the `confluent-cloud-plugins` and `confluent-security-plugins` repos as downstream repos in `Jenkinsfile`.  This change allows the `confluent-cloud-plugins` and `confluent-security-plugins` repos to finish Jenkins deprecation without causing this repo (ksql) downstream build to fail because Jenkins would not be present in `confluent-cloud-plugins` and `confluent-security-plugins`. `confluent-cloud-plugins` and `confluent-security-plugins` can be added again as downstream repos in `service.yml` when the semaphore migration occurs (the Semaphore migration PR already has `confluent-cloud-plugins` and `confluent-security-plugins` listed as downstream repos in `service.yml`). I made the removal of the downstream repos as a commenting out (instead of just removing the line) for visibility that the downstream repos were disabled and should be added again during Semaphore migration.

### Testing done 
This change was done before in other repos without fail: 
https://github.com/confluentinc/rest-utils/pull/443
https://github.com/confluentinc/kafka-rest/pull/1232

### Reviewer checklist
- [x] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [x] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
