### PR TITLE
KSQL-12882 | CVE fix for netty-common dependency.

### DIFF
--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
@@ -51,7 +51,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.security.auth.login.Configuration;
-import kafka.security.authorizer.AclAuthorizer;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -80,6 +79,7 @@ import org.apache.kafka.common.security.plain.PlainLoginModule;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.metadata.authorizer.StandardAuthorizer;
 import org.apache.kafka.test.TestUtils;
 import org.hamcrest.Matcher;
 import org.junit.rules.ExternalResource;
@@ -721,9 +721,8 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
     private final Map<AclKey, Set<AclOperation>> acls = new HashMap<>();
 
     Builder() {
-      brokerConfig.put(AUTHORIZER_CLASS_NAME_CONFIG, AclAuthorizer.class.getName());
-      brokerConfig.put(AclAuthorizer.AllowEveryoneIfNoAclIsFoundProp(),
-          true);
+      brokerConfig.put(AUTHORIZER_CLASS_NAME_CONFIG, StandardAuthorizer.class.getName());
+      brokerConfig.put("allow.everyone.if.no.acl.found", true);
       brokerConfig.put(LISTENERS_PROP, "PLAINTEXT://:0");
       brokerConfig.put(AUTO_CREATE_TOPICS_ENABLE_PROP, true);
     }
@@ -761,8 +760,8 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
     }
 
     public Builder withAclsEnabled(final String... superUsers) {
-      brokerConfig.remove(AclAuthorizer.AllowEveryoneIfNoAclIsFoundProp());
-      brokerConfig.put(AclAuthorizer.SuperUsersProp(),
+      brokerConfig.remove("allow.everyone.if.no.acl.found");
+      brokerConfig.put("super.users",
           Stream.concat(Arrays.stream(superUsers), Stream.of("broker"))
               .map(s -> "User:" + s)
               .collect(Collectors.joining(";")));

--- a/pom.xml
+++ b/pom.xml
@@ -143,15 +143,15 @@
         <apache.io.version>2.11.0</apache.io.version>
         <io.confluent.ksql.version>8.0.0-0</io.confluent.ksql.version>
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
-        <netty-tcnative-version>2.0.65.Final</netty-tcnative-version>
+        <netty-tcnative-version>2.0.69.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`
              we might need to bump `tcnative`, too.
              Please check top level `pom.xml` at https://github.com/netty/netty
              for the netty version we bump to (ie, corresponding git tag),
              to find the correct `tcnative` version. -->
-        <netty.version>4.1.113.Final</netty.version>
-        <netty-codec-http2-version>4.1.113.Final</netty-codec-http2-version>
+        <netty.version>4.1.115.Final</netty.version>
+        <netty-codec-http2-version>4.1.115.Final</netty-codec-http2-version>
         <jersey-common>2.39.1</jersey-common>
         <multi-threaded-testing.forkCount>3</multi-threaded-testing.forkCount>
         <kafka.version>${ce.kafka.version}</kafka.version>


### PR DESCRIPTION
### Description 
CVE fix for netty-common dependency.

### Testing done 
Unit and Integration tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
