### PR TITLE
KSQL-12484: Update protobuf schema assertion (#80)

### DIFF
--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/ProtobufSchemaTranslatorTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/ProtobufSchemaTranslatorTest.java
@@ -159,9 +159,9 @@ public class ProtobufSchemaTranslatorTest {
     assertThat(schema.canonicalString(), is("syntax = \"proto3\";\n"
         + "\n"
         + "message ConnectDefault1 {\n"
-        + "  optional int32 optional_int32 = 1 [deprecated = false];\n"
-        + "  optional bool optional_boolean = 2 [deprecated = false];\n"
-        + "  optional string optional_string = 3 [deprecated = false];\n"
+        + "  optional int32 optional_int32 = 1;\n"
+        + "  optional bool optional_boolean = 2;\n"
+        + "  optional string optional_string = 3;\n"
         + "}\n"));
   }
 


### PR DESCRIPTION
### Description 
One test shouldApplyNullableAsOptional in ProtobufSchemaTranslatorTest.java has started failing on `7.8.x` and `master`.
```
java.lang.AssertionError Expected: is "syntax = \"proto3\";\n\nmessage ConnectDefault1 {\n optional int32 optional_int32 = 1 [deprecated = false];\n optional bool optional_boolean = 2 [deprecated = false];\n optional string optional_string = 3 [deprecated = false];\n}\n" but: was "syntax = \"proto3\";\n\nmessage ConnectDefault1 {\n optional int32 optional_int32 = 1;\n optional bool optional_boolean = 2;\n optional string optional_string = 3;\n}\n"
java.lang.AssertionError: 

Expected: is "syntax = \"proto3\";\n\nmessage ConnectDefault1 {\n  optional int32 optional_int32 = 1 [deprecated = false];\n  optional bool optional_boolean = 2 [deprecated = false];\n  optional string optional_string = 3 [deprecated = false];\n}\n"
     but: was "syntax = \"proto3\";\n\nmessage ConnectDefault1 {\n  optional int32 optional_int32 = 1;\n  optional bool optional_boolean = 2;\n  optional string optional_string = 3;\n}\n"
```

Discussed with Schema registry team, it's because of the changes they have made from their end on `7.8.x`.
We would need to update the assertion.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
