### PR TITLE
KSQL-12737 | CVE fix for netty-common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,15 +143,15 @@
         <apache.io.version>2.11.0</apache.io.version>
         <io.confluent.ksql.version>7.7.2-0</io.confluent.ksql.version>
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
-        <netty-tcnative-version>2.0.65.Final</netty-tcnative-version>
+        <netty-tcnative-version>2.0.69.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`
              we might need to bump `tcnative`, too.
              Please check top level `pom.xml` at https://github.com/netty/netty
              for the netty version we bump to (ie, corresponding git tag),
              to find the correct `tcnative` version. -->
-        <netty.version>4.1.113.Final</netty.version>
-        <netty-codec-http2-version>4.1.113.Final</netty-codec-http2-version>
+        <netty.version>4.1.115.Final</netty.version>
+        <netty-codec-http2-version>4.1.115.Final</netty-codec-http2-version>
         <jersey-common>2.39.1</jersey-common>
         <multi-threaded-testing.forkCount>3</multi-threaded-testing.forkCount>
         <kafka.version>${ce.kafka.version}</kafka.version>


### PR DESCRIPTION
### Description 
CVE fix for netty-common. Bump up tcnative dependency as per https://github.com/netty/netty/blob/netty-4.1.115.Final/pom.xml

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
