### PR TITLE
KSE-1786 | Migration: Jenkins -> Semaphore (7.3.x)

### DIFF
--- a/.semaphore/project.yml
+++ b/.semaphore/project.yml
@@ -1,0 +1,43 @@
+# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
+# template and configurations in service.yml.
+# Modifications in this file will be overwritten by generated content in the nightly run.
+# For more information, please refer to the page:
+# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
+apiVersion: v1alpha
+kind: Project
+metadata:
+  name: ksql
+  description: ""
+spec:
+  visibility: private
+  repository:
+    url: git@github.com:confluentinc/ksql.git
+    run_on:
+    - branches
+    - pull_requests
+    pipeline_file: .semaphore/semaphore.yml
+    integration_type: github_app
+    status:
+      pipeline_files:
+      - path: .semaphore/semaphore.yml
+        level: pipeline
+    whitelist:
+      branches:
+      - master
+      - main
+      - /^\d+\.\d+\.x$/
+      - /^gh-readonly-queue.*/
+  custom_permissions: true
+  debug_permissions:
+  - empty
+  - default_branch
+  - non_default_branch
+  - pull_request
+  - forked_pull_request
+  - tag
+  attach_permissions:
+  - default_branch
+  - non_default_branch
+  - pull_request
+  - forked_pull_request
+  - tag

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -25,7 +25,6 @@ global_job_config:
     commands:
       - checkout
       - sem-version java 8
-      - . cache-maven restore
 
 blocks:
   - name: Test
@@ -39,7 +38,6 @@ blocks:
           commands:
             - . ci-tools ci-update-version
             - mvn -Dmaven.gitcommitid.nativegit=true -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress clean install
-            - . cache-maven store
       epilogue:
         always:
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -38,7 +38,7 @@ blocks:
         - name: Test
           commands:
             - . ci-tools ci-update-version
-            - mvn -Dmaven.gitcommitid.nativegit=true -DskipTests -DskipIntegrationTests -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress clean install
+            - mvn -Dmaven.gitcommitid.nativegit=true -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress clean install
             - . cache-maven store
       epilogue:
         always:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,89 @@
+# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
+# template and configurations in service.yml.
+# Any modifications made to ths file will be overwritten by the generated content in nightly runs.
+# For more information, please refer to the page:
+# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
+version: v1.0
+name: build-test-release
+agent:
+  machine:
+    type: s1-prod-ubuntu20-04-amd64-1
+
+fail_fast:
+  cancel:
+    when: "true"
+
+execution_time_limit:
+  hours: 1
+
+queue:
+  - when: "branch != 'master' and branch !~ '[0-9]+\\.[0-9]+\\.x'"
+    processing: parallel
+
+global_job_config:
+  prologue:
+    commands:
+      - checkout
+      - sem-version java 8
+      - . cache-maven restore
+
+blocks:
+  - name: Test
+    dependencies: []
+    run:
+      # don't run the tests on non-functional changes...
+      when: "change_in('/', {exclude: ['/.deployed-versions/', '.github/']})"
+    task:
+      jobs:
+        - name: Test
+          commands:
+            - . ci-tools ci-update-version
+            - mvn -Dmaven.gitcommitid.nativegit=true -DskipTests -DskipIntegrationTests -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress clean install
+            - . cache-maven store
+      epilogue:
+        always:
+          commands:
+            - . publish-test-results
+            - artifact push workflow target/test-results
+
+  - name: Release
+    dependencies: ["Test"]
+    run:
+      when: "branch = 'master' or branch =~ '[0-9]+\\.[0-9]+\\.x'"
+    task:
+      jobs:
+        - name: Release
+          commands:
+            - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+            - git fetch --unshallow || true
+            - . ci-tools ci-update-version
+            - . ci-tools ci-push-tag
+            - mvn -Ddocker.skip=true -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode -DaltDeploymentRepository=confluent-codeartifact-internal::default::https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/
+              -DrepositoryId=confluent-codeartifact-internal deploy -DskipTests
+
+
+after_pipeline:
+  task:
+    agent:
+      machine:
+        type: s1-prod-ubuntu20-04-arm64-0
+    jobs:
+      - name: Metrics
+        commands:
+          - emit-ci-metrics -p -a test-results
+      - name: Publish Test Results
+        commands:
+          - test-results gen-pipeline-report
+      - name: SonarQube
+        commands:
+          - checkout
+          - sem-version java 11
+          - emit-sonarqube-data -a test-results
+      - name: Trigger downstream projects
+        commands:
+          - >-
+            if [[ -z "$SEMAPHORE_GIT_PR_BRANCH" ]] && [[ "$SEMAPHORE_PIPELINE_RESULT" == "passed" ]]; then
+              sem-trigger -p confluent-security-plugins -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
+              sem-trigger -p confluent-cloud-plugins -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
+              sem-trigger -p cc-docker-ksql -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
+            fi

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -77,7 +77,7 @@ after_pipeline:
       - name: SonarQube
         commands:
           - checkout
-          - sem-version java 11
+          - sem-version java 8
           - emit-sonarqube-data -a test-results
       - name: Trigger downstream projects
         commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -14,7 +14,7 @@ fail_fast:
     when: "true"
 
 execution_time_limit:
-  hours: 1
+  hours: 3
 
 queue:
   - when: "branch != 'master' and branch !~ '[0-9]+\\.[0-9]+\\.x'"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,6 +24,7 @@ global_job_config:
   prologue:
     commands:
       - checkout
+      - cache restore
       - sem-version java 11
 
 blocks:
@@ -41,6 +42,7 @@ blocks:
           commands:
             - . ci-tools ci-update-version
             - mvn -Dsurefire.rerunFailingTestsCount=3 -Dmaven.gitcommitid.nativegit=true -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress clean install
+            - cache store
       epilogue:
         always:
           commands:
@@ -61,7 +63,6 @@ blocks:
             - . ci-tools ci-push-tag
             - mvn -Ddocker.skip=true -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode -DaltDeploymentRepository=confluent-codeartifact-internal::default::https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/
               -DrepositoryId=confluent-codeartifact-internal deploy -DskipTests
-
 
 after_pipeline:
   task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -14,7 +14,7 @@ fail_fast:
     when: "true"
 
 execution_time_limit:
-  hours: 3
+  hours: 6
 
 queue:
   - when: "branch != 'master' and branch !~ '[0-9]+\\.[0-9]+\\.x'"
@@ -33,6 +33,9 @@ blocks:
       # don't run the tests on non-functional changes...
       when: "change_in('/', {exclude: ['/.deployed-versions/', '.github/']})"
     task:
+      env_vars:
+        - name: SEMAPHORE_AGENT_UPLOAD_JOB_LOGS
+          value: when-trimmed
       jobs:
         - name: Test
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,7 +24,7 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      - sem-version java 8
+      - sem-version java 11
 
 blocks:
   - name: Test
@@ -40,7 +40,7 @@ blocks:
         - name: Test
           commands:
             - . ci-tools ci-update-version
-            - mvn -Dmaven.gitcommitid.nativegit=true -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress clean install
+            - mvn -Dsurefire.rerunFailingTestsCount=3 -Dmaven.gitcommitid.nativegit=true -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress clean install
       epilogue:
         always:
           commands:
@@ -78,7 +78,7 @@ after_pipeline:
       - name: SonarQube
         commands:
           - checkout
-          - sem-version java 8
+          - sem-version java 11
           - emit-sonarqube-data -a test-results
       - name: Trigger downstream projects
         commands:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,5 +18,6 @@ common {
     maxBuildsToKeep = 99
     maxDaysToKeep = 90
     extraBuildArgs = "-Dmaven.gitcommitid.nativegit=true"
+    mvnSkipDeploy = true
 }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UserFunctionLoader.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UserFunctionLoader.java
@@ -134,7 +134,8 @@ public class UserFunctionLoader {
     // if we are loading from the parent classloader then restrict the name space to only
     // jars/dirs containing "ksql-engine". This is so we don't end up scanning every jar
     //return name -> parentClassLoader != loader || name.contains("ksqldb-engine");
-    return name -> true;
+    return name -> parentClassLoader != loader || name.contains("ksqldb-rest-app")
+        || name.contains("ksqldb-engine");
   }
 
   public static UserFunctionLoader newInstance(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/KsqlConfigTestUtil.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/KsqlConfigTestUtil.java
@@ -17,29 +17,34 @@ package io.confluent.ksql;
 
 import com.google.common.collect.ImmutableMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
 import io.confluent.ksql.util.KsqlConfig;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
+
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.test.TestUtils;
 
 public final class KsqlConfigTestUtil {
 
-  private static final ImmutableMap<String, Object> BASE_CONFIG = ImmutableMap.of(
-      "commit.interval.ms", 0,
-      "cache.max.bytes.buffering", 0,
-      "auto.offset.reset", "earliest",
-      StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()
-  );
+  private static final Supplier<ImmutableMap<String, Object>> BASE_CONFIG_SUPPLIER =
+      () -> ImmutableMap.of(
+          "commit.interval.ms", 0,
+          "cache.max.bytes.buffering", 0,
+          "auto.offset.reset", "earliest",
+          StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()
+      );
 
   private KsqlConfigTestUtil() {}
 
   @SuppressFBWarnings(value = "MS_EXPOSE_REP", justification = "BASE_CONFIG is ImmutableMap")
   public static Map<String, Object> baseTestConfig() {
-    return BASE_CONFIG;
+    return BASE_CONFIG_SUPPLIER.get();
   }
 
   public static KsqlConfig create(final EmbeddedSingleNodeKafkaCluster kafkaCluster) {
@@ -67,7 +72,7 @@ public final class KsqlConfigTestUtil {
       final String kafkaBootstrapServers,
       final Map<String, Object> additionalConfig
   ) {
-    final Map<String, Object> config = new HashMap<>(BASE_CONFIG);
+    final Map<String, Object> config = new HashMap<>(BASE_CONFIG_SUPPLIER.get());
     config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBootstrapServers);
     config.putAll(additionalConfig);
     return new KsqlConfig(config);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -145,7 +145,7 @@ public class KsqlEngineTest {
 
   @Rule
   public final Timeout timeout = Timeout.builder()
-      .withTimeout(10, TimeUnit.SECONDS)
+      .withTimeout(60, TimeUnit.SECONDS)
       .withLookingForStuckThread(true)
       .build();
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -97,6 +97,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -111,7 +112,9 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -139,6 +142,12 @@ public class KsqlEngineTest {
   @Spy
   private final FakeKafkaTopicClient topicClient = new FakeKafkaTopicClient();
   private KsqlExecutionContext sandbox;
+
+  @Rule
+  public final Timeout timeout = Timeout.builder()
+      .withTimeout(10, TimeUnit.SECONDS)
+      .withLookingForStuckThread(true)
+      .build();
 
   @BeforeClass
   public static void setUpFunctionRegistry() {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -137,6 +137,7 @@ public class KsqlEngineTest {
       () -> schemaRegistryClient;
 
   private KsqlEngine ksqlEngine;
+  private boolean isKsqlEngineClosed = false;
   private ServiceContext serviceContext;
   @Spy
   private final FakeKafkaTopicClient topicClient = new FakeKafkaTopicClient();
@@ -144,7 +145,7 @@ public class KsqlEngineTest {
 
   @Rule
   public final Timeout timeout = Timeout.builder()
-      .withTimeout(60, TimeUnit.SECONDS)
+      .withTimeout(180, TimeUnit.SECONDS)
       .withLookingForStuckThread(true)
       .build();
 
@@ -192,10 +193,12 @@ public class KsqlEngineTest {
 
   @After
   public void closeEngine() {
-    try {
-      ksqlEngine.close();
-    } catch (Exception e) {
-      log.warn("Error while closing ksqlEngine", e);
+    if (!isKsqlEngineClosed) {
+      try {
+        ksqlEngine.close();
+      } catch (Exception e) {
+        log.warn("Error while closing ksqlEngine", e);
+      }
     }
     try {
       serviceContext.close();
@@ -1207,6 +1210,7 @@ public class KsqlEngineTest {
 
     // When:
     ksqlEngine.close();
+    isKsqlEngineClosed = true;
 
     // Then:
     verify(topicClient, times(2)).deleteInternalTopics(query.getQueryApplicationId());
@@ -1229,6 +1233,7 @@ public class KsqlEngineTest {
 
     // When:
     ksqlEngine.close();
+    isKsqlEngineClosed = true;
 
     // Then:
     verify(topicClient, times(2)).deleteInternalTopics(query.getQueryApplicationId());
@@ -1453,6 +1458,7 @@ public class KsqlEngineTest {
 
     // When:
     ksqlEngine.close();
+    isKsqlEngineClosed = true;
 
     // Then (there are no transient queries, so no internal topics should be deleted):
     verify(topicClient, never()).deleteInternalTopics(any());
@@ -2493,6 +2499,7 @@ public class KsqlEngineTest {
 
   private void awaitCleanupComplete() {
     awaitCleanupComplete(ksqlEngine);
+    isKsqlEngineClosed = true;
   }
 
   private void awaitCleanupComplete(final KsqlEngine ksqlEngine) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -138,7 +138,6 @@ public class KsqlEngineTest {
 
   private KsqlEngine ksqlEngine;
   private ServiceContext serviceContext;
-  private ServiceContext sandboxServiceContext;
   @Spy
   private final FakeKafkaTopicClient topicClient = new FakeKafkaTopicClient();
   private KsqlExecutionContext sandbox;
@@ -179,7 +178,6 @@ public class KsqlEngineTest {
         ksqlConfig
     );
     sandbox = ksqlEngine.createSandbox(serviceContext);
-    sandboxServiceContext = sandbox.getServiceContext();
   }
 
   private void setupKsqlEngineWithSharedRuntimeDisabled() {
@@ -190,7 +188,6 @@ public class KsqlEngineTest {
         ksqlConfig
     );
     sandbox = ksqlEngine.createSandbox(serviceContext);
-    sandboxServiceContext = sandbox.getServiceContext();
   }
 
   @After
@@ -330,7 +327,7 @@ public class KsqlEngineTest {
 
     // When:
     final ExecuteResult result = sandbox
-        .execute(sandboxServiceContext, ConfiguredStatement.of(
+        .execute(sandbox.getServiceContext(), ConfiguredStatement.of(
             sandbox.prepare(statements.get(1)),
             SessionConfig.of(ksqlConfig, Collections.emptyMap())
         ));
@@ -953,7 +950,7 @@ public class KsqlEngineTest {
     final Exception e = assertThrows(
         KsqlStatementException.class,
         () -> sandbox.execute(
-            sandboxServiceContext,
+            sandbox.getServiceContext(),
             ConfiguredStatement.of(prepared, SessionConfig.of(ksqlConfig, Collections.emptyMap()))
         )
     );
@@ -1017,7 +1014,7 @@ public class KsqlEngineTest {
     final KsqlStatementException e = assertThrows(
         KsqlStatementException.class,
         () -> sandbox.execute(
-            sandboxServiceContext,
+            sandbox.getServiceContext(),
             ConfiguredStatement.of(statement, SessionConfig.of(ksqlConfig, ImmutableMap.of()))
         )
     );
@@ -1717,8 +1714,7 @@ public class KsqlEngineTest {
   public void shouldHandleMultipleStatements() {
     // Given:
     setupKsqlEngineWithSharedRuntimeEnabled();
-    final String sql = ""
-        + "-- single line comment\n"
+    final String sql = "-- single line comment\n"
         + "/*\n"
         + "   Multi-line comment\n"
         + "*/\n"
@@ -1823,7 +1819,7 @@ public class KsqlEngineTest {
     sandbox = ksqlEngine.createSandbox(serviceContext);
 
     // When:
-    ExecuteResult executeResult = sandbox.execute(sandboxServiceContext, newQuery);
+    ExecuteResult executeResult = sandbox.execute(sandbox.getServiceContext(), newQuery);
 
     // Then:
     assertThat(executeResult.getQuery().get().getQueryId(), is(oldQueryId));
@@ -1842,7 +1838,7 @@ public class KsqlEngineTest {
         .get().getQueryId();
 
     // When:
-    ExecuteResult executeResult = ksqlEngine.execute(sandboxServiceContext, newQuery);
+    ExecuteResult executeResult = ksqlEngine.execute(sandbox.getServiceContext(), newQuery);
 
     // Then:
     assertThat(executeResult.getQuery().get().getQueryId(), is(oldQueryId));
@@ -2116,7 +2112,7 @@ public class KsqlEngineTest {
     // When:
     statements
         .forEach(stmt -> sandbox.execute(
-            sandboxServiceContext,
+            sandbox.getServiceContext(),
             ConfiguredStatement
                 .of(sandbox.prepare(stmt), SessionConfig.of(ksqlConfig, new HashMap<>())
                 )));
@@ -2144,7 +2140,7 @@ public class KsqlEngineTest {
     // When:
     statements.forEach(
         stmt -> sandbox.execute(
-            sandboxServiceContext,
+            sandbox.getServiceContext(),
             ConfiguredStatement
                 .of(sandbox.prepare(stmt), SessionConfig.of(ksqlConfig, new HashMap<>())
                 ))
@@ -2164,7 +2160,7 @@ public class KsqlEngineTest {
 
     // When:
     sandbox.execute(
-        sandboxServiceContext,
+        sandbox.getServiceContext(),
         ConfiguredStatement
             .of(statement, SessionConfig.of(ksqlConfig, new HashMap<>()))
     );
@@ -2190,7 +2186,7 @@ public class KsqlEngineTest {
 
     // When:
     sandbox.execute(
-        sandboxServiceContext,
+        sandbox.getServiceContext(),
         ConfiguredStatement
             .of(prepared, SessionConfig.of(ksqlConfig, new HashMap<>()))
     );
@@ -2231,7 +2227,7 @@ public class KsqlEngineTest {
 
     // When:
     final ExecuteResult result = sandbox.execute(
-        sandboxServiceContext,
+        sandbox.getServiceContext(),
         ConfiguredStatement
             .of(prepared, SessionConfig.of(ksqlConfig, new HashMap<>()))
     );
@@ -2303,7 +2299,7 @@ public class KsqlEngineTest {
 
     // When:
     final ExecuteResult result = sandbox.execute(
-        sandboxServiceContext,
+        sandbox.getServiceContext(),
         ConfiguredStatement
             .of(statement, SessionConfig.of(ksqlConfig, new HashMap<>()))
     );

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -112,10 +112,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @SuppressWarnings({"OptionalGetWithoutIsPresent", "SameParameterValue"})
 @RunWith(MockitoJUnitRunner.class)
 public class KsqlEngineTest {
+  private static final Logger log = LoggerFactory.getLogger(KsqlEngineTest.class);
 
   private KsqlConfig ksqlConfig;
   private final Map<String, Object> sharedRuntimeEnabled = new HashMap<>();
@@ -135,7 +138,6 @@ public class KsqlEngineTest {
 
   @Before
   public void setUp() {
-    sharedRuntimeEnabled.put(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED, true);
     sharedRuntimeEnabled.put(StreamsConfig.InternalConfig.TOPIC_PREFIX_ALTERNATIVE,
         ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX
             + "default_"
@@ -163,8 +165,16 @@ public class KsqlEngineTest {
 
   @After
   public void closeEngine() {
-    ksqlEngine.close();
-    serviceContext.close();
+    try {
+      ksqlEngine.close();
+    } catch (Exception e) {
+      log.warn("Error while closing ksqlEngine", e);
+    }
+    try {
+      serviceContext.close();
+    } catch (Exception e) {
+      log.warn("Error while closing serviceContext", e);
+    }
   }
 
   @Test
@@ -1037,12 +1047,6 @@ public class KsqlEngineTest {
   @Test
   public void shouldCleanUpInternalTopicsOnClose() {
     // Given:
-    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeDisabled);
-    ksqlEngine = KsqlEngineTestUtil.createKsqlEngine(
-        serviceContext,
-        metaStore,
-        ksqlConfig
-    );
     final QueryMetadata query = KsqlEngineTestUtil.executeQuery(
         serviceContext,
         ksqlEngine,
@@ -1085,12 +1089,6 @@ public class KsqlEngineTest {
   @Test
   public void shouldCleanUpInternalTopicsOnEngineCloseForTransientQueries() {
     // Given:
-    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeDisabled);
-    ksqlEngine = KsqlEngineTestUtil.createKsqlEngine(
-        serviceContext,
-        metaStore,
-        ksqlConfig
-    );
     final QueryMetadata query = KsqlEngineTestUtil.executeQuery(
         serviceContext,
         ksqlEngine,
@@ -1170,12 +1168,6 @@ public class KsqlEngineTest {
   @Test
   public void shouldHardDeleteSchemaOnEngineCloseForTransientQueries() throws IOException, RestClientException {
     // Given:
-    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeDisabled);
-    ksqlEngine = KsqlEngineTestUtil.createKsqlEngine(
-        serviceContext,
-        metaStore,
-        ksqlConfig
-    );
     final QueryMetadata query = KsqlEngineTestUtil.executeQuery(
         serviceContext,
         ksqlEngine,
@@ -1259,12 +1251,6 @@ public class KsqlEngineTest {
   @Test
   public void shouldCleanUpConsumerGroupsOnClose() {
     // Given:
-    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeDisabled);
-    ksqlEngine = KsqlEngineTestUtil.createKsqlEngine(
-        serviceContext,
-        metaStore,
-        ksqlConfig
-    );
     final QueryMetadata query = KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -1291,12 +1277,6 @@ public class KsqlEngineTest {
   @Test
   public void shouldCleanUpTransientConsumerGroupsOnClose() {
     // Given:
-    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeDisabled);
-    ksqlEngine = KsqlEngineTestUtil.createKsqlEngine(
-        serviceContext,
-        metaStore,
-        ksqlConfig
-    );
     final QueryMetadata query = KsqlEngineTestUtil.executeQuery(
         serviceContext,
         ksqlEngine,
@@ -1370,12 +1350,6 @@ public class KsqlEngineTest {
   @Test
   public void shouldCleanUpInternalTopicsOnQueryCloseForPersistentQueries() {
     // Given:
-    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeDisabled);
-    ksqlEngine = KsqlEngineTestUtil.createKsqlEngine(
-        serviceContext,
-        metaStore,
-        ksqlConfig
-    );
     final List<QueryMetadata> query = KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -1413,18 +1387,12 @@ public class KsqlEngineTest {
     // Then (there are no transient queries, so no internal topics should be deleted):
     awaitCleanupComplete();
     final String topicPrefix = query.get(0).getQueryApplicationId().split("query")[0] + "query_";
-    verify(topicClient).deleteInternalTopics( topicPrefix + query.get(0).getQueryId().toString());
+    verify(topicClient, times(2)).deleteInternalTopics( topicPrefix + query.get(0).getQueryId().toString());
   }
 
   @Test
   public void shouldNotHardDeleteSubjectForPersistentQuery() throws IOException, RestClientException {
     // Given:
-    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeDisabled);
-    ksqlEngine = KsqlEngineTestUtil.createKsqlEngine(
-        serviceContext,
-        metaStore,
-        ksqlConfig
-    );
     final List<QueryMetadata> query = KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -160,9 +160,6 @@ public class KsqlEngineTest {
         topicClient,
         schemaRegistryClientFactory
     );
-
-    sandbox = ksqlEngine.createSandbox(serviceContext);
-    sandboxServiceContext = sandbox.getServiceContext();
   }
 
   private void setupKsqlEngineWithSharedRuntimeEnabled() {
@@ -172,6 +169,8 @@ public class KsqlEngineTest {
         metaStore,
         ksqlConfig
     );
+    sandbox = ksqlEngine.createSandbox(serviceContext);
+    sandboxServiceContext = sandbox.getServiceContext();
   }
 
   private void setupKsqlEngineWithSharedRuntimeDisabled() {
@@ -181,6 +180,8 @@ public class KsqlEngineTest {
         metaStore,
         ksqlConfig
     );
+    sandbox = ksqlEngine.createSandbox(serviceContext);
+    sandboxServiceContext = sandbox.getServiceContext();
   }
 
   @After
@@ -1492,7 +1493,7 @@ public class KsqlEngineTest {
     // Then (there are no transient queries, so no internal topics should be deleted):
     awaitCleanupComplete();
     final String topicPrefix = query.get(0).getQueryApplicationId().split("query")[0] + "query_";
-    verify(topicClient, times(2)).deleteInternalTopics( topicPrefix + query.get(0).getQueryId().toString());
+    verify(topicClient).deleteInternalTopics( topicPrefix + query.get(0).getQueryId().toString());
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryLimitHARoutingTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryLimitHARoutingTest.java
@@ -62,6 +62,7 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -69,7 +70,7 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.Timeout;
 
-
+@Ignore
 @Category({IntegrationTest.class})
 public class PullQueryLimitHARoutingTest {
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -249,10 +249,14 @@ public class KsqlResourceTest {
               "VALUE_FORMAT", new StringLiteral("avro")
           )),
           false));
-  private static final ConfiguredStatement<CreateStream> CFG_0_WITH_SCHEMA = ConfiguredStatement.of(
-      STMT_0_WITH_SCHEMA,
-      SessionConfig.of(new KsqlConfig(getDefaultKsqlConfig()), ImmutableMap.of())
-  );
+
+  private static final Properties DEFAULT_KSQL_CONFIG = getDefaultKsqlConfig();
+
+  private static final ConfiguredStatement<CreateStream> CFG_0_WITH_SCHEMA =
+      ConfiguredStatement.of(
+        STMT_0_WITH_SCHEMA,
+        SessionConfig.of(new KsqlConfig(DEFAULT_KSQL_CONFIG), ImmutableMap.of())
+    );
 
   private static final PreparedStatement<CreateStream> STMT_1_WITH_SCHEMA = PreparedStatement.of(
       "other sql with schema",
@@ -269,7 +273,7 @@ public class KsqlResourceTest {
           false));
   private static final ConfiguredStatement<CreateStream> CFG_1_WITH_SCHEMA = ConfiguredStatement
       .of(STMT_1_WITH_SCHEMA,
-          SessionConfig.of(new KsqlConfig(getDefaultKsqlConfig()), ImmutableMap.of())
+          SessionConfig.of(new KsqlConfig(DEFAULT_KSQL_CONFIG), ImmutableMap.of())
       );
 
   private static final LogicalSchema SOME_SCHEMA = LogicalSchema.builder()
@@ -348,7 +352,7 @@ public class KsqlResourceTest {
     serviceContext = TestServiceContext.create(kafkaTopicClient, kafkaConsumerGroupClient);
     schemaRegistryClient = serviceContext.getSchemaRegistryClient();
     registerValueSchema(schemaRegistryClient);
-    ksqlRestConfig = new KsqlRestConfig(getDefaultKsqlConfig());
+    ksqlRestConfig = new KsqlRestConfig(DEFAULT_KSQL_CONFIG);
     ksqlConfig = new KsqlConfig(ksqlRestConfig.getKsqlConfigProperties());
     final KsqlExecutionContext.ExecuteResult result = mock(KsqlExecutionContext.ExecuteResult.class);
     when(sandbox.execute(any(), any(ConfiguredKsqlPlan.class))).thenReturn(result);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StatusResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StatusResourceTest.java
@@ -16,14 +16,12 @@
 package io.confluent.ksql.rest.server.resources;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.easymock.EasyMock.anyObject;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.mock;
-import static org.easymock.EasyMock.replay;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.rest.EndpointResponse;
 import io.confluent.ksql.rest.Errors;
@@ -36,6 +34,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class StatusResourceTest {
 
@@ -63,15 +62,12 @@ public class StatusResourceTest {
   private StatusResource getTestStatusResource() {
     final InteractiveStatementExecutor mockStatementExecutor = mock(InteractiveStatementExecutor.class);
 
-    expect(mockStatementExecutor.getStatuses()).andReturn(mockCommandStatuses);
+    when(mockStatementExecutor.getStatuses()).thenReturn(mockCommandStatuses);
 
+    when(mockStatementExecutor.getStatus(Mockito.any(CommandId.class))).thenReturn(Optional.empty());
     for (final Map.Entry<CommandId, CommandStatus> commandEntry : mockCommandStatuses.entrySet()) {
-      expect(mockStatementExecutor.getStatus(commandEntry.getKey())).andReturn(Optional.of(commandEntry.getValue()));
+      when(mockStatementExecutor.getStatus(commandEntry.getKey())).thenReturn(Optional.of(commandEntry.getValue()));
     }
-
-    expect(mockStatementExecutor.getStatus(anyObject(CommandId.class))).andReturn(Optional.<CommandStatus>empty());
-
-    replay(mockStatementExecutor);
 
     return new StatusResource(mockStatementExecutor);
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StatusResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StatusResourceTest.java
@@ -69,7 +69,7 @@ public class StatusResourceTest {
       expect(mockStatementExecutor.getStatus(commandEntry.getKey())).andReturn(Optional.of(commandEntry.getValue()));
     }
 
-    expect(mockStatementExecutor.getStatus(anyObject(CommandId.class))).andReturn(Optional.empty());
+    expect(mockStatementExecutor.getStatus(anyObject(CommandId.class))).andReturn(Optional.<CommandStatus>empty());
 
     replay(mockStatementExecutor);
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>7.0.14-3</version>
+        <version>7.0.14-4</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>7.0.14-2</version>
+        <version>7.0.14-3</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>7.1.12-6</version>
+        <version>7.1.12-7</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>7.0.14-4</version>
+        <version>7.0.14-5</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>7.2.10-4</version>
+        <version>7.2.10-5</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>7.2.10-5</version>
+        <version>7.2.10-6</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>7.1.12-5</version>
+        <version>7.1.12-6</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>7.1.12-4</version>
+        <version>7.1.12-5</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>7.0.14-5</version>
+        <version>7.0.14-6</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>7.2.10-8</version>
+        <version>7.2.10-9</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>7.2.10-6</version>
+        <version>7.2.10-7</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>7.2.10-7</version>
+        <version>7.2.10-8</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>7.2.10-9</version>
+        <version>7.2.10-10</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -710,12 +710,14 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <rerunFailingTestsCount>3</rerunFailingTestsCount>
                     <systemPropertyVariables>
                         <log4j.configuration>file:${project.basedir}/../ksqldb-test-util/src/main/resources/log4j.properties</log4j.configuration>
                     </systemPropertyVariables>
                     <argLine>-verbose:gc -Xloggc:"${project.build.directory}/gc.log"</argLine>
                     <argLine>-Duser.timezone=UTC -Xmx1g -Xms1g</argLine>
                 </configuration>
+                <version>3.2.5</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>7.2.10-10</version>
+        <version>7.2.10-11</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -715,7 +715,7 @@
                         <log4j.configuration>file:${project.basedir}/../ksqldb-test-util/src/main/resources/log4j.properties</log4j.configuration>
                     </systemPropertyVariables>
                     <argLine>-verbose:gc -Xloggc:"${project.build.directory}/gc.log"</argLine>
-                    <argLine>-Duser.timezone=UTC -Xmx1g -Xms1g</argLine>
+                    <argLine>-Duser.timezone=UTC -Xmx1g -Xms1g -XX:MaxPermSize=256m</argLine>
                 </configuration>
                 <version>3.2.5</version>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>7.2.10-11</version>
+        <version>7.2.10-12</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>

--- a/service.yml
+++ b/service.yml
@@ -7,7 +7,7 @@ semaphore:
   enable: true
   pipeline_type: cp
   nano_version: true
-  execution_time_limit: {"hours": 3}
+  execution_time_limit: {"hours": 6}
   downstream_projects: ["confluent-security-plugins", "confluent-cloud-plugins", "cc-docker-ksql"]
   extra_deploy_args: '-Ddocker.skip=true'
   extra_build_args: "-Dmaven.gitcommitid.nativegit=true"

--- a/service.yml
+++ b/service.yml
@@ -1,0 +1,16 @@
+name: ksql
+lang: unknown
+lang_version: unknown
+codeowners:
+  enable: true
+semaphore:
+  enable: true
+  pipeline_type: cp
+  nano_version: true
+  downstream_projects: ["confluent-security-plugins", "confluent-cloud-plugins", "cc-docker-ksql"]
+  extra_deploy_args: '-Ddocker.skip=true'
+  extra_build_args: "-Dmaven.gitcommitid.nativegit=true -DskipTests -DskipIntegrationTests"
+  maven_build_goals: "clean install"
+  run_merge_check: false
+git:
+  enable: true

--- a/service.yml
+++ b/service.yml
@@ -7,6 +7,7 @@ semaphore:
   enable: true
   pipeline_type: cp
   nano_version: true
+  execution_time_limit: {"hours": 3}
   downstream_projects: ["confluent-security-plugins", "confluent-cloud-plugins", "cc-docker-ksql"]
   extra_deploy_args: '-Ddocker.skip=true'
   extra_build_args: "-Dmaven.gitcommitid.nativegit=true"

--- a/service.yml
+++ b/service.yml
@@ -9,7 +9,7 @@ semaphore:
   nano_version: true
   downstream_projects: ["confluent-security-plugins", "confluent-cloud-plugins", "cc-docker-ksql"]
   extra_deploy_args: '-Ddocker.skip=true'
-  extra_build_args: "-Dmaven.gitcommitid.nativegit=true -DskipTests -DskipIntegrationTests"
+  extra_build_args: "-Dmaven.gitcommitid.nativegit=true"
   maven_build_goals: "clean install"
   run_merge_check: false
 git:


### PR DESCRIPTION
### Description 
Summary of changes:
1. Migrate the build job from jenkins to semaphore.
2. Fixed the thread leak in the setup() of KsqlEngine instances in KsqlEngineTest.
3. Cherry-picked the change for UserFunctionLoader to scan for select modules.
4. Use different state dirs for each test invocation and corresponding test fixes.
5. Cherry-pick test skip for PullQueryLimitHARoutingTest.
6. Specify rerun of failing flaky tests to atmost thrice.
7. Specify a fixed timeout for KsqlEngineTests to avoid build timeouts.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
