### PR TITLE
refactor: refactored ksqltransformer and its implementations

### DIFF
--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/function/udaf/KudafAggregator.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/function/udaf/KudafAggregator.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.function.UdafAggregator;
-import io.confluent.ksql.execution.transform.KsqlProcessingContext;
 import io.confluent.ksql.execution.transform.KsqlTransformer;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.List;
@@ -131,8 +130,7 @@ public class KudafAggregator<K> implements UdafAggregator<K> {
     @Override
     public GenericRow transform(
         final K readOnlyKey,
-        final GenericRow value,
-        final KsqlProcessingContext ctx
+        final GenericRow value
     ) {
       if (value == null) {
         return null;

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/function/udtf/KudtfFlatMapper.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/function/udtf/KudtfFlatMapper.java
@@ -20,7 +20,6 @@ import static java.util.Objects.requireNonNull;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.transform.KsqlProcessingContext;
 import io.confluent.ksql.execution.transform.KsqlTransformer;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.testing.EffectivelyImmutable;
@@ -55,8 +54,7 @@ public class KudtfFlatMapper<K> implements KsqlTransformer<K, Iterable<GenericRo
   @Override
   public Iterable<GenericRow> transform(
       final K readOnlyKey,
-      final GenericRow value,
-      final KsqlProcessingContext ctx
+      final GenericRow value
   ) {
     if (value == null) {
       return null;

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/transform/KsqlTransformer.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/transform/KsqlTransformer.java
@@ -29,5 +29,5 @@ import io.confluent.ksql.GenericRow;
  */
 public interface KsqlTransformer<K, R> {
 
-  R transform(K readOnlyKey, GenericRow value, KsqlProcessingContext ctx);
+  R transform(K readOnlyKey, GenericRow value);
 }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/transform/select/SelectValueMapper.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/transform/select/SelectValueMapper.java
@@ -20,7 +20,6 @@ import static java.util.Objects.requireNonNull;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.transform.ExpressionEvaluator;
-import io.confluent.ksql.execution.transform.KsqlProcessingContext;
 import io.confluent.ksql.execution.transform.KsqlTransformer;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.name.ColumnName;
@@ -104,8 +103,7 @@ public class SelectValueMapper<K> {
     @Override
     public GenericRow transform(
         final K readOnlyKey,
-        final GenericRow value,
-        final KsqlProcessingContext ctx
+        final GenericRow value
     ) {
       if (value == null) {
         return null;

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/transform/sqlpredicate/SqlPredicate.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/transform/sqlpredicate/SqlPredicate.java
@@ -21,7 +21,6 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.codegen.CodeGenRunner;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.transform.ExpressionEvaluator;
-import io.confluent.ksql.execution.transform.KsqlProcessingContext;
 import io.confluent.ksql.execution.transform.KsqlTransformer;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
@@ -85,8 +84,7 @@ public final class SqlPredicate {
     @Override
     public Optional<GenericRow> transform(
         final K readOnlyKey,
-        final GenericRow value,
-        final KsqlProcessingContext ctx
+        final GenericRow value
     ) {
       if (value == null) {
         return Optional.empty();

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/function/udaf/KudafAggregatorTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/function/udaf/KudafAggregatorTest.java
@@ -102,7 +102,7 @@ public class KudafAggregatorTest {
     final GenericRow agg = GenericRow.genericRow(1, 2L, 4);
 
     // When:
-    final GenericRow result = aggregator.getResultMapper().transform("k", agg, ctx);
+    final GenericRow result = aggregator.getResultMapper().transform("k", agg);
 
     // Then:
     assertThat(agg, is(GenericRow.genericRow(1, 2L, 4)));

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/function/udtf/KudtfFlatMapperTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/function/udtf/KudtfFlatMapperTest.java
@@ -53,7 +53,7 @@ public class KudtfFlatMapperTest {
         new KudtfFlatMapper<>(ImmutableList.of(applier), processingLogger);
 
     // When:
-    final Iterable<GenericRow> iterable = flatMapper.transform(KEY, VALUE, ctx);
+    final Iterable<GenericRow> iterable = flatMapper.transform(KEY, VALUE);
 
     // Then:
     final Iterator<GenericRow> iter = iterable.iterator();
@@ -72,7 +72,7 @@ public class KudtfFlatMapperTest {
         new KudtfFlatMapper<>(ImmutableList.of(applier1, applier2), processingLogger);
 
     // When:
-    final Iterable<GenericRow> iterable = flatMapper.transform(KEY, VALUE, ctx);
+    final Iterable<GenericRow> iterable = flatMapper.transform(KEY, VALUE);
 
     // Then:
     final Iterator<GenericRow> iter = iterable.iterator();
@@ -90,7 +90,7 @@ public class KudtfFlatMapperTest {
         new KudtfFlatMapper<>(ImmutableList.of(applier), processingLogger);
 
     // When:
-    flatMapper.transform(KEY, VALUE, ctx);
+    flatMapper.transform(KEY, VALUE);
 
     // Then:
     verify(applier).apply(VALUE, processingLogger);

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/transform/select/SelectValueMapperTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/transform/select/SelectValueMapperTest.java
@@ -88,7 +88,7 @@ public class SelectValueMapperTest {
   @Test
   public void shouldInvokeEvaluatorsWithCorrectParams() {
     // When:
-    transformer.transform(KEY, VALUE, ctx);
+    transformer.transform(KEY, VALUE);
 
     // Then:
     final ArgumentCaptor<Supplier<String>> errorMsgCaptor = ArgumentCaptor.forClass(Supplier.class);
@@ -115,7 +115,7 @@ public class SelectValueMapperTest {
     when(col2.evaluate(any(), any(), any(), any())).thenReturn(300);
 
     // When:
-    final GenericRow result = transformer.transform(KEY, VALUE, ctx);
+    final GenericRow result = transformer.transform(KEY, VALUE);
 
     // Then:
     assertThat(result, equalTo(genericRow(100, 200, 300)));
@@ -124,7 +124,7 @@ public class SelectValueMapperTest {
   @Test
   public void shouldHandleNullRows() {
     // When:
-    final GenericRow result = transformer.transform(KEY, null, ctx);
+    final GenericRow result = transformer.transform(KEY, null);
 
     // Then:
     assertThat(result, is(nullValue()));

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/transform/sqlpredicate/SqlPredicateTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/transform/sqlpredicate/SqlPredicateTest.java
@@ -105,8 +105,8 @@ public class SqlPredicateTest {
     transformer = predicate.getTransformer(processingLogger);
 
     // When:
-    final Optional<GenericRow> result1 = transformer.transform("key", genericRow(99L), ctx);
-    final Optional<GenericRow> result2 = transformer.transform("key", genericRow(100L), ctx);
+    final Optional<GenericRow> result1 = transformer.transform("key", genericRow(99L));
+    final Optional<GenericRow> result2 = transformer.transform("key", genericRow(100L));
 
     // Then:
     assertThat(result1, is(not(Optional.empty())));
@@ -119,7 +119,7 @@ public class SqlPredicateTest {
     when(evaluator.evaluate(any(), any(), any(), any())).thenReturn(true);
 
     // When:
-    final Optional<GenericRow> result = transformer.transform("key", VALUE, ctx);
+    final Optional<GenericRow> result = transformer.transform("key", VALUE);
 
     // Then:
     assertThat(result, is(Optional.of(VALUE)));
@@ -131,7 +131,7 @@ public class SqlPredicateTest {
     when(evaluator.evaluate(any(), any(), any(), any())).thenReturn(false);
 
     // When:
-    final Optional<GenericRow> result = transformer.transform("key", VALUE, ctx);
+    final Optional<GenericRow> result = transformer.transform("key", VALUE);
 
     // Then:
     assertThat(result, is(Optional.empty()));
@@ -140,7 +140,7 @@ public class SqlPredicateTest {
   @Test
   public void shouldIgnoreNullRows() {
     // When:
-    final Optional<GenericRow> result = transformer.transform("key", null, ctx);
+    final Optional<GenericRow> result = transformer.transform("key", null);
 
     // Then:
     assertThat(result, is(Optional.empty()));
@@ -155,7 +155,7 @@ public class SqlPredicateTest {
     when(evaluator.evaluate(any(), any(), any(), any())).thenReturn(true);
 
     // When:
-    transformer.transform("key", VALUE, ctx);
+    transformer.transform("key", VALUE);
 
     // Then:
     final ArgumentCaptor<Supplier<String>> errorMsgCaptor = ArgumentCaptor.forClass(Supplier.class);

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
@@ -29,7 +29,6 @@ import io.confluent.ksql.execution.plan.StreamWindowedAggregate;
 import io.confluent.ksql.execution.runtime.MaterializedFactory;
 import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.streams.transform.KsValueTransformer;
-import io.confluent.ksql.execution.transform.KsqlProcessingContext;
 import io.confluent.ksql.execution.transform.KsqlTransformer;
 import io.confluent.ksql.execution.windows.HoppingWindowExpression;
 import io.confluent.ksql.execution.windows.KsqlWindowExpression;
@@ -371,8 +370,7 @@ public final class StreamAggregateBuilder {
     @Override
     public GenericRow transform(
         final Windowed<GenericKey> readOnlyKey,
-        final GenericRow value,
-        final KsqlProcessingContext ctx
+        final GenericRow value
     ) {
       if (value == null) {
         return null;

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectBuilder.java
@@ -81,7 +81,7 @@ public final class StreamSelectBuilder {
       return stream.withStream(
           stream.getStream().transform(
             () -> new KsTransformer<>(
-                (readOnlyKey, value, ctx) -> {
+                (readOnlyKey, value) -> {
                   if (keyIndices.isEmpty()) {
                     return null;
                   }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSelectBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSelectBuilder.java
@@ -114,8 +114,7 @@ public final class TableSelectBuilder {
 
         final KTable<K, GenericRow> transFormedTable = table.getTable().transformValues(
             () -> new KsValueTransformer<>(selectMapper.getTransformer(logger)),
-            materialized
-        );
+            materialized);
 
         return KTableHolder.materialized(
             transFormedTable,

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSuppressBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSuppressBuilder.java
@@ -110,7 +110,7 @@ public final class TableSuppressBuilder {
     with the correct key and val serdes is passed on when we call suppress
      */
     final KTable<K, GenericRow> suppressed = table.getTable().transformValues(
-        (() -> new KsValueTransformer<>((k, v, ctx) -> v)),
+        (() -> new KsValueTransformer<>((k, v) -> v)),
         materialized
     ).suppress(
         (Suppressed<? super K>) Suppressed

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/KsqlMaterializationFactory.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/KsqlMaterializationFactory.java
@@ -108,7 +108,7 @@ public final class KsqlMaterializationFactory {
       final KsqlTransformer<Object, GenericRow> resultMapper = info
           .getMapper(this::getLogger);
 
-      return (k, v, ctx) -> Optional.of(resultMapper.transform(k, v, ctx));
+      return (k, v, ctx) -> Optional.of(resultMapper.transform(k, v));
     }
 
     @Override
@@ -118,7 +118,7 @@ public final class KsqlMaterializationFactory {
       final KsqlTransformer<Object, Optional<GenericRow>> predicate = info
           .getPredicate(this::getLogger);
 
-      return predicate::transform;
+      return (readOnlyKey, value, ctx) -> predicate.transform(readOnlyKey, value);
     }
 
     private ProcessingLogger getLogger(final QueryContext queryContext) {

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/transform/KsTransformer.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/transform/KsTransformer.java
@@ -18,9 +18,7 @@ package io.confluent.ksql.execution.streams.transform;
 import static java.util.Objects.requireNonNull;
 
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.streams.transform.KsValueTransformer.KsProcessingContext;
 import io.confluent.ksql.execution.transform.KsqlTransformer;
-import java.util.Optional;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Transformer;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -39,7 +37,6 @@ public class KsTransformer<KInT, KOutT>
 
   private final KsqlTransformer<KInT, KOutT> keyDelegate;
   private final KsqlTransformer<KInT, GenericRow> valueDelegate;
-  private Optional<KsProcessingContext> context;
 
   public KsTransformer(
       final KsqlTransformer<KInT, KOutT> keyDelegate,
@@ -47,26 +44,21 @@ public class KsTransformer<KInT, KOutT>
   ) {
     this.keyDelegate = requireNonNull(keyDelegate, "keyDelegate");
     this.valueDelegate = requireNonNull(valueDelegate, "valueDelegate");
-    this.context = Optional.empty();
   }
 
   @Override
-  public void init(final ProcessorContext processorContext) {
-    this.context = Optional.of(new KsProcessingContext(processorContext));
-  }
+  public void init(final ProcessorContext processorContext) {}
 
   @Override
   public KeyValue<KOutT, GenericRow> transform(final KInT key, final GenericRow value) {
     return KeyValue.pair(
         keyDelegate.transform(
             key,
-            value,
-            context.orElseThrow(() -> new IllegalStateException("Not initialized"))
+            value
         ),
         valueDelegate.transform(
             key,
-            value,
-            context.orElseThrow(() -> new IllegalStateException("Not initialized"))
+            value
         )
     );
   }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/transform/KsValueTransformer.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/transform/KsValueTransformer.java
@@ -18,9 +18,7 @@ package io.confluent.ksql.execution.streams.transform;
 import static java.util.Objects.requireNonNull;
 
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.transform.KsqlProcessingContext;
 import io.confluent.ksql.execution.transform.KsqlTransformer;
-import java.util.Optional;
 import org.apache.kafka.streams.kstream.ValueTransformerWithKey;
 import org.apache.kafka.streams.processor.ProcessorContext;
 
@@ -36,42 +34,22 @@ import org.apache.kafka.streams.processor.ProcessorContext;
 public class KsValueTransformer<K, R> implements ValueTransformerWithKey<K, GenericRow, R> {
 
   private final KsqlTransformer<K, R> delegate;
-  private Optional<KsProcessingContext> context;
 
   public KsValueTransformer(final KsqlTransformer<K, R> delegate) {
     this.delegate = requireNonNull(delegate, "delegate");
-    this.context = Optional.empty();
   }
 
   @Override
-  public void init(final ProcessorContext processorContext) {
-    this.context = Optional.of(new KsProcessingContext(processorContext));
-  }
+  public void init(final ProcessorContext processorContext) {}
 
   @Override
   public R transform(final K readOnlyKey, final GenericRow value) {
     return delegate.transform(
         readOnlyKey,
-        value,
-        context.orElseThrow(() -> new IllegalStateException("Not initialized"))
+        value
     );
   }
 
   @Override
-  public void close() {
-  }
-
-  public static final class KsProcessingContext implements KsqlProcessingContext {
-
-    private final ProcessorContext processingContext;
-
-    public KsProcessingContext(final ProcessorContext processorContext) {
-      this.processingContext = requireNonNull(processorContext, "processorContext");
-    }
-
-    @Override
-    public long getRowTime() {
-      return processingContext.timestamp();
-    }
-  }
+  public void close() {}
 }

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamAggregateBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamAggregateBuilderTest.java
@@ -696,9 +696,9 @@ public class StreamAggregateBuilderTest {
     final GenericRow value = mock(GenericRow.class);
 
     // When:
-    mapper.transform(key, value, ctx);
+    mapper.transform(key, value);
 
     // Then:
-    verify(resultMapper).transform(key, value, ctx);
+    verify(resultMapper).transform(key, value);
   }
 }

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableAggregateBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableAggregateBuilderTest.java
@@ -297,9 +297,9 @@ public class TableAggregateBuilderTest {
     final GenericRow value = mock(GenericRow.class);
 
     // When:
-    mapper.transform(key, value, ctx);
+    mapper.transform(key, value);
 
     // Then:
-    verify(resultMapper).transform(key, value, ctx);
+    verify(resultMapper).transform(key, value);
   }
 }

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableFilterBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableFilterBuilderTest.java
@@ -24,18 +24,18 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.materialization.MaterializationInfo;
 import io.confluent.ksql.execution.materialization.MaterializationInfo.TransformFactory;
+import io.confluent.ksql.execution.plan.ExecutionKeyFactory;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.ExecutionStepPropertiesV1;
-import io.confluent.ksql.execution.plan.PlanInfo;
 import io.confluent.ksql.execution.plan.KTableHolder;
-import io.confluent.ksql.execution.plan.ExecutionKeyFactory;
 import io.confluent.ksql.execution.plan.PlanBuilder;
+import io.confluent.ksql.execution.plan.PlanInfo;
 import io.confluent.ksql.execution.plan.TableFilter;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.transform.KsqlProcessingContext;
 import io.confluent.ksql.execution.transform.KsqlTransformer;
 import io.confluent.ksql.execution.transform.sqlpredicate.SqlPredicate;
@@ -131,9 +131,10 @@ public class TableFilterBuilderTest {
     final ExecutionStepPropertiesV1 properties = new ExecutionStepPropertiesV1(queryContext);
     step = new TableFilter<>(properties, sourceStep, filterExpression);
     when(sourceStep.build(any(), eq(planInfo))).thenReturn(
-        KTableHolder.materialized(sourceKTable, schema, executionKeyFactory, materializationBuilder))
+        KTableHolder.materialized(sourceKTable, schema, executionKeyFactory,
+            materializationBuilder))
     ;
-    when(preTransformer.transform(any(), any(), any())).thenReturn(Optional.empty());
+    when(preTransformer.transform(any(), any())).thenReturn(Optional.empty());
     planBuilder = new KSPlanBuilder(
         buildContext,
         predicateFactory,
@@ -199,21 +200,21 @@ public class TableFilterBuilderTest {
         .getValue()
         .apply(processingLogger);
 
-    when(preTransformer.transform(any(), any(), any())).thenReturn(Optional.empty());
+    when(preTransformer.transform(any(), any())).thenReturn(Optional.empty());
 
     // When:
-    Optional<GenericRow> result = predicate.transform(key, value, ctx);
+    Optional<GenericRow> result = predicate.transform(key, value);
 
     // Then:
-    verify(preTransformer).transform(key, value, ctx);
+    verify(preTransformer).transform(key, value);
     assertThat(result, is(Optional.empty()));
 
     // Given:
-    when(preTransformer.transform(any(), any(), any()))
+    when(preTransformer.transform(any(), any()))
         .thenAnswer(inv -> Optional.of(inv.getArgument(1)));
 
     // When:
-    result = predicate.transform(key, value, ctx);
+    result = predicate.transform(key, value);
 
     // Then:
     assertThat(result, is(Optional.of(value)));

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/KsqlMaterializationFactoryTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/KsqlMaterializationFactoryTest.java
@@ -177,7 +177,7 @@ public class KsqlMaterializationFactoryTest {
   public void shouldBuildMaterializationWithMapTransform() {
     // Given:
     factory.create(materialization, info, queryId, contextStacker);
-    when(mapper.transform(any(), any(), any())).thenReturn(rowOut);
+    when(mapper.transform(any(), any())).thenReturn(rowOut);
 
     final Transform transform = getTransform(0);
 
@@ -192,7 +192,7 @@ public class KsqlMaterializationFactoryTest {
   public void shouldBuildMaterializationWithNegativePredicateTransform() {
     // Given:
     factory.create(materialization, info, queryId, contextStacker);
-    when(predicate.transform(any(), any(), any())).thenReturn(Optional.empty());
+    when(predicate.transform(any(), any())).thenReturn(Optional.empty());
 
     final Transform transform = getTransform(1);
 
@@ -207,7 +207,7 @@ public class KsqlMaterializationFactoryTest {
   public void shouldBuildMaterializationWithPositivePredicateTransform() {
     // Given:
     factory.create(materialization, info, queryId, contextStacker);
-    when(predicate.transform(any(), any(), any()))
+    when(predicate.transform(any(), any()))
         .thenAnswer(inv -> Optional.of(inv.getArgument(1)));
 
     final Transform transform = getTransform(1);

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/transform/KsTransformerTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/transform/KsTransformerTest.java
@@ -60,8 +60,8 @@ public class KsTransformerTest {
     ksTransformer = new KsTransformer<>(ksqlKeyTransformer, ksqlValueTransformer);
     ksTransformer.init(ctx);
 
-    when(ksqlKeyTransformer.transform(any(), any(), any())).thenReturn(RESULT_KEY);
-    when(ksqlValueTransformer.transform(any(), any(), any())).thenReturn(RESULT_VALUE);
+    when(ksqlKeyTransformer.transform(any(), any())).thenReturn(RESULT_KEY);
+    when(ksqlValueTransformer.transform(any(), any())).thenReturn(RESULT_VALUE);
 
     when(ctx.timestamp()).thenReturn(ROWTIME);
   }
@@ -83,13 +83,11 @@ public class KsTransformerTest {
     // Then:
     verify(ksqlKeyTransformer).transform(
         eq(KEY),
-        eq(VALUE),
-        any()
+        eq(VALUE)
     );
     verify(ksqlValueTransformer).transform(
         eq(KEY),
-        eq(VALUE),
-        any()
+        eq(VALUE)
     );
   }
 
@@ -119,8 +117,7 @@ public class KsTransformerTest {
   private KsqlProcessingContext getKsqlProcessingContext() {
     verify(ksqlKeyTransformer).transform(
         any(),
-        any(),
-        ctxCaptor.capture()
+        any()
     );
 
     return ctxCaptor.getValue();

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/transform/KsValueTransformerTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/transform/KsValueTransformerTest.java
@@ -56,7 +56,7 @@ public class KsValueTransformerTest {
     ksTransformer = new KsValueTransformer<>(ksqlTransformer);
     ksTransformer.init(ctx);
 
-    when(ksqlTransformer.transform(any(), any(), any())).thenReturn(RESULT);
+    when(ksqlTransformer.transform(any(), any())).thenReturn(RESULT);
 
     when(ctx.timestamp()).thenReturn(ROWTIME);
   }
@@ -78,8 +78,7 @@ public class KsValueTransformerTest {
     // Then:
     verify(ksqlTransformer).transform(
         eq(KEY),
-        eq(VALUE),
-        any()
+        eq(VALUE)
     );
   }
 
@@ -109,8 +108,7 @@ public class KsValueTransformerTest {
   private KsqlProcessingContext getKsqlProcessingContext() {
     verify(ksqlTransformer).transform(
         any(),
-        any(),
-        ctxCaptor.capture()
+        any()
     );
 
     return ctxCaptor.getValue();


### PR DESCRIPTION
### Description 
KSQL transformer has an unused argument `ctx` across all its implementation. Current PR removes that. It is being done to ease the changes related to migration from kstream.transform to kstream.process function.

### Testing done 
Not doing it explicitly with this PR. Will do it with this [PR#10628](https://github.com/confluentinc/ksql/pull/10628) Master is broken and fix required is split into 2 PRs.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
