### PR TITLE
[KSQL-12662] Add default window size in WindowingIntTest

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
@@ -68,10 +68,10 @@ public class WindowingIntTest {
 
   private static final StringDeserializer STRING_DESERIALIZER = new StringDeserializer();
 
-  private static final long DEFAULT_WINDOW_SIZE = Long.MAX_VALUE;
+  private static final long TEN_SECONDS_WINDOW = Duration.ofSeconds(10).toMillis();
 
   private static final TimeWindowedDeserializer<String> TIME_WINDOWED_DESERIALIZER =
-      new TimeWindowedDeserializer<>(STRING_DESERIALIZER, DEFAULT_WINDOW_SIZE);
+      new TimeWindowedDeserializer<>(STRING_DESERIALIZER, TEN_SECONDS_WINDOW);
 
   private static final SessionWindowedDeserializer<String> SESSION_WINDOWED_DESERIALIZER =
       new SessionWindowedDeserializer<>(STRING_DESERIALIZER);
@@ -153,7 +153,7 @@ public class WindowingIntTest {
         + "WHERE ITEMID = 'ITEM_1' GROUP BY ITEMID;");
 
     final Map<Windowed<String>, GenericRow> expected = ImmutableMap.of(
-        new Windowed<>("ITEM_1", new TimeWindow(tenSecWindowStartMs, Long.MAX_VALUE)),
+        new Windowed<>("ITEM_1", new TimeWindow(tenSecWindowStartMs, tenSecWindowStartMs + TEN_SECONDS_WINDOW)),
         genericRow(2L, 20.0, 100.0)
     );
 
@@ -174,9 +174,9 @@ public class WindowingIntTest {
     final long secondWindowStart = firstWindowStart + TimeUnit.SECONDS.toMillis(5);
 
     final Map<Windowed<String>, GenericRow> expected = ImmutableMap.of(
-        new Windowed<>("ITEM_1", new TimeWindow(firstWindowStart, Long.MAX_VALUE)),
+        new Windowed<>("ITEM_1", new TimeWindow(firstWindowStart, firstWindowStart + TEN_SECONDS_WINDOW)),
         genericRow(2L, 20.0, 200.0),
-        new Windowed<>("ITEM_1", new TimeWindow(secondWindowStart, Long.MAX_VALUE)),
+        new Windowed<>("ITEM_1", new TimeWindow(secondWindowStart, secondWindowStart + TEN_SECONDS_WINDOW)),
         genericRow(2L, 20.0, 200.0)
     );
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
@@ -68,8 +68,10 @@ public class WindowingIntTest {
 
   private static final StringDeserializer STRING_DESERIALIZER = new StringDeserializer();
 
+  private static final long DEFAULT_WINDOW_SIZE = 1L;
+
   private static final TimeWindowedDeserializer<String> TIME_WINDOWED_DESERIALIZER =
-      new TimeWindowedDeserializer<>(STRING_DESERIALIZER);
+      new TimeWindowedDeserializer<>(STRING_DESERIALIZER, DEFAULT_WINDOW_SIZE);
 
   private static final SessionWindowedDeserializer<String> SESSION_WINDOWED_DESERIALIZER =
       new SessionWindowedDeserializer<>(STRING_DESERIALIZER);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
@@ -68,7 +68,7 @@ public class WindowingIntTest {
 
   private static final StringDeserializer STRING_DESERIALIZER = new StringDeserializer();
 
-  private static final long DEFAULT_WINDOW_SIZE = 1L;
+  private static final long DEFAULT_WINDOW_SIZE = Long.MAX_VALUE;
 
   private static final TimeWindowedDeserializer<String> TIME_WINDOWED_DESERIALIZER =
       new TimeWindowedDeserializer<>(STRING_DESERIALIZER, DEFAULT_WINDOW_SIZE);

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/ExpectedExceptionNode.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/ExpectedExceptionNode.java
@@ -29,18 +29,25 @@ public final class ExpectedExceptionNode {
   private final Optional<String> type;
   private final Optional<String> message;
   private final Optional<String> cause;
+  private final Optional<String> causeMessage;
 
   ExpectedExceptionNode(
       @JsonProperty("type") final String type,
       @JsonProperty("message") final String message,
-      @JsonProperty("cause") final String cause
+      @JsonProperty("cause") final String cause,
+      @JsonProperty("causeMessage") final String causeMessage
   ) {
     this.type = Optional.ofNullable(type);
     this.message = Optional.ofNullable(message);
     this.cause = Optional.ofNullable(cause);
+    this.causeMessage = Optional.ofNullable(causeMessage);
 
     if (!this.type.isPresent() && !this.message.isPresent()) {
       throw new MissingFieldException("expectedException.type or expectedException.message");
+    }
+
+    if (this.causeMessage.isPresent() && !this.cause.isPresent()) {
+      throw new MissingFieldException("expectedException.cause");
     }
   }
 
@@ -53,6 +60,7 @@ public final class ExpectedExceptionNode {
 
     message.ifPresent(expectedException::expectMessage);
     cause.ifPresent(c -> expectedException.expectCause(instanceOf(parseThrowable(c))));
+    causeMessage.ifPresent(expectedException::expectCauseMessage);
     return expectedException.build();
   }
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/exceptions/KsqlExpectedException.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/exceptions/KsqlExpectedException.java
@@ -35,6 +35,7 @@ import org.hamcrest.TypeSafeMatcher;
 public class KsqlExpectedException {
   public final List<Matcher<?>> matchers = new ArrayList<>();
   private Matcher<Throwable> expectedCause;
+  private Matcher<String> expectedCauseMessage;
 
   public static KsqlExpectedException none() {
     return new KsqlExpectedException();
@@ -58,6 +59,14 @@ public class KsqlExpectedException {
 
   public void expectCause(final Matcher<Throwable> causeMatcher) {
     this.expectedCause = causeMatcher;
+  }
+
+  public void expectCauseMessage(final String substring) {
+    expectCauseMessage(containsString(substring));
+  }
+
+  public void expectCauseMessage(final Matcher<String> matcher) {
+    this.expectedCauseMessage = matcher;
   }
 
   /**
@@ -116,6 +125,20 @@ public class KsqlExpectedException {
         public void describeTo(final Description description) {
           description.appendText("exception with cause ");
           expectedCause.describeTo(description);
+        }
+      });
+    }
+    if (expectedCauseMessage != null) {
+      allMatchers.add(new TypeSafeMatcher<Throwable>() {
+        @Override
+        protected boolean matchesSafely(final Throwable item) {
+          return item.getCause() != null && expectedCauseMessage.matches(item.getCause().getMessage());
+        }
+
+        @Override
+        public void describeTo(final Description description) {
+          description.appendText("exception with cause message ");
+          expectedCauseMessage.describeTo(description);
         }
       });
     }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/exceptions/KsqlExpectedException.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/exceptions/KsqlExpectedException.java
@@ -132,7 +132,8 @@ public class KsqlExpectedException {
       allMatchers.add(new TypeSafeMatcher<Throwable>() {
         @Override
         protected boolean matchesSafely(final Throwable item) {
-          return item.getCause() != null && expectedCauseMessage.matches(item.getCause().getMessage());
+          return item.getCause() != null
+              && expectedCauseMessage.matches(item.getCause().getMessage());
         }
 
         @Override

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/elements.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/elements.json
@@ -1328,7 +1328,8 @@
       "outputs": [{"topic": "OUTPUT", "key": 42, "value": {"c1": 4}}],
       "expectedException": {
         "type": "org.apache.kafka.streams.errors.StreamsException",
-        "message": "Unable to serialize record. ProducerRecord(topic=[OUTPUT], partition=[null], timestamp=[0]"
+        "message": "Exception caught in process",
+        "cause": "org.apache.kafka.streams.errors.StreamsException"
       }
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/elements.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/elements.json
@@ -1329,7 +1329,8 @@
       "expectedException": {
         "type": "org.apache.kafka.streams.errors.StreamsException",
         "message": "Exception caught in process",
-        "cause": "org.apache.kafka.streams.errors.StreamsException"
+        "cause": "org.apache.kafka.streams.errors.StreamsException",
+        "causeMessage": "Unable to serialize record"
       }
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/sum.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/sum.json
@@ -125,7 +125,7 @@
       ],
       "expectedException": {
         "type": "org.apache.kafka.streams.errors.StreamsException",
-        "message": "Numeric field overflow",
+        "message": "Exception caught in process",
         "cause": "io.confluent.ksql.function.KsqlFunctionException"
       }
     },
@@ -169,7 +169,7 @@
       ],
       "expectedException": {
         "type": "org.apache.kafka.streams.errors.StreamsException",
-        "message": "Numeric field overflow",
+        "message": "Exception caught in process",
         "cause": "io.confluent.ksql.function.KsqlFunctionException"
       }
     },

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/sum.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/sum.json
@@ -126,7 +126,8 @@
       "expectedException": {
         "type": "org.apache.kafka.streams.errors.StreamsException",
         "message": "Exception caught in process",
-        "cause": "io.confluent.ksql.function.KsqlFunctionException"
+        "cause": "io.confluent.ksql.function.KsqlFunctionException",
+        "causeMessage": "Numeric field overflow"
       }
     },
     {
@@ -170,7 +171,8 @@
       "expectedException": {
         "type": "org.apache.kafka.streams.errors.StreamsException",
         "message": "Exception caught in process",
-        "cause": "io.confluent.ksql.function.KsqlFunctionException"
+        "cause": "io.confluent.ksql.function.KsqlFunctionException",
+        "causeMessage": "Numeric field overflow"
       }
     },
     {


### PR DESCRIPTION
### Description 
tldr; This PR fixes the ksql build by updating the usage of `TimeWindowedDeserializer`

The method used by our test has been deprecated for quite some time, it was recently removed in [this commit](https://github.com/confluentinc/ce-kafka/commit/8148361c090ef2749385004fb815f5d2caf6ab66) in ce-kafka, which broke our build. We have now used the more generic method and provided the window size as `Long.MAX_VALUE`, which is exactly what it was in the deprecated method

### Testing done 
Ran build and tests locally

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
