### PR TITLE
Added logger for orphan topics & streams

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -216,6 +216,11 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
                 ExecutorUtil.RetryBehaviour.ON_RETRYABLE);
       }
     } catch (final ExecutionException e) {
+      if (Throwables.getRootCause(e) instanceof UnknownTopicOrPartitionException) {
+        throw new KafkaResponseGetFailedException(
+                "Failed to Describe due to UnknownTopicOrPartitionException "
+                        + "for Kafka Topic(s): " + topicNames, e);
+      }
       throw new KafkaResponseGetFailedException(
           "Failed to Describe Kafka Topic(s): " + topicNames, e.getCause());
     } catch (final TopicAuthorizationException e) {


### PR DESCRIPTION
### Description 
[KSQL-12852] Added logger for orphan topics & streams

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.


[KSQL-12852]: https://confluentinc.atlassian.net/browse/KSQL-12852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ