### PR TITLE
CPBR-1887: adding cp-jar-build semaphoreCI block

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -60,6 +60,31 @@ blocks:
             - mvn -Ddocker.skip=true -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode -DaltDeploymentRepository=confluent-codeartifact-internal::default::https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/
               -DrepositoryId=confluent-codeartifact-internal deploy -DskipTests
 
+  - name: CP Jar Build CI Gating
+    dependencies: [ ]
+    run:
+      # Run this block only for pull requests
+      when: "pull_request =~ '.*'"
+    task:
+      env_vars:
+        - name: COMPONENT_NAME
+          value: ksqldb
+      jobs:
+        - name: Trigger and wait for CP Jar Build Task
+          commands:
+            # Don't run this block if target branch for PR is not a CP nightly branch
+            - |
+              if [[ "$SEMAPHORE_GIT_BRANCH" =~ ^[0-9]+\.[0-9]+\.x$ ]] ; then \
+                  echo "PR is targeted to ${SEMAPHORE_GIT_BRANCH} branch which is CP nightly branch. Triggering cp-jar-build task."; \
+                  sem-trigger -p packaging \
+                    -t cp-jar-build \
+                    -b $SEMAPHORE_GIT_BRANCH \
+                    -d "|" -i "CUSTOM_BRANCH_COMPONENTS|${COMPONENT_NAME}=${SEMAPHORE_GIT_WORKING_BRANCH}" \
+                    -w; \
+              else \
+                  echo "PR is targeted to ${SEMAPHORE_GIT_BRANCH} branch which is not CP nightly branch. Skipping cp-jar-build task."; \
+              fi;
+
 after_pipeline:
   task:
     agent:


### PR DESCRIPTION
### Description 
Enabling PR CI gating by adding cp jar build block for CP 7.9.x 
This block is present for all the CP versions till 7.8.x

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
