### PR TITLE
KSQL-12187: Add property name in the ksql codebase

### DIFF
--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
@@ -125,7 +125,7 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
   private static final String AUTO_CREATE_TOPICS_ENABLE_PROP = "auto.create.topics.enable";
   private static final String INTER_BROKER_SECURITY_PROTOCOL_PROP =
       "security.inter.broker.protocol";
-
+  private static final String LISTENERS_PROP = "listeners";
   public static final Credentials VALID_USER1 =
       new Credentials("valid_user_1", "some-password");
   public static final Credentials VALID_USER2 =
@@ -717,7 +717,7 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
       brokerConfig.put(KafkaConfig.AuthorizerClassNameProp(), AclAuthorizer.class.getName());
       brokerConfig.put(AclAuthorizer.AllowEveryoneIfNoAclIsFoundProp(),
           true);
-      brokerConfig.put(KafkaConfig.ListenersProp(), "PLAINTEXT://:0");
+      brokerConfig.put(LISTENERS_PROP, "PLAINTEXT://:0");
       brokerConfig.put(AUTO_CREATE_TOPICS_ENABLE_PROP, true);
     }
 
@@ -791,16 +791,16 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
     }
 
     private void addListenersProp(final String listenerType) {
-      final Object current = brokerConfig.get(KafkaConfig.ListenersProp());
-      brokerConfig.put(KafkaConfig.ListenersProp(), current + "," + listenerType + "://:0");
+      final Object current = brokerConfig.get(LISTENERS_PROP);
+      brokerConfig.put(LISTENERS_PROP, current + "," + listenerType + "://:0");
     }
 
     private void removeListenersProp(final String listenerType) {
-      final String current = (String)brokerConfig.get(KafkaConfig.ListenersProp());
+      final String current = (String)brokerConfig.get(LISTENERS_PROP);
       final String replacement = Arrays.stream(current.split(","))
           .filter(part -> !part.startsWith(listenerType + "://"))
           .collect(Collectors.joining(","));
-      brokerConfig.put(KafkaConfig.ListenersProp(), replacement);
+      brokerConfig.put(LISTENERS_PROP, replacement);
     }
   }
 


### PR DESCRIPTION
### Description 
We make of kafka configs property in Ksql code base.
The property name was dependent on ce-kafka.
Recently the code in ce-kafka got refactored and the config name was moved.
Old code: https://github.com/confluentinc/ce-kafka/commit/a402dfb01e7ab5499d502fb83fc10cb4d806dae3#diff-cbe6a8b71b05ed22cf09d97591225b588e9fca6caaf95d3b34a43262cfd23aa6L172
New Code: https://github.com/confluentinc/ce-kafka/commit/a402dfb01e7ab5499d502fb83fc10cb4d806dae3#diff-8eb3e01716508551f203b0b37c2d5f951e93cce7ffed7c00c2b33633d7c8ed23R45

We could 2 approaches now:
1. Add the name of the propoerty in ksql codebase explicitly.
2. Or include the ce-server dependency in ksql codebase and use the new path for the config name

I am going ahead with approach 1.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
