### PR TITLE
chore: enable pinned nanoversions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ common {
     // downStreamRepos = ["confluent-security-plugins", "confluent-cloud-plugins"]
     downStreamValidate = false
     nanoVersion = true
+    pinnedNanoVersions = true
     maxBuildsToKeep = 99
     maxDaysToKeep = 90
     extraBuildArgs = "-Dmaven.gitcommitid.nativegit=true"

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>7.1.12-0</version>
+        <version>7.1.12-3</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>


### PR DESCRIPTION
### Description 
This PR enables pinned nanoversions and sets the version of dependency common to a specific version.


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
