### PR TITLE
KSE-1795 | Add support for AnyOf Json type while encoding Ksql schemas.

### DIFF
--- a/ksqldb-common/pom.xml
+++ b/ksqldb-common/pom.xml
@@ -47,6 +47,12 @@
 
         <dependency>
             <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-json-schema-converter</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.confluent</groupId>
             <artifactId>common-logging</artifactId>
             <version>${io.confluent.common.version}</version>
         </dependency>

--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/SchemaConverters.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/SchemaConverters.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.schema.ksql;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableMap;
+import io.confluent.connect.json.JsonSchemaData;
 import io.confluent.ksql.function.types.ArrayType;
 import io.confluent.ksql.function.types.MapType;
 import io.confluent.ksql.function.types.ParamType;
@@ -221,7 +222,7 @@ public final class SchemaConverters {
         .<Schema.Type, Function<Schema, SqlType>>builder()
         .put(Schema.Type.INT32, ConnectToSqlConverter::toIntegerType)
         .put(Schema.Type.INT64, s ->
-            s.name() == Timestamp.LOGICAL_NAME ? SqlTypes.TIMESTAMP : SqlTypes.BIGINT)
+            Timestamp.LOGICAL_NAME.equals(s.name()) ? SqlTypes.TIMESTAMP : SqlTypes.BIGINT)
         .put(Schema.Type.FLOAT64, s -> SqlTypes.DOUBLE)
         .put(Schema.Type.BOOLEAN, s -> SqlTypes.BOOLEAN)
         .put(Schema.Type.STRING, s -> SqlTypes.STRING)
@@ -271,9 +272,9 @@ public final class SchemaConverters {
     }
 
     private static SqlPrimitiveType toIntegerType(final Schema schema) {
-      if (schema.name() == Time.LOGICAL_NAME) {
+      if (Time.LOGICAL_NAME.equals(schema.name())) {
         return SqlTypes.TIME;
-      } else if (schema.name() == Date.LOGICAL_NAME) {
+      } else if (Date.LOGICAL_NAME.equals(schema.name())) {
         return SqlTypes.DATE;
       } else {
         return SqlTypes.INTEGER;
@@ -344,8 +345,11 @@ public final class SchemaConverters {
       struct.fields()
           .forEach(field -> builder.field(field.name(), connectType(field.type()).build()));
 
-      return builder
-          .optional();
+      if (struct.isUnionType()) {
+        builder.name(JsonSchemaData.JSON_TYPE_ONE_OF);
+      }
+
+      return builder.optional();
     }
   }
 

--- a/ksqldb-common/src/test/java/io/confluent/ksql/schema/ksql/SchemaConvertersTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/schema/ksql/SchemaConvertersTest.java
@@ -15,12 +15,17 @@
 
 package io.confluent.ksql.schema.ksql;
 
+import static io.confluent.connect.json.JsonSchemaData.JSON_TYPE_ONE_OF;
 import static io.confluent.ksql.schema.ksql.SchemaConverters.javaToSqlConverter;
+import static io.confluent.ksql.schema.ksql.SchemaConverters.sqlToConnectConverter;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
@@ -36,6 +41,7 @@ import io.confluent.ksql.schema.ksql.types.SqlArray;
 import io.confluent.ksql.schema.ksql.types.SqlBaseType;
 import io.confluent.ksql.schema.ksql.types.SqlDecimal;
 import io.confluent.ksql.schema.ksql.types.SqlMap;
+import io.confluent.ksql.schema.ksql.types.SqlPrimitiveType;
 import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
@@ -307,6 +313,66 @@ public class SchemaConvertersTest {
   public void shouldConvertJavaStringToSqlTimestamp() {
     assertThat(javaToSqlConverter().toSqlType(Timestamp.class),
         is(SqlBaseType.TIMESTAMP));
+  }
+
+  @Test
+  public void shouldConvertUnionTypeFromSqlToConnect() {
+    // Given:
+    SqlStruct sqlStruct = SqlStruct.builder()
+        .field("io.confluent.connect.json.OneOf.field.0", SqlPrimitiveType.of(SqlBaseType.STRING))
+        .field("io.confluent.connect.json.OneOf.field.1", SqlPrimitiveType.of(SqlBaseType.BOOLEAN))
+        .field("io.confluent.connect.json.OneOf.field.2", SqlPrimitiveType.of(SqlBaseType.INTEGER))
+        .build();
+
+    // When:
+    Schema connectSchema = sqlToConnectConverter().toConnectSchema(sqlStruct);
+
+    // Then:
+    assertThat(connectSchema.type(), is(Schema.Type.STRUCT));
+    assertEquals(JSON_TYPE_ONE_OF, connectSchema.schema().name());
+  }
+
+  @Test
+  public void shouldConvertNestedUnionTypeFromSqlToConnect() {
+    // Given:
+    SqlStruct inner = SqlStruct.builder()
+        .field("io.confluent.connect.json.OneOf.field.0", SqlPrimitiveType.of(SqlBaseType.STRING))
+        .field("io.confluent.connect.json.OneOf.field.1", SqlPrimitiveType.of(SqlBaseType.BOOLEAN))
+        .field("io.confluent.connect.json.OneOf.field.2", SqlPrimitiveType.of(SqlBaseType.INTEGER))
+        .build();
+
+    SqlStruct outer = SqlStruct.builder()
+        .field("foo", inner)
+        .field("bar", SqlPrimitiveType.of(SqlBaseType.BOOLEAN))
+        .field("baz", SqlPrimitiveType.of(SqlBaseType.INTEGER))
+        .build();
+
+    // When:
+    Schema connectSchema = sqlToConnectConverter().toConnectSchema(outer);
+    Schema fooSchema = connectSchema.field("foo").schema();
+
+    // Then:
+    assertThat(connectSchema.type(), is(Schema.Type.STRUCT));
+    assertNull(connectSchema.schema().name());
+    assertThat(fooSchema.type(), is(Schema.Type.STRUCT));
+    assertEquals(JSON_TYPE_ONE_OF, fooSchema.schema().name());
+  }
+
+  @Test
+  public void shouldConvertRegularStructFromSqlToConnect() {
+    // Given:
+    SqlStruct sqlStruct = SqlStruct.builder()
+        .field("foo", SqlPrimitiveType.of(SqlBaseType.STRING))
+        .field("bar", SqlPrimitiveType.of(SqlBaseType.BOOLEAN))
+        .field("baz", SqlPrimitiveType.of(SqlBaseType.INTEGER))
+        .build();
+
+    // When:
+    Schema connectSchema = sqlToConnectConverter().toConnectSchema(sqlStruct);
+
+    // Then:
+    assertThat(connectSchema.type(), is(Schema.Type.STRUCT));
+    assertNull(connectSchema.schema().name());
   }
 
   @Test

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectDataTranslator.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectDataTranslator.java
@@ -205,16 +205,16 @@ public class ConnectDataTranslator implements DataTranslator {
     final Object convertedValue = maybeConvertLogicalType(connectSchema, connectValue);
     switch (schema.type()) {
       case INT64:
-        if (schema.name() == Timestamp.LOGICAL_NAME) {
+        if (Timestamp.LOGICAL_NAME.equals(schema.name())) {
           return new java.sql.Timestamp(((Number) convertedValue).longValue());
         } else {
           return ((Number) convertedValue).longValue();
         }
       case INT32:
         final int intVal = ((Number) convertedValue).intValue();
-        if (schema.name() == Time.LOGICAL_NAME) {
+        if (Time.LOGICAL_NAME.equals(schema.name())) {
           return new java.sql.Time(intVal);
-        } else if (schema.name() == Date.LOGICAL_NAME) {
+        } else if (Date.LOGICAL_NAME.equals(schema.name())) {
           return SerdeUtils.getDateFromEpochDays(intVal);
         } else {
           return intVal;

--- a/ksqldb-udf/pom.xml
+++ b/ksqldb-udf/pom.xml
@@ -29,8 +29,13 @@
     <version>7.6.2-0</version>
 
     <dependencies>
-        <!-- Required for running tests -->
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-json-schema-converter</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+        </dependency>
 
+        <!-- Required for running tests -->
         <dependency>
             <groupId>io.confluent.ksql</groupId>
             <artifactId>ksqldb-test-util</artifactId>

--- a/ksqldb-udf/src/test/java/io/confluent/ksql/schema/ksql/types/SqlStructTest.java
+++ b/ksqldb-udf/src/test/java/io/confluent/ksql/schema/ksql/types/SqlStructTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -75,11 +76,11 @@ public class SqlStructTest {
           new Field("f0", SqlTypes.BIGINT, 0),
           new Field("f1", SqlTypes.DOUBLE, 1)
       ));
-      assertFalse(struct.isUnionType());
+      assertFalse(struct.unionType().isPresent());
     }
 
     @Test
-    public void shouldRecognizeUnionType() {
+    public void shouldRecognizeOneOfUnionType() {
       // When:
       final SqlStruct struct = SqlStruct.builder()
           .field("io.confluent.connect.json.OneOf.field.0", SqlTypes.BIGINT)
@@ -87,13 +88,27 @@ public class SqlStructTest {
           .build();
 
       // Then:
-      assertTrue(struct.isUnionType());
+      assertTrue(struct.unionType().isPresent());
+      assertEquals(SqlStruct.UnionType.ONE_OF_TYPE, struct.unionType().get());
+    }
+
+    @Test
+    public void shouldRecognizeGeneralizedUnionType() {
+      // When:
+      final SqlStruct struct = SqlStruct.builder()
+          .field("connect_union_field_0", SqlTypes.BIGINT)
+          .field("connect_union_field_1", SqlTypes.DOUBLE)
+          .build();
+
+      // Then:
+      assertTrue(struct.unionType().isPresent());
+      assertEquals(SqlStruct.UnionType.GENERALIZED_TYPE, struct.unionType().get());
     }
 
     @Test
     public void shouldNotThrowIfNoFields() {
       SqlStruct struct = SqlStruct.builder().build();
-      assertFalse(struct.isUnionType());
+      assertFalse(struct.unionType().isPresent());
     }
 
     @Test
@@ -125,7 +140,7 @@ public class SqlStructTest {
           new Field("f0", SqlTypes.BOOLEAN, 0),
           new Field("F0", SqlTypes.BOOLEAN, 1)
       ));
-      assertFalse(struct.isUnionType());
+      assertFalse(struct.unionType().isPresent());
     }
 
     @Test
@@ -146,7 +161,7 @@ public class SqlStructTest {
               + ", `F1` " + SqlTypes.array(SqlTypes.DOUBLE)
               + ">"
       ));
-      assertFalse(struct.isUnionType());
+      assertFalse(struct.unionType().isPresent());
     }
 
     @Test
@@ -159,7 +174,7 @@ public class SqlStructTest {
 
       // Then:
       assertThat(sql, is("STRUCT< >"));
-      assertFalse(emptyStruct.isUnionType());
+      assertFalse(emptyStruct.unionType().isPresent());
     }
 
     @Test
@@ -182,7 +197,7 @@ public class SqlStructTest {
               + ", `F1` " + SqlTypes.array(SqlTypes.DOUBLE)
               + ">"
       ));
-      assertFalse(struct.isUnionType());
+      assertFalse(struct.unionType().isPresent());
     }
 
     @SuppressWarnings("OptionalGetWithoutIsPresent")
@@ -199,7 +214,7 @@ public class SqlStructTest {
       // Then:
       assertThat(result, is(not(Optional.empty())));
       assertThat(result.get().name(), is("f0"));
-      assertFalse(schema.isUnionType());
+      assertFalse(schema.unionType().isPresent());
     }
 
     @Test
@@ -214,7 +229,7 @@ public class SqlStructTest {
 
       // Then:
       assertThat(result, is(Optional.empty()));
-      assertFalse(schema.isUnionType());
+      assertFalse(schema.unionType().isPresent());
     }
 
     @Test
@@ -229,7 +244,7 @@ public class SqlStructTest {
 
       // Then:
       assertThat(result, is(Optional.empty()));
-      assertFalse(schema.isUnionType());
+      assertFalse(schema.unionType().isPresent());
     }
   }
 

--- a/ksqldb-udf/src/test/java/io/confluent/ksql/schema/ksql/types/SqlStructTest.java
+++ b/ksqldb-udf/src/test/java/io/confluent/ksql/schema/ksql/types/SqlStructTest.java
@@ -20,7 +20,9 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
@@ -73,11 +75,25 @@ public class SqlStructTest {
           new Field("f0", SqlTypes.BIGINT, 0),
           new Field("f1", SqlTypes.DOUBLE, 1)
       ));
+      assertFalse(struct.isUnionType());
+    }
+
+    @Test
+    public void shouldRecognizeUnionType() {
+      // When:
+      final SqlStruct struct = SqlStruct.builder()
+          .field("io.confluent.connect.json.OneOf.field.0", SqlTypes.BIGINT)
+          .field("io.confluent.connect.json.OneOf.field.1", SqlTypes.DOUBLE)
+          .build();
+
+      // Then:
+      assertTrue(struct.isUnionType());
     }
 
     @Test
     public void shouldNotThrowIfNoFields() {
-      SqlStruct.builder().build();
+      SqlStruct struct = SqlStruct.builder().build();
+      assertFalse(struct.isUnionType());
     }
 
     @Test
@@ -109,6 +125,7 @@ public class SqlStructTest {
           new Field("f0", SqlTypes.BOOLEAN, 0),
           new Field("F0", SqlTypes.BOOLEAN, 1)
       ));
+      assertFalse(struct.isUnionType());
     }
 
     @Test
@@ -129,6 +146,7 @@ public class SqlStructTest {
               + ", `F1` " + SqlTypes.array(SqlTypes.DOUBLE)
               + ">"
       ));
+      assertFalse(struct.isUnionType());
     }
 
     @Test
@@ -141,6 +159,7 @@ public class SqlStructTest {
 
       // Then:
       assertThat(sql, is("STRUCT< >"));
+      assertFalse(emptyStruct.isUnionType());
     }
 
     @Test
@@ -163,6 +182,7 @@ public class SqlStructTest {
               + ", `F1` " + SqlTypes.array(SqlTypes.DOUBLE)
               + ">"
       ));
+      assertFalse(struct.isUnionType());
     }
 
     @SuppressWarnings("OptionalGetWithoutIsPresent")
@@ -179,6 +199,7 @@ public class SqlStructTest {
       // Then:
       assertThat(result, is(not(Optional.empty())));
       assertThat(result.get().name(), is("f0"));
+      assertFalse(schema.isUnionType());
     }
 
     @Test
@@ -193,6 +214,7 @@ public class SqlStructTest {
 
       // Then:
       assertThat(result, is(Optional.empty()));
+      assertFalse(schema.isUnionType());
     }
 
     @Test
@@ -207,6 +229,7 @@ public class SqlStructTest {
 
       // Then:
       assertThat(result, is(Optional.empty()));
+      assertFalse(schema.isUnionType());
     }
   }
 


### PR DESCRIPTION
### Description 

Union/AnyOf types in Schema Registry are encoded in Connect as a Struct with a special schema name: **io.confluent.connect.json.OneOf** and one field for each of the alternative types.

{"anyOf":[{"type":"string"},{"type":"integer"},{"type":"boolean"}]

The fields for each alternative types are named as following for the given example:
**io.confluent.connect.json.OneOf.field.0** - String type
**io.confluent.connect.json.OneOf.field.1** - Integer type
**io.confluent.connect.json.OneOf.field.2** - boolean type

During Ser/De in the JsonSchemaConverter the first field with a non-null value is picked as the value of the current Union/AnyOf type. (see Class JsonSchemaData in Schema Registry).

KsqlDB schema in the Command object does not maintain this special information for the Structs (nor does it store the names associated with the field schemas) and hence it ends up treating it as a regular struct thereby changing its interpretation during serialization. This results in Schema mismatch errors.

To handle this, If all the fields in this struct follow the above naming convention, we infer this Struct to be of a Union type.

While preparing the Connect record for Serialization, we explicitly set the schema name as io.confluent.connect.json.OneOf if the current Struct is of Union type.
see io.confluent.ksql.schema.ksql.SchemaConverters

### Testing done 
Tested these changes via docker image built locally
1. Register a schema with anyOf type in SR.
`{"schemaType":"JSON", "schema": "{"additionalProperties":false,"properties":{"name":{"oneOf":[{"type":"null"},{"type":"string"}]},"value":{"anyOf":[{"type":"null"},{"type":"object"},{"type":"string"},{"type":"integer"},{"type":"boolean"}]},"valueType":{"oneOf":[{"type":"null"},{"type":"string"}]}},"type":"object"}"}`

2. Produce records to a topic with this schema
`kafka-json-schema-console-producer --bootstrap-server ksql_kafka_1:9092 --topic test-value --property value.schema.id=1`

3. Create a stream with the schema id.
`CREATE STREAM test1 WITH (kafka_topic='test-value',value_format='json_sr',value_schema_id=1);`

4. Create another stream from the previous stream
`CREATE STREAM another as SELECT * FROM test1;`

This registers a new schema (oneOf with multiple alternatives)
`{"type":"object","properties":{"valueType":{"connect.index":0,"oneOf":[{"type":"null"},{"type":"string"}]},"name":{"connect.index":1,"oneOf":[{"type":"null"},{"type":"string"}]},"value":{"connect.index":2,"oneOf":[{"type":"null"},{"type":"object","connect.index":0},{"type":"string","connect.index":1},{"type":"integer","connect.index":2,"connect.type":"int64"},{"connect.index":3,"type":"boolean"}]}}}`

5. Create another stream with explicit schema id (doesn't register a new schema)
`CREATE STREAM AnotherWithSchema WITH (value_schema_id=1) as SELECT * FROM test1;`




### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
