### PR TITLE
chore: enable pinned nanoversions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ common {
     // downStreamRepos = ["confluent-security-plugins", "confluent-cloud-plugins"]
     downStreamValidate = false
     nanoVersion = true
+    pinnedNanoVersions = true
     maxBuildsToKeep = 99
     maxDaysToKeep = 90
     extraBuildArgs = "-Dmaven.gitcommitid.nativegit=true"

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>6.1.16-0</version>
+        <version>6.1.16-5</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>


### PR DESCRIPTION
Similar to #10180 #10181 #10182 #10183 #10184 #10185 #10186 but for the 6.1.x series.
