### PR TITLE
Disable the the custom SecurityManager to enable ITs.

### DIFF
--- a/ksqldb-api-client/pom.xml
+++ b/ksqldb-api-client/pom.xml
@@ -273,10 +273,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <!-- Skip ITs temporarily -->
-                    <skipITs>true</skipITs>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/ksqldb-cli/pom.xml
+++ b/ksqldb-cli/pom.xml
@@ -157,10 +157,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <!-- Skip ITs temporarily -->
-                    <skipITs>true</skipITs>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UserFunctionLoader.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UserFunctionLoader.java
@@ -22,7 +22,6 @@ import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udtf.UdtfDescription;
 import io.confluent.ksql.metastore.TypeRegistry;
 import io.confluent.ksql.schema.ksql.SqlTypeParser;
-import io.confluent.ksql.security.ExtensionSecurityManager;
 import io.confluent.ksql.util.KsqlConfig;
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ClassInfo;
@@ -154,9 +153,9 @@ public class UserFunctionLoader {
         ? Optional.of(metricsRegistry)
         : empty();
 
-    if (config.getBoolean(KsqlConfig.KSQL_UDF_SECURITY_MANAGER_ENABLED)) {
-      System.setSecurityManager(ExtensionSecurityManager.INSTANCE);
-    }
+    //    if (config.getBoolean(KsqlConfig.KSQL_UDF_SECURITY_MANAGER_ENABLED)) {
+    //      System.setSecurityManager(ExtensionSecurityManager.INSTANCE);
+    //    }
     return new UserFunctionLoader(
         metaStore,
         pluginDir,

--- a/ksqldb-rest-app/pom.xml
+++ b/ksqldb-rest-app/pom.xml
@@ -277,10 +277,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <!-- Skip ITs temporarily -->
-                    <skipITs>true</skipITs>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/ksqldb-tools/pom.xml
+++ b/ksqldb-tools/pom.xml
@@ -148,10 +148,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <!-- Skip ITs temporarily -->
-                    <skipITs>true</skipITs>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -865,8 +865,6 @@
                             <useUnlimitedThreads>true</useUnlimitedThreads>
                             <forkedProcessTimeoutInSeconds>3600</forkedProcessTimeoutInSeconds>
                             <forkedProcessExitTimeoutInSeconds>180</forkedProcessExitTimeoutInSeconds>
-                            <!-- Skip ITs temporarily -->
-                            <skipITs>true</skipITs>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Disable the the custom SecurityManager registered while loading the user defined functions to enable ITs.
SecurityManager is marked for deprecation in java 17 Will be handled with the resolution of KSQL-12220.
