### PR TITLE
KSQL-12544 | Update numeric overflow exception tests (#134)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,11 +181,11 @@ You can set up IntelliJ for CheckStyle. First install the CheckStyle IDEA plugin
        URL: https://raw.githubusercontent.com/confluentinc/common/master/build-tools/src/main/resources/checkstyle/checkstyle.xml
        Ignore invalid certs: true
 
-    - (Optional) Make the new configuration active.
+    - Make the new configuration active.
 
     - Highlight the newly added 'Confluent Checks' and click the edit button (pencil icon).
 
-    - Set properties to match the `checkstyle/checkstyle.properties` file in the repo.
+    - [!IMP] Set properties to match the `checkstyle/checkstyle.properties` file in the repo.
 
 'Confluent Checks' will now be available in the CheckStyle tool window in the IDE and will auto-highlight issues in the code editor.
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/ExpectedExceptionNode.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/ExpectedExceptionNode.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.test.model;
 
+import static org.hamcrest.Matchers.instanceOf;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.confluent.ksql.test.tools.exceptions.InvalidFieldException;
 import io.confluent.ksql.test.tools.exceptions.KsqlExpectedException;
@@ -26,13 +28,16 @@ public final class ExpectedExceptionNode {
 
   private final Optional<String> type;
   private final Optional<String> message;
+  private final Optional<String> cause;
 
   ExpectedExceptionNode(
       @JsonProperty("type") final String type,
-      @JsonProperty("message") final String message
+      @JsonProperty("message") final String message,
+      @JsonProperty("cause") final String cause
   ) {
     this.type = Optional.ofNullable(type);
     this.message = Optional.ofNullable(message);
+    this.cause = Optional.ofNullable(cause);
 
     if (!this.type.isPresent() && !this.message.isPresent()) {
       throw new MissingFieldException("expectedException.type or expectedException.message");
@@ -47,6 +52,7 @@ public final class ExpectedExceptionNode {
         .ifPresent(expectedException::expect);
 
     message.ifPresent(expectedException::expectMessage);
+    cause.ifPresent(c -> expectedException.expectCause(instanceOf(parseThrowable(c))));
     return expectedException.build();
   }
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/exceptions/KsqlExpectedException.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/exceptions/KsqlExpectedException.java
@@ -28,6 +28,9 @@ import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
+/**
+ * Helper class for testing exceptions.
+ */
 @SuppressFBWarnings("NM_CLASS_NOT_EXCEPTION")
 public class KsqlExpectedException {
   public final List<Matcher<?>> matchers = new ArrayList<>();
@@ -57,6 +60,10 @@ public class KsqlExpectedException {
     this.expectedCause = causeMatcher;
   }
 
+  /**
+   * Matcher that matches the message of a {@link KsqlStatementException} or its unlogged message.
+   * @param <T> the type of the exception
+   */
   public static class UnloggedMessageMatcher<T extends Throwable> extends TypeSafeMatcher<T> {
     private final Matcher<String> matcher;
 
@@ -97,16 +104,16 @@ public class KsqlExpectedException {
 
   @SuppressWarnings("unchecked")
   public Matcher<Throwable> build() {
-    List<Matcher<?>> allMatchers = new ArrayList<>(matchers);
+    final List<Matcher<?>> allMatchers = new ArrayList<>(matchers);
     if (expectedCause != null) {
       allMatchers.add(new TypeSafeMatcher<Throwable>() {
         @Override
-        protected boolean matchesSafely(Throwable item) {
+        protected boolean matchesSafely(final Throwable item) {
           return expectedCause.matches(item.getCause());
         }
 
         @Override
-        public void describeTo(Description description) {
+        public void describeTo(final Description description) {
           description.appendText("exception with cause ");
           expectedCause.describeTo(description);
         }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/sum.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/sum.json
@@ -124,8 +124,9 @@
         {"topic": "S2", "key": 100,"value": {"SUM": "801.7"}}
       ],
       "expectedException": {
-        "type": "io.confluent.ksql.function.KsqlFunctionException",
-        "message": "Numeric field overflow"
+        "type": "org.apache.kafka.streams.errors.StreamsException",
+        "message": "Numeric field overflow",
+        "cause": "io.confluent.ksql.function.KsqlFunctionException"
       }
     },
     {
@@ -167,8 +168,9 @@
         {"topic": "S2", "key": 100,"value": {"SUM": "50.9"}}
       ],
       "expectedException": {
-        "type": "io.confluent.ksql.function.KsqlFunctionException",
-        "message": "Numeric field overflow"
+        "type": "org.apache.kafka.streams.errors.StreamsException",
+        "message": "Numeric field overflow",
+        "cause": "io.confluent.ksql.function.KsqlFunctionException"
       }
     },
     {


### PR DESCRIPTION
### Description 
With the implementation of [KIP-1033](https://lists.apache.org/thread/1nhhsrogmmv15o7mk9nj4kvkb5k2bx9s), KStream now wraps all errors in a StreamsException, including the original KsqlFunctionException. This change affects exception handling in test cases, where previously only the KsqlFunctionException was expected.

Changes includes
- Implementation of Expectation.Cause Matcher in Tests
- Updated Tests with New Expectations

### Testing done 
- [x] Local Testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
