### PR TITLE
KSQL-12481: Ignore Public PhoneHomeServer endpoint usage tests (#79)

### DIFF
--- a/ksqldb-version-metrics-client/src/test/java/io/confluent/support/metrics/utils/WebClientTest.java
+++ b/ksqldb-version-metrics-client/src/test/java/io/confluent/support/metrics/utils/WebClientTest.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.core5.http.HttpStatus;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class WebClientTest {
@@ -82,6 +83,7 @@ public class WebClientTest {
                     HttpStatus.SC_OK, WebClient.send(invalidCustomerId, anyData, p, null));
   }
 
+  @Ignore
   @Test
   public void testSubmitValidCustomer() {
     // Given
@@ -97,6 +99,7 @@ public class WebClientTest {
                status == HttpStatus.SC_OK || status == HttpStatus.SC_BAD_GATEWAY);
   }
 
+  @Ignore
   @Test
   public void testSubmitValidAnonymousUser() {
     // Given


### PR DESCRIPTION
### Description 
The test is trying to access the server that is under maintainence. Ignoring the tests for now.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
