### PR TITLE
[KSQL-12793] | Vedarth Sharma | Fix close query context error

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/CloseQueryHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/CloseQueryHandler.java
@@ -39,7 +39,6 @@ public class CloseQueryHandler implements Handler<RoutingContext> {
 
   @Override
   public void handle(final RoutingContext routingContext) {
-
     final Optional<CloseQueryArgs> closeQueryArgs = ServerUtils
         .deserialiseObject(routingContext.getBody(), routingContext, CloseQueryArgs.class);
     if (!closeQueryArgs.isPresent()) {
@@ -55,7 +54,8 @@ public class CloseQueryHandler implements Handler<RoutingContext> {
                   ERROR_CODE_BAD_REQUEST));
       return;
     }
-    query.get().close();
+    // We may be using a different context to the one that created the query
+    query.get().close(false);
     routingContext.response().end();
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/PushQueryHolder.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/PushQueryHolder.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.api.server;
 
 import io.confluent.ksql.api.spi.QueryPublisher;
 import io.confluent.ksql.rest.entity.PushQueryId;
-
 import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -54,7 +53,7 @@ public class PushQueryHolder {
    *
    * @param isOriginalContext whether the context is the original context that created the query
    */
-  public void close(Boolean isOriginalContext) {
+  public void close(final Boolean isOriginalContext) {
     server.removeQuery(id);
     queryPublisher.close();
     if (isOriginalContext) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/PushQueryHolder.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/PushQueryHolder.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.api.server;
 
 import io.confluent.ksql.api.spi.QueryPublisher;
 import io.confluent.ksql.rest.entity.PushQueryId;
-import io.vertx.core.Vertx;
 
 import java.util.Objects;
 import java.util.UUID;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/PushQueryHolder.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/PushQueryHolder.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.api.server;
 
 import io.confluent.ksql.api.spi.QueryPublisher;
 import io.confluent.ksql.rest.entity.PushQueryId;
+import io.vertx.core.Vertx;
+
 import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -45,9 +47,14 @@ public class PushQueryHolder {
   }
 
   public void close() {
+    this.close(true);
+  }
+  public void close(Boolean isOriginalContext) {
     server.removeQuery(id);
     queryPublisher.close();
-    closeHandler.accept(this);
+    if (isOriginalContext) {
+      closeHandler.accept(this);
+    }
   }
 
   public PushQueryId getId() {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/PushQueryHolder.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/PushQueryHolder.java
@@ -48,6 +48,12 @@ public class PushQueryHolder {
   public void close() {
     this.close(true);
   }
+
+  /**
+   * Close the query.
+   *
+   * @param isOriginalContext whether the context is the original context that created the query
+   */
   public void close(Boolean isOriginalContext) {
     server.removeQuery(id);
     queryPublisher.close();


### PR DESCRIPTION
### Description 
Fixes context mismatch error while closing query using close query rest api endpoint.

### Testing done 
Tested locally

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
