### PR TITLE
[MINOR] Update common nano version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>7.6.1-0</version>
+        <version>7.6.1-1</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>


### PR DESCRIPTION
# What

Updating `common` version from `7.6.1-0` to `7.6.1-1`.

# Why

Common version `7.6.1-0` is not present which is causing build to fail, hence impacting the release process for `confluent-security-plugins`