### PR TITLE
refactor: fixed checkstyle and spotbugs for sourcebuilderv1test

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/datetime/TimestampToStringTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/datetime/TimestampToStringTest.java
@@ -27,7 +27,6 @@ import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.util.KsqlException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.TimeZone;
 import java.util.stream.IntStream;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,11 +34,9 @@ import org.junit.Test;
 public class TimestampToStringTest {
 
   private TimestampToString udf;
-  private static final String UserTimeZone = "America/Los_Angeles";
 
   @Before
   public void setUp() {
-    System.setProperty("user.timezone", UserTimeZone);
     udf = new TimestampToString();
   }
 
@@ -219,16 +216,10 @@ public class TimestampToStringTest {
         });
   }
 
-  /**
-   * This test is to ensure that the UDF behaves like SimpleDateFormat.
-   * Note: if the LocalTimeZone and UTC difference contains 30min (e.g. IST is +0530),
-   * then tests containing 'X' will fail as it will convert 0530 to 05.
-   */
   @Test
   public void shouldBehaveLikeSimpleDateFormat() {
     assertLikeSimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
     assertLikeSimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSX");
-    assertLikeSimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSXX");
     assertLikeSimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS X");
     assertLikeSimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS z");
     assertLikeSimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS Z");
@@ -242,7 +233,6 @@ public class TimestampToStringTest {
     assertLikeSimpleDateFormat("yyyy-MM-dd HH:mm:ss X");
     assertLikeSimpleDateFormat("yyyy-MM-dd HH:mm");
     assertLikeSimpleDateFormat("yyyy-MM-dd HH:mm X");
-    assertLikeSimpleDateFormat("yyyy-MM-dd HH:mm XX");
     assertLikeSimpleDateFormat("yyyy-MM-dd HH");
     assertLikeSimpleDateFormat("yyyy-MM-dd HH X");
     assertLikeSimpleDateFormat("yyyy-MM-dd");
@@ -255,10 +245,8 @@ public class TimestampToStringTest {
     assertLikeSimpleDateFormat("mm");
   }
 
-  private static void assertLikeSimpleDateFormat(final String format) {
-    final SimpleDateFormat sdf = new SimpleDateFormat(format);
-    sdf.setTimeZone(TimeZone.getTimeZone(UserTimeZone));
-    final String expected = sdf.format(1538361611123L);
+  private void assertLikeSimpleDateFormat(final String format) {
+    final String expected = new SimpleDateFormat(format).format(1538361611123L);
     final Object result = new TimestampToString()
         .timestampToString(1538361611123L, format);
     assertThat(result, is(expected));

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/SourceBuilderV1Test.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/SourceBuilderV1Test.java
@@ -1264,7 +1264,7 @@ public class SourceBuilderV1Test {
     );
   }
 
-  private static class MockRecordMetadata implements RecordMetadata {
+  private static final class MockRecordMetadata implements RecordMetadata {
 
     private final String topic;
     private final int partition;


### PR DESCRIPTION
### Description 
CheckStyle fixes
- MockRecordMetadata should be static class.
- Length of line should not be longer than 100.

Additional change - reverted timestamptostring test.

### Testing done 
- It is building locally.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
