### PR TITLE
KSE-1824 | Add a no-arg constructor for ProtobufNoSRConverter.

### DIFF
--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufNoSRConverter.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufNoSRConverter.java
@@ -44,6 +44,16 @@ public class ProtobufNoSRConverter implements Converter {
 
   private ProtobufData protobufData;
 
+  /**
+   * This constructor is defined only to adhere to the Converter plugin semantics of defining a
+   * no-arg constructor. The usage of this class is internal to ksqldb and is instantiated
+   * explicitly with Schema argument.
+   */
+  public ProtobufNoSRConverter() {
+    super();
+    this.schema = null;
+  }
+
   public ProtobufNoSRConverter(final Schema schema) {
     this.schema = schema;
   }
@@ -55,6 +65,11 @@ public class ProtobufNoSRConverter implements Converter {
 
   @Override
   public byte[] fromConnectData(final String topic, final Schema schema, final Object value) {
+    if (this.schema == null) {
+      throw new UnsupportedOperationException("ProtobufNoSRConverter is an internal "
+          + "converter to ksqldb. It should not be used via reflection through a no-arg "
+          + "constructor.");
+    }
     try {
       final ProtobufSchemaAndValue schemaAndValue = protobufData.fromConnectData(schema, value);
       final Object v = schemaAndValue.getValue();
@@ -79,6 +94,11 @@ public class ProtobufNoSRConverter implements Converter {
 
   @Override
   public SchemaAndValue toConnectData(final String topic, final byte[] value) {
+    if (this.schema == null) {
+      throw new UnsupportedOperationException("ProtobufNoSRConverter is an internal "
+          + "converter to ksqldb. It should not be instantiated via reflection through a no-arg "
+          + "constructor.");
+    }
     try {
       final ProtobufSchema protobufSchema = protobufData.fromConnectSchema(schema);
       final Object deserialized = deserializer.deserialize(value, protobufSchema);
@@ -126,8 +146,6 @@ public class ProtobufNoSRConverter implements Converter {
     }
   }
 
-
-
   @VisibleForTesting
   public static class Deserializer {
     public Object deserialize(final byte[] payload, final ProtobufSchema schema) {
@@ -155,5 +173,4 @@ public class ProtobufNoSRConverter implements Converter {
       }
     }
   }
-
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufNoSRConverter.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufNoSRConverter.java
@@ -45,13 +45,19 @@ public class ProtobufNoSRConverter implements Converter {
   private ProtobufData protobufData;
 
   /**
-   * This constructor is defined only to adhere to the Converter plugin semantics of defining a
-   * no-arg constructor. The usage of this class is internal to ksqldb and is instantiated
-   * explicitly with Schema argument.
+   * This constructor is defined only to adhere to the Connect Converter plugin semantics of
+   * defining a no-arg constructor. The Connect framework scans for all the subtypes of the
+   * Converter (along with other plugin types) and uses the no-arg constructor to create an instance
+   * of each of these converter implementations.
+   * A no-arg constructor is added here only to ensure a successful start of the Connect Worker
+   * in case this module (the jar) is present in the configured connect plugin path.
+   * This class is not intended to be used via a Worker config or a Connector config definition
+   * and its methods to convert to/from Connect record will throw an
+   * UnsupportedOperationException in such a case.
+   * This class is internal to Ksqldb and is instantiated explicitly with Schema argument.
    */
   public ProtobufNoSRConverter() {
-    super();
-    this.schema = null;
+    this(null);
   }
 
   public ProtobufNoSRConverter(final Schema schema) {
@@ -67,7 +73,7 @@ public class ProtobufNoSRConverter implements Converter {
   public byte[] fromConnectData(final String topic, final Schema schema, final Object value) {
     if (this.schema == null) {
       throw new UnsupportedOperationException("ProtobufNoSRConverter is an internal "
-          + "converter to ksqldb. It should not be used via reflection through a no-arg "
+          + "converter to ksqldb. It should not be instantiated via reflection through a no-arg "
           + "constructor.");
     }
     try {

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/ProtobufNoSRConverterTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/ProtobufNoSRConverterTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.serde.protobuf;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+public class ProtobufNoSRConverterTest {
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void shouldThrowExceptionWhenUsedWithNoArgConstructor1() {
+    // Given
+    final ProtobufNoSRConverter protobufNoSRConverter = new ProtobufNoSRConverter();
+
+    // When
+    protobufNoSRConverter.toConnectData("topic", "test".getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void shouldThrowExceptionWhenUsedWithNoArgConstructor2() {
+    // Given
+    final ProtobufNoSRConverter protobufNoSRConverter = new ProtobufNoSRConverter();
+
+    // When
+    protobufNoSRConverter.fromConnectData("topic", Schema.STRING_SCHEMA, "test");
+  }
+
+  @Test
+  public void shouldConvertFromSchemaAndValueWhenInstantiatedWithSchema() {
+    // Given
+    final ProtobufNoSRConverter protobufNoSRConverter =
+        new ProtobufNoSRConverter(Schema.STRING_SCHEMA);
+    protobufNoSRConverter.configure(Collections.emptyMap(), false);
+
+    // When
+    final byte[] bytes = protobufNoSRConverter.fromConnectData(
+        "topic",
+        Schema.STRING_SCHEMA,
+        "test"
+    );
+    final SchemaAndValue schemaAndValue = protobufNoSRConverter.toConnectData("topic", bytes);
+
+    //Then
+    Assert.assertEquals(Schema.STRING_SCHEMA, schemaAndValue.schema());
+    Assert.assertEquals("test", schemaAndValue.value());
+  }
+}


### PR DESCRIPTION
### Description 
This PR adds a no-arg constructor for a Converter implementation.
Even though the Converter is used only in ksqldb and instantiated explicitly with a Schema argument, this class might be in the plugin path for the Connect framework. To avoid failures while loading the Converter we add a no-arg constructor - though it is not intended to be used with that pattern.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
