### PR TITLE
Added Warn Logger for Orphan Topics (UnknownTopicOrPartitionException) & for Command Topic Size exceeding threshold

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
@@ -68,6 +68,7 @@ public class CommandRunner implements Closeable {
   private static final int MAX_STATEMENT_RETRY_MS = 5 * 1000;
   private static final Duration NEW_CMDS_TIMEOUT = Duration.ofMillis(MAX_STATEMENT_RETRY_MS);
   private static final int SHUTDOWN_TIMEOUT_MS = 3 * MAX_STATEMENT_RETRY_MS;
+  private static final int COMMAND_TOPIC_THRESHOLD_LIMIT = 10000;
 
   private final InteractiveStatementExecutor statementExecutor;
   private final CommandQueue commandStore;
@@ -271,6 +272,9 @@ public class CommandRunner implements Closeable {
       final List<QueuedCommand> compatibleCommands = checkForIncompatibleCommands(restoreCommands);
 
       LOG.info("Restoring previous state from {} commands.", compatibleCommands.size());
+      if (compatibleCommands.size() > COMMAND_TOPIC_THRESHOLD_LIMIT) {
+        LOG.warn("Command topic size exceeded {} commands.", COMMAND_TOPIC_THRESHOLD_LIMIT);
+      }
 
       final Optional<QueuedCommand> terminateCmd =
           findTerminateCommand(compatibleCommands, commandDeserializer);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
@@ -273,7 +273,8 @@ public class CommandRunner implements Closeable {
 
       LOG.info("Restoring previous state from {} commands.", compatibleCommands.size());
       if (compatibleCommands.size() > COMMAND_TOPIC_THRESHOLD_LIMIT) {
-        LOG.warn("Command topic size exceeded {} commands.", COMMAND_TOPIC_THRESHOLD_LIMIT);
+        LOG.warn("Command topic size exceeded. [commands={}, threshold={}]",
+                compatibleCommands.size(), COMMAND_TOPIC_THRESHOLD_LIMIT);
       }
 
       final Optional<QueuedCommand> terminateCmd =

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -304,10 +304,8 @@ public final class ListSourceExecutor {
       );
       sourceConstraints = getSourceConstraints(name, ksqlExecutionContext.getMetaStore());
     } catch (final KafkaException | KafkaResponseGetFailedException e) {
-      if (Throwables.getRootCause(e) instanceof UnknownTopicOrPartitionException) {
-        LOG.warn("Failed to Describe due to UnknownTopicOrPartitionException for {} "
-                + "with topic name {}", name.text(), dataSource.getKafkaTopicName());
-      }
+      LOG.warn("Failed to Describe. [Error={}, Topic={}, Source={}]",
+              Throwables.getRootCause(e), dataSource.getKafkaTopicName(), name.text());
       warnings.add(new KsqlWarning("Error from Kafka: " + e.getMessage()));
     }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -76,7 +76,6 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.TopicPartitionInfo;
-import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
[KSQL-12853]- Added Warn Logger for Orphan Topics (UnknownTopicOrPartitionException) & for Command Topic Size exceeding threshold
![image](https://github.com/user-attachments/assets/c52c64e1-5eb0-4c2b-9c3d-ee3bd17e77aa)


### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.


[KSQL-12853]: https://confluentinc.atlassian.net/browse/KSQL-12853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ