### PR TITLE
Added Warn Logger for Orphan Topics (UnknownTopicOrPartitionException) & for Command Topic Size exceeding threshold

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
@@ -262,6 +262,17 @@ public class CommandRunner implements Closeable {
       final List<QueuedCommand> compatibleCommands = checkForIncompatibleCommands(restoreCommands);
 
       LOG.info("Restoring previous state from {} commands.", compatibleCommands.size());
+      if (compatibleCommands.size() > 100000) {
+        LOG.warn("Command topic size exceeded 100000 commands.");
+      } else if (compatibleCommands.size() > 80000) {
+        LOG.warn("Command topic size exceeded 80000 commands.");
+      } else if (compatibleCommands.size() > 60000) {
+        LOG.warn("Command topic size exceeded 60000 commands.");
+      } else if (compatibleCommands.size() > 40000) {
+        LOG.warn("Command topic size exceeded 40000 commands.");
+      } else if (compatibleCommands.size() > 20000) {
+        LOG.warn("Command topic size exceeded 20000 commands.");
+      }
 
       final Optional<QueuedCommand> terminateCmd =
           findTerminateCommand(compatibleCommands, commandDeserializer);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server.execution;
 
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
@@ -75,10 +76,14 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.TopicPartitionInfo;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 public final class ListSourceExecutor {
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
+  private static final Logger LOG = LoggerFactory.getLogger(ListSourceExecutor.class);
 
   private ListSourceExecutor() {
   }
@@ -297,6 +302,10 @@ public final class ListSourceExecutor {
       );
       sourceConstraints = getSourceConstraints(name, ksqlExecutionContext.getMetaStore());
     } catch (final KafkaException | KafkaResponseGetFailedException e) {
+      if (Throwables.getRootCause(e) instanceof UnknownTopicOrPartitionException) {
+        LOG.warn("Failed to Describe due to UnknownTopicOrPartitionException for {} "
+                + "with topic name {}", name.text(), dataSource.getKafkaTopicName());
+      }
       warnings.add(new KsqlWarning("Error from Kafka: " + e.getMessage()));
     }
 


### PR DESCRIPTION
[KSQL-12853] - Added Warn Logger for Orphan Topics (UnknownTopicOrPartitionException) & for Command Topic Size exceeding threshold

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.


[KSQL-12853]: https://confluentinc.atlassian.net/browse/KSQL-12853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ