### PR TITLE
[KSQL-13105] | Vedarth Sharma | Downgrade jetty version to fix build

### DIFF
--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientOAuthTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientOAuthTest.java
@@ -37,6 +37,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static io.confluent.ksql.rest.Errors.ERROR_CODE_UNAUTHORIZED;
+import static org.apache.kafka.common.config.internals.BrokerSecurityConfigs.ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG;
 
 public class ClientOAuthTest extends ClientTest {
   private static final String APP1_DEVELOPER = "app1-developer";
@@ -47,6 +48,7 @@ public class ClientOAuthTest extends ClientTest {
   public void setUp() {
     idp.start();
     super.setUp();
+    System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG, "*");
   }
 
   @Override

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientOAuthTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientOAuthTest.java
@@ -47,8 +47,8 @@ public class ClientOAuthTest extends ClientTest {
   @Override
   public void setUp() {
     idp.start();
-    super.setUp();
     System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG, "*");
+    super.setUp();
   }
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,7 @@
         <kafka.version>${ce.kafka.version}</kafka.version>
         <!-- This needs to be removed once the version is populated in common -->
         <log4j2.version>2.17.1</log4j2.version>
+        <jetty.version>9.4.57.v20241219</jetty.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
### Description 
- Jetty version comes from common.
- Right now it’s upgraded to 12.
- We need dependencies to be on jetty 12 before jetty 12 works with ksql.
- Downgrading will fix build failure

### Testing done 
Tested locally

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

