### PR TITLE
fix: port placement when path based routing is used

### DIFF
--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -386,7 +386,12 @@ public final class KsqlRestClient implements Closeable {
     try {
       final URL url = new URL(serverAddress);
       if (url.getPort() == -1) {
-        return new URL(serverAddress.concat(":") + url.getDefaultPort()).toURI();
+        return new URL(
+          url.getProtocol(),
+          url.getHost(),
+          url.getDefaultPort(),
+          url.getPath() + (url.getQuery() != null ? "?" + url.getQuery() : "")
+        ).toURI();
       }
       return url.toURI();
     } catch (final Exception e) {

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -390,7 +390,7 @@ public final class KsqlRestClient implements Closeable {
           url.getProtocol(),
           url.getHost(),
           url.getDefaultPort(),
-          url.getPath() + (url.getQuery() != null ? "?" + url.getQuery() : "")
+          url.getFile())
         ).toURI();
       }
       return url.toURI();


### PR DESCRIPTION
### Description 
As per #10641, when path routing is used without port, port is appended to serverAddress resulting in incorrect endpoint.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
