### PR TITLE
remove monitoring interceptor classes

### DIFF
--- a/config/datagen.properties
+++ b/config/datagen.properties
@@ -14,4 +14,3 @@
 #
 
 # This properties file should ONLY be used when you run KSQL with Confluent Enterprise Platform.
-interceptor.classes=io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_
need to remove `interceptor.classes=io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor` as monitoring-interceptors are going out of support from 8.0 onwards

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

