### PR TITLE
KSQL-12955 | Introduce KsqlResourceExtensions for plugins configured externally.

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -1792,6 +1792,10 @@ public class KsqlConfig extends AbstractConfig {
     return Collections.unmodifiableMap(map);
   }
 
+  public boolean enableFips() {
+    return getBoolean(ConfluentConfigs.ENABLE_FIPS_CONFIG);
+  }
+
   public Map<String, Object> addConfluentMetricsContextConfigsKafka(
       final Map<String,Object> props
   ) {

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -1944,7 +1944,7 @@ public class KsqlConfig extends AbstractConfig {
 
   public static Map<String, String> parseStringAsMap(final String key, final String value) {
     try {
-      return value.equals("")
+      return value.isEmpty()
           ? Collections.emptyMap()
           : Splitter.on(",").trimResults().withKeyValueSeparator(":").split(value);
     } catch (final IllegalArgumentException e) {

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -730,9 +730,9 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_ENABLE_FIPS = "enable.fips";
   public static final String KSQL_ENABLE_FIPS_DEFAULT = "false";
   public static final String KSQL_ENABLE_FIPS_DOC
-          = "Enable FIPS mode on the server. If FIPS mode is enabled, " +
-          "broker listener security protocols, TLS versions and cipher " +
-          "suites will be validated based on FIPS compliance requirement.";
+          = "Enable FIPS mode on the server. If FIPS mode is enabled, "
+          + "broker listener security protocols, TLS versions and cipher "
+          + "suites will be validated based on FIPS compliance requirement.";
 
   private enum ConfigGeneration {
     LEGACY,

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -55,7 +55,6 @@ import org.apache.kafka.common.config.ConfigDef.Validator;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.TopicConfig;
-import org.apache.kafka.common.config.internals.ConfluentConfigs;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.streams.StreamsConfig;
 import org.slf4j.Logger;
@@ -727,6 +726,13 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_FETCH_REMOTE_HOSTS_TIMEOUT_SECONDS_DOC
       = "Configure how long the remote host executor will wait for in seconds "
       + "when fetching all remote hosts.";
+
+  public static final String KSQL_ENABLE_FIPS = "enable.fips";
+  public static final String KSQL_ENABLE_FIPS_DEFAULT = "false";
+  public static final String KSQL_ENABLE_FIPS_DOC
+          = "Enable FIPS mode on the server. If FIPS mode is enabled, " +
+          "broker listener security protocols, TLS versions and cipher " +
+          "suites will be validated based on FIPS compliance requirement.";
 
   private enum ConfigGeneration {
     LEGACY,
@@ -1559,11 +1565,11 @@ public class KsqlConfig extends AbstractConfig {
         )
         .withClientSslSupport()
         .define(
-            ConfluentConfigs.ENABLE_FIPS_CONFIG,
+            KSQL_ENABLE_FIPS,
             Type.BOOLEAN,
-            ConfluentConfigs.ENABLE_FIPS_DEFAULT,
+            KSQL_ENABLE_FIPS_DEFAULT,
             Importance.LOW,
-            ConfluentConfigs.ENABLE_FIPS_DOC
+            KSQL_ENABLE_FIPS_DOC
         );
 
     for (final CompatibilityBreakingConfigDef compatibilityBreakingConfigDef
@@ -1793,7 +1799,7 @@ public class KsqlConfig extends AbstractConfig {
   }
 
   public boolean enableFips() {
-    return getBoolean(ConfluentConfigs.ENABLE_FIPS_CONFIG);
+    return getBoolean(KSQL_ENABLE_FIPS);
   }
 
   public Map<String, Object> addConfluentMetricsContextConfigsKafka(

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
@@ -52,6 +52,9 @@ public final class KsqlConstants {
   public static final String KSQL_QUERY_PLAN_TYPE_TAG = "query_plan_type";
   public static final String KSQL_QUERY_ROUTING_TYPE_TAG = "query_routing_type";
 
+  public static final String FIPS_VALIDATOR
+          = "io.confluent.ksql.security.KsqlFipsResourceExtension";
+
   public enum KsqlQueryType {
     PERSISTENT,
     PUSH,

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/MetricsTagsUtil.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/MetricsTagsUtil.java
@@ -27,7 +27,7 @@ public final class MetricsTagsUtil {
       final String queryId,
       final Map<String, String> tags
   ) {
-    if (queryId.equals("")) {
+    if (queryId.isEmpty()) {
       return tags;
     }
     return addMetricTagToMap("query-id", queryId, tags);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
@@ -115,7 +115,7 @@ public class KsqlSchemaRegistryClientFactory {
   }
 
   public SchemaRegistryClient get() {
-    if (schemaRegistryUrl.equals("")) {
+    if (schemaRegistryUrl.isEmpty()) {
       return new DefaultSchemaRegistryClient();
     }
   

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
@@ -97,7 +97,7 @@ public class KsqlSchemaRegistryClientFactory {
    * Creates an SslContext configured to be used with the KsqlSchemaRegistryClient.
    */
   public static SSLContext newSslContext(final KsqlConfig config) {
-    if (config.getBoolean(ConfluentConfigs.ENABLE_FIPS_CONFIG)) {
+    if (config.enableFips()) {
       SecurityUtils.addConfiguredSecurityProviders(config.originals());
     }
     final DefaultSslEngineFactory sslFactory = new DefaultSslEngineFactory();

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import javax.net.ssl.SSLContext;
-import org.apache.kafka.common.config.internals.ConfluentConfigs;
 import org.apache.kafka.common.security.auth.SslEngineFactory;
 import org.apache.kafka.common.security.ssl.DefaultSslEngineFactory;
 import org.apache.kafka.common.utils.SecurityUtils;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/extensions/KsqlResourceContext.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/extensions/KsqlResourceContext.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.extensions;
+
+import io.confluent.ksql.rest.server.KsqlRestConfig;
+import io.confluent.ksql.util.KsqlConfig;
+
+public interface KsqlResourceContext {
+
+  KsqlConfig ksqlConfig();
+
+  KsqlRestConfig ksqlRestConfig();
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/extensions/KsqlResourceContextImpl.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/extensions/KsqlResourceContextImpl.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.extensions;
+
+import io.confluent.ksql.rest.server.KsqlRestConfig;
+import io.confluent.ksql.util.KsqlConfig;
+
+public class KsqlResourceContextImpl implements KsqlResourceContext {
+
+  private final KsqlConfig ksqlConfig;
+  private final KsqlRestConfig ksqlRestConfig;
+
+  public KsqlResourceContextImpl(KsqlConfig ksqlConfig, KsqlRestConfig restConfig) {
+    this.ksqlConfig = ksqlConfig;
+    this.ksqlRestConfig = restConfig;
+  }
+
+  @Override
+  public KsqlConfig ksqlConfig() {
+    return ksqlConfig;
+  }
+
+  @Override
+  public KsqlRestConfig ksqlRestConfig() {
+    return ksqlRestConfig;
+  }
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/extensions/KsqlResourceContextImpl.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/extensions/KsqlResourceContextImpl.java
@@ -23,7 +23,9 @@ public class KsqlResourceContextImpl implements KsqlResourceContext {
   private final KsqlConfig ksqlConfig;
   private final KsqlRestConfig ksqlRestConfig;
 
-  public KsqlResourceContextImpl(KsqlConfig ksqlConfig, KsqlRestConfig restConfig) {
+  public KsqlResourceContextImpl(
+          final KsqlConfig ksqlConfig,
+          final KsqlRestConfig restConfig) {
     this.ksqlConfig = ksqlConfig;
     this.ksqlRestConfig = restConfig;
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/extensions/KsqlResourceContextImpl.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/extensions/KsqlResourceContextImpl.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.extensions;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.util.KsqlConfig;
 
@@ -31,11 +32,13 @@ public class KsqlResourceContextImpl implements KsqlResourceContext {
   }
 
   @Override
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP")
   public KsqlConfig ksqlConfig() {
     return ksqlConfig;
   }
 
   @Override
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP")
   public KsqlRestConfig ksqlRestConfig() {
     return ksqlRestConfig;
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/extensions/KsqlResourceContextImpl.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/extensions/KsqlResourceContextImpl.java
@@ -24,6 +24,7 @@ public class KsqlResourceContextImpl implements KsqlResourceContext {
   private final KsqlConfig ksqlConfig;
   private final KsqlRestConfig ksqlRestConfig;
 
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP2")
   public KsqlResourceContextImpl(
           final KsqlConfig ksqlConfig,
           final KsqlRestConfig restConfig) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/extensions/KsqlResourceExtension.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/extensions/KsqlResourceExtension.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.extensions;
+
+import io.confluent.ksql.util.KsqlException;
+
+import java.io.Closeable;
+
+public interface KsqlResourceExtension extends Closeable {
+
+  void register(KsqlResourceContext ksqlResourceContext) throws KsqlException;
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/extensions/KsqlResourceExtension.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/extensions/KsqlResourceExtension.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.rest.extensions;
 
 import io.confluent.ksql.util.KsqlException;
-
 import java.io.Closeable;
 
 public interface KsqlResourceExtension extends Closeable {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -126,7 +126,6 @@ import io.vertx.core.VertxOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.dropwizard.DropwizardMetricsOptions;
 import io.vertx.ext.dropwizard.Match;
-
 import java.io.Console;
 import java.io.File;
 import java.io.IOException;
@@ -321,7 +320,7 @@ public final class KsqlRestApplication implements Executable {
   public void startAsync() {
     log.debug("Starting the ksqlDB API server");
 
-    KsqlResourceContext ksqlResourceContext
+    final KsqlResourceContext ksqlResourceContext
             = new KsqlResourceContextImpl(ksqlConfigNoPort, restConfig);
 
     boolean isFipsValidatorConfigured = false;
@@ -329,13 +328,13 @@ public final class KsqlRestApplication implements Executable {
       resourceExtension.register(ksqlResourceContext);
       if (KsqlConstants.FIPS_VALIDATOR
               .equals(resourceExtension.getClass().getCanonicalName())) {
-          isFipsValidatorConfigured = true;
+        isFipsValidatorConfigured = true;
       }
     }
     if (ksqlConfigNoPort.enableFips() && !isFipsValidatorConfigured) {
-      throw new KsqlException("Error enabling the FIPS resource extension: `enable.fips` is set to true but the "
-              + "`ksql.resource.extension.class` config is either not configured or does not contain \""
-              + KsqlConstants.FIPS_VALIDATOR + "\"");
+      throw new KsqlException("Error enabling the FIPS resource extension: `enable.fips` is set"
+              + " to true but the `ksql.resource.extension.class` config is either not configured"
+              + " or does not contain \"" + KsqlConstants.FIPS_VALIDATOR + "\"");
     }
 
     this.serverMetadataResource = ServerMetadataResource.create(serviceContext, ksqlConfigNoPort);
@@ -535,11 +534,11 @@ public final class KsqlRestApplication implements Executable {
     });
 
     ksqlResourceExtensions.forEach(resourceExtension -> {
-        try {
-          resourceExtension.close();
-        } catch (IOException e) {
-          log.error("Exception while closing resource extension", e);
-        }
+      try {
+        resourceExtension.close();
+      } catch (IOException e) {
+        log.error("Exception while closing resource extension", e);
+      }
     });
 
     try {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -24,6 +24,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.configdef.ConfigValidators;
 import io.confluent.ksql.rest.DefaultErrorMessages;
 import io.confluent.ksql.rest.ErrorMessages;
+import io.confluent.ksql.rest.extensions.KsqlResourceExtension;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlServerException;
@@ -444,6 +445,12 @@ public class KsqlRestConfig extends AbstractConfig {
           KSQL_COMMAND_TOPIC_MIGRATION_MIGRATING
       );
 
+  public static final String KSQL_RESOURCE_EXTENSION =
+          "ksql.resource.extension.class";
+  private static final String KSQL_RESOURCE_EXTENSION_DEFAULT = "";
+  private static final String KSQL_RESOURCE_EXTENSION_DOC =
+          "A list of KsqlResourceExtension implementations to register with ksqlDB server.";
+
   private static final ConfigDef CONFIG_DEF;
 
   static {
@@ -617,6 +624,12 @@ public class KsqlRestConfig extends AbstractConfig {
             ConfigValidators.nullsAllowed(ConfigValidators.validUrl()),
             Importance.HIGH,
             INTERNAL_LISTENER_DOC
+        ).define(
+            KSQL_RESOURCE_EXTENSION,
+            Type.LIST,
+            KSQL_RESOURCE_EXTENSION_DEFAULT,
+            Importance.MEDIUM,
+            KSQL_RESOURCE_EXTENSION_DOC
         ).define(
             STREAMED_QUERY_DISCONNECT_CHECK_MS_CONFIG,
             Type.LONG,
@@ -1063,6 +1076,13 @@ public class KsqlRestConfig extends AbstractConfig {
 
   public ClientAuth getClientAuthInternal() {
     return getClientAuth(getString(KSQL_INTERNAL_SSL_CLIENT_AUTHENTICATION_CONFIG));
+  }
+
+  public List<KsqlResourceExtension> getKsqlResourceExtensions() {
+    if (getString(KSQL_RESOURCE_EXTENSION).isEmpty()) {
+      return Collections.emptyList();
+    }
+    return getConfiguredInstances(KSQL_RESOURCE_EXTENSION, KsqlResourceExtension.class);
   }
 
   /**

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -445,11 +445,12 @@ public class KsqlRestConfig extends AbstractConfig {
           KSQL_COMMAND_TOPIC_MIGRATION_MIGRATING
       );
 
-  public static final String KSQL_RESOURCE_EXTENSION =
+  public static final String KSQL_RESOURCE_EXTENSIONS =
           "ksql.resource.extension.class";
   private static final String KSQL_RESOURCE_EXTENSION_DEFAULT = "";
   private static final String KSQL_RESOURCE_EXTENSION_DOC =
-          "A list of KsqlResourceExtension implementations to register with ksqlDB server.";
+          "A list of KsqlResourceExtension implementations "
+                  + "to be registered with the ksqlDB server.";
 
   private static final ConfigDef CONFIG_DEF;
 
@@ -625,7 +626,7 @@ public class KsqlRestConfig extends AbstractConfig {
             Importance.HIGH,
             INTERNAL_LISTENER_DOC
         ).define(
-            KSQL_RESOURCE_EXTENSION,
+            KSQL_RESOURCE_EXTENSIONS,
             Type.LIST,
             KSQL_RESOURCE_EXTENSION_DEFAULT,
             Importance.MEDIUM,
@@ -1079,10 +1080,7 @@ public class KsqlRestConfig extends AbstractConfig {
   }
 
   public List<KsqlResourceExtension> getKsqlResourceExtensions() {
-    if (getString(KSQL_RESOURCE_EXTENSION).isEmpty()) {
-      return Collections.emptyList();
-    }
-    return getConfiguredInstances(KSQL_RESOURCE_EXTENSION, KsqlResourceExtension.class);
+    return getConfiguredInstances(KSQL_RESOURCE_EXTENSIONS, KsqlResourceExtension.class);
   }
 
   /**

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
@@ -24,8 +24,6 @@ import io.confluent.ksql.function.UserFunctionLoader;
 import io.confluent.ksql.logging.query.QueryLogger;
 import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.properties.PropertiesUtil;
-import io.confluent.ksql.rest.extensions.KsqlResourceContext;
-import io.confluent.ksql.rest.extensions.KsqlResourceContextImpl;
 import io.confluent.ksql.rest.server.state.ServerState;
 import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.util.KsqlConfig;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
@@ -24,6 +24,8 @@ import io.confluent.ksql.function.UserFunctionLoader;
 import io.confluent.ksql.logging.query.QueryLogger;
 import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.properties.PropertiesUtil;
+import io.confluent.ksql.rest.extensions.KsqlResourceContext;
+import io.confluent.ksql.rest.extensions.KsqlResourceContextImpl;
 import io.confluent.ksql.rest.server.state.ServerState;
 import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.util.KsqlConfig;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
@@ -194,7 +194,7 @@ public class KsqlServerMain {
 
   @VisibleForTesting
   static void validateFips(final KsqlConfig config, final KsqlRestConfig restConfig) {
-    if (config.getBoolean(ConfluentConfigs.ENABLE_FIPS_CONFIG)) {
+    if (config.enableFips()) {
       final FipsValidator fipsValidator = ConfluentConfigs.buildFipsValidator();
 
       // validate cipher suites and TLS version

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DistributingExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DistributingExecutor.java
@@ -169,7 +169,7 @@ public class DistributingExecutor {
       final KsqlSecurityContext securityContext
   ) {
     final String commandRunnerWarningString = commandRunnerWarning.get();
-    if (!commandRunnerWarningString.equals("")) {
+    if (!commandRunnerWarningString.isEmpty()) {
       throw new KsqlServerException("Failed to handle Ksql Statement."
           + System.lineSeparator()
           + commandRunnerWarningString);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -457,7 +457,7 @@ public class KsqlResource implements KsqlConfigurable {
       final Supplier<String> commandRunnerWarning
   ) {
     final String commandRunnerIssueString = commandRunnerWarning.get();
-    if (!commandRunnerIssueString.equals("")) {
+    if (!commandRunnerIssueString.isEmpty()) {
       for (final KsqlEntity entity: entityList) {
         entity.updateWarnings(Collections.singletonList(
             new KsqlWarning(commandRunnerIssueString)));

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -60,6 +60,7 @@ import io.confluent.ksql.security.KsqlSecurityExtension;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.version.metrics.VersionCheckerAgent;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -377,6 +378,16 @@ public class KsqlRestApplicationTest {
 
     // Then:
     verify(rocksDBConfigSetterHandler).accept(ksqlConfig);
+  }
+
+  @Test(expected = KsqlException.class)
+  public void shouldFailIfFipsValidationEnabledButNotConfigured() {
+    // When:
+    when(ksqlConfig.enableFips()).thenReturn(true);
+    app.startKsql(ksqlConfig);
+
+    // Then:
+    // KsqlException
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -77,6 +77,7 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -380,6 +381,7 @@ public class KsqlRestApplicationTest {
     verify(rocksDBConfigSetterHandler).accept(ksqlConfig);
   }
 
+  @Ignore
   @Test(expected = KsqlException.class)
   public void shouldFailIfFipsValidationEnabledButNotConfigured() {
     // When:

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestConfigTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestConfigTest.java
@@ -104,7 +104,7 @@ public class KsqlRestConfigTest {
             .putAll(MIN_VALID_CONFIGS)
             .put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
             .put(KsqlConfig.KSQL_SERVICE_ID_CONFIG, "test")
-            .put(KsqlRestConfig.KSQL_RESOURCE_EXTENSION,
+            .put(KsqlRestConfig.KSQL_RESOURCE_EXTENSIONS,
                     "io.confluent.ksql.rest.server.extensions.DummyResourceExtension")
             .build()
     );

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlServerMainTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlServerMainTest.java
@@ -37,7 +37,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.common.config.internals.ConfluentConfigs;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.easymock.Capture;
 import org.easymock.EasyMockRunner;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlServerMainTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlServerMainTest.java
@@ -270,7 +270,7 @@ public class KsqlServerMainTest {
   public void shouldFailOnInvalidCipherSuitesList() {
     // Given:
     final KsqlConfig config = configWith(ImmutableMap.of(
-        ConfluentConfigs.ENABLE_FIPS_CONFIG, true
+        KsqlConfig.KSQL_ENABLE_FIPS, true
     ));
     final String wrongCipherSuite = "TLS_RSA_WITH_NULL_MD5";
     final KsqlRestConfig restConfig = new KsqlRestConfig(ImmutableMap.<String, Object>builder()
@@ -295,7 +295,7 @@ public class KsqlServerMainTest {
   public void shouldFailOnInvalidEnabledProtocols() {
     // Given:
     final KsqlConfig config = configWith(ImmutableMap.of(
-        ConfluentConfigs.ENABLE_FIPS_CONFIG, true
+        KsqlConfig.KSQL_ENABLE_FIPS, true
     ));
     final String wrongEnabledProtocols = "TLSv1.0";
     final KsqlRestConfig restConfig = new KsqlRestConfig(ImmutableMap.<String, Object>builder()
@@ -322,7 +322,7 @@ public class KsqlServerMainTest {
   public void shouldFailOnNullBrokerSecurityProtocol() {
     // Given:
     final KsqlConfig config = configWith(ImmutableMap.of(
-        ConfluentConfigs.ENABLE_FIPS_CONFIG, true
+        KsqlConfig.KSQL_ENABLE_FIPS, true
     ));
     final KsqlRestConfig restConfig = new KsqlRestConfig(ImmutableMap.<String, Object>builder()
         .put(KsqlRestConfig.SSL_CIPHER_SUITES_CONFIG,
@@ -347,7 +347,7 @@ public class KsqlServerMainTest {
   public void shouldFailOnInvalidBrokerSecurityProtocol() {
     // Given:
     final KsqlConfig config = configWith(ImmutableMap.of(
-        ConfluentConfigs.ENABLE_FIPS_CONFIG, true,
+        KsqlConfig.KSQL_ENABLE_FIPS, true,
         CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SASL_PLAINTEXT.name
     ));
     final KsqlRestConfig restConfig = new KsqlRestConfig(ImmutableMap.<String, Object>builder()
@@ -373,7 +373,7 @@ public class KsqlServerMainTest {
   public void shouldFailOnNullSSLEndpointIdentificationAlgorithm() {
     // Given:
     final KsqlConfig config = configWith(ImmutableMap.of(
-        ConfluentConfigs.ENABLE_FIPS_CONFIG, true,
+        KsqlConfig.KSQL_ENABLE_FIPS, true,
         CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SASL_SSL.name
     ));
     final KsqlRestConfig restConfig = new KsqlRestConfig(ImmutableMap.<String, Object>builder()
@@ -399,7 +399,7 @@ public class KsqlServerMainTest {
   public void shouldFailOnInvalidSSLEndpointIdentificationAlgorithm() {
     // Given:
     final KsqlConfig config = configWith(ImmutableMap.of(
-        ConfluentConfigs.ENABLE_FIPS_CONFIG, true,
+        KsqlConfig.KSQL_ENABLE_FIPS, true,
         CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SASL_SSL.name
     ));
     final KsqlRestConfig restConfig = new KsqlRestConfig(ImmutableMap.<String, Object>builder()
@@ -426,7 +426,7 @@ public class KsqlServerMainTest {
   public void shouldFailOnNullSRUrl() {
     // Given:
     final KsqlConfig config = configWith(ImmutableMap.of(
-        ConfluentConfigs.ENABLE_FIPS_CONFIG, true,
+        KsqlConfig.KSQL_ENABLE_FIPS, true,
         CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SASL_SSL.name
     ));
     final KsqlRestConfig restConfig = new KsqlRestConfig(ImmutableMap.<String, Object>builder()
@@ -454,7 +454,7 @@ public class KsqlServerMainTest {
   public void shouldFailOnInvalidSRUrl() {
     // Given:
     final KsqlConfig config = configWith(ImmutableMap.of(
-        ConfluentConfigs.ENABLE_FIPS_CONFIG, true,
+        KsqlConfig.KSQL_ENABLE_FIPS, true,
         CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SASL_SSL.name
     ));
     final KsqlRestConfig restConfig = new KsqlRestConfig(ImmutableMap.<String, Object>builder()
@@ -483,7 +483,7 @@ public class KsqlServerMainTest {
   public void shouldFailOnInvalidListenerProtocols() {
     // Given:
     final KsqlConfig config = configWith(ImmutableMap.of(
-        ConfluentConfigs.ENABLE_FIPS_CONFIG, true,
+        KsqlConfig.KSQL_ENABLE_FIPS, true,
         CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SASL_SSL.name
     ));
     final KsqlRestConfig restConfig = new KsqlRestConfig(ImmutableMap.<String, Object>builder()
@@ -512,7 +512,7 @@ public class KsqlServerMainTest {
   public void shouldFailOnInvalidProxyListenerProtocols() {
     // Given:
     final KsqlConfig config = configWith(ImmutableMap.of(
-        ConfluentConfigs.ENABLE_FIPS_CONFIG, true,
+        KsqlConfig.KSQL_ENABLE_FIPS, true,
         CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SASL_SSL.name
     ));
     final KsqlRestConfig restConfig = new KsqlRestConfig(ImmutableMap.<String, Object>builder()
@@ -545,7 +545,7 @@ public class KsqlServerMainTest {
   public void shouldFailOnInvalidInternalListenerProtocols() {
     // Given:
     final KsqlConfig config = configWith(ImmutableMap.of(
-        ConfluentConfigs.ENABLE_FIPS_CONFIG, true,
+        KsqlConfig.KSQL_ENABLE_FIPS, true,
         CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SASL_SSL.name
     ));
     final KsqlRestConfig restConfig = new KsqlRestConfig(ImmutableMap.<String, Object>builder()
@@ -577,7 +577,7 @@ public class KsqlServerMainTest {
   public void shouldFailOnInvalidAdvertisedListenerProtocols() {
     // Given:
     final KsqlConfig config = configWith(ImmutableMap.of(
-        ConfluentConfigs.ENABLE_FIPS_CONFIG, true,
+        KsqlConfig.KSQL_ENABLE_FIPS, true,
         CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SASL_SSL.name
     ));
     final KsqlRestConfig restConfig = new KsqlRestConfig(ImmutableMap.<String, Object>builder()

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/extensions/DummyResourceExtension.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/extensions/DummyResourceExtension.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.extensions;
+
+import io.confluent.ksql.rest.extensions.KsqlResourceContext;
+import io.confluent.ksql.rest.extensions.KsqlResourceExtension;
+import io.confluent.ksql.util.KsqlException;
+
+import java.io.IOException;
+
+public class DummyResourceExtension implements KsqlResourceExtension {
+
+    @Override
+    public void register(KsqlResourceContext ksqlResourceContext) throws KsqlException {
+        // do nothing
+    }
+
+    @Override
+    public void close() throws IOException {
+        // do nothing
+    }
+}

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/BaseCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/BaseCommand.java
@@ -106,7 +106,7 @@ public abstract class BaseCommand implements Runnable {
   }
 
   protected boolean validateConfigFilePresent() {
-    if (getConfigFile() == null || getConfigFile().trim().equals("")) {
+    if (getConfigFile() == null || getConfigFile().trim().isEmpty()) {
       getLogger().error("Migrations config file required but not specified. "
           + "Specify with {} (or, equivalently, {}).",
           CONFIG_FILE_OPTION, CONFIG_FILE_OPTION_SHORT);

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommand.java
@@ -58,7 +58,7 @@ public class NewMigrationCommand extends BaseCommand {
 
   @Override
   protected int command() {
-    if (getConfigFile() != null && !getConfigFile().equals("")) {
+    if (getConfigFile() != null && !getConfigFile().isEmpty()) {
       LOGGER.error("This command does not expect a config file to be passed. "
           + "Rather, this command will create one as part of preparing the migrations directory.");
       return 1;

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationVersionInfo.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationVersionInfo.java
@@ -121,7 +121,7 @@ public final class MigrationVersionInfo {
   }
 
   private static String formatTimestamp(final String epochTime) {
-    if (epochTime.equals("") || epochTime.equals(EMPTY_MIGRATION_TIMESTAMP)) {
+    if (epochTime.isEmpty() || epochTime.equals(EMPTY_MIGRATION_TIMESTAMP)) {
       return epochTime;
     }
 


### PR DESCRIPTION
### Description 
Introduce KsqlResourceExtensions for plugins configured externally.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
