### PR TITLE
KSE-1786 | Migration: Jenkins -> Semaphore (7.5.x)

### DIFF
--- a/.semaphore/project.yml
+++ b/.semaphore/project.yml
@@ -1,0 +1,43 @@
+# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
+# template and configurations in service.yml.
+# Modifications in this file will be overwritten by generated content in the nightly run.
+# For more information, please refer to the page:
+# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
+apiVersion: v1alpha
+kind: Project
+metadata:
+  name: ksql
+  description: ""
+spec:
+  visibility: private
+  repository:
+    url: git@github.com:confluentinc/ksql.git
+    run_on:
+    - branches
+    - pull_requests
+    pipeline_file: .semaphore/semaphore.yml
+    integration_type: github_app
+    status:
+      pipeline_files:
+      - path: .semaphore/semaphore.yml
+        level: pipeline
+    whitelist:
+      branches:
+      - master
+      - main
+      - /^\d+\.\d+\.x$/
+      - /^gh-readonly-queue.*/
+  custom_permissions: true
+  debug_permissions:
+  - empty
+  - default_branch
+  - non_default_branch
+  - pull_request
+  - forked_pull_request
+  - tag
+  attach_permissions:
+  - default_branch
+  - non_default_branch
+  - pull_request
+  - forked_pull_request
+  - tag

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,91 @@
+# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
+# template and configurations in service.yml.
+# Any modifications made to ths file will be overwritten by the generated content in nightly runs.
+# For more information, please refer to the page:
+# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
+version: v1.0
+name: build-test-release
+agent:
+  machine:
+    type: s1-prod-ubuntu20-04-amd64-1
+
+fail_fast:
+  cancel:
+    when: "true"
+
+execution_time_limit:
+  hours: 6
+
+queue:
+  - when: "branch != 'master' and branch !~ '[0-9]+\\.[0-9]+\\.x'"
+    processing: parallel
+
+global_job_config:
+  prologue:
+    commands:
+      - checkout
+      - cache restore
+      - sem-version java 11
+
+blocks:
+  - name: Test
+    dependencies: []
+    run:
+      # don't run the tests on non-functional changes...
+      when: "change_in('/', {exclude: ['/.deployed-versions/', '.github/']})"
+    task:
+      env_vars:
+        - name: SEMAPHORE_AGENT_UPLOAD_JOB_LOGS
+          value: when-trimmed
+      jobs:
+        - name: Test
+          commands:
+            - . ci-tools ci-update-version
+            - mvn -Dsurefire.rerunFailingTestsCount=3 -Dmaven.gitcommitid.nativegit=true -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress clean install
+            - cache store
+      epilogue:
+        always:
+          commands:
+            - . publish-test-results
+            - artifact push workflow target/test-results
+
+  - name: Release
+    dependencies: ["Test"]
+    run:
+      when: "branch = 'master' or branch =~ '[0-9]+\\.[0-9]+\\.x'"
+    task:
+      jobs:
+        - name: Release
+          commands:
+            - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+            - git fetch --unshallow || true
+            - . ci-tools ci-update-version
+            - . ci-tools ci-push-tag
+            - mvn -Ddocker.skip=true -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode -DaltDeploymentRepository=confluent-codeartifact-internal::default::https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/
+              -DrepositoryId=confluent-codeartifact-internal deploy -DskipTests
+
+after_pipeline:
+  task:
+    agent:
+      machine:
+        type: s1-prod-ubuntu20-04-arm64-0
+    jobs:
+      - name: Metrics
+        commands:
+          - emit-ci-metrics -p -a test-results
+      - name: Publish Test Results
+        commands:
+          - test-results gen-pipeline-report
+      - name: SonarQube
+        commands:
+          - checkout
+          - sem-version java 11
+          - emit-sonarqube-data -a test-results
+      - name: Trigger downstream projects
+        commands:
+          - >-
+            if [[ -z "$SEMAPHORE_GIT_PR_BRANCH" ]] && [[ "$SEMAPHORE_PIPELINE_RESULT" == "passed" ]]; then
+              sem-trigger -p confluent-security-plugins -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
+              sem-trigger -p confluent-cloud-plugins -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
+              sem-trigger -p cc-docker-ksql -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
+            fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,5 +25,6 @@ common {
     extraBuildArgs = "-Dmaven.gitcommitid.nativegit=true"
     mavenBuildGoals = "clean install"
     runMergeCheck = false
+    mvnSkipDeploy = true
 }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UserFunctionLoader.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UserFunctionLoader.java
@@ -134,7 +134,8 @@ public class UserFunctionLoader {
     // if we are loading from the parent classloader then restrict the name space to only
     // jars/dirs containing "ksql-engine". This is so we don't end up scanning every jar
     //return name -> parentClassLoader != loader || name.contains("ksqldb-engine");
-    return name -> true;
+    return name -> parentClassLoader != loader || name.contains("ksqldb-rest-app")
+        || name.contains("ksqldb-engine");
   }
 
   public static UserFunctionLoader newInstance(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/KsqlConfigTestUtil.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/KsqlConfigTestUtil.java
@@ -17,29 +17,34 @@ package io.confluent.ksql;
 
 import com.google.common.collect.ImmutableMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
 import io.confluent.ksql.util.KsqlConfig;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
+
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.test.TestUtils;
 
 public final class KsqlConfigTestUtil {
 
-  private static final ImmutableMap<String, Object> BASE_CONFIG = ImmutableMap.of(
-      "commit.interval.ms", 0,
-      "cache.max.bytes.buffering", 0,
-      "auto.offset.reset", "earliest",
-      StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()
-  );
+  private static final Supplier<ImmutableMap<String, Object>> BASE_CONFIG_SUPPLIER =
+      () -> ImmutableMap.of(
+          "commit.interval.ms", 0,
+          "cache.max.bytes.buffering", 0,
+          "auto.offset.reset", "earliest",
+          StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()
+      );
 
   private KsqlConfigTestUtil() {}
 
   @SuppressFBWarnings(value = "MS_EXPOSE_REP", justification = "BASE_CONFIG is ImmutableMap")
   public static Map<String, Object> baseTestConfig() {
-    return BASE_CONFIG;
+    return BASE_CONFIG_SUPPLIER.get();
   }
 
   public static KsqlConfig create(final EmbeddedSingleNodeKafkaCluster kafkaCluster) {
@@ -67,7 +72,7 @@ public final class KsqlConfigTestUtil {
       final String kafkaBootstrapServers,
       final Map<String, Object> additionalConfig
   ) {
-    final Map<String, Object> config = new HashMap<>(BASE_CONFIG);
+    final Map<String, Object> config = new HashMap<>(BASE_CONFIG_SUPPLIER.get());
     config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBootstrapServers);
     config.putAll(additionalConfig);
     return new KsqlConfig(config);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -98,6 +98,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -144,6 +145,8 @@ public class KsqlEngineTest {
   private final FakeKafkaTopicClient topicClient = new FakeKafkaTopicClient();
   private KsqlExecutionContext sandbox;
 
+  private static final AtomicBoolean isFunctionRegistryLoaded = new AtomicBoolean(false);
+
   @Rule
   public final Timeout timeout = Timeout.builder()
       .withTimeout(180, TimeUnit.SECONDS)
@@ -152,18 +155,14 @@ public class KsqlEngineTest {
 
   @BeforeClass
   public static void setUpFunctionRegistry() {
-    loadAllUserFunctions(functionRegistry);
+    if (!isFunctionRegistryLoaded.get()) {
+      loadAllUserFunctions(functionRegistry);
+      isFunctionRegistryLoaded.compareAndSet(false, true);
+    }
   }
 
   @Before
   public void setUp() {
-    sharedRuntimeEnabled.put(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED, true);
-    sharedRuntimeEnabled.put(StreamsConfig.InternalConfig.TOPIC_PREFIX_ALTERNATIVE,
-        ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX
-            + "default_"
-            + "query");
-    sharedRuntimeDisabled.put(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED, false);
-
     metaStore = MetaStoreFixture.getNewMetaStore(functionRegistry);
 
     serviceContext = TestServiceContext.create(
@@ -173,6 +172,11 @@ public class KsqlEngineTest {
   }
 
   private void setupKsqlEngineWithSharedRuntimeEnabled() {
+    sharedRuntimeEnabled.put(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED, true);
+    sharedRuntimeEnabled.put(StreamsConfig.InternalConfig.TOPIC_PREFIX_ALTERNATIVE,
+        ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX
+            + "default_"
+            + "query");
     ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeEnabled);
     ksqlEngine = KsqlEngineTestUtil.createKsqlEngine(
         serviceContext,
@@ -183,6 +187,7 @@ public class KsqlEngineTest {
   }
 
   private void setupKsqlEngineWithSharedRuntimeDisabled() {
+    sharedRuntimeDisabled.put(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED, false);
     ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeDisabled);
     ksqlEngine = KsqlEngineTestUtil.createKsqlEngine(
         serviceContext,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -138,6 +138,7 @@ public class KsqlEngineTest {
       () -> schemaRegistryClient;
 
   private KsqlEngine ksqlEngine;
+  private boolean isKsqlEngineClosed = false;
   private ServiceContext serviceContext;
   @Spy
   private final FakeKafkaTopicClient topicClient = new FakeKafkaTopicClient();
@@ -145,7 +146,7 @@ public class KsqlEngineTest {
 
   @Rule
   public final Timeout timeout = Timeout.builder()
-      .withTimeout(60, TimeUnit.SECONDS)
+      .withTimeout(180, TimeUnit.SECONDS)
       .withLookingForStuckThread(true)
       .build();
 
@@ -193,10 +194,12 @@ public class KsqlEngineTest {
 
   @After
   public void closeEngine() {
-    try {
-      ksqlEngine.close();
-    } catch (Exception e) {
-      log.warn("Error while closing ksqlEngine", e);
+    if (!isKsqlEngineClosed) {
+      try {
+        ksqlEngine.close();
+      } catch (Exception e) {
+        log.warn("Error while closing ksqlEngine", e);
+      }
     }
     try {
       serviceContext.close();
@@ -1544,6 +1547,7 @@ public class KsqlEngineTest {
 
     // When:
     ksqlEngine.close();
+    isKsqlEngineClosed = true;
 
     // Then:
     verify(topicClient, times(2)).deleteInternalTopics(query.getQueryApplicationId());
@@ -1566,6 +1570,7 @@ public class KsqlEngineTest {
 
     // When:
     ksqlEngine.close();
+    isKsqlEngineClosed = true;
 
     // Then:
     verify(topicClient, times(2)).deleteInternalTopics(query.getQueryApplicationId());
@@ -1844,6 +1849,7 @@ public class KsqlEngineTest {
 
     // When:
     ksqlEngine.close();
+    isKsqlEngineClosed = true;
 
     // Then (there are no transient queries, so no internal topics should be deleted):
     verify(topicClient, never()).deleteInternalTopics(any());
@@ -2886,6 +2892,7 @@ public class KsqlEngineTest {
 
   private void awaitCleanupComplete() {
     awaitCleanupComplete(ksqlEngine);
+    isKsqlEngineClosed = true;
   }
 
   private void awaitCleanupComplete(final KsqlEngine ksqlEngine) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -97,6 +97,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -112,14 +113,19 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @SuppressWarnings({"OptionalGetWithoutIsPresent", "SameParameterValue"})
 @RunWith(MockitoJUnitRunner.class)
 public class KsqlEngineTest {
+  private static final Logger log = LoggerFactory.getLogger(KsqlEngineTest.class);
   private static final MutableFunctionRegistry functionRegistry = new InternalFunctionRegistry();
 
   private KsqlConfig ksqlConfig;
@@ -133,10 +139,15 @@ public class KsqlEngineTest {
 
   private KsqlEngine ksqlEngine;
   private ServiceContext serviceContext;
-  private ServiceContext sandboxServiceContext;
   @Spy
   private final FakeKafkaTopicClient topicClient = new FakeKafkaTopicClient();
   private KsqlExecutionContext sandbox;
+
+  @Rule
+  public final Timeout timeout = Timeout.builder()
+      .withTimeout(60, TimeUnit.SECONDS)
+      .withLookingForStuckThread(true)
+      .build();
 
   @BeforeClass
   public static void setUpFunctionRegistry() {
@@ -151,8 +162,6 @@ public class KsqlEngineTest {
             + "default_"
             + "query");
     sharedRuntimeDisabled.put(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED, false);
-    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeEnabled);
-
 
     metaStore = MetaStoreFixture.getNewMetaStore(functionRegistry);
 
@@ -160,26 +169,46 @@ public class KsqlEngineTest {
         topicClient,
         schemaRegistryClientFactory
     );
+  }
 
+  private void setupKsqlEngineWithSharedRuntimeEnabled() {
+    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeEnabled);
     ksqlEngine = KsqlEngineTestUtil.createKsqlEngine(
         serviceContext,
         metaStore,
         ksqlConfig
     );
-
     sandbox = ksqlEngine.createSandbox(serviceContext);
-    sandboxServiceContext = sandbox.getServiceContext();
+  }
+
+  private void setupKsqlEngineWithSharedRuntimeDisabled() {
+    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeDisabled);
+    ksqlEngine = KsqlEngineTestUtil.createKsqlEngine(
+        serviceContext,
+        metaStore,
+        ksqlConfig
+    );
+    sandbox = ksqlEngine.createSandbox(serviceContext);
   }
 
   @After
   public void closeEngine() {
-    ksqlEngine.close();
-    serviceContext.close();
+    try {
+      ksqlEngine.close();
+    } catch (Exception e) {
+      log.warn("Error while closing ksqlEngine", e);
+    }
+    try {
+      serviceContext.close();
+    } catch (Exception e) {
+      log.warn("Error while closing serviceContext", e);
+    }
   }
 
   @Test
   public void shouldCreatePersistentQueries() {
     // When:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final List<QueryMetadata> queries
         = KsqlEngineTestUtil.execute(
         serviceContext,
@@ -203,6 +232,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldCreateSourceTablesQueries() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     givenTopicsExist("t1_topic");
 
     // When:
@@ -231,6 +261,9 @@ public class KsqlEngineTest {
 
   @Test
   public void shouldNotHaveRowTimeAndRowKeyColumnsInPersistentQueryValueSchema() {
+    // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
+
     // When:
     final PersistentQueryMetadata query = (PersistentQueryMetadata) KsqlEngineTestUtil.execute(
         serviceContext,
@@ -251,6 +284,9 @@ public class KsqlEngineTest {
   @Test
   public void shouldThrowOnTerminateAsNotExecutable() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
+
+    // When:
     final PersistentQueryMetadata query = (PersistentQueryMetadata) KsqlEngineTestUtil
         .execute(
             serviceContext,
@@ -260,7 +296,7 @@ public class KsqlEngineTest {
             Collections.emptyMap())
         .get(0);
 
-    // When:
+
     final KsqlStatementException e = assertThrows(
         KsqlStatementException.class,
         () -> KsqlEngineTestUtil.execute(
@@ -282,6 +318,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldExecuteInsertIntoStreamOnSandBox() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final List<ParsedStatement> statements = parse(
         "create stream bar as select * from orders;"
             + "insert into bar select * from orders;"
@@ -291,7 +328,7 @@ public class KsqlEngineTest {
 
     // When:
     final ExecuteResult result = sandbox
-        .execute(sandboxServiceContext, ConfiguredStatement.of(
+        .execute(sandbox.getServiceContext(), ConfiguredStatement.of(
             sandbox.prepare(statements.get(1)),
             SessionConfig.of(ksqlConfig, Collections.emptyMap())
         ));
@@ -302,6 +339,9 @@ public class KsqlEngineTest {
 
   @Test
   public void shouldThrowWhenExecutingInsertIntoTable() {
+    // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
+
     KsqlEngineTestUtil.execute(
         serviceContext, ksqlEngine, "create table bar as select * from test2;", ksqlConfig,
         Collections.emptyMap());
@@ -322,6 +362,9 @@ public class KsqlEngineTest {
 
   @Test
   public void shouldThrowForBadSumAggregate() {
+    // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
+
     // When:
     final KsqlStatementException e = assertThrows(
         KsqlStatementException.class,
@@ -341,6 +384,9 @@ public class KsqlEngineTest {
 
   @Test
   public void shouldThrowOnInsertIntoStreamWithTableResult() {
+    // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
+
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -371,6 +417,9 @@ public class KsqlEngineTest {
 
   @Test
   public void shouldThrowOnInsertIntoWithKeyMismatch() {
+    // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
+
     execute(
         serviceContext,
         ksqlEngine,
@@ -403,6 +452,9 @@ public class KsqlEngineTest {
   @Test
   public void shouldThrowWhenInsertIntoSchemaDoesNotMatch() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
+
+    // Given:
     execute(
         serviceContext,
         ksqlEngine,
@@ -434,6 +486,9 @@ public class KsqlEngineTest {
   @Test
   public void shouldExecuteInsertIntoWithCustomQueryId() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
+
+    // Given:
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -459,6 +514,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldThrowInsertIntoIfCustomQueryIdAlreadyExists() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -485,6 +541,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldExecuteInsertIntoStream() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -508,6 +565,9 @@ public class KsqlEngineTest {
 
   @Test
   public void shouldMaintainOrderOfReturnedQueries() {
+    // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
+
     // When:
     final List<QueryMetadata> queries = KsqlEngineTestUtil.execute(
         serviceContext,
@@ -524,6 +584,9 @@ public class KsqlEngineTest {
 
   @Test(expected = KsqlStatementException.class)
   public void shouldFailToCreateQueryIfSelectingFromNonExistentEntity() {
+    // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
+
     KsqlEngineTestUtil
         .execute(
             serviceContext,
@@ -537,6 +600,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldShowHintWhenFailingToCreateQueryIfSelectingFromSourceNameWithoutQuotes() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -567,6 +631,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldShowHintWhenFailingToCreateQueryIfSelectingFromSourceNameWithMisspelling() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -596,6 +661,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldShowCorrectHintsWhenIncorrectSourceMatchesWithTwo() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -627,6 +693,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldShowCorrectHintsWhenIncorrectSourceMatchesWithThree() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -659,6 +726,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldShowHintWhenFailingToCreateQueryIfSelectingFromSourceNameWithQuotes() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -689,6 +757,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldShowHintWhenFailingToDropStreamWithSourceNameWithQuotes() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -719,6 +788,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldShowHintWhenFailingToDropTableWithSourceNameWithoutQuotes() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -749,6 +819,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldNotShowHintWhenFailingToDropNonExistingTable() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -778,6 +849,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldNotShowHintWhenFailingToDropNonExistingStream() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -806,6 +878,9 @@ public class KsqlEngineTest {
 
   @Test(expected = ParseFailedException.class)
   public void shouldFailWhenSyntaxIsInvalid() {
+    // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
+
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -818,6 +893,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldFailDropTableWhenAnotherTableIsReadingTheTable() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -850,6 +926,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldFailDropStreamWhenAnotherStreamIsReadingTheTable() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -882,6 +959,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldFailDropStreamWhenMultipleStreamsAreReadingTheTable() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -915,6 +993,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldFailDropStreamWhenAnInsertQueryIsWritingTheStream() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -948,6 +1027,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldFailDropStreamWhenAnInsertQueryIsReadingTheStream() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -982,6 +1062,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldFailDropStreamWhenMultipleInsertQueriesAreReadingAndWritingTheStream() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -1020,6 +1101,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldDropTableAndTerminateQuery() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -1049,6 +1131,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldDropStreamAndTerminateQuery() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -1078,6 +1161,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldDropStreamIfQueryWasTerminatedManually() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -1106,6 +1190,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldDropTableIfQueryWasTerminatedManually() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -1134,6 +1219,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldFailDDLStatementIfTopicDoesNotExist() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final ParsedStatement stmt = parse(
         "CREATE STREAM S1_NOTEXIST (COL1 BIGINT, COL2 VARCHAR) "
             + "WITH  (KAFKA_TOPIC = 'S1_NOTEXIST', VALUE_FORMAT = 'JSON', KEY_FORMAT = 'KAFKA');").get(0);
@@ -1144,7 +1230,7 @@ public class KsqlEngineTest {
     final Exception e = assertThrows(
         KsqlStatementException.class,
         () -> sandbox.execute(
-            sandboxServiceContext,
+            sandbox.getServiceContext(),
             ConfiguredStatement.of(prepared, SessionConfig.of(ksqlConfig, Collections.emptyMap()))
         )
     );
@@ -1156,6 +1242,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldDropTableIfAllReferencedQueriesTerminated() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final QueryMetadata secondQuery = KsqlEngineTestUtil.execute(
             serviceContext,
             ksqlEngine,
@@ -1182,6 +1269,7 @@ public class KsqlEngineTest {
 
   @Test
   public void shouldNotEnforceTopicExistenceWhileParsing() {
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final String runScriptContent = "CREATE STREAM S1 (COL1 BIGINT, COL2 VARCHAR) "
         + "WITH  (KAFKA_TOPIC = 's1_topic', VALUE_FORMAT = 'JSON', KEY_FORMAT = 'KAFKA');\n"
         + "CREATE TABLE T1 AS SELECT COL1, count(*) FROM "
@@ -1197,6 +1285,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldThrowFromSandBoxOnPrepareIfSourceTopicDoesNotExist() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final PreparedStatement<?> statement = prepare(parse(
         "CREATE STREAM S1 (COL1 BIGINT) "
             + "WITH (KAFKA_TOPIC = 'i_do_not_exist', VALUE_FORMAT = 'JSON', KEY_FORMAT = 'KAFKA');").get(0));
@@ -1205,7 +1294,7 @@ public class KsqlEngineTest {
     final KsqlStatementException e = assertThrows(
         KsqlStatementException.class,
         () -> sandbox.execute(
-            sandboxServiceContext,
+            sandbox.getServiceContext(),
             ConfiguredStatement.of(statement, SessionConfig.of(ksqlConfig, ImmutableMap.of()))
         )
     );
@@ -1221,6 +1310,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldThrowFromExecuteIfSourceTopicDoesNotExist() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final PreparedStatement<?> statement = prepare(parse(
         "CREATE STREAM S1 (COL1 BIGINT) "
             + "WITH (KAFKA_TOPIC = 'i_do_not_exist', VALUE_FORMAT = 'JSON', KEY_FORMAT = 'KAFKA');").get(0));
@@ -1240,6 +1330,7 @@ public class KsqlEngineTest {
 
   @Test
   public void shouldHandleCommandsSpreadOverMultipleLines() {
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final String runScriptContent = "CREATE STREAM S1 \n"
         + "(COL1 BIGINT, COL2 VARCHAR)\n"
         + " WITH \n"
@@ -1253,6 +1344,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldThrowIfSchemaNotPresent() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     givenTopicsExist("bar");
 
     // When:
@@ -1279,6 +1371,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldNotFailIfAvroSchemaEvolvable() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final Schema evolvableSchema = SchemaBuilder
         .record("KsqlDataSourceSchema").fields()
         .nullableInt("f1", 1)
@@ -1302,6 +1395,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldNotDeleteSchemaNorTopicForTable() throws Exception {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     givenTopicsExist("BAR");
     final QueryMetadata query = KsqlEngineTestUtil.execute(
         serviceContext,
@@ -1336,6 +1430,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldNotDeleteSchemaNorTopicForStream() throws Exception {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     givenTopicsExist("BAR");
     final QueryMetadata query = KsqlEngineTestUtil.execute(
         serviceContext,
@@ -1371,12 +1466,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldCleanUpInternalTopicsOnClose() {
     // Given:
-    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeDisabled);
-    ksqlEngine = KsqlEngineTestUtil.createKsqlEngine(
-        serviceContext,
-        metaStore,
-        ksqlConfig
-    );
+    setupKsqlEngineWithSharedRuntimeDisabled();
     final QueryMetadata query = KsqlEngineTestUtil.executeQuery(
         serviceContext,
         ksqlEngine,
@@ -1397,12 +1487,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldCleanUpInternalTopicsOnCloseForPersistentQueries() {
     // Given:
-    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeDisabled);
-    ksqlEngine = KsqlEngineTestUtil.createKsqlEngine(
-        serviceContext,
-        metaStore,
-        ksqlConfig
-    );
+    setupKsqlEngineWithSharedRuntimeDisabled();
 
     final List<QueryMetadata> query = KsqlEngineTestUtil.execute(
         serviceContext,
@@ -1424,7 +1509,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldCleanUpInternalTopicsOnCloseSharedRuntimes() {
     // Given:
-    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeEnabled);
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final QueryMetadata query = KsqlEngineTestUtil.executeQuery(
         serviceContext,
         ksqlEngine,
@@ -1446,12 +1531,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldCleanUpInternalTopicsOnEngineCloseForTransientQueries() {
     // Given:
-    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeDisabled);
-    ksqlEngine = KsqlEngineTestUtil.createKsqlEngine(
-        serviceContext,
-        metaStore,
-        ksqlConfig
-    );
+    setupKsqlEngineWithSharedRuntimeDisabled();
     final QueryMetadata query = KsqlEngineTestUtil.executeQuery(
         serviceContext,
         ksqlEngine,
@@ -1472,7 +1552,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldCleanUpInternalTopicsOnEngineCloseForTransientQueriesSharedRuntimes() {
     // Given:
-    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeEnabled);
+    setupKsqlEngineWithSharedRuntimeEnabled();
 
     final QueryMetadata query = KsqlEngineTestUtil.executeQuery(
         serviceContext,
@@ -1494,6 +1574,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldCreateSandboxWithSandboxedQueryMetadata() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final QueryMetadata transientQ = KsqlEngineTestUtil.executeQuery(
         serviceContext,
         ksqlEngine,
@@ -1531,12 +1612,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldHardDeleteSchemaOnEngineCloseForTransientQueries() throws IOException, RestClientException {
     // Given:
-    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeDisabled);
-    ksqlEngine = KsqlEngineTestUtil.createKsqlEngine(
-        serviceContext,
-        metaStore,
-        ksqlConfig
-    );
+    setupKsqlEngineWithSharedRuntimeDisabled();
     final QueryMetadata query = KsqlEngineTestUtil.executeQuery(
         serviceContext,
         ksqlEngine,
@@ -1578,7 +1654,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldHardDeleteSchemaOnEngineCloseForTransientQueriesSharedRuntimes() throws IOException, RestClientException {
     // Given:
-    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeEnabled);
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final QueryMetadata query = KsqlEngineTestUtil.executeQuery(
         serviceContext,
         ksqlEngine,
@@ -1620,12 +1696,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldCleanUpConsumerGroupsOnClose() {
     // Given:
-    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeDisabled);
-    ksqlEngine = KsqlEngineTestUtil.createKsqlEngine(
-        serviceContext,
-        metaStore,
-        ksqlConfig
-    );
+    setupKsqlEngineWithSharedRuntimeDisabled();
     final QueryMetadata query = KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -1652,12 +1723,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldCleanUpTransientConsumerGroupsOnClose() {
     // Given:
-    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeDisabled);
-    ksqlEngine = KsqlEngineTestUtil.createKsqlEngine(
-        serviceContext,
-        metaStore,
-        ksqlConfig
-    );
+    setupKsqlEngineWithSharedRuntimeDisabled();
     final QueryMetadata query = KsqlEngineTestUtil.executeQuery(
         serviceContext,
         ksqlEngine,
@@ -1684,12 +1750,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldCleanUpPersistentConsumerGroupsOnClose() {
     // Given:
-    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeDisabled);
-    ksqlEngine = KsqlEngineTestUtil.createKsqlEngine(
-        serviceContext,
-        metaStore,
-        ksqlConfig
-    );
+    setupKsqlEngineWithSharedRuntimeDisabled();
     final QueryMetadata query = KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -1716,7 +1777,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldCleanUpTransientConsumerGroupsOnCloseSharedRuntimes() {
     // Given:
-    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeEnabled);
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final QueryMetadata query = KsqlEngineTestUtil.executeQuery(
         serviceContext,
         ksqlEngine,
@@ -1744,12 +1805,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldCleanUpPersistentConsumerGroupsOnCloseSharedRuntimes() {
     // Given:
-    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeEnabled);
-    ksqlEngine = KsqlEngineTestUtil.createKsqlEngine(
-        serviceContext,
-        metaStore,
-        ksqlConfig
-    );
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final QueryMetadata query = KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -1776,6 +1832,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldNotCleanUpInternalTopicsOnEngineCloseForPersistentQueries() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final List<QueryMetadata> query = KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -1795,12 +1852,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldCleanUpInternalTopicsOnQueryCloseForPersistentQueries() {
     // Given:
-    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeDisabled);
-    ksqlEngine = KsqlEngineTestUtil.createKsqlEngine(
-        serviceContext,
-        metaStore,
-        ksqlConfig
-    );
+    setupKsqlEngineWithSharedRuntimeDisabled();
     final List<QueryMetadata> query = KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -1822,7 +1874,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldCleanUpInternalTopicsOnQueryCloseForPersistentQueriesSharedRuntimes() {
     // Given:
-    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeEnabled);
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final List<QueryMetadata> query = KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -1844,12 +1896,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldHardDeleteSubjectForPersistentQuery() throws IOException, RestClientException {
     // Given:
-    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeDisabled);
-    ksqlEngine = KsqlEngineTestUtil.createKsqlEngine(
-        serviceContext,
-        metaStore,
-        ksqlConfig
-    );
+    setupKsqlEngineWithSharedRuntimeDisabled();
     final List<QueryMetadata> query = KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -1890,7 +1937,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldHardDeleteSubjectForPersistentQuerySharedRuntimes() throws IOException, RestClientException {
     // Given:
-    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeEnabled);
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final List<QueryMetadata> query = KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -1932,6 +1979,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldNotCleanUpInternalTopicsOnCloseIfQueryNeverStarted() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final QueryMetadata query = KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -1950,6 +1998,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldNotCleanUpInternalTopicsOnReplace() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -1974,6 +2023,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldNotCleanUpInternalTopicsOnSandboxQueryClose() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -1993,6 +2043,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldRemovePersistentQueryFromEngineWhenClosed() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final int startingLiveQueries = ksqlEngine.numberOfLiveQueries();
     final int startingPersistentQueries = ksqlEngine.getPersistentQueries().size();
 
@@ -2016,6 +2067,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldRemoveTransientQueryFromEngineWhenClosed() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final int startingLiveQueries = ksqlEngine.numberOfLiveQueries();
 
     final QueryMetadata query = KsqlEngineTestUtil.executeQuery(
@@ -2035,6 +2087,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldSetKsqlSinkForSinks() {
     // When:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -2048,17 +2101,12 @@ public class KsqlEngineTest {
     assertThat(metaStore.getSource(SourceName.of("T")).isCasTarget(), is(true));
   }
 
-  @Test
-  public void shouldThrowIfLeftTableNotJoiningOnTableKey() {
-
-  }
-
   @SuppressWarnings("unchecked")
   @Test
   public void shouldHandleMultipleStatements() {
     // Given:
-    final String sql = ""
-        + "-- single line comment\n"
+    setupKsqlEngineWithSharedRuntimeEnabled();
+    final String sql = "-- single line comment\n"
         + "/*\n"
         + "   Multi-line comment\n"
         + "*/\n"
@@ -2111,6 +2159,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldNotThrowWhenPreparingDuplicateTable() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final List<ParsedStatement> parsed = ksqlEngine.parse(
         "CREATE TABLE FOO AS SELECT * FROM TEST2; "
             + "CREATE TABLE FOO WITH (KAFKA_TOPIC='BAR') AS SELECT * FROM TEST2;");
@@ -2126,6 +2175,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldNotThrowWhenExecutingDuplicateTableWithIfNotExists() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final List<ParsedStatement> parsed = ksqlEngine.parse(
         "CREATE TABLE FOO WITH (KAFKA_TOPIC='BAR') AS SELECT * FROM TEST2; "
             + "CREATE TABLE IF NOT EXISTS FOO WITH (KAFKA_TOPIC='BAR') AS SELECT * FROM TEST2;");
@@ -2149,6 +2199,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldNotThrowWhenExecutingDuplicateTableWithCreateOrReplaceOnSandbox() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final ConfiguredStatement<?> oldQuery =
         configuredStatement("CREATE TABLE FOO AS SELECT * FROM TEST2;");
     final ConfiguredStatement<?> newQuery =
@@ -2160,7 +2211,7 @@ public class KsqlEngineTest {
     sandbox = ksqlEngine.createSandbox(serviceContext);
 
     // When:
-    ExecuteResult executeResult = sandbox.execute(sandboxServiceContext, newQuery);
+    ExecuteResult executeResult = sandbox.execute(sandbox.getServiceContext(), newQuery);
 
     // Then:
     assertThat(executeResult.getQuery().get().getQueryId(), is(oldQueryId));
@@ -2169,6 +2220,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldNotThrowWhenExecutingDuplicateTableWithCreateOrReplace() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final ConfiguredStatement<?> oldQuery =
         configuredStatement("CREATE TABLE FOO AS SELECT * FROM TEST2;");
     final ConfiguredStatement<?> newQuery =
@@ -2178,7 +2230,7 @@ public class KsqlEngineTest {
         .get().getQueryId();
 
     // When:
-    ExecuteResult executeResult = ksqlEngine.execute(sandboxServiceContext, newQuery);
+    ExecuteResult executeResult = ksqlEngine.execute(sandbox.getServiceContext(), newQuery);
 
     // Then:
     assertThat(executeResult.getQuery().get().getQueryId(), is(oldQueryId));
@@ -2187,6 +2239,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldThrowWhenExecutingDuplicateTable() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final List<ParsedStatement> parsed = ksqlEngine.parse(
         "CREATE TABLE FOO AS SELECT * FROM TEST2; "
             + "CREATE TABLE FOO WITH (KAFKA_TOPIC='BAR') AS SELECT * FROM TEST2;");
@@ -2215,6 +2268,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldThrowWhenPreparingUnknownSource() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final ParsedStatement stmt = ksqlEngine.parse(
         "CREATE STREAM FOO AS SELECT * FROM UNKNOWN;").get(0);
 
@@ -2233,6 +2287,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldNotThrowWhenPreparingDuplicateStream() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final ParsedStatement stmt = ksqlEngine.parse(
         "CREATE STREAM FOO AS SELECT * FROM ORDERS; "
             + "CREATE STREAM FOO WITH (KAFKA_TOPIC='BAR') AS SELECT * FROM ORDERS;").get(0);
@@ -2246,6 +2301,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldNotThrowWhenExecutingDuplicateStreamWithIfNotExists() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final List<ParsedStatement> parsed = ksqlEngine.parse(
         "CREATE STREAM FOO WITH (KAFKA_TOPIC='BAR') AS SELECT * FROM ORDERS; "
             + "CREATE STREAM IF NOT EXISTS FOO WITH (KAFKA_TOPIC='BAR') AS SELECT * FROM ORDERS;");
@@ -2269,6 +2325,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldThrowWhenExecutingDuplicateStream() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final List<ParsedStatement> parsed = ksqlEngine.parse(
         "CREATE STREAM FOO WITH (KAFKA_TOPIC='BAR') AS SELECT * FROM ORDERS; "
             + "CREATE STREAM FOO WITH (KAFKA_TOPIC='BAR') AS SELECT * FROM ORDERS;");
@@ -2297,6 +2354,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldThrowWhenExecutingQueriesIfCsasCreatesTable() {
     // When:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final KsqlStatementException e = assertThrows(
         KsqlStatementException.class,
         () -> KsqlEngineTestUtil.execute(
@@ -2318,6 +2376,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldThrowWhenExecutingQueriesIfCtasCreatesStream() {
     // When:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final KsqlStatementException e = assertThrows(
         KsqlStatementException.class,
         () -> KsqlEngineTestUtil.execute(
@@ -2339,6 +2398,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldThrowWhenTryExecuteCsasThatCreatesTable() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final PreparedStatement<?> statement = prepare(parse(
         "CREATE STREAM FOO AS SELECT ORDERID, COUNT(ORDERID) FROM ORDERS GROUP BY ORDERID;").get(0));
 
@@ -2363,6 +2423,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldThrowWhenTryExecuteCtasThatCreatesStream() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final PreparedStatement<?> statement = prepare(parse(
         "CREATE TABLE FOO AS SELECT * FROM ORDERS;").get(0));
 
@@ -2386,6 +2447,7 @@ public class KsqlEngineTest {
 
   @Test
   public void shouldThrowIfStatementMissingTopicConfig() {
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final List<ParsedStatement> parsed = parse(
         "CREATE TABLE FOO (viewtime BIGINT, pageid VARCHAR) WITH (VALUE_FORMAT='AVRO', KEY_FORMAT='KAFKA');"
             + "CREATE STREAM FOO (viewtime BIGINT, pageid VARCHAR) WITH (VALUE_FORMAT='AVRO', KEY_FORMAT='KAFKA');"
@@ -2394,7 +2456,6 @@ public class KsqlEngineTest {
     );
 
     for (final ParsedStatement statement : parsed) {
-
       try {
         ksqlEngine.prepare(statement);
         Assert.fail();
@@ -2408,6 +2469,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldThrowOnNoneExecutableDdlStatement() {
     // When:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final KsqlStatementException e = assertThrows(
         KsqlStatementException.class,
         () -> KsqlEngineTestUtil.execute(
@@ -2427,6 +2489,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldNotUpdateMetaStoreDuringTryExecute() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final int numberOfLiveQueries = ksqlEngine.numberOfLiveQueries();
     final int numPersistentQueries = ksqlEngine.getPersistentQueries().size();
 
@@ -2441,7 +2504,7 @@ public class KsqlEngineTest {
     // When:
     statements
         .forEach(stmt -> sandbox.execute(
-            sandboxServiceContext,
+            sandbox.getServiceContext(),
             ConfiguredStatement
                 .of(sandbox.prepare(stmt), SessionConfig.of(ksqlConfig, new HashMap<>())
                 )));
@@ -2457,6 +2520,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldNotCreateAnyTopicsDuringTryExecute() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     Map<String, ?> configs = ImmutableMap.of(TopicConfig.RETENTION_MS_CONFIG, 604800000L);
     topicClient.preconditionTopicExists("s1_topic", 1, (short) 1, configs);
 
@@ -2469,7 +2533,7 @@ public class KsqlEngineTest {
     // When:
     statements.forEach(
         stmt -> sandbox.execute(
-            sandboxServiceContext,
+            sandbox.getServiceContext(),
             ConfiguredStatement
                 .of(sandbox.prepare(stmt), SessionConfig.of(ksqlConfig, new HashMap<>())
                 ))
@@ -2483,12 +2547,13 @@ public class KsqlEngineTest {
   @Test
   public void shouldNotIncrementQueryIdCounterDuringTryExecute() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final String sql = "create table foo as select * from test2;";
     final PreparedStatement<?> statement = prepare(parse(sql).get(0));
 
     // When:
     sandbox.execute(
-        sandboxServiceContext,
+        sandbox.getServiceContext(),
         ConfiguredStatement
             .of(statement, SessionConfig.of(ksqlConfig, new HashMap<>()))
     );
@@ -2503,6 +2568,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldNotRegisterAnySchemasDuringSandboxExecute() throws Exception {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final List<ParsedStatement> statements = parse(
         "create table foo WITH(VALUE_FORMAT='AVRO') as select * from test2;"
             + "create stream foo2 WITH(VALUE_FORMAT='AVRO') as select * from orders;");
@@ -2513,7 +2579,7 @@ public class KsqlEngineTest {
 
     // When:
     sandbox.execute(
-        sandboxServiceContext,
+        sandbox.getServiceContext(),
         ConfiguredStatement
             .of(prepared, SessionConfig.of(ksqlConfig, new HashMap<>()))
     );
@@ -2525,6 +2591,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldOnlyUpdateSandboxOnQueryClose() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     givenSqlAlreadyExecuted("create table bar as select * from test2;");
 
     final QueryId queryId = ksqlEngine.getPersistentQueries()
@@ -2547,12 +2614,13 @@ public class KsqlEngineTest {
   @Test
   public void shouldRegisterPersistentQueriesOnlyInSandbox() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final PreparedStatement<?> prepared = prepare(parse(
         "create table bar as select * from test2;").get(0));
 
     // When:
     final ExecuteResult result = sandbox.execute(
-        sandboxServiceContext,
+        sandbox.getServiceContext(),
         ConfiguredStatement
             .of(prepared, SessionConfig.of(ksqlConfig, new HashMap<>()))
     );
@@ -2568,6 +2636,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldNotStartKafkaStreamsInSandbox() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     givenSqlAlreadyExecuted("create table bar as select * from test2;");
     final QueryMetadata query = ksqlEngine.getPersistentQueries().get(0);
     KafkaStreams.State state = ksqlEngine.getPersistentQuery(query.getQueryId()).get().getState();
@@ -2583,6 +2652,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldNotStopKafkaStreamsInSandbox() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     givenSqlAlreadyExecuted("create table bar as select * from test2;");
     final QueryMetadata query = ksqlEngine.getPersistentQueries().get(0);
     ksqlEngine.getPersistentQuery(query.getQueryId()).get().start();
@@ -2598,6 +2668,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldNotCloseKafkaStreamsInSandbox() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     givenSqlAlreadyExecuted("create table bar as select * from test2;");
     final QueryMetadata query = ksqlEngine.getPersistentQueries().get(0);
     ksqlEngine.getPersistentQuery(query.getQueryId()).get().start();
@@ -2614,13 +2685,14 @@ public class KsqlEngineTest {
   @Test
   public void shouldExecuteDdlStatement() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     givenTopicsExist("foo");
     final PreparedStatement<?> statement =
         prepare(parse("CREATE STREAM FOO (a int) WITH (kafka_topic='foo', value_format='json', key_format='kafka');").get(0));
 
     // When:
     final ExecuteResult result = sandbox.execute(
-        sandboxServiceContext,
+        sandbox.getServiceContext(),
         ConfiguredStatement
             .of(statement, SessionConfig.of(ksqlConfig, new HashMap<>()))
     );
@@ -2632,6 +2704,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldBeAbleToParseInvalidThings() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     // No Stream called 'I_DO_NOT_EXIST' exists
 
     // When:
@@ -2645,6 +2718,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldThrowOnPrepareIfSourcesDoNotExist() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final ParsedStatement parsed = ksqlEngine
         .parse("CREATE STREAM FOO AS SELECT * FROM I_DO_NOT_EXIST;")
         .get(0);
@@ -2662,6 +2736,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldBeAbleToPrepareTerminateAndDrop() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     givenSqlAlreadyExecuted("CREATE STREAM FOO AS SELECT * FROM TEST1;");
 
     final List<ParsedStatement> parsed = ksqlEngine.parse(
@@ -2677,6 +2752,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldBeAbleToPreparePauseAndResume() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     givenSqlAlreadyExecuted("CREATE STREAM FOO AS SELECT * FROM TEST1;");
 
     final List<ParsedStatement> parsed = ksqlEngine.parse(
@@ -2692,6 +2768,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldIgnoreLegacyDeleteTopicPartOfDropCommand() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final QueryMetadata query = KsqlEngineTestUtil.execute(
         serviceContext,
         ksqlEngine,
@@ -2716,6 +2793,7 @@ public class KsqlEngineTest {
 
   @Test
   public void shouldRaiseExceptionIfValueIsErroneous() {
+    setupKsqlEngineWithSharedRuntimeEnabled();
     assertThrows(ConfigException.class, () ->
         ksqlEngine.alterSystemProperty(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, "TEST"));
   }
@@ -2723,6 +2801,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldOverrideKsqlConfigsWhenAlterSystemPropertyIsCalled() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final Object valueBefore = ksqlEngine.getKsqlConfig().originals().get(KsqlConfig.KSQL_DEFAULT_VALUE_FORMAT_CONFIG);
 
     // When:
@@ -2737,12 +2816,14 @@ public class KsqlEngineTest {
   @Test
   public void shouldThrowIfConfigureNotCalledWithAppServerConfig() {
     // When/Then:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     assertThrows(IllegalArgumentException.class, () -> ksqlEngine.configure(KsqlConfig.empty()));
   }
 
   @Test
   public void shouldConfigure() {
     // Given:
+    setupKsqlEngineWithSharedRuntimeEnabled();
     final KsqlConfig config
         = new KsqlConfig(ImmutableMap.of(StreamsConfig.APPLICATION_SERVER_CONFIG, "foo:bar//"));
 
@@ -2755,6 +2836,7 @@ public class KsqlEngineTest {
 
   @Test
   public void shouldCheckStreamPullQueryEnabledFlag() {
+    setupKsqlEngineWithSharedRuntimeEnabled();
     @SuppressWarnings("unchecked") final ConfiguredStatement<Query> statementOrig =
         mock(ConfiguredStatement.class);
     when(statementOrig.getMaskedStatementText()).thenReturn("TEXT");

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -249,10 +249,14 @@ public class KsqlResourceTest {
               "VALUE_FORMAT", new StringLiteral("avro")
           )),
           false));
-  private static final ConfiguredStatement<CreateStream> CFG_0_WITH_SCHEMA = ConfiguredStatement.of(
-      STMT_0_WITH_SCHEMA,
-      SessionConfig.of(new KsqlConfig(getDefaultKsqlConfig()), ImmutableMap.of())
-  );
+
+  private static final Properties DEFAULT_KSQL_CONFIG = getDefaultKsqlConfig();
+
+  private static final ConfiguredStatement<CreateStream> CFG_0_WITH_SCHEMA =
+      ConfiguredStatement.of(
+        STMT_0_WITH_SCHEMA,
+        SessionConfig.of(new KsqlConfig(DEFAULT_KSQL_CONFIG), ImmutableMap.of())
+    );
 
   private static final PreparedStatement<CreateStream> STMT_1_WITH_SCHEMA = PreparedStatement.of(
       "other sql with schema",
@@ -269,7 +273,7 @@ public class KsqlResourceTest {
           false));
   private static final ConfiguredStatement<CreateStream> CFG_1_WITH_SCHEMA = ConfiguredStatement
       .of(STMT_1_WITH_SCHEMA,
-          SessionConfig.of(new KsqlConfig(getDefaultKsqlConfig()), ImmutableMap.of())
+          SessionConfig.of(new KsqlConfig(DEFAULT_KSQL_CONFIG), ImmutableMap.of())
       );
 
   private static final LogicalSchema SOME_SCHEMA = LogicalSchema.builder()
@@ -348,7 +352,7 @@ public class KsqlResourceTest {
     serviceContext = TestServiceContext.create(kafkaTopicClient, kafkaConsumerGroupClient);
     schemaRegistryClient = serviceContext.getSchemaRegistryClient();
     registerValueSchema(schemaRegistryClient);
-    ksqlRestConfig = new KsqlRestConfig(getDefaultKsqlConfig());
+    ksqlRestConfig = new KsqlRestConfig(DEFAULT_KSQL_CONFIG);
     ksqlConfig = new KsqlConfig(ksqlRestConfig.getKsqlConfigProperties());
     final KsqlExecutionContext.ExecuteResult result = mock(KsqlExecutionContext.ExecuteResult.class);
     when(sandbox.execute(any(), any(ConfiguredKsqlPlan.class))).thenReturn(result);

--- a/pom.xml
+++ b/pom.xml
@@ -803,12 +803,14 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <rerunFailingTestsCount>3</rerunFailingTestsCount>
                     <systemPropertyVariables>
                         <log4j.configuration>file:${project.basedir}/../ksqldb-test-util/src/main/resources/log4j.properties</log4j.configuration>
                     </systemPropertyVariables>
                     <argLine>-verbose:gc -Xloggc:"${project.build.directory}/gc.log"</argLine>
                     <argLine>-Duser.timezone=UTC -Xmx1g -Xms1g</argLine>
                 </configuration>
+                <version>3.0.0-M4</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -808,9 +808,9 @@
                         <log4j.configuration>file:${project.basedir}/../ksqldb-test-util/src/main/resources/log4j.properties</log4j.configuration>
                     </systemPropertyVariables>
                     <argLine>-verbose:gc -Xloggc:"${project.build.directory}/gc.log"</argLine>
-                    <argLine>-Duser.timezone=UTC -Xmx1g -Xms1g</argLine>
+                    <argLine>-Duser.timezone=UTC -Xmx1g -Xms1g -XX:MaxPermSize=256m</argLine>
                 </configuration>
-                <version>3.0.0-M4</version>
+                <version>3.2.5</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/service.yml
+++ b/service.yml
@@ -1,0 +1,17 @@
+name: ksql
+lang: unknown
+lang_version: unknown
+codeowners:
+  enable: true
+semaphore:
+  enable: true
+  pipeline_type: cp
+  nano_version: true
+  execution_time_limit: {"hours": 6}
+  downstream_projects: ["confluent-security-plugins", "confluent-cloud-plugins", "cc-docker-ksql"]
+  extra_deploy_args: '-Ddocker.skip=true'
+  extra_build_args: "-Dmaven.gitcommitid.nativegit=true"
+  maven_build_goals: "clean install"
+  run_merge_check: false
+git:
+  enable: true


### PR DESCRIPTION
### Description 
Summary of changes:
1. Migrate the build job from jenkins to semaphore.
2. Fixed the thread leak in the setup() of KsqlEngine instances in KsqlEngineTest.
3. Cherry-picked the change for UserFunctionLoader to scan for select modules.
4. Use different state dirs for each test invocation and corresponding test fixes.
5. Specify rerun of failing flaky tests to atmost thrice.
6. Specify a fixed timeout for KsqlEngineTests to avoid build timeouts.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
