### PR TITLE
KSE-1627: Update org.testng:testng to 7.5.1

### DIFF
--- a/ksqldb-api-reactive-streams-tck/pom.xml
+++ b/ksqldb-api-reactive-streams-tck/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>6.11</version>
+            <version>7.7.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/ksqldb-api-reactive-streams-tck/pom.xml
+++ b/ksqldb-api-reactive-streams-tck/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.7.0</version>
+            <version>7.5.1</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
### Description 
To fix  `CVE-2022-4065`, updating the version of  `org.testng:testng` to 7.5.1
Refer: https://confluentinc.atlassian.net/browse/KSE-1627

### Testing done 
Checked using `mvn dependency:tree`, 7.5.1  version was observed for the same

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
