### PR TITLE
Pin JDK to 17

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -359,7 +359,7 @@ public class EndToEndIntegrationTest {
 
     final List<QueryMetadata> newQueries = queries.stream()
         .filter(q -> !(q instanceof PersistentQueryMetadata))
-        .toList();
+        .collect(Collectors.toList());
 
     newQueries.forEach(QueryMetadata::start);
 

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
     </pluginRepositories>
 
     <properties>
+        <java.version>17</java.version>
         <apache.directory.server.version>2.0.0-M22</apache.directory.server.version>
         <apache.directory.api.version>1.0.0-M33</apache.directory.api.version>
         <apache.httpcomponents.version>5.4.2</apache.httpcomponents.version>


### PR DESCRIPTION
### Description 
Pin JDK to 17 since common will use 11 (since some clients rely on common)

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

