### PR TITLE
CPSEC-485: Fix bugs found in manual testing

### DIFF
--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/ClientImplTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/ClientImplTest.java
@@ -27,6 +27,7 @@ import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.api.client.Client;
 import io.confluent.ksql.api.client.ClientOptions;
 import io.confluent.ksql.rest.entity.KsqlMediaType;
+import io.confluent.ksql.security.KsqlClientConfig;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -35,6 +36,8 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.RequestOptions;
 import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -103,4 +106,67 @@ public class ClientImplTest {
             is(true));
   }
 
+  @Test
+  public void shouldSetSslConfigs() {
+    ClientOptions clientOptions = ClientOptions.create()
+        .setUseTls(true)
+        .setTrustStore("abc")
+        .setTrustStorePassword("  abc  ")
+        .setKeyStore("   abc   ")
+        .setKeyStorePassword("abc")
+        .setKeyPassword("abc")
+        .setKeyAlias("  abc  ");
+    Map<String, Object> props = ClientImpl.getSslConfigs(clientOptions);
+    assertThat(props.get(KsqlClientConfig.SSL_TRUSTSTORE_LOCATION), is("abc"));
+    assertThat(props.get(KsqlClientConfig.SSL_TRUSTSTORE_PASSWORD), is("  abc  "));
+    assertThat(props.get(KsqlClientConfig.SSL_KEYSTORE_LOCATION), is("   abc   "));
+    assertThat(props.get(KsqlClientConfig.SSL_KEYSTORE_PASSWORD), is("abc"));
+    assertThat(props.get(KsqlClientConfig.SSL_KEY_PASSWORD), is("abc"));
+    assertThat(props.get(KsqlClientConfig.SSL_KEY_ALIAS), is("  abc  "));
+    assertThat(props.get(KsqlClientConfig.SSL_ALPN), is(false));
+    assertThat(props.get(KsqlClientConfig.SSL_VERIFY_HOST), is(true));
+  }
+
+  @Test
+  public void shouldNotSetSslConfigsIfValuesAreEmpty() {
+    ClientOptions clientOptions = ClientOptions.create()
+        .setUseTls(true)
+        .setTrustStore("    ")
+        .setTrustStorePassword("  ")
+        .setKeyStore("    ")
+        .setKeyStorePassword(" ")
+        .setKeyPassword("   ")
+        .setKeyAlias("    ");
+    Map<String, Object> props = ClientImpl.getSslConfigs(clientOptions);
+    assertThat(props.containsKey(KsqlClientConfig.SSL_TRUSTSTORE_LOCATION), is(false));
+    assertThat(props.containsKey(KsqlClientConfig.SSL_TRUSTSTORE_PASSWORD), is(false));
+    assertThat(props.containsKey(KsqlClientConfig.SSL_KEYSTORE_LOCATION), is(false));
+    assertThat(props.containsKey(KsqlClientConfig.SSL_KEYSTORE_PASSWORD), is(false));
+    assertThat(props.containsKey(KsqlClientConfig.SSL_KEY_PASSWORD), is(false));
+    assertThat(props.containsKey(KsqlClientConfig.SSL_KEY_ALIAS), is(false));
+    assertThat(props.get(KsqlClientConfig.SSL_ALPN), is(false));
+    assertThat(props.get(KsqlClientConfig.SSL_VERIFY_HOST), is(true));
+  }
+
+  @Test
+  public void shouldNotSetSslConfigsIfOptionsAreNull() {
+    ClientOptions clientOptions = ClientOptions.create()
+        .setUseTls(true)
+        .setTrustStore(null)
+        .setTrustStorePassword(null)
+        .setKeyStore(null)
+        .setKeyStorePassword(null)
+        .setKeyPassword(null)
+        .setKeyAlias(null)
+        .setVerifyHost(false);
+    Map<String, Object> props = ClientImpl.getSslConfigs(clientOptions);
+    assertThat(props.containsKey(KsqlClientConfig.SSL_TRUSTSTORE_LOCATION), is(false));
+    assertThat(props.containsKey(KsqlClientConfig.SSL_TRUSTSTORE_PASSWORD), is(false));
+    assertThat(props.containsKey(KsqlClientConfig.SSL_KEYSTORE_LOCATION), is(false));
+    assertThat(props.containsKey(KsqlClientConfig.SSL_KEYSTORE_PASSWORD), is(false));
+    assertThat(props.containsKey(KsqlClientConfig.SSL_KEY_PASSWORD), is(false));
+    assertThat(props.containsKey(KsqlClientConfig.SSL_KEY_ALIAS), is(false));
+    assertThat(props.get(KsqlClientConfig.SSL_ALPN), is(false));
+    assertThat(props.get(KsqlClientConfig.SSL_VERIFY_HOST), is(false));
+  }
 }

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/Ksql.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/Ksql.java
@@ -21,11 +21,8 @@ import io.confluent.ksql.cli.Options;
 import io.confluent.ksql.cli.console.OutputFormat;
 import io.confluent.ksql.properties.PropertiesUtil;
 import io.confluent.ksql.rest.client.KsqlRestClient;
-import io.confluent.ksql.security.AuthType;
 import io.confluent.ksql.security.BasicCredentials;
 import io.confluent.ksql.security.Credentials;
-import io.confluent.ksql.security.CredentialsFactory;
-import io.confluent.ksql.security.KsqlClientConfig;
 import io.confluent.ksql.util.ErrorMessageUtil;
 import io.confluent.ksql.util.KsqlException;
 import java.io.Console;
@@ -147,27 +144,11 @@ public final class Ksql {
     final Map<String, String> localProps = stripClientSideProperties(configProps);
     final Map<String, String> clientProps = PropertiesUtil.applyOverrides(configProps, systemProps);
     final String server = options.getServer();
-    final Optional<Credentials> creds = getCredentials(configProps);
+    final Optional<Credentials> creds = options.getUserNameAndPassword();
     final Optional<BasicCredentials> ccloudApiKey = options.getCCloudApiKey();
 
     return clientBuilder.build(
         server, localProps, clientProps, creds, ccloudApiKey);
-  }
-
-  private Optional<Credentials> getCredentials(final Map<String, String> configProps) {
-    // Credentials are only configured if username and password is provided
-    // through ksqldb-cli flags -u and -p
-    AuthType authType = AuthType.NONE;
-    if (options.requiresPassword()) {
-      authType = AuthType.BASIC;
-      configProps.put(KsqlClientConfig.KSQL_BASIC_AUTH_USERNAME, options.getUserName());
-      configProps.put(KsqlClientConfig.KSQL_BASIC_AUTH_PASSWORD, options.getPassword());
-    }
-    final Credentials credentials = CredentialsFactory.createCredentials(authType);
-    if (credentials != null) {
-      credentials.configure(configProps);
-    }
-    return Optional.ofNullable(credentials);
   }
 
   private static Map<String, String> stripClientSideProperties(final Map<String, String> props) {

--- a/ksqldb-common/src/main/java/io/confluent/ksql/security/BasicCredentials.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/security/BasicCredentials.java
@@ -81,7 +81,7 @@ public final class BasicCredentials implements Credentials {
     final String password = (String) configs.get(KsqlClientConfig.KSQL_BASIC_AUTH_PASSWORD);
 
     if ((username == null || username.isEmpty()) || (password == null || password.isEmpty())) {
-      throw new ConfigException("Cannot configure BasicCredential without "
+      throw new ConfigException("Cannot configure BasicCredentials without "
           + "proper username or password");
     }
   }


### PR DESCRIPTION
What
---- 
Fixes for bugs found in KSQL OAuth integration end to end manual testing

Why
----
Blocker for KSQL 7.8 release

Testing
----
Unit tests added.
Manual validation of all changes and fixes in the following scenarios has been done.


Feature to be tested | Status | Description | After Fixing the bug
-- | -- | -- | --
KSQL OAuth Server Side changes | PASSED | |PASSED
KSQL external client with OAuth | PASSED | | PASSED
KSQL external client with OAuth and SSL enabled | FAILED (bug found) - BLOCKER | Doesn’t work when IDP is using TLS. | PASSED
KSQL migrations tool with OAuth and SSL enabled | FAILED (bug found) - BLOCKER | Doesn’t work when IDP is using TLS. Same flow as the above. | PASSED
KSQL migrations tool with OAuth | PASSED |  | PASSED
KSQL CLI with basic auth | FAILED (bug found) - BLOCKER | Username and Password were not being set correctly. | PASSED
KSQL external client with basic auth | PASSED |  | PASSED
KSQL migrations tool with basic auth | PASSED |  | PASSED

