### PR TITLE
build: Include ksqldb-rocksdb-config-setter in docker image

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -1796,8 +1796,7 @@ public class KsqlConfig extends AbstractConfig {
       final Map<String,Object> props
   ) {
     final Map<String, Object> updatedProps = new HashMap<>(props);
-    final AppInfoParser.AppInfo appInfo = new AppInfoParser.AppInfo(System.currentTimeMillis(),
-            KsqlConstants.enableLoggingAppInfo);
+    final AppInfoParser.AppInfo appInfo = new AppInfoParser.AppInfo(System.currentTimeMillis());
     updatedProps.putAll(getConfigsForPrefix(REPORTER_CONFIGS_PREFIXES));
     updatedProps.put(MetricCollectors.RESOURCE_LABEL_VERSION, appInfo.getVersion());
     updatedProps.put(MetricCollectors.RESOURCE_LABEL_COMMIT_ID, appInfo.getCommitId());

--- a/ksqldb-tools/pom.xml
+++ b/ksqldb-tools/pom.xml
@@ -64,6 +64,12 @@
 
         <dependency>
             <groupId>io.confluent.ksql</groupId>
+            <artifactId>ksqldb-rocksdb-config-setter</artifactId>
+        </dependency>
+
+
+        <dependency>
+            <groupId>io.confluent.ksql</groupId>
             <artifactId>ksqldb-api-client</artifactId>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>7.7.0-736</version>
+        <version>7.6.0</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>
@@ -143,7 +143,7 @@
         <apache.io.version>2.11.0</apache.io.version>
         <io.confluent.ksql.version>7.7.0-0</io.confluent.ksql.version>
         <!-- We need to bump this version manually after each version bump on `master`: next bump should be 8.0.0-0 -->
-        <io.confluent.schema-registry.version>7.7.0-529</io.confluent.schema-registry.version>
+        <io.confluent.schema-registry.version>7.7.0-0</io.confluent.schema-registry.version>
         <netty-tcnative-version>2.0.61.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`
@@ -281,6 +281,12 @@
             <dependency>
                 <groupId>io.confluent.ksql</groupId>
                 <artifactId>ksqldb-engine-common</artifactId>
+                <version>${io.confluent.ksql.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.confluent.ksql</groupId>
+                <artifactId>ksqldb-rocksdb-config-setter</artifactId>
                 <version>${io.confluent.ksql.version}</version>
             </dependency>
 


### PR DESCRIPTION
### Description 
Fixes #6838 the ksqldb-rocksdb-config-setter is now part of the docker image

### Testing done 
I have built a docker image and verified manually that the jar is there

### Reviewer checklist
- [X] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [X] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [X] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
