### PR TITLE
KSQL-12384 | Add a null check in the response object to avoid NPE while accessing the connection status.

### DIFF
--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
@@ -354,7 +354,7 @@ public final class KsqlTarget {
         resp -> responseSupplier.get(),
         (resp, vcf) -> {
         final ReadStream<Buffer> readStream;
-        if (resp.request().connection().isSsl()) {
+        if (resp != null && resp.request().connection().isSsl()) {
           readStream = new BufferCopyStream(resp);
         } else {
           readStream = resp;


### PR DESCRIPTION
### Description 
The response object is nullable and accessing the connection status to check if it was SSL results in an NPE.
This PR adds a null check for the object.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
