### PR TITLE
[KSQL-12378] Downgrade classgraph to 4.8.59

### DIFF
--- a/ksqldb-engine/pom.xml
+++ b/ksqldb-engine/pom.xml
@@ -122,11 +122,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.github.classgraph</groupId>
-            <artifactId>classgraph</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.squareup</groupId>
             <artifactId>javapoet</artifactId>
             <version>1.9.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -610,6 +610,11 @@
                 <artifactId>jersey-common</artifactId>
                 <version>${jersey-common}</version>
             </dependency>
+            <dependency>
+                <groupId>io.github.classgraph</groupId>
+                <artifactId>classgraph</artifactId>
+                <version>4.8.59</version>
+            </dependency>
 
             <!-- Required for running tests -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -613,7 +613,7 @@
             <dependency>
                 <groupId>io.github.classgraph</groupId>
                 <artifactId>classgraph</artifactId>
-                <version>4.8.59</version>
+                <version>4.8.148</version>
             </dependency>
 
             <!-- Required for running tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -610,6 +610,8 @@
                 <artifactId>jersey-common</artifactId>
                 <version>${jersey-common}</version>
             </dependency>
+            <!-- classgraph needs to be pinned to 4.8.59 as the latest versions have a
+            regression which breaks the Integration Tests. -->
             <dependency>
                 <groupId>io.github.classgraph</groupId>
                 <artifactId>classgraph</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -613,7 +613,7 @@
             <dependency>
                 <groupId>io.github.classgraph</groupId>
                 <artifactId>classgraph</artifactId>
-                <version>4.8.148</version>
+                <version>4.8.59</version>
             </dependency>
 
             <!-- Required for running tests -->


### PR DESCRIPTION
### Description 
Revert classgraph version to older one

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
