### PR TITLE
fix: for dependency update for jsonschema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ junit*/
 .tern-port
 ui/
 /ksqldb-functional-tests/src/test/resources/**/scratch.json
+
+# Local Development Files
+docker-compose.local.yml
+config/ksql-server.local.properties
+.env.local

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestCase.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestCase.java
@@ -90,10 +90,12 @@ class RestTestCase implements Test {
     return statements;
   }
 
+  @SuppressWarnings("EI_EXPOSE_REP")
   public ImmutableList<Record> getInputRecords() {
     return inputRecords;
   }
 
+  @SuppressWarnings("EI_EXPOSE_REP")
   public ImmutableList<Record> getOutputRecords() {
     return outputRecords;
   }
@@ -116,6 +118,7 @@ class RestTestCase implements Test {
     return expectedError;
   }
 
+  @SuppressWarnings("EI_EXPOSE_REP")
   public Map<String, Object> getProperties() {
     return properties;
   }

--- a/ksqldb-rest-app/pom.xml
+++ b/ksqldb-rest-app/pom.xml
@@ -175,6 +175,9 @@
         </dependency>
 
         <dependency>
+            <!-- one.ducking is a fork of com.kjetland -->
+            <!-- schema-registry is dependent on one.duckling:mbknor-jackson-jsonschema-java8 -->
+            <!-- hence all the downstream projects had to use that one only -->
             <groupId>one.duckling</groupId>
             <artifactId>mbknor-jackson-jsonschema-java8</artifactId>
             <version>1.0.39.1</version>

--- a/ksqldb-rest-app/pom.xml
+++ b/ksqldb-rest-app/pom.xml
@@ -175,9 +175,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.kjetland</groupId>
-            <artifactId>mbknor-jackson-jsonschema_${kafka.scala.version}</artifactId>
-            <version>1.0.39</version>
+            <groupId>one.duckling</groupId>
+            <artifactId>mbknor-jackson-jsonschema-java8</artifactId>
+            <version>1.0.39.1</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/utils/KsqlPlanSchemaGenerator.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/utils/KsqlPlanSchemaGenerator.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.rest.server.utils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -39,39 +40,45 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Optional;
+
 
 public final class KsqlPlanSchemaGenerator {
 
   private static final ObjectMapper MAPPER = PlanJsonMapper.INSTANCE.get();
 
-  private static final Map<Class<?>, JsonNode> POLYMORPHIC_TYPES = ImmutableMap.of(
-      ExecutionStep.class, definitionForPolymorphicType(ExecutionStep.class)
-  );
+  private static final Map<Class<?>, JsonNode> POLYMORPHIC_TYPES;
+
+  static {
+    try {
+      POLYMORPHIC_TYPES = ImmutableMap.of(
+          ExecutionStep.class, definitionForPolymorphicType(ExecutionStep.class)
+      );
+    } catch (final JsonMappingException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
   private KsqlPlanSchemaGenerator() {
   }
 
   private static JsonSchemaConfig configure() {
-    final JsonSchemaConfig vanilla = JsonSchemaConfig.vanillaJsonSchemaDraft4();
-    return JsonSchemaConfig.create(
-        vanilla.autoGenerateTitleForProperties(),
-        Optional.empty(),
-        false,
-        false,
-        vanilla.usePropertyOrdering(),
-        vanilla.hidePolymorphismTypeProperty(),
-        vanilla.disableWarnings(),
-        vanilla.useMinLengthForNotNull(),
-        vanilla.useTypeIdForDefinitionName(),
-        Collections.emptyMap(),
-        vanilla.useMultipleEditorSelectViaProperty(),
-        Collections.emptySet(),
-        // the schema generator doesn't play nice with custom serializers, so we add a
-        // config to remap the custom-serialized types to their underlying primitive
-        new ImmutableMap.Builder<Class<?>, Class<?>>()
+    return JsonSchemaConfig.builder()
+        .autoGenerateTitleForProperties(false)
+        .defaultArrayFormat(null)
+        .useOneOfForOption(false)
+        .useOneOfForNullables(false)
+        .usePropertyOrdering(false)
+        .hidePolymorphismTypeProperty(false)
+        .useMinLengthForNotNull(false)
+        .useTypeIdForDefinitionName(false)
+        .customType2FormatMapping(Collections.emptyMap())
+        .useMultipleEditorSelectViaProperty(false)
+        .uniqueItemClasses(new HashSet<>())
+        .classTypeReMapping(
+            new ImmutableMap.Builder<Class<?>, Class<?>>()
             .put(LogicalSchema.class, String.class)
             .put(SqlType.class, String.class)
             .put(SelectExpression.class, String.class)
@@ -79,20 +86,65 @@ public final class KsqlPlanSchemaGenerator {
             .put(FunctionCall.class, String.class)
             .put(KsqlWindowExpression.class, String.class)
             .put(Duration.class, Long.class)
-            .build(),
-        Collections.emptyMap(),
-        null,
-        true,
-        null
-    );
+            .build()
+        )
+        .jsonSuppliers(Collections.emptyMap())
+        .build();
+
+//    final JsonSchemaConfig vanilla = JsonSchemaConfig.create(
+//        false, // autoGenerateTitleForProperties
+//        null, // defaultArrayFormat
+//        false, // useOneOfForOption
+//        false, // useOneOfForNullables
+//        false, // usePropertyOrdering
+//        false, // hidePolymorphismTypeProperty
+//        false, // disableWarnings
+//        false, // useMinLengthForNotNull
+//        false, // useTypeIdForDefinitionName
+//        Collections.emptyMap(), // customType2FormatMapping
+//        false, // useMultipleEditorSelectViaProperty
+//        Collections.emptySet(), // uniqueItemClasses
+//        Collections.emptyMap(), // classTypeReMapping
+//        Collections.emptyMap() // jsonSuppliers
+//    );
+//    return JsonSchemaConfig.create(
+//        vanilla.autoGenerateTitleForProperties,
+//        vanilla.defaultArrayFormat,
+//        false,
+//        false,
+//        vanilla.usePropertyOrdering,
+//        vanilla.hidePolymorphismTypeProperty,
+//        false,
+//        vanilla.useMinLengthForNotNull,
+//        vanilla.useTypeIdForDefinitionName,
+//        Collections.emptyMap(),
+//        vanilla.useMultipleEditorSelectViaProperty,
+//        Collections.emptySet(),
+//        // the schema generator doesn't play nice with custom serializers, so we add a
+//        // config to remap the custom-serialized types to their underlying primitive
+//        new ImmutableMap.Builder<Class<?>, Class<?>>()
+//            .put(LogicalSchema.class, String.class)
+//            .put(SqlType.class, String.class)
+//            .put(SelectExpression.class, String.class)
+//            .put(Expression.class, String.class)
+//            .put(FunctionCall.class, String.class)
+//            .put(KsqlWindowExpression.class, String.class)
+//            .put(Duration.class, Long.class)
+//            .build(),
+//        Collections.emptyMap(),
+//        null,
+//        true,
+//        null
+//    );
   }
 
-  private static JsonNode generate(final Class<?> clazz) {
+  private static JsonNode generate(final Class<?> clazz) throws JsonMappingException {
     final JsonSchemaGenerator generator = new JsonSchemaGenerator(MAPPER, configure());
     return generator.generateJsonSchema(clazz);
   }
 
-  private static JsonNode definitionForPolymorphicType(final Class<?> clazz) {
+  private static JsonNode definitionForPolymorphicType(final Class<?> clazz)
+      throws JsonMappingException {
     final JsonNode generated = generate(clazz);
     return new ObjectNode(JsonNodeFactory.instance).set(
         "oneOf", generated.get("oneOf")
@@ -139,7 +191,7 @@ public final class KsqlPlanSchemaGenerator {
     return schema;
   }
 
-  public static JsonNode generate() {
+  public static JsonNode generate() throws JsonMappingException {
     final JsonSchemaGenerator generator = new JsonSchemaGenerator(MAPPER, configure());
     return rewriteWithPolymorphicAsDefinition(generator.generateJsonSchema(KsqlPlan.class));
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/utils/KsqlPlanSchemaGenerator.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/utils/KsqlPlanSchemaGenerator.java
@@ -90,52 +90,6 @@ public final class KsqlPlanSchemaGenerator {
         )
         .jsonSuppliers(Collections.emptyMap())
         .build();
-
-//    final JsonSchemaConfig vanilla = JsonSchemaConfig.create(
-//        false, // autoGenerateTitleForProperties
-//        null, // defaultArrayFormat
-//        false, // useOneOfForOption
-//        false, // useOneOfForNullables
-//        false, // usePropertyOrdering
-//        false, // hidePolymorphismTypeProperty
-//        false, // disableWarnings
-//        false, // useMinLengthForNotNull
-//        false, // useTypeIdForDefinitionName
-//        Collections.emptyMap(), // customType2FormatMapping
-//        false, // useMultipleEditorSelectViaProperty
-//        Collections.emptySet(), // uniqueItemClasses
-//        Collections.emptyMap(), // classTypeReMapping
-//        Collections.emptyMap() // jsonSuppliers
-//    );
-//    return JsonSchemaConfig.create(
-//        vanilla.autoGenerateTitleForProperties,
-//        vanilla.defaultArrayFormat,
-//        false,
-//        false,
-//        vanilla.usePropertyOrdering,
-//        vanilla.hidePolymorphismTypeProperty,
-//        false,
-//        vanilla.useMinLengthForNotNull,
-//        vanilla.useTypeIdForDefinitionName,
-//        Collections.emptyMap(),
-//        vanilla.useMultipleEditorSelectViaProperty,
-//        Collections.emptySet(),
-//        // the schema generator doesn't play nice with custom serializers, so we add a
-//        // config to remap the custom-serialized types to their underlying primitive
-//        new ImmutableMap.Builder<Class<?>, Class<?>>()
-//            .put(LogicalSchema.class, String.class)
-//            .put(SqlType.class, String.class)
-//            .put(SelectExpression.class, String.class)
-//            .put(Expression.class, String.class)
-//            .put(FunctionCall.class, String.class)
-//            .put(KsqlWindowExpression.class, String.class)
-//            .put(Duration.class, Long.class)
-//            .build(),
-//        Collections.emptyMap(),
-//        null,
-//        true,
-//        null
-//    );
   }
 
   private static JsonNode generate(final Class<?> clazz) throws JsonMappingException {


### PR DESCRIPTION
### Description 
Fix#KSQL-12720 JsonConfig lib used in ksqldb-rest-app tests will be one.ducking instead of original one. Original has dependency on scala.

#### Details Description
one.ducking is a fork of com.kjetland. Schema-registry is dependent on one.duckling:mbknor-jackson-jsonschema-java8
hence all the downstream projects had to use that one only. [Ref PR](https://github.com/confluentinc/schema-registry/pull/3396/files)

### Testing done 

- [x] Locally Building
- [x] Tests are Passing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
