### PR TITLE
CPBR-1736: updating cp-jar-build block in semaphore pipeline

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -70,15 +70,24 @@ blocks:
       # Run this block only for pull requests
       when: "pull_request =~ '.*'"
     task:
+      env_vars:
+        - name: COMPONENT_NAME
+          value: ksqldb
       jobs:
         - name: Trigger and wait for CP Jar Build Task
           commands:
+            # Don't run this block if target branch for PR is not a CP nightly branch
             - |
-              sem-trigger -p packaging \
-              -t cp-jar-build \
-              -b $SEMAPHORE_GIT_BRANCH \
-              -d "|" -i "CUSTOM_BRANCH_COMPONENTS|ksqldb=${SEMAPHORE_GIT_WORKING_BRANCH}" \
-              -w
+              if [[ "$SEMAPHORE_GIT_BRANCH" =~ ^[0-9]+\.[0-9]+\.x$ ]] ; then \
+                  echo "PR is targeted to ${SEMAPHORE_GIT_BRANCH} branch which is CP nightly branch. Triggering cp-jar-build task."; \
+                  sem-trigger -p packaging \
+                    -t cp-jar-build \
+                    -b $SEMAPHORE_GIT_BRANCH \
+                    -d "|" -i "CUSTOM_BRANCH_COMPONENTS|${COMPONENT_NAME}=${SEMAPHORE_GIT_WORKING_BRANCH}" \
+                    -w; \
+              else \
+                  echo "PR is targeted to ${SEMAPHORE_GIT_BRANCH} branch which is not CP nightly branch. Skipping cp-jar-build task."; \
+              fi;
 
 
 after_pipeline:


### PR DESCRIPTION
### Description 
This PR updates cp jar build task invocation for PR builds to make sure downstream components don't break with the PR changes.

### Testing done 
cp jar build task is invoked as part of SemaphoreCI pipeline running as part of this PR.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
