### PR TITLE
KSQL-13139 | Add a sleep for 100ms before the select queries.

### DIFF
--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
@@ -100,6 +100,7 @@ public class RestTestExecutor implements Closeable {
   private static final String STATEMENT_MACRO = "\\{STATEMENT}";
   private static final Duration MAX_QUERY_RUNNING_CHECK = Duration.ofSeconds(45);
   private static final Duration MAX_TRANSIENT_QUERY_COMPLETION_TIME = Duration.ofSeconds(10);
+  private static final int QUERY_PROCESSING_DELAY_MS = 100;
   private static final String MATCH_OPERATOR_DELIMITER = "|";
   private static final String QUERY_KEY = "query";
   private static final String ROW_KEY = "row";
@@ -200,8 +201,13 @@ public class RestTestExecutor implements Closeable {
         IntegrationTestUtil.waitForPersistentQueriesToProcessInputs(kafkaCluster, engine);
       }
 
+      try {
+        Thread.sleep(QUERY_PROCESSING_DELAY_MS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
       final List<RqttResponse> queryResults = sendQueryStatements(testCase, statements.queries,
-          postInputConditionRunnable);
+        postInputConditionRunnable);
 
       if (!queryResults.isEmpty()) {
         failIfExpectingError(testCase);


### PR DESCRIPTION
### Description 
Add a sleep for 100ms before the select queries.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

