### PR TITLE
KSQL-11784: Change groupID to a more secure name

### DIFF
--- a/ksqldb-engine/src/test/resources/udf-example-2/pom.xml
+++ b/ksqldb-engine/src/test/resources/udf-example-2/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project>
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.example2.ksql.udf</groupId>
+  <groupId>io.confluent.example2.ksql.udf</groupId>
   <artifactId>udf-example-2</artifactId>
   <version>1</version>
 

--- a/ksqldb-engine/src/test/resources/udf-example-2/src/main/java/io/confluent/example2/ksql/udf/BackwardConcat.java
+++ b/ksqldb-engine/src/test/resources/udf-example-2/src/main/java/io/confluent/example2/ksql/udf/BackwardConcat.java
@@ -13,7 +13,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package org.example2.ksql.udf;
+package io.confluent.example2.ksql.udf;
 
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;


### PR DESCRIPTION
### Description 
Group ID: "org.example2.ksql.udf" has domain available for registration: "[example2.org](http://example2.org/)"  which makes it vulnerable to supply chain attacks in Maven where an attacker could potentially purchase domains of abandoned projects and claim their group ids

Fix: Changing the groupID to `io.confluent.example2.ksql.udf`
Also, the usage is in the `test` folder, so changing the groupID appears to be a safe approach.

I searched for the usages of the existing groupID in the github, and these were the only 2 occurrences. 

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
