### PR TITLE
KSQL-12387 | SystemTime is refactored to a singleton class. Fix the ref in the class KafkaEmbedded.

### DIFF
--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
@@ -53,7 +53,7 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
-import org.apache.kafka.common.utils.SystemTime;
+import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.collection.Iterator;
@@ -92,7 +92,7 @@ class KafkaEmbedded {
     log.debug("Starting embedded Kafka broker (with log.dirs={} and ZK ensemble at {}) ...",
         logDir(), zookeeperConnect());
 
-    kafka = TestUtils.createServer(kafkaConfig, new SystemTime());
+    kafka = TestUtils.createServer(kafkaConfig, Time.SYSTEM);
     log.debug("Startup of embedded Kafka broker at {} completed (with ZK ensemble at {}) ...",
         brokerList(), zookeeperConnect());
   }


### PR DESCRIPTION
### Description 
Make the appropriate changes in ksql repo.
Kafka changes for ref: https://github.com/apache/kafka/commit/133f2b0f311ba1fd5a999f477bad38370c1772ca

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
