### PR TITLE
KSQL-12705 | Fix the deprecated api methods.

### DIFF
--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
@@ -360,7 +360,7 @@ public final class StreamAggregateBuilder {
           );
     }
 
-    private Duration defaultGrace(Duration windowSize) {
+    private Duration defaultGrace(final Duration windowSize) {
       return Duration.ofMillis(Math.max(DEFAULT_24_HR_GRACE_PERIOD - windowSize.toMillis(), 0));
     }
   }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
@@ -41,7 +41,6 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.OutputRefinement;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
-
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
@@ -271,9 +270,9 @@ public final class StreamAggregateBuilder {
     public KTable<Windowed<GenericKey>, GenericRow> visitHoppingWindowExpression(
         final HoppingWindowExpression window,
         final Void ctx) {
-        Duration windowSize = window.getSize().toDuration();
-        Duration advanceBy = window.getAdvanceBy().toDuration();
-        TimeWindows windows = window.getGracePeriod()
+      Duration windowSize = window.getSize().toDuration();
+      Duration advanceBy = window.getAdvanceBy().toDuration();
+      TimeWindows windows = window.getGracePeriod()
                 .map(grace -> TimeWindows.ofSizeAndGrace(windowSize, grace.toDuration())
                         .advanceBy(advanceBy))
                 .orElse(TimeWindows.ofSizeWithNoGrace(windowSize).advanceBy(advanceBy));
@@ -303,7 +302,8 @@ public final class StreamAggregateBuilder {
         final Void ctx) {
       Duration windowDuration = window.getGap().toDuration();
       SessionWindows windows = window.getGracePeriod()
-              .map(grace -> SessionWindows.ofInactivityGapAndGrace(windowDuration, grace.toDuration()))
+              .map(grace ->
+                      SessionWindows.ofInactivityGapAndGrace(windowDuration, grace.toDuration()))
               .orElse(SessionWindows.ofInactivityGapWithNoGrace(windowDuration));
 
       SessionWindowedKStream<GenericKey, GenericRow> sessionWindowedKStream =

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
@@ -340,7 +340,7 @@ public final class StreamAggregateBuilder {
       final Duration grace = window.getGracePeriod()
               .map(WindowTimeClause::toDuration)
               .orElse(defaultGrace(windowSize));
-      TimeWindows windows = TimeWindows.ofSizeAndGrace(windowSize, grace);
+      final TimeWindows windows = TimeWindows.ofSizeAndGrace(windowSize, grace);
 
       TimeWindowedKStream<GenericKey, GenericRow> timeWindowedKStream =
           groupedStream.windowedBy(windows);

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
@@ -276,11 +276,9 @@ public final class StreamAggregateBuilder {
         final Void ctx) {
       final Duration windowSize = window.getSize().toDuration();
       final Duration advanceBy = window.getAdvanceBy().toDuration();
-      final Duration defaultGrace =
-              Duration.ofMillis(Math.max(DEFAULT_24_HR_GRACE_PERIOD - windowSize.toMillis(), 0));
       final Duration grace = window.getGracePeriod()
               .map(WindowTimeClause::toDuration)
-              .orElse(defaultGrace);
+              .orElse(defaultGrace(windowSize));
 
       final TimeWindows windows =
               TimeWindows.ofSizeAndGrace(windowSize, grace).advanceBy(advanceBy);
@@ -309,11 +307,9 @@ public final class StreamAggregateBuilder {
         final SessionWindowExpression window,
         final Void ctx) {
       final Duration windowSize = window.getGap().toDuration();
-      final Duration defaultGrace =
-              Duration.ofMillis(Math.max(DEFAULT_24_HR_GRACE_PERIOD - windowSize.toMillis(), 0));
       final Duration grace = window.getGracePeriod()
               .map(WindowTimeClause::toDuration)
-              .orElse(defaultGrace);
+              .orElse(defaultGrace(windowSize));
       final SessionWindows windows =
               SessionWindows.ofInactivityGapAndGrace(windowSize, grace);
       SessionWindowedKStream<GenericKey, GenericRow> sessionWindowedKStream =
@@ -341,11 +337,9 @@ public final class StreamAggregateBuilder {
         final TumblingWindowExpression window,
         final Void ctx) {
       final Duration windowSize = window.getSize().toDuration();
-      final Duration defaultGrace =
-              Duration.ofMillis(Math.max(DEFAULT_24_HR_GRACE_PERIOD - windowSize.toMillis(), 0));
       final Duration grace = window.getGracePeriod()
               .map(WindowTimeClause::toDuration)
-              .orElse(defaultGrace);
+              .orElse(defaultGrace(windowSize));
       TimeWindows windows = TimeWindows.ofSizeAndGrace(windowSize, grace);
 
       TimeWindowedKStream<GenericKey, GenericRow> timeWindowedKStream =
@@ -364,6 +358,10 @@ public final class StreamAggregateBuilder {
                   StreamsUtil.buildOpName(queryContext),
                   window.getRetention().map(WindowTimeClause::toDuration))
           );
+    }
+
+    private Duration defaultGrace(Duration windowSize) {
+      return Duration.ofMillis(Math.max(DEFAULT_24_HR_GRACE_PERIOD - windowSize.toMillis(), 0));
     }
   }
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
@@ -308,14 +308,14 @@ public final class StreamAggregateBuilder {
     public KTable<Windowed<GenericKey>, GenericRow> visitSessionWindowExpression(
         final SessionWindowExpression window,
         final Void ctx) {
-      final Duration windowDuration = window.getGap().toDuration();
+      final Duration windowSize = window.getGap().toDuration();
       final Duration defaultGrace =
-              Duration.ofMillis(Math.max(DEFAULT_24_HR_GRACE_PERIOD - windowDuration.toMillis(), 0));
+              Duration.ofMillis(Math.max(DEFAULT_24_HR_GRACE_PERIOD - windowSize.toMillis(), 0));
       final Duration grace = window.getGracePeriod()
               .map(WindowTimeClause::toDuration)
               .orElse(defaultGrace);
       final SessionWindows windows =
-              SessionWindows.ofInactivityGapAndGrace(windowDuration, grace);
+              SessionWindows.ofInactivityGapAndGrace(windowSize, grace);
       SessionWindowedKStream<GenericKey, GenericRow> sessionWindowedKStream =
           groupedStream.windowedBy(windows);
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
@@ -273,9 +273,9 @@ public final class StreamAggregateBuilder {
       Duration windowSize = window.getSize().toDuration();
       Duration advanceBy = window.getAdvanceBy().toDuration();
       TimeWindows windows = window.getGracePeriod()
-                .map(grace -> TimeWindows.ofSizeAndGrace(windowSize, grace.toDuration())
-                        .advanceBy(advanceBy))
-                .orElse(TimeWindows.ofSizeWithNoGrace(windowSize).advanceBy(advanceBy));
+          .map(grace -> TimeWindows.ofSizeAndGrace(windowSize, grace.toDuration())
+                .advanceBy(advanceBy))
+          .orElse(TimeWindows.ofSizeWithNoGrace(windowSize).advanceBy(advanceBy));
 
       TimeWindowedKStream<GenericKey, GenericRow> timeWindowedKStream =
           groupedStream.windowedBy(windows);
@@ -302,9 +302,9 @@ public final class StreamAggregateBuilder {
         final Void ctx) {
       Duration windowDuration = window.getGap().toDuration();
       SessionWindows windows = window.getGracePeriod()
-              .map(grace ->
-                      SessionWindows.ofInactivityGapAndGrace(windowDuration, grace.toDuration()))
-              .orElse(SessionWindows.ofInactivityGapWithNoGrace(windowDuration));
+          .map(grace ->
+                  SessionWindows.ofInactivityGapAndGrace(windowDuration, grace.toDuration()))
+          .orElse(SessionWindows.ofInactivityGapWithNoGrace(windowDuration));
 
       SessionWindowedKStream<GenericKey, GenericRow> sessionWindowedKStream =
           groupedStream.windowedBy(windows);
@@ -332,8 +332,8 @@ public final class StreamAggregateBuilder {
         final Void ctx) {
       Duration windowSize = window.getSize().toDuration();
       TimeWindows windows = window.getGracePeriod()
-              .map(grace -> TimeWindows.ofSizeAndGrace(windowSize, grace.toDuration()))
-              .orElse(TimeWindows.ofSizeWithNoGrace(windowSize));
+          .map(grace -> TimeWindows.ofSizeAndGrace(windowSize, grace.toDuration()))
+          .orElse(TimeWindows.ofSizeWithNoGrace(windowSize));
 
       TimeWindowedKStream<GenericKey, GenericRow> timeWindowedKStream =
           groupedStream.windowedBy(windows);

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
@@ -270,9 +270,9 @@ public final class StreamAggregateBuilder {
     public KTable<Windowed<GenericKey>, GenericRow> visitHoppingWindowExpression(
         final HoppingWindowExpression window,
         final Void ctx) {
-      Duration windowSize = window.getSize().toDuration();
-      Duration advanceBy = window.getAdvanceBy().toDuration();
-      TimeWindows windows = window.getGracePeriod()
+      final Duration windowSize = window.getSize().toDuration();
+      final Duration advanceBy = window.getAdvanceBy().toDuration();
+      final TimeWindows windows = window.getGracePeriod()
           .map(grace -> TimeWindows.ofSizeAndGrace(windowSize, grace.toDuration())
                 .advanceBy(advanceBy))
           .orElse(TimeWindows.ofSizeWithNoGrace(windowSize).advanceBy(advanceBy));
@@ -300,8 +300,8 @@ public final class StreamAggregateBuilder {
     public KTable<Windowed<GenericKey>, GenericRow> visitSessionWindowExpression(
         final SessionWindowExpression window,
         final Void ctx) {
-      Duration windowDuration = window.getGap().toDuration();
-      SessionWindows windows = window.getGracePeriod()
+      final Duration windowDuration = window.getGap().toDuration();
+      final SessionWindows windows = window.getGracePeriod()
           .map(grace ->
                   SessionWindows.ofInactivityGapAndGrace(windowDuration, grace.toDuration()))
           .orElse(SessionWindows.ofInactivityGapWithNoGrace(windowDuration));
@@ -330,8 +330,8 @@ public final class StreamAggregateBuilder {
     public KTable<Windowed<GenericKey>, GenericRow> visitTumblingWindowExpression(
         final TumblingWindowExpression window,
         final Void ctx) {
-      Duration windowSize = window.getSize().toDuration();
-      TimeWindows windows = window.getGracePeriod()
+      final Duration windowSize = window.getSize().toDuration();
+      final TimeWindows windows = window.getGracePeriod()
           .map(grace -> TimeWindows.ofSizeAndGrace(windowSize, grace.toDuration()))
           .orElse(TimeWindows.ofSizeWithNoGrace(windowSize));
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
@@ -41,6 +41,8 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.OutputRefinement;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
+
+import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import org.apache.kafka.common.serialization.Serde;
@@ -269,12 +271,12 @@ public final class StreamAggregateBuilder {
     public KTable<Windowed<GenericKey>, GenericRow> visitHoppingWindowExpression(
         final HoppingWindowExpression window,
         final Void ctx) {
-      TimeWindows windows = TimeWindows
-          .of(window.getSize().toDuration())
-          .advanceBy(window.getAdvanceBy().toDuration());
-      windows = window.getGracePeriod().map(WindowTimeClause::toDuration)
-          .map(windows::grace)
-          .orElse(windows);
+        Duration windowSize = window.getSize().toDuration();
+        Duration advanceBy = window.getAdvanceBy().toDuration();
+        TimeWindows windows = window.getGracePeriod()
+                .map(grace -> TimeWindows.ofSizeAndGrace(windowSize, grace.toDuration())
+                        .advanceBy(advanceBy))
+                .orElse(TimeWindows.ofSizeWithNoGrace(windowSize).advanceBy(advanceBy));
 
       TimeWindowedKStream<GenericKey, GenericRow> timeWindowedKStream =
           groupedStream.windowedBy(windows);
@@ -299,10 +301,10 @@ public final class StreamAggregateBuilder {
     public KTable<Windowed<GenericKey>, GenericRow> visitSessionWindowExpression(
         final SessionWindowExpression window,
         final Void ctx) {
-      SessionWindows windows = SessionWindows.with(window.getGap().toDuration());
-      windows = window.getGracePeriod().map(WindowTimeClause::toDuration)
-          .map(windows::grace)
-          .orElse(windows);
+      Duration windowDuration = window.getGap().toDuration();
+      SessionWindows windows = window.getGracePeriod()
+              .map(grace -> SessionWindows.ofInactivityGapAndGrace(windowDuration, grace.toDuration()))
+              .orElse(SessionWindows.ofInactivityGapWithNoGrace(windowDuration));
 
       SessionWindowedKStream<GenericKey, GenericRow> sessionWindowedKStream =
           groupedStream.windowedBy(windows);
@@ -328,10 +330,10 @@ public final class StreamAggregateBuilder {
     public KTable<Windowed<GenericKey>, GenericRow> visitTumblingWindowExpression(
         final TumblingWindowExpression window,
         final Void ctx) {
-      TimeWindows windows = TimeWindows.of(window.getSize().toDuration());
-      windows = window.getGracePeriod().map(WindowTimeClause::toDuration)
-          .map(windows::grace)
-          .orElse(windows);
+      Duration windowSize = window.getSize().toDuration();
+      TimeWindows windows = window.getGracePeriod()
+              .map(grace -> TimeWindows.ofSizeAndGrace(windowSize, grace.toDuration()))
+              .orElse(TimeWindows.ofSizeWithNoGrace(windowSize));
 
       TimeWindowedKStream<GenericKey, GenericRow> timeWindowedKStream =
           groupedStream.windowedBy(windows);


### PR DESCRIPTION
### Description 
Fix the apis for deprecated methods in Kafka Streams.
The default 24 hour grace period in Kafka Streams was marked for deprecation in 
https://cwiki.apache.org/confluence/display/KAFKA/KIP-633%3A+Deprecate+24-hour+Default+Grace+Period+for+Windowed+Operations+in+Streams

To keep the existing ksqlDB behaviour unchanged, this default is explicitly set here.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
