### PR TITLE
KSQL-12164: Remove disable ITs flag

### DIFF
--- a/ksqldb-api-client/pom.xml
+++ b/ksqldb-api-client/pom.xml
@@ -264,6 +264,14 @@
                     <notree>true</notree>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <!-- Skip ITs temporarily -->
+                    <skipITs>true</skipITs>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/ksqldb-cli/pom.xml
+++ b/ksqldb-cli/pom.xml
@@ -154,6 +154,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <!-- Skip ITs temporarily -->
+                    <skipITs>true</skipITs>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/ksqldb-rest-app/pom.xml
+++ b/ksqldb-rest-app/pom.xml
@@ -272,7 +272,7 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <!-- Skip ITs temporarily -->
-                    <skipITs>false</skipITs>
+                    <skipITs>true</skipITs>
                 </configuration>
             </plugin>
         </plugins>

--- a/ksqldb-rest-app/pom.xml
+++ b/ksqldb-rest-app/pom.xml
@@ -267,6 +267,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <!-- Skip ITs temporarily -->
+                    <skipITs>false</skipITs>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/ksqldb-tools/pom.xml
+++ b/ksqldb-tools/pom.xml
@@ -138,6 +138,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <!-- Skip ITs temporarily -->
+                    <skipITs>true</skipITs>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -831,6 +831,8 @@
                     <systemPropertyVariables>
                         <junit.platform.execution.listeners.deactivate>org.apache.kafka.test.ThreadLeakListener</junit.platform.execution.listeners.deactivate>
                     </systemPropertyVariables>
+                    <!-- Skip ITs temporarily -->
+                    <skipITs>true</skipITs>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -831,8 +831,6 @@
                     <systemPropertyVariables>
                         <junit.platform.execution.listeners.deactivate>org.apache.kafka.test.ThreadLeakListener</junit.platform.execution.listeners.deactivate>
                     </systemPropertyVariables>
-                    <!-- Skip ITs temporarily -->
-                    <skipITs>true</skipITs>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
### Description 
Background: Currently, all the ITs of ksqldb are getting skipped due to some failures(as per historical context - the failures are not due to functionality issues) cc @pbadani 

Instead of skipping all the ITs, this change will skip only the failing ITs.
Then we can pick up to fix them one by one.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
