### PR TITLE
Set timeout to 6 hours on branches starting on 7.3.x

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ def channel = "${env.BRANCH_NAME}".contains('master') ? '#ksqldb-quality-oncall'
 common {
     nodeLabel = 'docker-debian-jdk11'
     slackChannel = channel
-    timeoutHours = 5
+    timeoutHours = 6
     upstreamProjects = 'confluentinc/schema-registry'
     extraDeployArgs = '-Ddocker.skip=true'
     dockerPush = false


### PR DESCRIPTION
### Description 
Bumping timeout to 6 hours from the current limit of 5 hours due to builds hitting timeout. Last 2 builds on 7.3.x timed out, the last green build took 4.5 hours on Jan 3rd and the previous build directly before the green build on Jan 3rd timed out. 

Noticed the branches before 7.3.x have timeout of 4 hours while branches starting on 7.3.x and after have timeout of 5 hours so just bumping the branches 7.3.x to master (will pint merge) from 5 hours to 6 hours.

### Testing done 
N/A

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
