### PR TITLE
fix base_dir as / causing  java.net.UnknownHostException: etc

### DIFF
--- a/bin/ksql
+++ b/bin/ksql
@@ -6,6 +6,9 @@
 #
 
 base_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
+if [ "$base_dir" = "/" ]; then
+    base_dir=""
+fi
 
 : "${KSQL_CONFIG_DIR:="$base_dir/config"}"
 

--- a/bin/ksql-datagen
+++ b/bin/ksql-datagen
@@ -7,6 +7,9 @@
 set -ue
 
 base_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
+if [ "$base_dir" = "/" ]; then
+    base_dir=""
+fi
 : "${KSQL_CONFIG_DIR:="$base_dir/config"}"
 
 : "${KSQL_LOG4J_OPTS:=""}"

--- a/bin/ksql-restore-command-topic
+++ b/bin/ksql-restore-command-topic
@@ -2,6 +2,9 @@
 # (Copyright) [2020] Confluent, Inc.
 
 base_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
+if [ "$base_dir" = "/" ]; then
+    base_dir=""
+fi
 
 : "${KSQL_CONFIG_DIR:="$base_dir/config"}"
 

--- a/bin/ksql-server-start
+++ b/bin/ksql-server-start
@@ -12,6 +12,9 @@ then
 fi
 
 base_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
+if [ "$base_dir" = "/" ]; then
+    base_dir=""
+fi
 : "${KSQL_CONFIG_DIR:="$base_dir/config"}"
 
 : "${KSQL_LOG4J_OPTS:=""}"

--- a/bin/ksql-test-runner
+++ b/bin/ksql-test-runner
@@ -7,6 +7,9 @@
 set -ue
 
  base_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
+if [ "$base_dir" = "/" ]; then
+    base_dir=""
+fi
 : "${KSQL_CONFIG_DIR:="$base_dir/config"}"
 
  : "${KSQL_LOG4J_OPTS:=""}"

--- a/bin/run-ksql-test
+++ b/bin/run-ksql-test
@@ -7,6 +7,9 @@
 set -ue
 
  base_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
+if [ "$base_dir" = "/" ]; then
+    base_dir=""
+fi
 : "${KSQL_CONFIG_DIR:="$base_dir/config"}"
 
  : "${KSQL_LOG4J_OPTS:=""}"


### PR DESCRIPTION
### Description 

When installing with cp-ansible , it could be that the path is installed into /etc/ksqldb/
When done so a user will get an error on the CLI: 

```

[root@ksql01-dev]#  ksql  https://localhost:8088 -u moshe
log4j:ERROR Could not read configuration file from URL [file://etc/ksqldb/log4j-file.properties].
java.net.UnknownHostException: etc
        at java.base/java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:229)
        at java.base/java.net.Socket.connect(Socket.java:609)
        at java.base/sun.net.ftp.impl.FtpClient.doConnect(FtpClient.java:1062)
        at java.base/sun.net.ftp.impl.FtpClient.tryConnect(FtpClient.java:1024)
        at java.base/sun.net.ftp.impl.FtpClient.connect(FtpClient.java:1119)
        at java.base/sun.net.ftp.impl.FtpClient.connect(FtpClient.java:1105)
        at java.base/sun.net.www.protocol.ftp.FtpURLConnection.connect(FtpURLConnection.java:312)
        at java.base/sun.net.www.protocol.ftp.FtpURLConnection.getInputStream(FtpURLConnection.java:418)
        at org.apache.log4j.PropertyConfigurator.doConfigure(PropertyConfigurator.java:532)
        at org.apache.log4j.helpers.OptionConverter.selectAndConfigure(OptionConverter.java:485)
        at org.apache.log4j.LogManager.<clinit>(LogManager.java:115)
        at org.slf4j.impl.Reload4jLoggerFactory.<init>(Reload4jLoggerFactory.java:67)
        at org.slf4j.impl.StaticLoggerBinder.<init>(StaticLoggerBinder.java:72)
        at org.slf4j.impl.StaticLoggerBinder.<clinit>(StaticLoggerBinder.java:45)
        at org.slf4j.LoggerFactory.bind(LoggerFactory.java:150)
        at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:124)
        at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:417)
        at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:362)
        at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:388)
        at io.confluent.ksql.Ksql.<clinit>(Ksql.java:40)
log4j:ERROR Ignoring configuration file [file://etc/ksqldb/log4j-file.properties].
Enter password: 
```

You will still be able to log into the server but the above is misleading. 
The problem is with the path to the log4j file, so if the base dir is just `/` we should blank the var. 


