### PR TITLE
Ksql 13066 - Propogate original exception

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaConsumerGroupClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaConsumerGroupClientImpl.java
@@ -66,9 +66,7 @@ public class KafkaConsumerGroupClientImpl implements KafkaConsumerGroupClient {
                   .describeConsumerGroups(Collections.singleton(group))
                   .all()
                   .get(),
-              RetryBehaviour.ON_RETRYABLE,
-              retry -> Duration.ofSeconds(1),
-              10);
+              RetryBehaviour.ON_RETRYABLE);
 
       final Set<ConsumerSummary> results = groupDescriptions
           .values()

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaConsumerGroupClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaConsumerGroupClientImpl.java
@@ -66,7 +66,9 @@ public class KafkaConsumerGroupClientImpl implements KafkaConsumerGroupClient {
                   .describeConsumerGroups(Collections.singleton(group))
                   .all()
                   .get(),
-              RetryBehaviour.ON_RETRYABLE);
+              RetryBehaviour.ON_RETRYABLE,
+              retry -> Duration.ofSeconds(1),
+              10);
 
       final Set<ConsumerSummary> results = groupDescriptions
           .values()

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaConsumerGroupClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaConsumerGroupClientImpl.java
@@ -34,6 +34,7 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.errors.GroupAuthorizationException;
+import org.apache.kafka.common.errors.GroupIdNotFoundException;
 import org.apache.kafka.common.errors.GroupNotEmptyException;
 import org.apache.kafka.common.errors.RetriableException;
 
@@ -83,6 +84,10 @@ public class KafkaConsumerGroupClientImpl implements KafkaConsumerGroupClient {
       return new ConsumerGroupSummary(results);
     } catch (final GroupAuthorizationException e) {
       throw new KsqlGroupAuthorizationException(AclOperation.DESCRIBE, group);
+    } catch (final GroupIdNotFoundException e) {
+      // KIP-1043: GroupIdNotFoundException signals group doesn't exist (a state, not a failure).
+      // Re-throw the specific exception, rather than generalizing it as a KafkaResponseGetFailedException.
+      throw e;
     } catch (final Exception e) {
       throw new KafkaResponseGetFailedException(
           "Failed to describe Kafka consumer groups: " + group, e);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
@@ -31,7 +31,6 @@ import io.confluent.ksql.test.util.TopicTestUtil;
 import io.confluent.ksql.services.KafkaConsumerGroupClient;
 import io.confluent.ksql.services.KafkaConsumerGroupClient.ConsumerSummary;
 import io.confluent.ksql.services.KafkaConsumerGroupClientImpl;
-import io.confluent.ksql.util.ExecutorUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.OrderDataProvider;
 import java.time.Duration;
@@ -42,7 +41,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -72,7 +70,7 @@ public class KafkaConsumerGroupClientTest {
   private static final int PARTITION_COUNT = 3;
 
   private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
-  private static final Logger log = LogManager.getLogger(ExecutorUtil.class);
+  private static final Logger log = LogManager.getLogger(KafkaConsumerGroupClientTest.class);
 
   @ClassRule
   public static final RuleChain clusterWithRetry = RuleChain

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
@@ -140,9 +140,11 @@ public class KafkaConsumerGroupClientTest {
           .sum();
 
       return new ConsumerAndPartitionCount(consumers.size(), (int) partitionCount);
-      }catch(Exception exception){
-          log.error("Error describing consumer group" + exception.getMessage());
-          return new ConsumerAndPartitionCount(0, 0); // Return invalid state to force retry
+      }catch(final GroupIdNotFoundException exception){
+        // Treat this scenario as a group with zero consumers.
+        log.warn("Consumer group '{}' not found. Returning 0 consumers and 0 partitions. Reason: {}",
+                group, exception.getMessage());
+        return new ConsumerAndPartitionCount(0, 0);
       }
     };
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
@@ -108,11 +108,11 @@ public class KafkaConsumerGroupClientTest {
   public void shouldDescribeConsumerGroup() {
     givenTopicExistsWithData();
     try (KafkaConsumer<String, byte[]> c1 = createConsumer(group0)) {
-        c1.poll(Duration.ofMillis(200));  // Force consumer to join group
+        c1.poll(Duration.ofMillis(10));  // Force consumer to join group
 
         verifyDescribeConsumerGroup(1, group0, ImmutableList.of(c1));
         try (KafkaConsumer<String, byte[]> c2 = createConsumer(group0)) {
-            c2.poll(Duration.ofMillis(200));  // Force consumer to join group
+            c2.poll(Duration.ofMillis(10));  // Force consumer to join group
 
             verifyDescribeConsumerGroup(2, group0, ImmutableList.of(c1, c2));
         }
@@ -131,7 +131,7 @@ public class KafkaConsumerGroupClientTest {
       final List<KafkaConsumer<?, ?>> consumers
   ) {
     final Supplier<ConsumerAndPartitionCount> pollAndGetCounts = () -> {
-        consumers.forEach(consumer -> consumer.poll(Duration.ofMillis(200)));
+        consumers.forEach(consumer -> consumer.poll(Duration.ofMillis(10)));
 
         final Collection<ConsumerSummary> summaries = consumerGroupClient
             .describeConsumerGroup(group).consumers();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
@@ -18,9 +18,7 @@ package io.confluent.ksql.integration;
 import static io.confluent.ksql.serde.FormatFactory.JSON;
 import static io.confluent.ksql.serde.FormatFactory.KAFKA;
 import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 import com.google.common.collect.ImmutableList;
 
@@ -142,9 +140,9 @@ public class KafkaConsumerGroupClientTest {
           .sum();
 
       return new ConsumerAndPartitionCount(consumers.size(), (int) partitionCount);
-      }catch(GroupIdNotFoundException groupIdNotFoundException) {
-        log.error("Error describing consumer group" + groupIdNotFoundException.getMessage());
-        return new ConsumerAndPartitionCount(0, 0); // Return invalid state to force retry
+      }catch(Exception exception){
+          log.error("Error describing consumer group" + exception.getMessage());
+          return new ConsumerAndPartitionCount(0, 0); // Return invalid state to force retry
       }
     };
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
@@ -104,16 +104,16 @@ public class KafkaConsumerGroupClientTest {
     verifyListsGroups(group1, ImmutableList.of(group0, group1));
   }
 
-//  @Test
-//  public void shouldDescribeConsumerGroup() {
-//    givenTopicExistsWithData();
-//    try (KafkaConsumer<String, byte[]> c1 = createConsumer(group0)) {
-//      verifyDescribeConsumerGroup(1, group0, ImmutableList.of(c1));
-//      try (KafkaConsumer<String, byte[]> c2 = createConsumer(group0)) {
-//        verifyDescribeConsumerGroup(2, group0, ImmutableList.of(c1, c2));
-//      }
-//    }
-//  }
+  @Test
+  public void shouldDescribeConsumerGroup() {
+    givenTopicExistsWithData();
+    try (KafkaConsumer<String, byte[]> c1 = createConsumer(group0)) {
+      verifyDescribeConsumerGroup(1, group0, ImmutableList.of(c1));
+      try (KafkaConsumer<String, byte[]> c2 = createConsumer(group0)) {
+        verifyDescribeConsumerGroup(2, group0, ImmutableList.of(c1, c2));
+      }
+    }
+  }
 
   @Test
   public void shouldListConsumerGroupOffsetsWhenTheyExist() {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.test.util.TopicTestUtil;
 import io.confluent.ksql.services.KafkaConsumerGroupClient;
 import io.confluent.ksql.services.KafkaConsumerGroupClient.ConsumerSummary;
 import io.confluent.ksql.services.KafkaConsumerGroupClientImpl;
+import io.confluent.ksql.util.ExecutorUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.OrderDataProvider;
 import java.time.Duration;
@@ -41,6 +42,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -50,6 +52,8 @@ import org.apache.kafka.common.errors.GroupIdNotFoundException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.raft.errors.RaftException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -68,6 +72,7 @@ public class KafkaConsumerGroupClientTest {
   private static final int PARTITION_COUNT = 3;
 
   private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
+  private static final Logger log = LogManager.getLogger(ExecutorUtil.class);
 
   @ClassRule
   public static final RuleChain clusterWithRetry = RuleChain
@@ -140,8 +145,7 @@ public class KafkaConsumerGroupClientTest {
 
       return new ConsumerAndPartitionCount(consumers.size(), (int) partitionCount);
       }catch(GroupIdNotFoundException groupIdNotFoundException) {
-        // Log the exception to help with debugging
-        System.out.println("Error describing consumer group, will retry: " + groupIdNotFoundException.getMessage());
+        log.error("Error describing consumer group" + groupIdNotFoundException.getMessage());
         return new ConsumerAndPartitionCount(0, 0); // Return invalid state to force retry
       }
     };

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
@@ -108,11 +108,11 @@ public class KafkaConsumerGroupClientTest {
   public void shouldDescribeConsumerGroup() {
     givenTopicExistsWithData();
     try (KafkaConsumer<String, byte[]> c1 = createConsumer(group0)) {
-        c1.poll(Duration.ofMillis(10));  // Force consumer to join group
+        c1.poll(Duration.ofMillis(5));  // Force consumer to join group
 
         verifyDescribeConsumerGroup(1, group0, ImmutableList.of(c1));
         try (KafkaConsumer<String, byte[]> c2 = createConsumer(group0)) {
-            c2.poll(Duration.ofMillis(10));  // Force consumer to join group
+            c2.poll(Duration.ofMillis(5));  // Force consumer to join group
 
             verifyDescribeConsumerGroup(2, group0, ImmutableList.of(c1, c2));
         }
@@ -131,21 +131,20 @@ public class KafkaConsumerGroupClientTest {
       final List<KafkaConsumer<?, ?>> consumers
   ) {
     final Supplier<ConsumerAndPartitionCount> pollAndGetCounts = () -> {
-        consumers.forEach(consumer -> consumer.poll(Duration.ofMillis(10)));
+      consumers.forEach(consumer -> consumer.poll(Duration.ofMillis(5)));
 
-        final Collection<ConsumerSummary> summaries = consumerGroupClient
-            .describeConsumerGroup(group).consumers();
+      final Collection<ConsumerSummary> summaries = consumerGroupClient
+          .describeConsumerGroup(group).consumers();
 
-        final long partitionCount = summaries.stream()
-            .mapToLong(summary -> summary.partitions().size())
-            .sum();
+      final long partitionCount = summaries.stream()
+          .mapToLong(summary -> summary.partitions().size())
+          .sum();
 
-        return new ConsumerAndPartitionCount(consumers.size(), (int) partitionCount);
+      return new ConsumerAndPartitionCount(consumers.size(), (int) partitionCount);
     };
 
     assertThatEventually(pollAndGetCounts,
-        is(new ConsumerAndPartitionCount(expectedNumConsumers, PARTITION_COUNT))
-    );
+        is(new ConsumerAndPartitionCount(expectedNumConsumers, PARTITION_COUNT)));
   }
 
   private void verifyListsGroups(final String newGroup, final List<String> consumerGroups) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
@@ -46,6 +46,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.GroupIdNotFoundException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.raft.errors.RaftException;
@@ -108,14 +109,10 @@ public class KafkaConsumerGroupClientTest {
   public void shouldDescribeConsumerGroup() {
     givenTopicExistsWithData();
     try (KafkaConsumer<String, byte[]> c1 = createConsumer(group0)) {
-        c1.poll(Duration.ofMillis(5));  // Force consumer to join group
-
-        verifyDescribeConsumerGroup(1, group0, ImmutableList.of(c1));
-        try (KafkaConsumer<String, byte[]> c2 = createConsumer(group0)) {
-            c2.poll(Duration.ofMillis(5));  // Force consumer to join group
-
-            verifyDescribeConsumerGroup(2, group0, ImmutableList.of(c1, c2));
-        }
+      verifyDescribeConsumerGroup(1, group0, ImmutableList.of(c1));
+      try (KafkaConsumer<String, byte[]> c2 = createConsumer(group0)) {
+        verifyDescribeConsumerGroup(2, group0, ImmutableList.of(c1, c2));
+      }
     }
   }
 
@@ -131,7 +128,8 @@ public class KafkaConsumerGroupClientTest {
       final List<KafkaConsumer<?, ?>> consumers
   ) {
     final Supplier<ConsumerAndPartitionCount> pollAndGetCounts = () -> {
-      consumers.forEach(consumer -> consumer.poll(Duration.ofMillis(5)));
+      try{
+      consumers.forEach(consumer -> consumer.poll(Duration.ofMillis(1)));
 
       final Collection<ConsumerSummary> summaries = consumerGroupClient
           .describeConsumerGroup(group).consumers();
@@ -141,6 +139,11 @@ public class KafkaConsumerGroupClientTest {
           .sum();
 
       return new ConsumerAndPartitionCount(consumers.size(), (int) partitionCount);
+      }catch(GroupIdNotFoundException groupIdNotFoundException) {
+        // Log the exception to help with debugging
+        System.out.println("Error describing consumer group, will retry: " + groupIdNotFoundException.getMessage());
+        return new ConsumerAndPartitionCount(0, 0); // Return invalid state to force retry
+      }
     };
 
     assertThatEventually(pollAndGetCounts,

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
@@ -100,6 +100,7 @@ public class RestTestExecutor implements Closeable {
   private static final String STATEMENT_MACRO = "\\{STATEMENT}";
   private static final Duration MAX_QUERY_RUNNING_CHECK = Duration.ofSeconds(45);
   private static final Duration MAX_TRANSIENT_QUERY_COMPLETION_TIME = Duration.ofSeconds(10);
+  private static final int QUERY_PROCESSING_DELAY_MS = 100;
   private static final String MATCH_OPERATOR_DELIMITER = "|";
   private static final String QUERY_KEY = "query";
   private static final String ROW_KEY = "row";
@@ -200,8 +201,13 @@ public class RestTestExecutor implements Closeable {
         IntegrationTestUtil.waitForPersistentQueriesToProcessInputs(kafkaCluster, engine);
       }
 
+      try {
+        Thread.sleep(QUERY_PROCESSING_DELAY_MS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
       final List<RqttResponse> queryResults = sendQueryStatements(testCase, statements.queries,
-          postInputConditionRunnable);
+        postInputConditionRunnable);
 
       if (!queryResults.isEmpty()) {
         failIfExpectingError(testCase);


### PR DESCRIPTION
### Description 
Context:
Following Kafka's KIP-1043, describing a non-existent consumer group now consistently throws GroupIdNotFoundException. 

In this approach, we are catching GroupIdNotFoundException and immediately re-throw it, propagating the specific " group id not found" signal to the caller. This preserves information and gives callers flexibility but requires them to implement their own handling logic for this exception.
Another approach: https://github.com/confluentinc/ksql/pull/10711

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

