### PR TITLE
docs: document settings for authenticated Kafka Connect (DOCS-28313)

### DIFF
--- a/docs/reference/server-configuration.md
+++ b/docs/reference/server-configuration.md
@@ -100,6 +100,42 @@ The amount of time an `ASSERT SCHEMA` statement will wait for the assertion to s
 
 The amount of time an `ASSERT TOPIC` assertion will wait for the assertion to succeed if no timeout is specified. The default is `1000`.
 
+## `ksql.connect.basic.auth.credentials.file`
+
+**Per query:** no
+
+The path to the file that contains credentials for basic authentication to
+a {{ site.kconnect }} cluster, for example,
+`/mnt/secrets/basic-credential/basic.txt`.
+
+The file contents are:
+
+```
+username: <user-name>
+password: <user-password>
+```
+
+Use in conjunction with the `ksql.connect.basic.auth.credentials.source`
+and `ksql.connect.url` settings, for example:
+
+```properties
+ksql.connect.url=https://url.to.your.kafka.connect/
+ksql.connect.basic.auth.credentials.source=FILE
+ksql.connect.basic.auth.credentials.file=/path/to/credentials
+```
+
+## `ksql.connect.basic.auth.credentials.source`
+
+**Per query:** no
+
+The source for credentials when using authentication with the
+{{ site.kconnect }} API. Valid values are "FILE" and "NONE". The default is
+"NONE".
+
+Use in conjunction with the `ksql.connect.basic.auth.credentials.file`
+setting.
+
+
 ## `ksql.connect.url`
 
 **Per query:** no

--- a/docs/reference/server-configuration.md
+++ b/docs/reference/server-configuration.md
@@ -129,8 +129,8 @@ ksql.connect.basic.auth.credentials.file=/path/to/credentials
 **Per query:** no
 
 The source for credentials when using authentication with the
-{{ site.kconnect }} API. Valid values are "FILE" and "NONE". The default is
-"NONE".
+{{ site.kconnect }} API. Valid values are `FILE` and `NONE`. The default
+is `NONE`.
 
 Use in conjunction with the `ksql.connect.basic.auth.credentials.file`
 setting.


### PR DESCRIPTION
### Description 
Fixes https://github.com/confluentinc/ksql/issues/10284 by adding sections for `ksql.connect.basic.auth.credentials.file` and `ksql.connect.basic.auth.credentials.source` configs.

![image](https://github.com/confluentinc/ksql/assets/12521043/1bf927db-66c4-4894-b2af-fa806f089b32)
