### PR TITLE
Fixes#KSE-1846: Fix for select struct->* for Pull Queries

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/QueryProjectNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/QueryProjectNode.java
@@ -27,7 +27,6 @@ import io.confluent.ksql.execution.util.ExpressionTypeManager;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.parser.tree.AllColumns;
 import io.confluent.ksql.parser.tree.SelectItem;
-import io.confluent.ksql.parser.tree.SingleColumn;
 import io.confluent.ksql.planner.Projection;
 import io.confluent.ksql.planner.QueryPlannerOptions;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -40,7 +39,6 @@ import io.confluent.ksql.util.KsqlException;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * The projection of a Pull query.
@@ -54,7 +52,7 @@ import java.util.stream.Collectors;
  * is created as follows:
  * Check if projection contains system or key columns. If not, the intermediate schema
  * is the input schema. If there are any of these columns, the input schema is extended by copying
- * the key and system columns (rowtime, windwostart and windowend) into the value of the schema.
+ * the key and system columns (rowtime, windowstart and windowend) into the value of the schema.
  *
  * <li>For the output schema, if the projection is SELECT *, add windowstart and windowend to key
  * columns and keep value columns the same as input. If projection is not SELECT *,
@@ -152,7 +150,7 @@ public class QueryProjectNode extends ProjectNode {
 
   /**
    * Builds the output schema of the project node.
-   * The output schema comprises of exactly the columns that appear in the SELECT clause of the
+   * The output schema comprises exactly the columns that appear in the SELECT clause of the
    * query.
    * @param metaStore the metastore
    * @return the project node's output schema
@@ -170,13 +168,7 @@ public class QueryProjectNode extends ProjectNode {
       outputSchema = buildPullQuerySelectStarSchema(
           parentSchema.withoutPseudoAndKeyColsInValue(), isWindowed);
     } else {
-      final List<SelectExpression> projects = projection.selectItems().stream()
-          .map(SingleColumn.class::cast)
-          .map(si -> SelectExpression
-              .of(si.getAlias().orElseThrow(IllegalStateException::new), si.getExpression()))
-          .collect(Collectors.toList());
-
-      outputSchema = selectOutputSchema(metaStore, projects, isWindowed);
+      outputSchema = selectOutputSchema(metaStore, this.selectExpressions, isWindowed);
     }
 
     if (isScalablePush) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/QueryProjectNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/QueryProjectNodeTest.java
@@ -36,6 +36,7 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.tree.AllColumns;
 import io.confluent.ksql.parser.tree.SelectItem;
 import io.confluent.ksql.parser.tree.SingleColumn;
+import io.confluent.ksql.parser.tree.StructAll;
 import io.confluent.ksql.planner.QueryPlannerOptions;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SystemColumns;
@@ -322,5 +323,88 @@ public class QueryProjectNodeTest {
         IllegalStateException.class,
         projectNode::getCompiledSelectExpressions
     );
+  }
+
+
+  @Test
+  public void shouldSelectEntireStruct() {
+    // Given:
+    final ColumnName structColumn = ColumnName.of("STRUCT_COL");
+
+    final LogicalSchema inputSchema = LogicalSchema.builder()
+        .keyColumn(K, SqlTypes.STRING)
+        .valueColumn(structColumn, SqlTypes.struct()
+            .field("NESTED_FIELD1", SqlTypes.STRING)
+            .field("NESTED_FIELD2", SqlTypes.INTEGER)
+            .build())
+        .build();
+
+    when(source.getSchema()).thenReturn(inputSchema);
+    selects = ImmutableList.of(new SingleColumn(new UnqualifiedColumnReferenceExp(structColumn), Optional.of(structColumn)));
+    when(keyFormat.isWindowed()).thenReturn(false);
+    when(analysis.getSelectColumnNames()).thenReturn(ImmutableSet.of(structColumn));
+
+    // When:
+    final QueryProjectNode projectNode = new QueryProjectNode(
+        NODE_ID,
+        source,
+        selects,
+        metaStore,
+        ksqlConfig,
+        analysis,
+        false,
+        plannerOptions,
+        false
+    );
+
+    // Then:
+    final LogicalSchema expectedSchema = LogicalSchema.builder()
+        .valueColumn(structColumn, SqlTypes.struct()
+            .field("NESTED_FIELD1", SqlTypes.STRING)
+            .field("NESTED_FIELD2", SqlTypes.INTEGER)
+            .build())
+        .build();
+
+    assertThat(expectedSchema, is(projectNode.getSchema()));
+  }
+
+  @Test
+  public void shouldExpandSelectStructStarColumns() {
+    // Given:
+    final ColumnName structColumn = ColumnName.of("STRUCT_COL");
+
+    final LogicalSchema inputSchema = LogicalSchema.builder()
+        .keyColumn(K, SqlTypes.STRING)
+        .valueColumn(structColumn, SqlTypes.struct()
+            .field("NESTED_FIELD1", SqlTypes.STRING)
+            .field("NESTED_FIELD2", SqlTypes.INTEGER)
+            .build())
+        .build();
+
+    when(source.getSchema()).thenReturn(inputSchema);
+    selects = ImmutableList.of(new StructAll(new UnqualifiedColumnReferenceExp(structColumn)));
+    when(keyFormat.isWindowed()).thenReturn(false);
+    when(analysis.getSelectColumnNames()).thenReturn(ImmutableSet.of(structColumn));
+
+    // When:
+    final QueryProjectNode projectNode = new QueryProjectNode(
+        NODE_ID,
+        source,
+        selects,
+        metaStore,
+        ksqlConfig,
+        analysis,
+        false,
+        plannerOptions,
+        false
+    );
+
+    // Then:
+    final LogicalSchema expectedSchema = LogicalSchema.builder()
+        .valueColumn(ColumnName.of("NESTED_FIELD1"), SqlTypes.STRING)
+        .valueColumn(ColumnName.of("NESTED_FIELD2"), SqlTypes.INTEGER)
+        .build();
+
+    assertThat(expectedSchema, is(projectNode.getSchema()));
   }
 }

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-with-struct-star.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-with-struct-star.json
@@ -1,0 +1,70 @@
+{
+  "comments": [
+    "Tests covering pull queries with struct column"
+  ],
+  "tests": [
+    {
+      "name": "select entire struct column",
+      "statements": [
+        "CREATE TABLE INPUT (ID STRING PRIMARY KEY, STRUCT_COL STRUCT<NESTED_FIELD1 STRING, NESTED_FIELD2 INTEGER>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE MATVIEW AS SELECT ID, STRUCT_COL FROM INPUT;",
+        "SELECT ID, STRUCT_COL FROM MATVIEW;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": "1", "value": {"struct_col": {"nested_field1": "value1", "nested_field2": 100}}},
+        {"topic": "test_topic", "timestamp": 12355, "key": "2", "value": {"struct_col": {"nested_field1": "value2", "nested_field2": 200}}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header": {"schema": "`ID` STRING KEY, `STRUCT_COL` STRUCT<`NESTED_FIELD1` STRING, `NESTED_FIELD2` INTEGER>"}},
+          {"row": {"columns": ["1", {"NESTED_FIELD1": "value1", "NESTED_FIELD2": 100}]}},
+          {"row": {"columns": ["2", {"NESTED_FIELD1": "value2", "NESTED_FIELD2": 200}]}}
+        ]}
+      ]
+    },
+    {
+      "name": "select all fields within struct column (struct_col->*)",
+      "statements": [
+        "CREATE TABLE INPUT (ID STRING PRIMARY KEY, STRUCT_COL STRUCT<A STRING, B INTEGER>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE MATVIEW AS SELECT ID, STRUCT_COL FROM INPUT;",
+        "SELECT ID, STRUCT_COL->* FROM MATVIEW;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": "1", "value": {"struct_col": {"a": "value1", "b": 100}}},
+        {"topic": "test_topic", "timestamp": 12355, "key": "2", "value": {"struct_col": {"a": "value2", "b": 200}}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header": {"schema": "`ID` STRING KEY, `A` STRING, `B` INTEGER"}},
+          {"row": {"columns": ["1", "value1", 100]}},
+          {"row": {"columns": ["2", "value2", 200]}}
+        ]}
+      ]
+    },
+    {
+      "name": "select all fields within struct column within struct column (struct_col->a->b)",
+      "statements": [
+        "CREATE TABLE INPUT (ID STRING PRIMARY KEY, STRUCT_COL STRUCT<A STRUCT<B STRING, C INTEGER>>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE MATVIEW AS SELECT ID, STRUCT_COL->A->B, STRUCT_COL->A->C FROM INPUT;",
+        "SELECT ID, B, C FROM MATVIEW;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": "1", "value": {"struct_col": {"a": {"b": "value1", "c": 100}}}},
+        {"topic": "test_topic", "timestamp": 12355, "key": "2", "value": {"struct_col": {"a": {"b": "value2", "c": 200}}}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header": {"schema": "`ID` STRING KEY, `B` STRING, `C` INTEGER"}},
+          {"row": {"columns": ["1", "value1", 100]}},
+          {"row": {"columns": ["2", "value2", 200]}}
+        ]}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Description 
Expansion of stuctField->* fails for pull-queries though works for streaming/push queries. This change is to fix the expansion. (Fixes #KSE-1846)

### Testing done 
**Yes** (Unit Tests & Functional Tests)

### Reviewer checklist
- [x] (Not Applicable) Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [x] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
