### PR TITLE
ksql-12727 | chore: updated maven repo urls

### DIFF
--- a/docs/developer-guide/ksqldb-clients/java-client.md
+++ b/docs/developer-guide/ksqldb-clients/java-client.md
@@ -68,14 +68,14 @@ Start by creating a `pom.xml` for your Java application:
         <repository>
             <id>ksqlDB</id>
             <name>ksqlDB</name>
-            <url>https://ksqldb-maven.s3.amazonaws.com/maven/</url>
+            <url>https://ksqldb-mvns.s3.amazonaws.com/maven/</url>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
             <id>ksqlDB</id>
-            <url>https://ksqldb-maven.s3.amazonaws.com/maven/</url>
+            <url>https://ksqldb-mvns.s3.amazonaws.com/maven/</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/maven-settings.xml
+++ b/maven-settings.xml
@@ -14,13 +14,13 @@
         <repository>
           <id>confluent-other</id>
           <name>Confluent</name>
-          <url>https://ksqldb-maven.s3.amazonaws.com/maven/</url>
+          <url>https://ksqldb-mvns.s3.amazonaws.com/maven/</url>
         </repository>
         <!-- needed for HTML API doc generation post-release only -->
         <repository>
           <id>ksqldb-staging</id>
           <name>ksqlDB staging</name>
-          <url>https://staging-ksqldb-maven.s3.amazonaws.com/maven/</url>
+          <url>https://stag-ksqldb-mvns.s3.amazonaws.com/maven/</url>
         </repository>
       </repositories>
 
@@ -28,7 +28,7 @@
         <pluginRepository>
           <id>confluent-other</id>
           <name>Confluent Plugin Repository</name>
-          <url>https://ksqldb-maven.s3.amazonaws.com/maven/</url>
+          <url>https://ksqldb-mvns.s3.amazonaws.com/maven/</url>
           <layout>default</layout>
           <snapshots>
             <enabled>true</enabled>
@@ -41,7 +41,7 @@
         <pluginRepository>
           <id>confluent-staging</id>
           <name>Confluent Staging Plugin Repository</name>
-          <url>https://staging-ksqldb-maven.s3.amazonaws.com/maven/</url>
+          <url>https://stag-ksqldb-mvns.s3.amazonaws.com/maven/</url>
           <layout>default</layout>
           <snapshots>
             <enabled>true</enabled>


### PR DESCRIPTION
### Description 
As part of account resources migration, the s3 content of existing repo is moved to a new s3 bucket.

### Testing done 
- [x] Files are accessible publically. (example: https://ksqldb-mvns.s3.amazonaws.com/maven/io/confluent/ksql/ksqldb-cli/0.29.0-rc3/ksqldb-cli-0.29.0-rc3-sources.jar)

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
