### PR TITLE
CPBR-1799: adding PR CI gating config in service.yml for cc-service-bot to enable cp jar build

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -13,6 +13,9 @@ semaphore:
   extra_build_args: "-Dmaven.gitcommitid.nativegit=true"
   maven_build_goals: "clean install"
   run_merge_check: false
+  pr_ci_gating:
+    enable: true
+    project_name: ksqldb
 git:
   enable: true
 code_artifact:


### PR DESCRIPTION
### Description 
This PR modifies service.yml to add cp jar build block in semaphore.yml to trigger cp jar build job on every PR build. This PR will be reverted if the changes don't work as expected.

### Testing done 
After merging the PR, cc-service-bot (using custom branch) will be invoked on ksql to test the actual changes done in semaphore.yml to make sure cp jar build block is added in semaphore.yml correctly.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
