### PR TITLE
fix: fixed udf config test to avoid write static from instance ctx err

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/DecimalUtil.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/DecimalUtil.java
@@ -271,7 +271,7 @@ public final class DecimalUtil {
   public static SqlType fromValue(final BigDecimal value) {
     // SqlDecimal does not support negative scale:
     final BigDecimal decimal = value.scale() < 0
-        ? value.setScale(0, BigDecimal.ROUND_UNNECESSARY)
+        ? value.setScale(0, RoundingMode.UNNECESSARY)
         : value;
 
     /* We can't use BigDecimal.precision() directly for all cases, since it defines

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
@@ -117,10 +117,9 @@ public class UdfLoaderTest {
   @Rule
   public TemporaryFolder tempFolder = KsqlTestFolder.temporaryFolder();
 
-  @SuppressFBWarnings("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD")
   @Before
   public void before() {
-    PASSED_CONFIG = null;
+    UdfConfigCapturer.getInstance().reset();
   }
 
   @Test
@@ -984,11 +983,12 @@ public class UdfLoaderTest {
     udf.newInstance(ksqlConfig);
 
     // Then:
-    assertThat(PASSED_CONFIG, is(notNullValue()));
-    assertThat(PASSED_CONFIG.keySet(), not(hasItem(KsqlConfig.KSQL_SERVICE_ID_CONFIG)));
-    assertThat(PASSED_CONFIG.get(KSQL_FUNCTIONS_PROPERTY_PREFIX + "configurableudf.some.setting"),
+    final Map<String, ?> capturedConfig = UdfConfigCapturer.getInstance().capturedConfig;
+    assertThat(capturedConfig, is(notNullValue()));
+    assertThat(capturedConfig.keySet(), not(hasItem(KsqlConfig.KSQL_SERVICE_ID_CONFIG)));
+    assertThat(capturedConfig.get(KSQL_FUNCTIONS_PROPERTY_PREFIX + "configurableudf.some.setting"),
         is("foo-bar"));
-    assertThat(PASSED_CONFIG.get(KSQL_FUNCTIONS_PROPERTY_PREFIX + "_global_.expected-param"),
+    assertThat(capturedConfig.get(KSQL_FUNCTIONS_PROPERTY_PREFIX + "_global_.expected-param"),
         is("expected-value"));
   }
 
@@ -1786,7 +1786,28 @@ public class UdfLoaderTest {
     }
   }
 
-  private static Map<String, ?> PASSED_CONFIG = null;
+  public static final class UdfConfigCapturer {
+    private static final UdfConfigCapturer INSTANCE = new UdfConfigCapturer();
+    private Map<String, ?> capturedConfig;
+
+    private UdfConfigCapturer() {}
+
+    public static UdfConfigCapturer getInstance() {
+      return INSTANCE;
+    }
+
+    public synchronized void setCapturedConfig(final Map<String, ?> config) {
+      this.capturedConfig = config;
+    }
+
+    public synchronized Map<String, ?> getCapturedConfig() {
+      return this.capturedConfig;
+    }
+
+    public synchronized void reset() {
+      this.capturedConfig = null;
+    }
+  }
 
   @SuppressWarnings({"unused", "MethodMayBeStatic"}) // Invoked via reflection in test.
   @UdfDescription(
@@ -1795,7 +1816,7 @@ public class UdfLoaderTest {
   public static class ConfigurableUdf implements Configurable {
     @Override
     public void configure(final Map<String, ?> map) {
-      PASSED_CONFIG = map;
+      UdfConfigCapturer.getInstance().setCapturedConfig(map);
     }
 
     @Udf


### PR DESCRIPTION
### Description 
Packaging flow is ignoring the warning suppression `ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD` and breaking. The current pr refactored the code to address that issue.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
