### PR TITLE
Fix path routed commands

### DIFF
--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlClient.java
@@ -130,7 +130,8 @@ public final class KsqlClient implements AutoCloseable {
     final HttpClient client = isUriTls ? httpTlsClient : httpNonTlsClient;
     return new KsqlTarget(client,
         socketAddressFactory.apply(server.getPort(), server.getHost()), localProperties,
-        authHeader, server.getHost(), additionalHeaders, RequestOptions.DEFAULT_TIMEOUT);
+        authHeader, server.getHost(), additionalHeaders, RequestOptions.DEFAULT_TIMEOUT,
+        server.getPath());
   }
 
   public KsqlTarget targetHttp2(final URI server) {
@@ -139,7 +140,8 @@ public final class KsqlClient implements AutoCloseable {
         () -> new IllegalStateException("Must provide http2 options to use targetHttp2"));
     return new KsqlTarget(client,
         socketAddressFactory.apply(server.getPort(), server.getHost()), localProperties,
-        authHeader, server.getHost(), Collections.emptyMap(), RequestOptions.DEFAULT_TIMEOUT);
+        authHeader, server.getHost(), Collections.emptyMap(), RequestOptions.DEFAULT_TIMEOUT,
+        server.getPath());
   }
 
   @VisibleForTesting

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
@@ -64,6 +64,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -117,7 +118,7 @@ public final class KsqlTarget {
     this.host = host;
     this.additionalHeaders = requireNonNull(additionalHeaders, "additionalHeaders");
     this.timeout = timeout;
-    this.subPath = subPath;
+    this.subPath = StringUtils.removeEnd(subPath, "/");
   }
 
   public KsqlTarget authorizationHeader(final String authHeader) {

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
@@ -90,6 +90,7 @@ public final class KsqlTarget {
   private final String host;
   private final Map<String, String> additionalHeaders;
   private final long timeout;
+  private final String subPath;
 
   /**
    * Create a KsqlTarget containing all of the connection information required to make a request
@@ -106,7 +107,8 @@ public final class KsqlTarget {
       final Optional<String> authHeader,
       final String host,
       final Map<String, String> additionalHeaders,
-      final long timeout
+      final long timeout,
+      final String subPath
   ) {
     this.httpClient = requireNonNull(httpClient, "httpClient");
     this.socketAddress = requireNonNull(socketAddress, "socketAddress");
@@ -115,23 +117,24 @@ public final class KsqlTarget {
     this.host = host;
     this.additionalHeaders = requireNonNull(additionalHeaders, "additionalHeaders");
     this.timeout = timeout;
+    this.subPath = subPath;
   }
 
   public KsqlTarget authorizationHeader(final String authHeader) {
     return new KsqlTarget(httpClient, socketAddress, localProperties,
-        Optional.of(authHeader), host, additionalHeaders, timeout);
+        Optional.of(authHeader), host, additionalHeaders, timeout, subPath);
   }
 
   public KsqlTarget properties(final Map<String, ?> properties) {
     return new KsqlTarget(httpClient, socketAddress,
         new LocalProperties(properties),
-        authHeader, host, additionalHeaders, timeout);
+        authHeader, host, additionalHeaders, timeout, subPath);
   }
 
   public KsqlTarget timeout(final long timeout) {
     return new KsqlTarget(httpClient, socketAddress,
         localProperties,
-        authHeader, host, additionalHeaders, timeout);
+        authHeader, host, additionalHeaders, timeout, subPath);
   }
 
   public RestResponse<ServerInfo> getServerInfo() {
@@ -503,7 +506,7 @@ public final class KsqlTarget {
     options.setServer(socketAddress);
     options.setPort(socketAddress.port());
     options.setHost(host);
-    options.setURI(path);
+    options.setURI(subPath + path);
     options.setTimeout(timeout);
 
     httpClient.request(options, ar -> {

--- a/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlTargetTest.java
+++ b/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlTargetTest.java
@@ -54,6 +54,7 @@ public class KsqlTargetTest {
 
   private static final String HOST = "host";
   private static final String QUERY = "SELECT * from RATINGS_TABLE;";
+  private static final String SUB_PATH = "";
 
   @Mock
   private HttpClient httpClient;
@@ -151,7 +152,7 @@ public class KsqlTargetTest {
   @Test
   public void shouldPostQueryRequest_chunkHandler() {
     ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST,
-        Collections.emptyMap(), RequestOptions.DEFAULT_TIMEOUT);
+        Collections.emptyMap(), RequestOptions.DEFAULT_TIMEOUT, SUB_PATH);
     executor.submit(this::expectPostQueryRequestChunkHandler);
     assertThatEventually(requestStarted::get, is(true));
 
@@ -167,7 +168,7 @@ public class KsqlTargetTest {
   @Test
   public void shouldPostQueryRequest_chunkHandler_exception() {
     ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST,
-        Collections.emptyMap(), RequestOptions.DEFAULT_TIMEOUT);
+        Collections.emptyMap(), RequestOptions.DEFAULT_TIMEOUT, SUB_PATH);
     executor.submit(this::expectPostQueryRequestChunkHandler);
 
     assertThatEventually(requestStarted::get, is(true));
@@ -183,7 +184,7 @@ public class KsqlTargetTest {
   public void shouldPostQueryRequest_chunkHandler_nonOkStatusCode() {
     when(httpClientResponse.statusCode()).thenReturn(BAD_REQUEST.code());
     ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST,
-        Collections.emptyMap(), RequestOptions.DEFAULT_TIMEOUT);
+        Collections.emptyMap(), RequestOptions.DEFAULT_TIMEOUT, SUB_PATH);
     executor.submit(this::expectPostQueryRequestChunkHandler);
 
     assertThatEventually(requestStarted::get, is(true));
@@ -198,7 +199,7 @@ public class KsqlTargetTest {
   @Test
   public void shouldPostQueryRequest_chunkHandler_closeEarly() {
     ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST,
-        Collections.emptyMap(), RequestOptions.DEFAULT_TIMEOUT);
+        Collections.emptyMap(), RequestOptions.DEFAULT_TIMEOUT, SUB_PATH);
     executor.submit(this::expectPostQueryRequestChunkHandler);
 
     assertThatEventually(requestStarted::get, is(true));
@@ -216,7 +217,7 @@ public class KsqlTargetTest {
   public void shouldPostQueryRequest_chunkHandler_closeEarlyWithError() {
     doThrow(new RuntimeException("Error!")).when(httpConnection).close();
     ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST,
-        Collections.emptyMap(), RequestOptions.DEFAULT_TIMEOUT);
+        Collections.emptyMap(), RequestOptions.DEFAULT_TIMEOUT, SUB_PATH);
     executor.submit(this::expectPostQueryRequestChunkHandler);
 
     assertThatEventually(requestStarted::get, is(true));
@@ -233,7 +234,7 @@ public class KsqlTargetTest {
   @Test
   public void shouldPostQueryRequest_chunkHandler_closeAfterFinish() {
     ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST,
-        Collections.emptyMap(), RequestOptions.DEFAULT_TIMEOUT);
+        Collections.emptyMap(), RequestOptions.DEFAULT_TIMEOUT, SUB_PATH);
     executor.submit(this::expectPostQueryRequestChunkHandler);
 
     assertThatEventually(requestStarted::get, is(true));
@@ -251,7 +252,7 @@ public class KsqlTargetTest {
   @Test
   public void shouldPostQueryRequest_chunkHandler_partialMessage() {
     ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST,
-        Collections.emptyMap(), RequestOptions.DEFAULT_TIMEOUT);
+        Collections.emptyMap(), RequestOptions.DEFAULT_TIMEOUT, SUB_PATH);
     executor.submit(this::expectPostQueryRequestChunkHandler);
 
     assertThatEventually(requestStarted::get, is(true));
@@ -272,7 +273,7 @@ public class KsqlTargetTest {
     // Given:
     final Map<String, String> additionalHeaders = ImmutableMap.of("h1", "v1", "h2", "v2");
     ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST,
-        additionalHeaders, RequestOptions.DEFAULT_TIMEOUT);
+        additionalHeaders, RequestOptions.DEFAULT_TIMEOUT, SUB_PATH);
 
     // When:
     executor.submit(() -> {
@@ -294,7 +295,7 @@ public class KsqlTargetTest {
   public void shouldUseTimeout() {
     // Given:
     ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST,
-        ImmutableMap.of(), 300L);
+        ImmutableMap.of(), 300L, SUB_PATH);
 
     // When:
     executor.submit(() -> {


### PR DESCRIPTION
### Description 
ksqldb-cli accepts server names with path based based routing but only uses host name for building the client. Added subPath in order to support path based routing to ksqldb servers. Fixes #6358.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
