### PR TITLE
feat: add error log for logging topic client errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ junit*/
 .tern-port
 ui/
 /ksqldb-functional-tests/src/test/resources/**/scratch.json
+
+# Local Development Files
+docker-compose.local.yml
+config/ksql-server.local.properties
+.env.local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,10 +144,10 @@ See the [KLIP Readme](design-proposals/README.md) for more info.
 Code changes are submitted via a pull request (PR). When submitting a PR use the following guidelines:
 
 * Follow the style guide below
-* Add/update documentation appropriately for the change you are making. For more information, see the [docs readme](docs/readme.md).
-* Non-trivial changes should include unit tests covering the new functionality and potentially [function tests](ksql-engine/src/test/resources/query-validation-tests/README.md).
-* All SQL syntax changes and enhancements should come with appropriate [function tests](ksql-engine/src/test/resources/query-validation-tests/README.md).
-* Bug fixes should include a unit test or integration test potentially [function tests](ksql-engine/src/test/resources/query-validation-tests/README.md) proving the issue is fixed.
+* Add/update documentation appropriately for the change you are making. For more information, see the [docs readme](docs/README.md).
+* Non-trivial changes should include unit tests covering the new functionality and potentially [function tests](ksqldb-functional-tests/README.md).
+* All SQL syntax changes and enhancements should come with appropriate [function tests](ksqldb-functional-tests/README.md).
+* Bug fixes should include a unit test or integration test potentially [function tests](ksqldb-functional-tests/README.md) proving the issue is fixed.
 * Try to keep pull requests short and submit separate ones for unrelated features.
 * Keep formatting changes in separate commits to make code reviews easier and distinguish them from actual code changes.
 
@@ -186,7 +186,7 @@ You can set up IntelliJ for CheckStyle. First install the CheckStyle IDEA plugin
 #### Commit messages
 
 The project uses [Conventional Commits][https://www.conventionalcommits.org/en/v1.0.0-beta.4/] for commit messages
-in order to aid in automatic generation of changelogs. As described in the Conventional Commmits specification,
+in order to aid in automatic generation of changelogs. As described in the Conventional Commits specification,
 commit messages should be of the form:
 
     <type>[optional scope]: <description>
@@ -195,7 +195,7 @@ commit messages should be of the form:
 
     [optional footer]
 
-where the `type` is one of the following, and determines whether or not the commit will appear in 
+where the `type` is one of the following, and determines whether the commit will appear in 
 the auto-generated changelog for releases. Commit types that do appear in changelogs are:
  * "fix": for bug fixes
  * "feat": for new features
@@ -243,12 +243,12 @@ Breaking changes must be called out in commit messages, PR descriptions, and upg
  * [Upgrade notes][https://github.com/confluentinc/ksql/blob/master/docs/installation/upgrading.rst]
    should also be updated as part of the same PR.
 
-##### Commitlint
+##### CommitLint
 
-This project has [commitlint][https://github.com/conventional-changelog/commitlint] configured
+This project has [commitlint](https://github.com/conventional-changelog/commitlint) configured
 to ensure that commit messages are of the expected format.
 To enable commitlint, simply run `npm install` from the root directory of the ksqlDB repo
-(after [installing `npm`][https://www.npmjs.com/get-npm].)
+(after [installing npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).)
 Once enabled, commitlint will reject commits with improperly formatted commit messages.
 
 ### GitHub Workflow

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -73,13 +73,12 @@ import org.slf4j.LoggerFactory;
 public class KafkaTopicClientImpl implements KafkaTopicClient {
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
 
-  private static final Logger LOG = LoggerFactory.getLogger(KafkaTopicClient.class);
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaTopicClientImpl.class);
 
   private static final String DEFAULT_REPLICATION_PROP = "default.replication.factor";
   private static final String DELETE_TOPIC_ENABLE = "delete.topic.enable";
 
   private final Supplier<Admin> adminClient;
-
   /**
    * Construct a topic client from an existing admin client. Note, the admin client is shared
    * between all methods of this class, i.e the admin client is created only once and then reused.
@@ -214,12 +213,15 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
           ).allTopicNames().get(),
           ExecutorUtil.RetryBehaviour.ON_RETRYABLE);
     } catch (final ExecutionException e) {
+      LOG.error("Failed to Describe Kafka Topic(s): {}", topicNames, e);
       throw new KafkaResponseGetFailedException(
           "Failed to Describe Kafka Topic(s): " + topicNames, e.getCause());
     } catch (final TopicAuthorizationException e) {
+      LOG.error("Topic authorization failed for topics: {}", topicNames, e);
       throw new KsqlTopicAuthorizationException(
           AclOperation.DESCRIBE, topicNames);
     } catch (final Exception e) {
+      LOG.error("Failed to Describe Kafka Topic(s): {}", topicNames, e);
       throw new KafkaResponseGetFailedException(
           "Failed to Describe Kafka Topic(s): " + topicNames, e);
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -221,7 +221,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
       throw new KsqlTopicAuthorizationException(
           AclOperation.DESCRIBE, topicNames);
     } catch (final Exception e) {
-      LOG.error("Failed to Describe Kafka Topic(s): {}", topicNames, e);
+      LOG.error("Error while trying to describe topics: {}", topicNames, e);
       throw new KafkaResponseGetFailedException(
           "Failed to Describe Kafka Topic(s): " + topicNames, e);
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -82,7 +82,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
 
   /**
    * Construct a topic client from an existing admin client. Note, the admin client is shared
-   * between all methods of this class, i.e the admin client is created only once and then reused.
+   * between all methods of this class, i.e. the admin client is created only once and then reused.
    *
    * @param sharedAdminClient the admin client .
    */
@@ -182,9 +182,11 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
       );
       return true;
     } catch (final TopicAuthorizationException e) {
+      LOG.error("Failed to check if exists for topic: {}", topic, e);
       throw new KsqlTopicAuthorizationException(
           AclOperation.DESCRIBE, Collections.singleton(topic));
     } catch (final Exception e) {
+      LOG.error("Failed to check if exists for topic: {}", topic, e);
       if (Throwables.getRootCause(e) instanceof UnknownTopicOrPartitionException) {
         return false;
       }
@@ -200,6 +202,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
           () -> adminClient.get().listTopics().names().get(),
           ExecutorUtil.RetryBehaviour.ON_RETRYABLE);
     } catch (final Exception e) {
+      LOG.error("Failed to list Kafka Topic names", e);
       throw new KafkaResponseGetFailedException("Failed to retrieve Kafka Topic names", e);
     }
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -79,6 +79,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
   private static final String DELETE_TOPIC_ENABLE = "delete.topic.enable";
 
   private final Supplier<Admin> adminClient;
+
   /**
    * Construct a topic client from an existing admin client. Note, the admin client is shared
    * between all methods of this class, i.e the admin client is created only once and then reused.


### PR DESCRIPTION
Added a log statement to capture and log errors when describing Kafka topics in the KafkaTopicClientImpl class. This helps in debugging and monitoring topic-related issues.

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
