### PR TITLE
KSQL-12154: Update plugin version

### DIFF
--- a/ksqldb-api-client/pom.xml
+++ b/ksqldb-api-client/pom.xml
@@ -177,7 +177,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.5.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
### Description 
**Issue**: KsqlDB build failing.

**RCA**: The version of the dependency `bouncycastle.jdk18` was changed recently
- https://github.com/confluentinc/common/pull/599/files
- https://github.com/confluentinc/common/pull/601/files

The new jars included classes build using JAVA 21. But the `maven-shade-plugin` version we used did not support the support the java 21 class files.

**Fix**: Upgraded the plugin to a version which supports java 21 as well.
### Testing done 
Build passing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
