### PR TITLE
Update jackson-json artifact for 7.8.x Packaging Build Failure

### DIFF
--- a/ksqldb-rest-app/pom.xml
+++ b/ksqldb-rest-app/pom.xml
@@ -203,9 +203,12 @@
         </dependency>
 
         <dependency>
-            <groupId>com.kjetland</groupId>
-            <artifactId>mbknor-jackson-jsonschema_${kafka.scala.version}</artifactId>
-            <version>1.0.39</version>
+            <!-- io.yokota is a fork of com.kjetland -->
+            <!-- schema-registry is dependent on io.yokota:mbknor-jackson-jsonschema-java8 -->
+            <!-- hence all the downstream projects had to use that one only -->
+            <groupId>io.yokota</groupId>
+            <artifactId>mbknor-jackson-jsonschema-java8</artifactId>
+            <version>1.0.39.2</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
[7.8.x] [nightly] [packaging] [Block = Build ksqldb jar] :cross-red:
ksqldb build has failed for 7.8.x branch.
Please check job logs and fix the build
Useful quick links: [Job](https://semaphore.ci.confluent.io/jobs/9aa7745a-3353-48f3-952f-755d0971b539/), [Workflow](https://semaphore.ci.confluent.io/workflows/c71eabd0-3797-4275-9653-f17d5764f707),

-------------------------------------------------------------

Error 1:
/.../KsqlPlanSchemaGenerator.java:[95,29] com.kjetland.jackson.jsonSchema.SubclassesResolver is abstract; cannot be instantiated

Reason : SubclassesResolver is abstract; cannot be instantiated:

--------------------------------------------------------------

Error 2:
/.../KsqlPlanSchemaGenerator.java:[71,28] cannot find symbol
  symbol:   method builder()
  location: class com.kjetland.jackson.jsonSchema.JsonSchemaConfig
  
Reason : The code is trying to call JsonSchemaConfig.builder() 
          but the compiler cannot find such a method in the class.

