### PR TITLE
[KSQL-13166] Remove deprecated kafka.zookeeper.ZooKeeperClientException usage from Integration tests

### DIFF
--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/AssertClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/AssertClientIntegrationTest.java
@@ -41,7 +41,7 @@ import io.vertx.core.Vertx;
 import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.After;
 import org.junit.Before;
@@ -76,7 +76,7 @@ public class AssertClientIntegrationTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS)
       .around(REST_APP);
 

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -121,7 +121,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
 import org.apache.kafka.clients.admin.OffsetSpec;
@@ -134,6 +133,7 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.storage.StringConverter;
 import org.apache.kafka.connect.tools.MockSourceConnector;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.test.TestUtils;
 import org.hamcrest.Description;
@@ -240,7 +240,7 @@ public class ClientIntegrationTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS)
       .around(REST_APP);
 

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientMutationIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientMutationIntegrationTest.java
@@ -81,9 +81,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
-import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.storage.StringConverter;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
@@ -166,7 +166,7 @@ public class ClientMutationIntegrationTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS)
       .around(REST_APP);
 

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/PushV2ClientContinueIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/PushV2ClientContinueIntegrationTest.java
@@ -76,7 +76,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.connect.data.Struct;
@@ -143,7 +143,7 @@ public class PushV2ClientContinueIntegrationTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS)
       .around(REST_APP);
 

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/RestClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/RestClientIntegrationTest.java
@@ -55,9 +55,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.storage.StringConverter;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
@@ -125,7 +125,7 @@ public class RestClientIntegrationTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS)
       .around(REST_APP);
 

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/StreamStreamJoinsDeprecationNoticesIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/StreamStreamJoinsDeprecationNoticesIntegrationTest.java
@@ -27,7 +27,7 @@ import io.confluent.ksql.rest.integration.RestIntegrationTestUtil;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.util.StructuredTypesDataProvider;
 import io.confluent.ksql.util.TestDataProvider;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -72,7 +72,7 @@ public class StreamStreamJoinsDeprecationNoticesIntegrationTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS)
       .around(REST_APP);
 

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/BasicAuthFunctionalTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/BasicAuthFunctionalTest.java
@@ -48,7 +48,7 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.common.security.JaasUtils;
 import org.eclipse.jetty.jaas.spi.PropertyFileLoginModule;
 import org.junit.ClassRule;
@@ -96,7 +96,7 @@ public class BasicAuthFunctionalTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(CLUSTER)
       .around(REST_APP);
 

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -100,7 +100,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.streams.StreamsConfig;
 import org.hamcrest.Matcher;
@@ -157,7 +157,7 @@ public class CliTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS)
       .around(REST_APP);
 

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslClientAuthFunctionalTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslClientAuthFunctionalTest.java
@@ -47,7 +47,7 @@ import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLHandshakeException;
 
 import io.netty.handler.codec.http.websocketx.WebSocketHandshakeException;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.common.config.SslConfigs;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -85,7 +85,7 @@ public class SslClientAuthFunctionalTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS)
       .around(REST_APP);
 

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslFunctionalTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslFunctionalTest.java
@@ -43,7 +43,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLHandshakeException;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -76,7 +76,7 @@ public class SslFunctionalTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS)
       .around(REST_APP);
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/DependentStatementsIntegrationTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/DependentStatementsIntegrationTest.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -46,7 +46,7 @@ public class DependentStatementsIntegrationTest {
 
   @ClassRule
   public static final RuleChain CLUSTER_WITH_RETRY = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS);
 
   public TestKsqlContext ksqlContext;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -56,7 +56,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerInterceptor;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -119,7 +119,7 @@ public class EndToEndIntegrationTest {
 
   @ClassRule
   public static final RuleChain CLUSTER_WITH_RETRY = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS);
 
   public TestKsqlContext ksqlContext;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/JoinIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/JoinIntTest.java
@@ -40,7 +40,7 @@ import io.confluent.ksql.util.OrderDataProvider;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -63,7 +63,7 @@ public class JoinIntTest {
 
   @ClassRule
   public static final RuleChain CLUSTER_WITH_RETRY = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS);
 
   @Rule

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
@@ -57,7 +57,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.common.metrics.Metrics;
 import org.junit.After;
 import org.junit.Before;
@@ -83,7 +83,7 @@ public class JsonFormatTest {
 
   @ClassRule
   public static final RuleChain CLUSTER_WITH_RETRY = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS);
 
   private MetaStore metaStore;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
@@ -41,7 +41,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -49,6 +48,7 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.raft.errors.RaftException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -70,7 +70,7 @@ public class KafkaConsumerGroupClientTest {
 
   @ClassRule
   public static final RuleChain clusterWithRetry = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS);
 
   private AdminClient adminClient;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
@@ -76,7 +76,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -129,7 +129,7 @@ public class SecureIntegrationTest {
 
   @ClassRule
   public static final RuleChain CLUSTER_WITH_RETRY = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS);
 
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/StreamsSelectAndProjectIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/StreamsSelectAndProjectIntTest.java
@@ -43,7 +43,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.junit.Before;
@@ -66,7 +66,7 @@ public class StreamsSelectAndProjectIntTest {
 
   @ClassRule
   public static final RuleChain CLUSTER_WITH_RETRY = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS);
 
   @Rule

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
@@ -51,7 +51,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import io.confluent.ksql.util.QueryMetadata;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.junit.After;
 import org.junit.Assume;
@@ -83,7 +83,7 @@ public class UdfIntTest {
 
   @ClassRule
   public static final RuleChain CLUSTER_WITH_RETRY = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS);
 
   @Rule

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
@@ -44,7 +44,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.streams.kstream.SessionWindowedDeserializer;
@@ -86,7 +86,7 @@ public class WindowingIntTest {
 
   @ClassRule
   public static final RuleChain CLUSTER_WITH_RETRY = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS);
 
   @Rule

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
@@ -70,7 +70,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.commons.compress.utils.Lists;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -127,7 +127,7 @@ public class KsMaterializationFunctionalTest {
 
   @ClassRule
   public static final RuleChain CLUSTER_WITH_RETRY = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS);
 
   @Rule

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplIntegrationTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplIntegrationTest.java
@@ -37,11 +37,11 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.raft.errors.RaftException;
 import org.junit.*;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
@@ -54,7 +54,7 @@ public class KafkaTopicClientImplIntegrationTest {
 
   @ClassRule
   public static final RuleChain CLUSTER_WITH_RETRY = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(KAFKA);
 
   private String testTopic;

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
@@ -44,8 +44,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.After;
 import org.junit.Rule;
@@ -109,7 +109,7 @@ public class RestQueryTranslationTest {
       final IntegrationTestHarness testHarness,
       final TestKsqlRestApp restApp) {
     return RuleChain
-        .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+        .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
         .around(testHarness)
         .around(restApp);
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
@@ -62,7 +62,8 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import kafka.zookeeper.ZooKeeperClientException;
+
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -115,7 +116,7 @@ public class ApiIntegrationTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS)
       .around(REST_APP);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/CommandTopicMigrationIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/CommandTopicMigrationIntegrationTest.java
@@ -25,7 +25,7 @@ import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.ReservedInternalTopics;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.After;
 import org.junit.Before;
@@ -57,7 +57,7 @@ public class CommandTopicMigrationIntegrationTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS)
       .around(OTHER_TEST_HARNESS);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/PullBandwidthThrottleIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/PullBandwidthThrottleIntegrationTest.java
@@ -46,7 +46,8 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 import java.util.concurrent.TimeUnit;
-import kafka.zookeeper.ZooKeeperClientException;
+
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.After;
 import org.junit.Before;
@@ -93,7 +94,7 @@ public class PullBandwidthThrottleIntegrationTest {
 
     @ClassRule
     public static final RuleChain CHAIN = RuleChain
-            .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+            .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
             .around(TEST_HARNESS);
     private static final String RATE_LIMIT_MESSAGE = "Host is at bandwidth rate limit for pull queries.";
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/QuickDegradeAndRestoreCommandTopicIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/QuickDegradeAndRestoreCommandTopicIntegrationTest.java
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.After;
 import org.junit.Before;
@@ -56,7 +56,7 @@ public class QuickDegradeAndRestoreCommandTopicIntegrationTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS);
 
   @ClassRule

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/RestoreCommandTopicIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/RestoreCommandTopicIntegrationTest.java
@@ -56,8 +56,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.After;
 import org.junit.Before;
@@ -78,7 +78,7 @@ public class RestoreCommandTopicIntegrationTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS);
 
   @ClassRule

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/RestoreCommandTopicMultipleKafkasIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/RestoreCommandTopicMultipleKafkasIntegrationTest.java
@@ -31,7 +31,7 @@ import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.MockSystemExit;
 import io.confluent.ksql.util.ReservedInternalTopics;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.After;
 import org.junit.Before;
@@ -73,7 +73,7 @@ public class RestoreCommandTopicMultipleKafkasIntegrationTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS);
 
   @ClassRule

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ScalablePushBandwidthThrottleIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ScalablePushBandwidthThrottleIntegrationTest.java
@@ -50,7 +50,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import kafka.zookeeper.ZooKeeperClientException;
+
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.After;
@@ -89,7 +90,7 @@ public class ScalablePushBandwidthThrottleIntegrationTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS);
 
   @Rule

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/BackupRollbackIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/BackupRollbackIntegrationTest.java
@@ -39,10 +39,10 @@ import io.confluent.ksql.rest.server.computation.InternalTopicSerdes;
 import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.ReservedInternalTopics;
-import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.After;
 import org.junit.Before;
@@ -74,7 +74,7 @@ public class BackupRollbackIntegrationTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS);
 
   @ClassRule

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ClusterTerminationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ClusterTerminationTest.java
@@ -43,7 +43,8 @@ import io.vertx.ext.web.client.HttpResponse;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import kafka.zookeeper.ZooKeeperClientException;
+
+import org.apache.kafka.raft.errors.RaftException;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -90,7 +91,7 @@ public class ClusterTerminationTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS));
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS));
 
   @Rule
   public final RuleChain CHAIN_TEST = RuleChain

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/CommandTopicFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/CommandTopicFunctionalTest.java
@@ -35,7 +35,8 @@ import io.confluent.ksql.util.ReservedInternalTopics;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import kafka.zookeeper.ZooKeeperClientException;
+
+import org.apache.kafka.raft.errors.RaftException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -63,7 +64,7 @@ public class CommandTopicFunctionalTest {
   
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS);
 
   @BeforeClass

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HealthCheckResourceFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HealthCheckResourceFunctionalTest.java
@@ -29,7 +29,7 @@ import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.rest.server.state.ServerState.State;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -47,7 +47,7 @@ public class HealthCheckResourceFunctionalTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS)
       .around(REST_APP);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HeartbeatAgentFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HeartbeatAgentFunctionalTest.java
@@ -34,7 +34,7 @@ import io.confluent.ksql.test.util.secure.ClientTrustStore;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PageViewDataProvider;
 import java.util.concurrent.TimeUnit;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -81,7 +81,7 @@ public class HeartbeatAgentFunctionalTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS)
       .around(REST_APP_0)
       .around(REST_APP_1);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/KsqlResourceFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/KsqlResourceFunctionalTest.java
@@ -53,7 +53,7 @@ import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.PageViewDataProvider;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -87,7 +87,7 @@ public class KsqlResourceFunctionalTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS)
       .around(REST_APP);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/LagReportingAgentFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/LagReportingAgentFunctionalTest.java
@@ -27,8 +27,8 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -111,7 +111,7 @@ public class LagReportingAgentFunctionalTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS)
       .around(REST_APP_0)
       .around(REST_APP_1);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PauseResumeIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PauseResumeIntegrationTest.java
@@ -25,7 +25,7 @@ import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.util.KsqlConstants.KsqlQueryStatus;
 import io.confluent.ksql.util.PageViewDataProvider;
 import io.confluent.ksql.util.PageViewDataProvider.Batch;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.junit.*;
@@ -80,7 +80,7 @@ public class PauseResumeIntegrationTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS);
 
   @Before

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
@@ -57,7 +57,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.After;
@@ -155,7 +155,7 @@ public class PullQueryFunctionalTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS)
       .around(JAAS_CONFIG)
       .around(REST_APP_0)

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryLimitHARoutingTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryLimitHARoutingTest.java
@@ -55,8 +55,8 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
-import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.After;
 import org.junit.Before;
@@ -171,7 +171,7 @@ public class PullQueryLimitHARoutingTest {
 
     @ClassRule
     public static final RuleChain CHAIN = RuleChain
-            .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+            .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
             .around(TEST_HARNESS)
             .around(TMP);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
@@ -85,7 +85,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.streams.StreamsConfig;
@@ -244,7 +244,7 @@ public class PullQueryRoutingFunctionalTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS)
       .around(JAAS_CONFIG)
       .around(TMP);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQuerySingleNodeFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQuerySingleNodeFunctionalTest.java
@@ -68,7 +68,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.streams.StreamsConfig;
@@ -153,7 +153,7 @@ public class PullQuerySingleNodeFunctionalTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS).around(TMP);
 
   @Rule

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ScalablePushQueryFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ScalablePushQueryFunctionalTest.java
@@ -61,7 +61,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import kafka.zookeeper.ZooKeeperClientException;
+
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.After;
@@ -137,7 +138,7 @@ public class ScalablePushQueryFunctionalTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS)
       .around(TMP);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ShowQueriesMultiNodeFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ShowQueriesMultiNodeFunctionalTest.java
@@ -46,7 +46,8 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import kafka.zookeeper.ZooKeeperClientException;
+
+import org.apache.kafka.raft.errors.RaftException;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -94,7 +95,7 @@ public class ShowQueriesMultiNodeFunctionalTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS)
       .around(JAAS_CONFIG)
       .around(REST_APP_0)

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ShowQueriesMultiNodeWithTlsFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ShowQueriesMultiNodeWithTlsFunctionalTest.java
@@ -33,7 +33,8 @@ import io.confluent.ksql.util.PageViewDataProvider;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-import kafka.zookeeper.ZooKeeperClientException;
+
+import org.apache.kafka.raft.errors.RaftException;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -78,7 +79,7 @@ public class ShowQueriesMultiNodeWithTlsFunctionalTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS)
       .around(REST_APP_0)
       .around(REST_APP_1);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/SystemAuthenticationFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/SystemAuthenticationFunctionalTest.java
@@ -55,7 +55,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.Before;
@@ -192,7 +192,7 @@ public class SystemAuthenticationFunctionalTest {
 
     @ClassRule
     public static final RuleChain CHAIN = RuleChain
-        .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+        .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
         .around(TEST_HARNESS)
         .around(REST_APP_0)
         .around(REST_APP_1);
@@ -285,7 +285,7 @@ public class SystemAuthenticationFunctionalTest {
 
     @ClassRule
     public static final RuleChain CHAIN = RuleChain
-        .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+        .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
         .around(TEST_HARNESS)
         .around(REST_APP_0)
         .around(REST_APP_1);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/TerminateTransientQueryFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/TerminateTransientQueryFunctionalTest.java
@@ -35,7 +35,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import kafka.zookeeper.ZooKeeperClientException;
+
+import org.apache.kafka.raft.errors.RaftException;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -78,7 +79,7 @@ public class TerminateTransientQueryFunctionalTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS)
       .around(REST_APP_0)
       .around(REST_APP_1);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/TransientQueryResourceCleanerIntTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/TransientQueryResourceCleanerIntTest.java
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -109,7 +109,7 @@ public class TransientQueryResourceCleanerIntTest {
 
     @ClassRule
     public static final RuleChain CHAIN = RuleChain
-            .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+            .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
             .around(TEST_HARNESS)
             .around(REST_APP_0);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/ConnectIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/ConnectIntegrationTest.java
@@ -59,7 +59,6 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
-import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.kafka.connect.json.JsonConverter;
 import io.confluent.ksql.rest.entity.ConnectorType;
@@ -68,6 +67,7 @@ import org.apache.kafka.connect.tools.MockSinkConnector;
 import org.apache.kafka.connect.tools.MockSourceConnector;
 import org.apache.kafka.connect.tools.VerifiableSinkConnector;
 import org.apache.kafka.connect.tools.VerifiableSourceConnector;
+import org.apache.kafka.raft.errors.RaftException;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -97,7 +97,7 @@ public class ConnectIntegrationTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS)
       .around(REST_APP);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/InsertionIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/InsertionIntegrationTest.java
@@ -23,7 +23,7 @@ import io.confluent.ksql.rest.client.RestResponse;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.junit.*;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
@@ -66,7 +66,7 @@ public class InsertionIntegrationTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS)
       .around(REST_APP);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
@@ -81,8 +81,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.streams.StreamsConfig;
 import org.hamcrest.CoreMatchers;
 import org.junit.After;
@@ -205,7 +205,7 @@ public class InteractiveStatementExecutorTest {
 
   @ClassRule
   public static final RuleChain CLUSTER_WITH_RETRY = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(CLUSTER);
 
   @Test(expected = IllegalStateException.class)

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
@@ -73,7 +73,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.raft.errors.RaftException;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.connect.json.JsonConverter;
 import io.confluent.ksql.rest.entity.ConnectorType;
@@ -133,7 +133,7 @@ public class MigrationsTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .outerRule(Retry.of(3, RaftException.class, 3, TimeUnit.SECONDS))
       .around(TEST_HARNESS)
       .around(REST_APP);
 


### PR DESCRIPTION
Reason (Build Failure) - https://semaphore.ci.confluent.io/jobs/cd85fbb2-aaed-465d-ac61-c4e78a02edeb/

-------------------------------------------------------------------------------------------------------

This is being used now:

package org.apache.kafka.raft.errors;

import org.apache.kafka.common.KafkaException;

public class RaftException extends KafkaException {
  private static final long serialVersionUID = 1L;

  public RaftException(String s) {
    super(s);
  }

  public RaftException(String s, Throwable throwable) {
    super(s, throwable);
  }

  public RaftException(Throwable throwable) {
    super(throwable);
  }
}


--------------------------------------------------------------------------------------------------------------

Error Logs from Semaphore:

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.10.0:testCompile (default-testCompile) on project ksqldb-engine: Compilation failure: Compilation failure: 07:27
[ERROR] /root/confluent-repos/ksql/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java:[44,23] package kafka.zookeeper does not exist07:27
[ERROR] /root/confluent-repos/ksql/ksqldb-engine/src/test/java/io/confluent/ksql/integration/DependentStatementsIntegrationTest.java:[28,23] package kafka.zookeeper does not exist07:27
[ERROR] /root/confluent-repos/ksql/ksqldb-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java:[59,23] package kafka.zookeeper does not exist07:27
[ERROR] /root/confluent-repos/ksql/ksqldb-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java:[47,23] package kafka.zookeeper does not exist07:27
[ERROR] /root/confluent-repos/ksql/ksqldb-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java:[79,23] package kafka.zookeeper does not exist07:27
[ERROR] /root/confluent-repos/ksql/ksqldb-engine/src/test/java/io/confluent/ksql/integration/StreamsSelectAndProjectIntTest.java:[46,23] package kafka.zookeeper does not exist07:27
[ERROR] /root/confluent-repos/ksql/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplIntegrationTest.java:[40,23] package kafka.zookeeper does not exist07:27
[ERROR] /root/confluent-repos/ksql/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java:[73,23] package kafka.zookeeper does not exist07:27
[ERROR] /root/confluent-repos/ksql/ksqldb-engine/src/test/java/io/confluent/ksql/integration/JoinIntTest.java:[43,23] package kafka.zookeeper does not exist07:27
[ERROR] /root/confluent-repos/ksql/ksqldb-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java:[54,23] package kafka.zookeeper does not exist07:27
[ERROR] /root/confluent-repos/ksql/ksqldb-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java:[60,23] package kafka.zookeeper does not exist