### PR TITLE
Add pinned nano version for common on 7.3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>7.3.8-0</version>
+        <version>7.3.8-1</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>


### PR DESCRIPTION
### Description 
Pin the nanoversion for common dependency for 7.3.x branch. This was done for branches like 7.1.x here: https://github.com/confluentinc/ksql/pull/10181 and 7.2.x here: https://github.com/confluentinc/ksql/pull/10182 but was skipped on 7.3.x here: https://github.com/confluentinc/ksql/pull/10183. This step was skipped likely due to a build failure in `common` repo on 7.3.x resulting in no artifacts being created yet on 7.3.x and as a result no nanoversion to pin.

### Testing done 
Build passing should prove this fix works

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
