### PR TITLE
feat(testing tool): add DEFINE/UNDEFINE statement support for ksqldb-testing-tool

### DIFF
--- a/docs/how-to-guides/test-an-app.md
+++ b/docs/how-to-guides/test-an-app.md
@@ -114,6 +114,8 @@ The following are the supported KSQL statements in `run-ksql-test`:
 - `UNSET`
 - `INSERT INTO`
 - `INSERT VALUES`
+- `DEFINE`
+- `UNDEFINE`
 
 There are also four test only statements for verifying data.
 

--- a/ksqldb-testing-tool/src/main/java/io/confluent/ksql/tools/test/SqlTestExecutor.java
+++ b/ksqldb-testing-tool/src/main/java/io/confluent/ksql/tools/test/SqlTestExecutor.java
@@ -46,9 +46,11 @@ import io.confluent.ksql.parser.tree.AssertTombstone;
 import io.confluent.ksql.parser.tree.AssertValues;
 import io.confluent.ksql.parser.tree.CreateAsSelect;
 import io.confluent.ksql.parser.tree.CreateSource;
+import io.confluent.ksql.parser.tree.DefineVariable;
 import io.confluent.ksql.parser.tree.DropStatement;
 import io.confluent.ksql.parser.tree.InsertValues;
 import io.confluent.ksql.parser.tree.SetProperty;
+import io.confluent.ksql.parser.tree.UndefineVariable;
 import io.confluent.ksql.parser.tree.UnsetProperty;
 import io.confluent.ksql.properties.PropertyOverrider;
 import io.confluent.ksql.query.QueryId;
@@ -124,6 +126,7 @@ public class SqlTestExecutor implements Closeable {
   private KafkaTopicClient topicClient;
   private Path tmpFolder;
   private final Map<String, Object> overrides;
+  private final Map<String, String> variables;
   private final Map<QueryId, DriverAndProperties> drivers;
 
   // populated during execution to handle the expected exception
@@ -204,6 +207,7 @@ public class SqlTestExecutor implements Closeable {
     this.formatInjector = new DefaultFormatInjector();
     this.topicClient = requireNonNull(topicClient, "topicClient");
     this.overrides = new HashMap<>();
+    this.variables = new HashMap<>();
     this.drivers = drivers;
     this.tmpFolder = requireNonNull(tmpFolder, "tmpFolder");
   }
@@ -242,7 +246,7 @@ public class SqlTestExecutor implements Closeable {
   }
 
   private void execute(final ParsedStatement parsedStatement) {
-    final PreparedStatement<?> engineStatement = engine.prepare(parsedStatement);
+    final PreparedStatement<?> engineStatement = engine.prepare(parsedStatement, variables);
     final ConfiguredStatement<?> configured = ConfiguredStatement
         .of(engineStatement, SessionConfig.of(config, overrides));
 
@@ -256,6 +260,12 @@ public class SqlTestExecutor implements Closeable {
       return;
     } else if (engineStatement.getStatement() instanceof UnsetProperty) {
       PropertyOverrider.unset((ConfiguredStatement<UnsetProperty>) configured, overrides);
+      return;
+    } else if (engineStatement.getStatement() instanceof DefineVariable variableStatement) {
+      variables.put(variableStatement.getVariableName(), variableStatement.getVariableValue());
+      return;
+    } else if (engineStatement.getStatement() instanceof UndefineVariable variableStatement) {
+      variables.remove(variableStatement.getVariableName());
       return;
     }
 

--- a/ksqldb-testing-tool/src/test/resources/sql-test-runner/test1.sql
+++ b/ksqldb-testing-tool/src/test/resources/sql-test-runner/test1.sql
@@ -86,6 +86,25 @@ INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 1);
 ASSERT VALUES bar (rowtime, id, col1) VALUES (1, 1, 2);
 
 ----------------------------------------------------------------------------------------------------
+--@test: basic test with `DEFINE` statement
+----------------------------------------------------------------------------------------------------
+DEFINE someVar='bar';
+CREATE STREAM foo (id INT KEY, col1 VARCHAR) WITH (kafka_topic='foo', value_format='JSON');
+
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 'val-${someVar}');
+ASSERT VALUES foo (rowtime, id, col1) VALUES (1, 1, 'val-bar');
+
+----------------------------------------------------------------------------------------------------
+--@test: basic test with `UNDEFINE` statement
+----------------------------------------------------------------------------------------------------
+DEFINE someVar='bar';
+UNDEFINE someVar;
+CREATE STREAM foo (id INT KEY, col1 VARCHAR) WITH (kafka_topic='foo', value_format='JSON');
+
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 'val-${someVar}');
+ASSERT VALUES foo (rowtime, id, col1) VALUES (1, 1, 'val-');
+
+----------------------------------------------------------------------------------------------------
 --@test: bad assert statement should fail
 
 --@expected.error: java.lang.AssertionError


### PR DESCRIPTION
### Description 

This changes allow define/undefine variables in test SQL files using `DEFINE` / `UNDEFINE` statement. It could be helpful in various cases, for example: when test sql file reuses main sql file (which relay on variables) via `RUN SCRIPT`.

Fixes: https://github.com/confluentinc/ksql/issues/9720

### Testing done 
Integration test cases were added under `SqlTestingToolTest`.

### Reviewer checklist
- [x] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [x] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

