### PR TITLE
KSE-1816: Update commons-compress

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -89,6 +89,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
@@ -97,7 +98,9 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -120,6 +123,12 @@ public class KsqlEngineTest {
   @Spy
   private final FakeKafkaTopicClient topicClient = new FakeKafkaTopicClient();
   private KsqlExecutionContext sandbox;
+
+  @Rule
+  public final Timeout timeout = Timeout.builder()
+      .withTimeout(180, TimeUnit.SECONDS)
+      .withLookingForStuckThread(true)
+      .build();
 
   @Before
   public void setUp() {

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <antlr.version>4.7.1</antlr.version>
         <commons-text.version>1.10.0</commons-text.version>
         <csv.version>1.4</csv.version>
-        <commons.compress.version>1.26</commons.compress.version>
+        <commons.compress.version>1.26.0</commons.compress.version>
         <lang3.version>3.3.1</lang3.version>
         <retrying.version>2.0.0</retrying.version>
         <inject.version>1</inject.version>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <antlr.version>4.7.1</antlr.version>
         <commons-text.version>1.10.0</commons-text.version>
         <csv.version>1.4</csv.version>
-        <commons.compress.version>1.21</commons.compress.version>
+        <commons.compress.version>1.26</commons.compress.version>
         <lang3.version>3.3.1</lang3.version>
         <retrying.version>2.0.0</retrying.version>
         <inject.version>1</inject.version>


### PR DESCRIPTION
This is to resolve CVE-2024-26308 and CVE-2024-25710

### Description 
Security patch

### Testing done 
Existing tests

### Reviewer checklist
- [x] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [x] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
