### PR TITLE
KSQL-12064: Add Num valued metrics corresponding to String valued metrics

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/query/QueryError.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/query/QueryError.java
@@ -56,6 +56,8 @@ public final class QueryError {
 
   /**
    * Specifies the type of error.
+   * The ordinal values of the Type enum are used as the metrics values.
+   * Please ensure preservation of the current order.
    */
   public enum Type {
     /**

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
@@ -66,6 +66,10 @@ public final class KsqlConstants {
     INSERT
   }
 
+  /**
+   * The ordinal values of the KsqlQueryStatus enum are used as the metrics values.
+   * Please ensure preservation of the current order.
+   */
   public enum KsqlQueryStatus {
     RUNNING,
     ERROR,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
@@ -92,12 +92,20 @@ public class CommandRunner implements Closeable {
   private boolean commandTopicDeleted;
   private Status state = new Status(CommandRunnerStatus.RUNNING, CommandRunnerDegradedReason.NONE);
 
+  /**
+   * The ordinal values of the CommandRunnerStatus enum are used as the metrics values.
+   * Please ensure preservation of the current order.
+   */
   public enum CommandRunnerStatus {
     RUNNING,
     ERROR,
     DEGRADED
   }
 
+  /**
+   * The ordinal values of the CommandRunnerDegradedReason enum are used as the metrics values.
+   * Please ensure preservation of the current order.
+   */
   public enum CommandRunnerDegradedReason {
     NONE(errors -> ""),
     CORRUPTED(Errors::commandRunnerDegradedCorruptedErrorMessage),

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunnerMetrics.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunnerMetrics.java
@@ -38,6 +38,8 @@ public class CommandRunnerMetrics implements Closeable {
   private final MetricName commandRunnerDegradedReasonMetricNameLegacy;
   private final MetricName commandRunnerStatusMetricName;
   private final MetricName commandRunnerDegradedReasonMetricName;
+  private final MetricName commandRunnerStatusNumMetricName;
+  private final MetricName commandRunnerDegradedReasonNumMetricName;
 
   CommandRunnerMetrics(
       final String ksqlServiceId,
@@ -90,6 +92,20 @@ public class CommandRunnerMetrics implements Closeable {
         Collections.singletonMap(KsqlConstants.KSQL_SERVICE_ID_METRICS_TAG, ksqlServiceId)
     );
 
+    this.commandRunnerStatusNumMetricName = metrics.metricName(
+            "status-num",
+            ReservedInternalTopics.CONFLUENT_PREFIX + metricGroupName,
+            "The status number of the commandRunner thread as it processes the command topic.",
+            Collections.singletonMap(KsqlConstants.KSQL_SERVICE_ID_METRICS_TAG, ksqlServiceId)
+    );
+
+    this.commandRunnerDegradedReasonNumMetricName = metrics.metricName(
+            "degraded-reason-num",
+            ReservedInternalTopics.CONFLUENT_PREFIX + metricGroupName,
+            "The reason number for why the commandRunner thread is in a DEGRADED state.",
+            Collections.singletonMap(KsqlConstants.KSQL_SERVICE_ID_METRICS_TAG, ksqlServiceId)
+    );
+
     this.metrics.addMetric(commandRunnerStatusMetricNameLegacy, (Gauge<String>)
         (config, now) -> commandRunner.checkCommandRunnerStatus().name());
     this.metrics.addMetric(commandRunnerDegradedReasonMetricNameLegacy, (Gauge<String>)
@@ -98,6 +114,10 @@ public class CommandRunnerMetrics implements Closeable {
         (config, now) -> commandRunner.checkCommandRunnerStatus().name());
     this.metrics.addMetric(commandRunnerDegradedReasonMetricName, (Gauge<String>)
         (config, now) -> commandRunner.getCommandRunnerDegradedReason().name());
+    this.metrics.addMetric(commandRunnerStatusNumMetricName, (Gauge<Integer>)
+            (config, now) -> commandRunner.checkCommandRunnerStatus().ordinal());
+    this.metrics.addMetric(commandRunnerDegradedReasonNumMetricName, (Gauge<Integer>)
+            (config, now) -> commandRunner.getCommandRunnerDegradedReason().ordinal());
   }
 
   /**
@@ -105,6 +125,8 @@ public class CommandRunnerMetrics implements Closeable {
    */
   @Override
   public void close() {
+    metrics.removeMetric(commandRunnerStatusNumMetricName);
+    metrics.removeMetric(commandRunnerDegradedReasonNumMetricName);
     metrics.removeMetric(commandRunnerStatusMetricName);
     metrics.removeMetric(commandRunnerDegradedReasonMetricName);
     metrics.removeMetric(commandRunnerStatusMetricNameLegacy);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerMetricsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerMetricsTest.java
@@ -53,6 +53,10 @@ public class CommandRunnerMetricsTest {
       new MetricName("dob", "g1", "d1", ImmutableMap.of());
   private static final MetricName METRIC_NAME_2 =
       new MetricName("bill", "g1", "d2", ImmutableMap.of());
+  private static final MetricName NUM_METRIC_NAME_1 =
+          new MetricName("n-dob", "g1", "d1", ImmutableMap.of());
+  private static final MetricName NUM_METRIC_NAME_2 =
+          new MetricName("n-bill", "g1", "d2", ImmutableMap.of());
   private static final String KSQL_SERVICE_ID = "kcql-1-";
 
   @Mock
@@ -62,6 +66,9 @@ public class CommandRunnerMetricsTest {
   @Captor
   private ArgumentCaptor<Gauge<String>> gaugeCaptor;
 
+  @Captor
+  private ArgumentCaptor<Gauge<Integer>> gaugeNumCaptor;
+
   private CommandRunnerMetrics commandRunnerMetrics;
 
   @Before
@@ -70,7 +77,9 @@ public class CommandRunnerMetricsTest {
         .thenReturn(METRIC_NAME_1_LEGACY)
         .thenReturn(METRIC_NAME_2_LEGACY)
         .thenReturn(METRIC_NAME_1)
-        .thenReturn(METRIC_NAME_2);
+        .thenReturn(METRIC_NAME_2)
+        .thenReturn(NUM_METRIC_NAME_1)
+        .thenReturn(NUM_METRIC_NAME_2);
     when(commandRunner.checkCommandRunnerStatus()).thenReturn(CommandRunner.CommandRunnerStatus.RUNNING);
     when(commandRunner.getCommandRunnerDegradedReason()).thenReturn(CommandRunner.CommandRunnerDegradedReason.NONE);
 
@@ -100,10 +109,20 @@ public class CommandRunnerMetricsTest {
         "The reason for why the commandRunner thread is in a DEGRADED state.",
         Collections.singletonMap(KsqlConstants.KSQL_SERVICE_ID_METRICS_TAG, KSQL_SERVICE_ID));
 
+    // same metrics but with num values
+    inOrder.verify(metrics).metricName("status-num", "_confluent-ksql-rest-command-runner",
+            "The status number of the commandRunner thread as it processes the command topic.",
+            Collections.singletonMap(KsqlConstants.KSQL_SERVICE_ID_METRICS_TAG, KSQL_SERVICE_ID));
+    inOrder.verify(metrics).metricName("degraded-reason-num", "_confluent-ksql-rest-command-runner",
+            "The reason number for why the commandRunner thread is in a DEGRADED state.",
+            Collections.singletonMap(KsqlConstants.KSQL_SERVICE_ID_METRICS_TAG, KSQL_SERVICE_ID));
+
     inOrder.verify(metrics).addMetric(eq(METRIC_NAME_1_LEGACY), isA(Gauge.class));
     inOrder.verify(metrics).addMetric(eq(METRIC_NAME_2_LEGACY), isA(Gauge.class));
     inOrder.verify(metrics).addMetric(eq(METRIC_NAME_1), isA(Gauge.class));
     inOrder.verify(metrics).addMetric(eq(METRIC_NAME_2), isA(Gauge.class));
+    inOrder.verify(metrics).addMetric(eq(NUM_METRIC_NAME_1), isA(Gauge.class));
+    inOrder.verify(metrics).addMetric(eq(NUM_METRIC_NAME_2), isA(Gauge.class));
   }
 
   @Test
@@ -112,6 +131,7 @@ public class CommandRunnerMetricsTest {
     // CommandRunnerStatusMetric created in setup
 
     // Then:
+    assertThat(commandRunnerStatusGaugeNumValue(), is(CommandRunner.CommandRunnerStatus.RUNNING.ordinal()));
     assertThat(commandRunnerStatusGaugeValue(), is(CommandRunner.CommandRunnerStatus.RUNNING.name()));
     assertThat(commandRunnerStatusGaugeValueLegacy(), is(CommandRunner.CommandRunnerStatus.RUNNING.name()));
   }
@@ -122,6 +142,7 @@ public class CommandRunnerMetricsTest {
     when(commandRunner.checkCommandRunnerStatus()).thenReturn(CommandRunner.CommandRunnerStatus.ERROR);
 
     // Then:
+    assertThat(commandRunnerStatusGaugeNumValue(), is(CommandRunner.CommandRunnerStatus.ERROR.ordinal()));
     assertThat(commandRunnerStatusGaugeValue(), is(CommandRunner.CommandRunnerStatus.ERROR.name()));
     assertThat(commandRunnerStatusGaugeValueLegacy(), is(CommandRunner.CommandRunnerStatus.ERROR.name()));
   }
@@ -132,6 +153,7 @@ public class CommandRunnerMetricsTest {
     when(commandRunner.checkCommandRunnerStatus()).thenReturn(CommandRunner.CommandRunnerStatus.DEGRADED);
 
     // Then:
+    assertThat(commandRunnerStatusGaugeNumValue(), is(CommandRunner.CommandRunnerStatus.DEGRADED.ordinal()));
     assertThat(commandRunnerStatusGaugeValue(), is(CommandRunner.CommandRunnerStatus.DEGRADED.name()));
     assertThat(commandRunnerStatusGaugeValueLegacy(), is(CommandRunner.CommandRunnerStatus.DEGRADED.name()));
   }
@@ -142,6 +164,7 @@ public class CommandRunnerMetricsTest {
     // CommandRunnerStatusMetric created in setup
 
     // Then:
+    assertThat(commandRunnerDegradedReasonGaugeNumValue(), is(CommandRunner.CommandRunnerDegradedReason.NONE.ordinal()));
     assertThat(commandRunnerDegradedReasonGaugeValue(), is(CommandRunner.CommandRunnerDegradedReason.NONE.name()));
     assertThat(commandRunnerDegradedReasonGaugeValueLegacy(), is(CommandRunner.CommandRunnerDegradedReason.NONE.name()));
   }
@@ -152,6 +175,7 @@ public class CommandRunnerMetricsTest {
     when(commandRunner.getCommandRunnerDegradedReason()).thenReturn(CommandRunner.CommandRunnerDegradedReason.CORRUPTED);
 
     // Then:
+    assertThat(commandRunnerDegradedReasonGaugeNumValue(), is(CommandRunner.CommandRunnerDegradedReason.CORRUPTED.ordinal()));
     assertThat(commandRunnerDegradedReasonGaugeValue(), is(CommandRunner.CommandRunnerDegradedReason.CORRUPTED.name()));
     assertThat(commandRunnerDegradedReasonGaugeValueLegacy(), is(CommandRunner.CommandRunnerDegradedReason.CORRUPTED.name()));
   }
@@ -162,6 +186,7 @@ public class CommandRunnerMetricsTest {
     when(commandRunner.getCommandRunnerDegradedReason()).thenReturn(CommandRunner.CommandRunnerDegradedReason.INCOMPATIBLE_COMMAND);
 
     // Then:
+    assertThat(commandRunnerDegradedReasonGaugeNumValue(), is(CommandRunner.CommandRunnerDegradedReason.INCOMPATIBLE_COMMAND.ordinal()));
     assertThat(commandRunnerDegradedReasonGaugeValue(), is(CommandRunner.CommandRunnerDegradedReason.INCOMPATIBLE_COMMAND.name()));
     assertThat(commandRunnerDegradedReasonGaugeValueLegacy(), is(CommandRunner.CommandRunnerDegradedReason.INCOMPATIBLE_COMMAND.name()));
   }
@@ -176,6 +201,18 @@ public class CommandRunnerMetricsTest {
     verify(metrics).removeMetric(METRIC_NAME_2_LEGACY);
     verify(metrics).removeMetric(METRIC_NAME_1);
     verify(metrics).removeMetric(METRIC_NAME_2);
+    verify(metrics).removeMetric(NUM_METRIC_NAME_1);
+    verify(metrics).removeMetric(NUM_METRIC_NAME_2);
+  }
+
+  private int commandRunnerStatusGaugeNumValue() {
+    verify(metrics).addMetric(eq(NUM_METRIC_NAME_1), gaugeNumCaptor.capture());
+    return gaugeNumCaptor.getValue().value(null, 0L);
+  }
+
+  private int commandRunnerDegradedReasonGaugeNumValue() {
+    verify(metrics).addMetric(eq(NUM_METRIC_NAME_2), gaugeNumCaptor.capture());
+    return gaugeNumCaptor.getValue().value(null, 0L);
   }
 
   private String commandRunnerStatusGaugeValue() {


### PR DESCRIPTION
### Description 
In process of migrating ksql metrics to otel, we found a few string valued metrics
```ksql.query.transient.status
ksql.server.command_runner.status
ksql.server.command_runner.degraded.reason
ksql.query.status
ksql.query.lifecycle.status
ksql.query.error.status
```
These metrics are currently getting dropped because TelemetryReporter [skips](https://github.com/confluentinc/ce-kafka/blob/e707e9b1db4aee6ef76c525e7b2155e2f9946aa7/ce-metrics/src/main/java/io/confluent/telemetry/collector/KafkaMetricsCollector.java#L102-L106) the String Valued metrics and JMX Metrics Insights [skips](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/1b7d3258618b2a54c42bb3b69a0bf689f606da28/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/engine/BeanAttributeExtractor.java#L130-L140) it as well.
Complete Explanation: [link](https://confluentinc.atlassian.net/browse/KSQL-12026)

To migrate such metrics without breaking the current flow, we are adding the Number valued metrics corresponding to the String valued metrics.
### Testing done 
Tested using UTs.
Also tested using jconsole - able to view the new metrics.
<img width="623" alt="Screenshot 2024-04-10 at 10 34 47 PM" src="https://github.com/confluentinc/ksql/assets/62741600/f45c225a-02db-43df-b98d-e998434a1fdd">


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
