### PR TITLE
KSQL-11272: Fix build failure

### DIFF
--- a/ksqldb-stream-lib/pom.xml
+++ b/ksqldb-stream-lib/pom.xml
@@ -3,7 +3,7 @@
   <parent>
       <groupId>io.confluent.ksql</groupId>
       <artifactId>ksqldb-parent</artifactId>
-      <version>7.7.0-0</version>
+      <version>7.8.0-0</version>
   </parent>
 
   <artifactId>ksqldb-stream-lib</artifactId>


### PR DESCRIPTION
### Description 
**Background:** We did a pint merge of the PR: https://github.com/confluentinc/ksql/pull/10305 from `7.7.x` to master.
**Bug:** The version in the pom.xml which was 7.7.0 also got propagated, which is causing build failure.

**Fix:** Changing the version to 7.8.0

### Testing done 
Ran the build locally

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
