### PR TITLE
Update vertx version (#52)

### DIFF
--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslClientAuthFunctionalTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslClientAuthFunctionalTest.java
@@ -19,6 +19,7 @@ import static io.confluent.ksql.serde.FormatFactory.JSON;
 import static io.confluent.ksql.serde.FormatFactory.KAFKA;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static java.util.Collections.emptyMap;
+import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -44,6 +45,8 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLHandshakeException;
+
+import io.netty.handler.codec.http.websocketx.WebSocketHandshakeException;
 import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.common.config.SslConfigs;
 import org.junit.Before;
@@ -112,7 +115,10 @@ public class SslClientAuthFunctionalTest {
 
     // Then:
     assertThat(e.getCause(), (is(instanceOf(ExecutionException.class))));
-    assertThat(e.getCause(), (hasCause(is(instanceOf(SSLHandshakeException.class)))));
+    // Make this compatible with both java 8 and 11.
+    assertThat(e.getCause(), anyOf(
+            hasCause(hasCause(is(instanceOf(SSLHandshakeException.class)))),
+            hasCause(is(instanceOf(SSLHandshakeException.class)))));
   }
 
   @Test
@@ -133,10 +139,16 @@ public class SslClientAuthFunctionalTest {
     givenClientConfiguredWithoutCertificate();
 
     // When:
-    assertThrows(
-        SSLHandshakeException.class,
-        () -> WebsocketUtils.makeWsRequest(JSON_KSQL_REQUEST, clientProps, REST_APP)
+    final Exception e = assertThrows(
+            Exception.class,
+            () -> WebsocketUtils.makeWsRequest(JSON_KSQL_REQUEST, clientProps, REST_APP)
     );
+    assertThat(e, anyOf(is(instanceOf(RuntimeException.class)),
+            is(instanceOf(SSLHandshakeException.class))));
+    if (e instanceof RuntimeException) {
+      assertThat(e.getCause(), is(instanceOf(ExecutionException.class)));
+      assertThat(e.getCause(), hasCause(instanceOf(WebSocketHandshakeException.class)));
+    }
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/CorsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/CorsTest.java
@@ -49,7 +49,7 @@ public class CorsTest extends BaseApiTest {
   private static final String DEFAULT_ACCESS_CONTROL_ALLOW_METHODS = "GET,POST,HEAD";
 
   private static final String URI = "/query-stream";
-  private static final String ORIGIN = "wibble.com";
+  private static final String ORIGIN = "http://wibble.com";
 
   private final Map<String, Object> config = new HashMap<>();
 
@@ -132,7 +132,7 @@ public class CorsTest extends BaseApiTest {
 
   @Test
   public void shouldAcceptCorsRequestOriginExactMatchOneOfList() throws Exception {
-    shouldAcceptCorsRequest(ORIGIN, "foo.com,wibble.com");
+    shouldAcceptCorsRequest(ORIGIN, "foo.com," + ORIGIN);
   }
 
   @Test

--- a/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientTest.java
+++ b/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientTest.java
@@ -539,7 +539,7 @@ public class KsqlClientTest {
     );
 
     // Then:
-    assertThat(e.getMessage(), containsString(
+    assertThat(e.getCause().getMessage(), containsString(
         "java.io.IOException: Keystore was tampered with, or password was incorrect"
     ));
   }
@@ -560,7 +560,7 @@ public class KsqlClientTest {
     );
 
     // Then:
-    assertThat(e.getMessage(), containsString(
+    assertThat(e.getCause().getMessage(), containsString(
         "java.io.IOException: Keystore was tampered with, or password was incorrect"
     ));
   }
@@ -788,6 +788,7 @@ public class KsqlClientTest {
     props.putAll(ClientTrustStore.trustStoreProps());
     props.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, password);
     createClient(props);
+    ksqlClient.target(serverUri).getServerInfo().get();
   }
 
   private void startServerWithTls() throws Exception {

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <wiremock.version>2.24.0</wiremock.version>
         <clearspring-analytics.version>2.9.5</clearspring-analytics.version>
         <icu.version>67.1</icu.version>
-        <vertx.version>4.3.2</vertx.version>
+        <vertx.version>4.4.8</vertx.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <skip.docker.build>true</skip.docker.build>
         <skip.docker.test>true</skip.docker.test>


### PR DESCRIPTION
### Description 
Follow-up of https://github.com/confluentinc/ksql/pull/10402

The version used in the above mentioned PR still have the CVE. Upgrading it to 4.4.8(version used in 7.3 and above as well). This version caused some test failures. These test failed in the higher branches as well which were then fixed. I have cherry-picked those commits
- https://github.com/confluentinc/ksql/pull/10159
- https://github.com/confluentinc/ksql/pull/9770


### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
