### PR TITLE
KSQL-12936 | Fix the placement of default port number and capture the sub path while creating a client to ksqlDB.

### DIFF
--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlClient.java
@@ -132,7 +132,7 @@ public final class KsqlClient implements AutoCloseable {
     final HttpClient client = isUriTls ? httpTlsClient : httpNonTlsClient;
     return new KsqlTarget(client,
         socketAddressFactory.apply(server.getPort(), server.getHost()), localProperties,
-        basicAuthHeader, server.getHost(), additionalHeaders);
+        basicAuthHeader, server.getHost(), server.getPath(), additionalHeaders);
   }
 
   public KsqlTarget targetHttp2(final URI server) {
@@ -141,7 +141,7 @@ public final class KsqlClient implements AutoCloseable {
         () -> new IllegalStateException("Must provide http2 options to use targetHttp2"));
     return new KsqlTarget(client,
         socketAddressFactory.apply(server.getPort(), server.getHost()), localProperties,
-        basicAuthHeader, server.getHost(), Collections.emptyMap());
+        basicAuthHeader, server.getHost(), server.getPath(), Collections.emptyMap());
   }
 
   @VisibleForTesting

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -376,7 +376,12 @@ public final class KsqlRestClient implements Closeable {
     try {
       final URL url = new URL(serverAddress);
       if (url.getPort() == -1) {
-        return new URL(serverAddress.concat(":") + url.getDefaultPort()).toURI();
+        return new URL(
+                url.getProtocol(),
+                url.getHost(),
+                url.getDefaultPort(),
+                url.getFile()
+        ).toURI();
       }
       return url.toURI();
     } catch (final Exception e) {

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
@@ -86,6 +86,7 @@ public final class KsqlTarget {
   private final LocalProperties localProperties;
   private final Optional<String> authHeader;
   private final String host;
+  private final String subPath;
   private final Map<String, String> additionalHeaders;
 
   /**
@@ -95,6 +96,7 @@ public final class KsqlTarget {
    * @param localProperties Properties sent with ksql requests
    * @param authHeader Optional auth headers
    * @param host The hostname to use for the request, used to set the host header of the request
+   * @param subPath Optional path that can be provided with server name
    */
   KsqlTarget(
       final HttpClient httpClient,
@@ -102,6 +104,7 @@ public final class KsqlTarget {
       final LocalProperties localProperties,
       final Optional<String> authHeader,
       final String host,
+      final String subPath,
       final Map<String, String> additionalHeaders
   ) {
     this.httpClient = requireNonNull(httpClient, "httpClient");
@@ -109,18 +112,19 @@ public final class KsqlTarget {
     this.localProperties = requireNonNull(localProperties, "localProperties");
     this.authHeader = requireNonNull(authHeader, "authHeader");
     this.host = host;
+    this.subPath = subPath.replaceAll("/\\z", "");
     this.additionalHeaders = requireNonNull(additionalHeaders, "additionalHeaders");
   }
 
   public KsqlTarget authorizationHeader(final String authHeader) {
     return new KsqlTarget(httpClient, socketAddress, localProperties,
-        Optional.of(authHeader), host, additionalHeaders);
+        Optional.of(authHeader), host, subPath, additionalHeaders);
   }
 
   public KsqlTarget properties(final Map<String, ?> properties) {
     return new KsqlTarget(httpClient, socketAddress,
         new LocalProperties(properties),
-        authHeader, host, additionalHeaders);
+        authHeader, host, subPath, additionalHeaders);
   }
 
   public RestResponse<ServerInfo> getServerInfo() {
@@ -455,7 +459,7 @@ public final class KsqlTarget {
     options.setServer(socketAddress);
     options.setPort(socketAddress.port());
     options.setHost(host);
-    options.setURI(path);
+    options.setURI(subPath + path);
 
     httpClient.request(options, ar -> {
       if (ar.failed()) {

--- a/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlTargetTest.java
+++ b/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlTargetTest.java
@@ -53,6 +53,7 @@ public class KsqlTargetTest {
 
   private static final String HOST = "host";
   private static final String QUERY = "SELECT * from RATINGS_TABLE;";
+  private static final String SUB_PATH = "";
 
   @Mock
   private HttpClient httpClient;
@@ -147,7 +148,7 @@ public class KsqlTargetTest {
 
   @Test
   public void shouldPostQueryRequest_chunkHandler() {
-    ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST, Collections.emptyMap());
+    ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST, SUB_PATH, Collections.emptyMap());
     executor.submit(this::expectPostQueryRequestChunkHandler);
     assertThatEventually(requestStarted::get, is(true));
 
@@ -162,7 +163,7 @@ public class KsqlTargetTest {
 
   @Test
   public void shouldPostQueryRequest_chunkHandler_exception() {
-    ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST, Collections.emptyMap());
+    ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST, SUB_PATH, Collections.emptyMap());
     executor.submit(this::expectPostQueryRequestChunkHandler);
 
     assertThatEventually(requestStarted::get, is(true));
@@ -176,7 +177,7 @@ public class KsqlTargetTest {
 
   @Test
   public void shouldPostQueryRequest_chunkHandler_closeEarly() {
-    ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST, Collections.emptyMap());
+    ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST, SUB_PATH, Collections.emptyMap());
     executor.submit(this::expectPostQueryRequestChunkHandler);
 
     assertThatEventually(requestStarted::get, is(true));
@@ -193,7 +194,7 @@ public class KsqlTargetTest {
   @Test
   public void shouldPostQueryRequest_chunkHandler_closeEarlyWithError() {
     doThrow(new RuntimeException("Error!")).when(httpConnection).close();
-    ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST, Collections.emptyMap());
+    ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST, SUB_PATH, Collections.emptyMap());
     executor.submit(this::expectPostQueryRequestChunkHandler);
 
     assertThatEventually(requestStarted::get, is(true));
@@ -209,7 +210,7 @@ public class KsqlTargetTest {
 
   @Test
   public void shouldPostQueryRequest_chunkHandler_closeAfterFinish() {
-    ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST, Collections.emptyMap());
+    ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST, SUB_PATH, Collections.emptyMap());
     executor.submit(this::expectPostQueryRequestChunkHandler);
 
     assertThatEventually(requestStarted::get, is(true));
@@ -226,7 +227,7 @@ public class KsqlTargetTest {
 
   @Test
   public void shouldPostQueryRequest_chunkHandler_partialMessage() {
-    ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST, Collections.emptyMap());
+    ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST, SUB_PATH, Collections.emptyMap());
     executor.submit(this::expectPostQueryRequestChunkHandler);
 
     assertThatEventually(requestStarted::get, is(true));
@@ -246,7 +247,7 @@ public class KsqlTargetTest {
   public void shouldSendAdditionalHeadersWithKsqlRequest() {
     // Given:
     final Map<String, String> additionalHeaders = ImmutableMap.of("h1", "v1", "h2", "v2");
-    ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST, additionalHeaders);
+    ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST, SUB_PATH, additionalHeaders);
 
     // When:
     executor.submit(() -> {


### PR DESCRIPTION
### Description 
Fix the placement of default port number and capture the sub path while creating a client to ksqlDB.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
