### PR TITLE
Ksql 13066 - Catch original GroupIdNotfoundException

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaConsumerGroupClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaConsumerGroupClientImpl.java
@@ -35,8 +35,8 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.errors.GroupAuthorizationException;
 import org.apache.kafka.common.errors.GroupNotEmptyException;
-import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.GroupIdNotFoundException;
+import org.apache.kafka.common.errors.RetriableException;
 
 public class KafkaConsumerGroupClientImpl implements KafkaConsumerGroupClient {
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaConsumerGroupClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaConsumerGroupClientImpl.java
@@ -36,6 +36,7 @@ import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.errors.GroupAuthorizationException;
 import org.apache.kafka.common.errors.GroupNotEmptyException;
 import org.apache.kafka.common.errors.RetriableException;
+import org.apache.kafka.common.errors.GroupIdNotFoundException;
 
 public class KafkaConsumerGroupClientImpl implements KafkaConsumerGroupClient {
 
@@ -83,6 +84,9 @@ public class KafkaConsumerGroupClientImpl implements KafkaConsumerGroupClient {
       return new ConsumerGroupSummary(results);
     } catch (final GroupAuthorizationException e) {
       throw new KsqlGroupAuthorizationException(AclOperation.DESCRIBE, group);
+    } catch (final GroupIdNotFoundException e) {
+      // Return empty result set when group is not found
+      return new ConsumerGroupSummary(Collections.emptySet());
     } catch (final Exception e) {
       throw new KafkaResponseGetFailedException(
           "Failed to describe Kafka consumer groups: " + group, e);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaConsumerGroupClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaConsumerGroupClientImpl.java
@@ -66,9 +66,7 @@ public class KafkaConsumerGroupClientImpl implements KafkaConsumerGroupClient {
                   .describeConsumerGroups(Collections.singleton(group))
                   .all()
                   .get(),
-              RetryBehaviour.ON_RETRYABLE,
-              retry -> Duration.ofSeconds(1),
-              10);
+              RetryBehaviour.ON_RETRYABLE);
 
       final Set<ConsumerSummary> results = groupDescriptions
           .values()

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaConsumerGroupClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaConsumerGroupClientImpl.java
@@ -66,7 +66,9 @@ public class KafkaConsumerGroupClientImpl implements KafkaConsumerGroupClient {
                   .describeConsumerGroups(Collections.singleton(group))
                   .all()
                   .get(),
-              RetryBehaviour.ON_RETRYABLE);
+              RetryBehaviour.ON_RETRYABLE,
+              retry -> Duration.ofSeconds(1),
+              10);
 
       final Set<ConsumerSummary> results = groupDescriptions
           .values()

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaConsumerGroupClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaConsumerGroupClientImpl.java
@@ -34,8 +34,8 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.errors.GroupAuthorizationException;
-import org.apache.kafka.common.errors.GroupNotEmptyException;
 import org.apache.kafka.common.errors.GroupIdNotFoundException;
+import org.apache.kafka.common.errors.GroupNotEmptyException;
 import org.apache.kafka.common.errors.RetriableException;
 
 public class KafkaConsumerGroupClientImpl implements KafkaConsumerGroupClient {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaConsumerGroupClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaConsumerGroupClientImpl.java
@@ -37,10 +37,13 @@ import org.apache.kafka.common.errors.GroupAuthorizationException;
 import org.apache.kafka.common.errors.GroupIdNotFoundException;
 import org.apache.kafka.common.errors.GroupNotEmptyException;
 import org.apache.kafka.common.errors.RetriableException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class KafkaConsumerGroupClientImpl implements KafkaConsumerGroupClient {
 
   private final Supplier<Admin> adminClient;
+  private static final Logger log = LogManager.getLogger(KafkaConsumerGroupClientImpl.class);
 
   public KafkaConsumerGroupClientImpl(final Supplier<Admin> adminClient) {
     this.adminClient = adminClient;
@@ -85,7 +88,9 @@ public class KafkaConsumerGroupClientImpl implements KafkaConsumerGroupClient {
     } catch (final GroupAuthorizationException e) {
       throw new KsqlGroupAuthorizationException(AclOperation.DESCRIBE, group);
     } catch (final GroupIdNotFoundException e) {
-      // Return empty result set when group is not found
+      // Per KIP-1043, Kafka now throws GroupIdNotFoundException if a group doesn't exist.
+      // Treat this expected scenario as a group with zero consumers by returning an empty summary.
+      log.debug("Consumer group '{}' not found, treating as empty. Reason: {}", group, e);
       return new ConsumerGroupSummary(Collections.emptySet());
     } catch (final Exception e) {
       throw new KafkaResponseGetFailedException(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
@@ -104,16 +104,16 @@ public class KafkaConsumerGroupClientTest {
     verifyListsGroups(group1, ImmutableList.of(group0, group1));
   }
 
-//  @Test
-//  public void shouldDescribeConsumerGroup() {
-//    givenTopicExistsWithData();
-//    try (KafkaConsumer<String, byte[]> c1 = createConsumer(group0)) {
-//      verifyDescribeConsumerGroup(1, group0, ImmutableList.of(c1));
-//      try (KafkaConsumer<String, byte[]> c2 = createConsumer(group0)) {
-//        verifyDescribeConsumerGroup(2, group0, ImmutableList.of(c1, c2));
-//      }
-//    }
-//  }
+  @Test
+  public void shouldDescribeConsumerGroup() {
+    givenTopicExistsWithData();
+    try (KafkaConsumer<String, byte[]> c1 = createConsumer(group0)) {
+      verifyDescribeConsumerGroup(1, group0, ImmutableList.of(c1));
+      try (KafkaConsumer<String, byte[]> c2 = createConsumer(group0)) {
+        verifyDescribeConsumerGroup(2, group0, ImmutableList.of(c1, c2));
+      }
+    }
+  }
 
   @Test
   public void shouldListConsumerGroupOffsetsWhenTheyExist() {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
@@ -108,11 +108,11 @@ public class KafkaConsumerGroupClientTest {
   public void shouldDescribeConsumerGroup() {
     givenTopicExistsWithData();
     try (KafkaConsumer<String, byte[]> c1 = createConsumer(group0)) {
-        c1.poll(Duration.ofMillis(200));  // Force consumer to join group
+        c1.poll(Duration.ofMillis(10));  // Force consumer to join group
 
         verifyDescribeConsumerGroup(1, group0, ImmutableList.of(c1));
         try (KafkaConsumer<String, byte[]> c2 = createConsumer(group0)) {
-            c2.poll(Duration.ofMillis(200));  // Force consumer to join group
+            c2.poll(Duration.ofMillis(10));  // Force consumer to join group
 
             verifyDescribeConsumerGroup(2, group0, ImmutableList.of(c1, c2));
         }
@@ -131,21 +131,20 @@ public class KafkaConsumerGroupClientTest {
       final List<KafkaConsumer<?, ?>> consumers
   ) {
     final Supplier<ConsumerAndPartitionCount> pollAndGetCounts = () -> {
-        consumers.forEach(consumer -> consumer.poll(Duration.ofMillis(200)));
+      consumers.forEach(consumer -> consumer.poll(Duration.ofMillis(1)));
 
-        final Collection<ConsumerSummary> summaries = consumerGroupClient
-            .describeConsumerGroup(group).consumers();
+      final Collection<ConsumerSummary> summaries = consumerGroupClient
+          .describeConsumerGroup(group).consumers();
 
-        final long partitionCount = summaries.stream()
-            .mapToLong(summary -> summary.partitions().size())
-            .sum();
+      final long partitionCount = summaries.stream()
+          .mapToLong(summary -> summary.partitions().size())
+          .sum();
 
-        return new ConsumerAndPartitionCount(consumers.size(), (int) partitionCount);
+      return new ConsumerAndPartitionCount(consumers.size(), (int) partitionCount);
     };
 
     assertThatEventually(pollAndGetCounts,
-        is(new ConsumerAndPartitionCount(expectedNumConsumers, PARTITION_COUNT))
-    );
+        is(new ConsumerAndPartitionCount(expectedNumConsumers, PARTITION_COUNT)));
   }
 
   private void verifyListsGroups(final String newGroup, final List<String> consumerGroups) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
@@ -108,46 +108,12 @@ public class KafkaConsumerGroupClientTest {
   public void shouldDescribeConsumerGroup() {
     givenTopicExistsWithData();
     try (KafkaConsumer<String, byte[]> c1 = createConsumer(group0)) {
-        System.out.println("Before first poll - Consumer 1");
-        logConsumerGroupState(group0);
-        c1.poll(Duration.ofMillis(10));  // Force consumer to join group
-        System.out.println("After first poll - Consumer 1");
-        logConsumerGroupState(group0);
-
         verifyDescribeConsumerGroup(1, group0, ImmutableList.of(c1));
-        System.out.println("After verify - Consumer 1");
-        logConsumerGroupState(group0);
         try (KafkaConsumer<String, byte[]> c2 = createConsumer(group0)) {
-            System.out.println("Before first poll - Consumer 2");
-            logConsumerGroupState(group0);
-            c2.poll(Duration.ofMillis(10));  // Force consumer to join group
-            System.out.println("After first poll - Consumer 2");
-            logConsumerGroupState(group0);
-
             verifyDescribeConsumerGroup(2, group0, ImmutableList.of(c1, c2));
-            System.out.println("After verify - Consumer 2");
-            logConsumerGroupState(group0);
         }
     }
   }
-
-  private void logConsumerGroupState(String groupId) {
-    try {
-        Collection<ConsumerSummary> summaries = consumerGroupClient
-            .describeConsumerGroup(groupId).consumers();
-        if (summaries != null) {
-            System.out.println("Group " + groupId + " state:");
-            System.out.println("  Number of consumers: " + summaries.size());
-            summaries.forEach(summary -> {
-                System.out.println("    Assigned partitions: " + summary.partitions().size() + "  partitions");
-            });
-        } else {
-            System.out.println("Group " + groupId + " not found or empty");
-        }
-    } catch (Exception e) {
-        System.out.println("Error getting group state: " + e.getMessage());
-    }
-}
 
   @Test
   public void shouldListConsumerGroupOffsetsWhenTheyExist() {
@@ -161,28 +127,17 @@ public class KafkaConsumerGroupClientTest {
       final List<KafkaConsumer<?, ?>> consumers
   ) {
     final Supplier<ConsumerAndPartitionCount> pollAndGetCounts = () -> {
-        System.out.println("\n=== Before internal poll ===");
-        logConsumerGroupState(group);
-        
-        consumers.forEach(consumer -> consumer.poll(Duration.ofMillis(10)));
-        
-        System.out.println("\n=== After internal poll ===");
-        logConsumerGroupState(group);
+
+        consumers.forEach(consumer -> consumer.poll(Duration.ofMillis(1)));
 
         final Collection<ConsumerSummary> summaries = consumerGroupClient
-            .describeConsumerGroup(group).consumers();
-        
-        final long partitionCount = summaries.stream()
-            .mapToLong(summary -> summary.partitions().size())
-            .sum();
+                .describeConsumerGroup(group).consumers();
 
-        ConsumerAndPartitionCount result = new ConsumerAndPartitionCount(
-            summaries.size(), 
-            (int) partitionCount
-        );
-        System.out.println("Current state: consumers=" + summaries.size() + 
-                         ", partitions=" + partitionCount);
-        return result;
+        final long partitionCount = summaries.stream()
+                .mapToLong(summary -> summary.partitions().size())
+                .sum();
+
+        return new ConsumerAndPartitionCount(summaries.size(), (int) partitionCount);
     };
 
     assertThatEventually(

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
@@ -100,6 +100,7 @@ public class RestTestExecutor implements Closeable {
   private static final String STATEMENT_MACRO = "\\{STATEMENT}";
   private static final Duration MAX_QUERY_RUNNING_CHECK = Duration.ofSeconds(45);
   private static final Duration MAX_TRANSIENT_QUERY_COMPLETION_TIME = Duration.ofSeconds(10);
+  private static final int QUERY_PROCESSING_DELAY_MS = 100;
   private static final String MATCH_OPERATOR_DELIMITER = "|";
   private static final String QUERY_KEY = "query";
   private static final String ROW_KEY = "row";
@@ -200,8 +201,13 @@ public class RestTestExecutor implements Closeable {
         IntegrationTestUtil.waitForPersistentQueriesToProcessInputs(kafkaCluster, engine);
       }
 
+      try {
+        Thread.sleep(QUERY_PROCESSING_DELAY_MS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
       final List<RqttResponse> queryResults = sendQueryStatements(testCase, statements.queries,
-          postInputConditionRunnable);
+        postInputConditionRunnable);
 
       if (!queryResults.isEmpty()) {
         failIfExpectingError(testCase);


### PR DESCRIPTION
### Description 
Context:
Following Kafka's KIP-1043, describing a non-existent consumer group now consistently throws GroupIdNotFoundException. 

Treat this expected scenario as a group with zero consumers by returning an empty consumerGroupSummary. This logs the exception, encapsulates the exception handling, simplifying the caller's contract.
Another approach: https://github.com/confluentinc/ksql/pull/10727


### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

