### PR TITLE
docs: update hardcoded copyright year in footer with script (DOCS-26825)

### DIFF
--- a/docs/overrides/partials/copyright.html
+++ b/docs/overrides/partials/copyright.html
@@ -1,4 +1,4 @@
-<p>Copyright &copy; 2022 <a href="https://www.confluent.io/">Confluent, Inc.</a></p>
+<p>Copyright &copy; <script>document.write(new Date().getFullYear());</script> <a href="https://www.confluent.io/">Confluent, Inc.</a></p>
 <p class="footer-feedback-link">
   <a href="mailto:docs-feedback@confluent.io?subject=Documentation feedback&body=[sub]" onclick="this.href = this.href.replace('[sub]',window.location)">Please report any inaccuracies on this page or suggest an edit.</a>
 </p>


### PR DESCRIPTION
Add script for year: `<script>document.write(new Date().getFullYear());</script>`.