### PR TITLE
remove jetty pin / outdated comment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,8 +136,6 @@
         <skip.docker.test>true</skip.docker.test>
         <!-- Temporarily disabling this because it is causing failures in packaging but not CI builds. -->
         <!-- <compile.warnings-flag>-Werror</compile.warnings-flag> -->
-        <!-- Only used to provide login module implementation for tests -->
-        <jetty.version>9.4.53.v20231009</jetty.version>
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
         <apache.io.version>2.14.0</apache.io.version>
         <io.confluent.ksql.version>7.1.16-0</io.confluent.ksql.version>


### PR DESCRIPTION
### Description 
Remove the pin of jetty and use version defined in common

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.
