### PR TITLE
Bouncy Castle and SunJSSE compatibility fix.

### DIFF
--- a/ksqldb-common/pom.xml
+++ b/ksqldb-common/pom.xml
@@ -129,6 +129,14 @@
             <version>${guava.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bc-fips</artifactId>
+            <version>${bouncycastle.fips.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/ksqldb-common/pom.xml
+++ b/ksqldb-common/pom.xml
@@ -106,6 +106,14 @@
         <version>${io.confluent.ksql.version}</version>
       </dependency>
 
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bctls-fips</artifactId>
+            <version>${bouncycastle.tls-fips.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+
         <!-- Required for running tests -->
 
         <dependency>

--- a/ksqldb-common/src/main/java/io/confluent/ksql/security/oauth/OAuthBearerCredentials.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/security/oauth/OAuthBearerCredentials.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.security.oauth;
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.security.Credentials;
 import io.confluent.ksql.security.KsqlClientConfig;
+import io.confluent.ksql.security.ssl.HostSslSocketFactory;
 import java.net.URL;
 import java.util.Map;
 import javax.net.ssl.SSLSocketFactory;
@@ -104,7 +105,8 @@ public class OAuthBearerCredentials implements Credentials {
         KsqlClientConfig.BEARER_AUTH_TOKEN_ENDPOINT_URL);
 
     if (jaasOptionsUtils.shouldCreateSSLSocketFactory(tokenEndpointUrl)) {
-      socketFactory = jaasOptionsUtils.createSSLSocketFactory();
+      socketFactory = new HostSslSocketFactory(jaasOptionsUtils.createSSLSocketFactory(),
+              tokenEndpointUrl.getHost());
     }
 
     return new HttpAccessTokenRetriever(clientId, clientSecret, scope, socketFactory,

--- a/ksqldb-common/src/main/java/io/confluent/ksql/security/ssl/HostSslSocketFactory.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/security/ssl/HostSslSocketFactory.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.security.ssl;
+
+import com.google.common.base.Strings;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.security.Provider;
+import java.security.Security;
+import javax.net.ssl.SSLSocketFactory;
+import org.bouncycastle.jsse.BCSSLSocket;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is a wrapper class on top of {@link SSLSocketFactory} to address
+ * issue where host name is not set on {@link BCSSLSocket} when creating a socket.
+ */
+public class HostSslSocketFactory extends SSLSocketFactory {
+
+  private static final Logger log = LoggerFactory.getLogger(HostSslSocketFactory.class);
+
+  private final SSLSocketFactory sslSocketFactory;
+  private final String peerHost;
+
+  private static final String BC_FIPS_SSL_PROVIDER = "BCJSSE";
+  private static final String BC_FIPS_SECURITY_PROVIDER = "BCFIPS";
+
+  public HostSslSocketFactory(final SSLSocketFactory sslSocketFactory, final String peerHost) {
+    this.sslSocketFactory = sslSocketFactory;
+    this.peerHost = peerHost;
+  }
+
+  @Override
+  public String[] getDefaultCipherSuites() {
+    return sslSocketFactory.getDefaultCipherSuites();
+  }
+
+  @Override
+  public String[] getSupportedCipherSuites() {
+    return sslSocketFactory.getSupportedCipherSuites();
+  }
+
+  @Override
+  public Socket createSocket(final Socket socket,
+                             final String host, final int port, final boolean autoClose)
+          throws IOException {
+    return interceptAndSetHost(sslSocketFactory.createSocket(socket, host, port, autoClose));
+  }
+
+  @Override
+  public Socket createSocket() throws IOException {
+    final Socket socket = sslSocketFactory.createSocket();
+    return interceptAndSetHost(socket);
+  }
+
+  @Override
+  public Socket createSocket(final String host, final int port) throws IOException {
+    final Socket socket = sslSocketFactory.createSocket(host, port);
+    return interceptAndSetHost(socket);
+  }
+
+  @Override
+  public Socket createSocket(final String host,
+                             final int port, final InetAddress localAddress, final int localPort)
+          throws IOException {
+    final Socket socket = sslSocketFactory.createSocket(host, port, localAddress, localPort);
+    return interceptAndSetHost(socket);
+  }
+
+  @Override
+  public Socket createSocket(final InetAddress address, final int port) throws IOException {
+    final Socket socket = sslSocketFactory.createSocket(address, port);
+    return interceptAndSetHost(socket);
+  }
+
+  @Override
+  public Socket createSocket(final InetAddress address,
+                             final int port, final InetAddress remoteAddress,
+                             final int remotePort) throws IOException {
+    final Socket socket = sslSocketFactory.createSocket(address, port, remoteAddress, remotePort);
+    return interceptAndSetHost(socket);
+  }
+
+  @Override
+  public Socket createSocket(final Socket socket,
+                             final InputStream inputStream, final boolean autoClose)
+          throws IOException {
+    return interceptAndSetHost(sslSocketFactory.createSocket(socket, inputStream, autoClose));
+  }
+
+  private Socket interceptAndSetHost(final Socket socket) {
+    if (peerHost != null && isFipsDeployment() && socket instanceof BCSSLSocket) {
+      final BCSSLSocket bcsslSocket = (BCSSLSocket) socket;
+      if (!Strings.isNullOrEmpty(peerHost)) {
+        log.debug("Setting hostname on Bouncy Castle SSL socket: {}", peerHost);
+        bcsslSocket.setHost(peerHost);
+      }
+    }
+    return socket;
+  }
+
+  public static boolean isFipsDeployment() {
+    final Provider bcFipsProvider = Security.getProvider(BC_FIPS_SECURITY_PROVIDER);
+    final Provider bcFipsJsseProvider = Security.getProvider(BC_FIPS_SSL_PROVIDER);
+    return (bcFipsProvider != null) && (bcFipsJsseProvider != null);
+  }
+
+}

--- a/ksqldb-common/src/test/java/io/confluent/ksql/security/ssl/HostSslSocketFactoryTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/security/ssl/HostSslSocketFactoryTest.java
@@ -1,0 +1,44 @@
+package io.confluent.ksql.security.ssl;
+
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import org.bouncycastle.jsse.provider.BouncyCastleJsseProvider;
+import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
+
+import org.bouncycastle.jsse.BCSSLSocket;
+import org.mockito.Mockito;
+
+import javax.net.ssl.SSLSocketFactory;
+import java.io.IOException;
+import java.net.Socket;
+import java.security.Security;
+
+class HostSslSocketFactoryTest {
+  private static final String BCFIPS_PROVIDER_NAME = "BCFIPS";
+  private static final String BCFIPS_JSSE_PROVIDER_NAME = "BCJSSE";
+
+  @Test
+  void testInterceptAndSetHost() throws IOException {
+
+    Security.addProvider(new BouncyCastleFipsProvider());
+    Security.addProvider(new BouncyCastleJsseProvider());
+
+    SSLSocketFactory mockSslSocketFactory = Mockito.mock(SSLSocketFactory.class);
+    SSLSocketFactory hostSslSocketFactory = new HostSslSocketFactory(mockSslSocketFactory, "peerHost");
+
+    Socket mockSocket = Mockito.mock(Socket.class, withSettings().extraInterfaces(BCSSLSocket.class));
+    when(mockSslSocketFactory.createSocket()).thenReturn(mockSocket);
+
+    hostSslSocketFactory.createSocket();
+
+    verify((BCSSLSocket) mockSocket).setHost("peerHost");
+
+    Security.removeProvider(BCFIPS_PROVIDER_NAME);
+    Security.removeProvider(BCFIPS_JSSE_PROVIDER_NAME);
+
+  }
+}


### PR DESCRIPTION
### Description 
This fixes a compatibility issue between SunJSSE' HttpsURLConnection and BCJSSE' sockets, where the host name information is not passed to BCJSSE sockets.

Implements the suggested fix https://github.com/bcgit/bc-java/blob/main/tls/src/main/java/org/bouncycastle/jsse/util/SetHostSocketFactory.java

i.e wraps and explicitly sets the hostname on bouncy castle sockets.

### Testing done 
Locally validated that the sockets are being wrapped and the host is being set correctly on Bouncy Castle Sockets.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

