### PR TITLE
[KSQL-13335] Remove zookeeper references from the codebase

### DIFF
--- a/docs/how-to-guides/create-a-user-defined-function.md
+++ b/docs/how-to-guides/create-a-user-defined-function.md
@@ -446,53 +446,45 @@ server. Create the following `docker-compose.yml` file:
 version: '2'
 
 services:
-  zookeeper:
-    image: confluentinc/cp-zookeeper:{{ site.cprelease }}
-    hostname: zookeeper
-    container_name: zookeeper
-    ports:
-      - "2181:2181"
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-
-  broker:
-    image: confluentinc/cp-enterprise-kafka:{{ site.cprelease }}
-    hostname: broker
-    container_name: broker
-    depends_on:
-      - zookeeper
+  kafka:
+    image: confluentinc/cp-server:{{ site.cprelease }}
+    hostname: kafka
+    container_name: kafka
     ports:
       - "29092:29092"
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_NODE_ID: 1
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:39093
+      KAFKA_LISTENERS: PLAINTEXT://kafka:9092,CONTROLLER://kafka:39093,PLAINTEXT_HOST://0.0.0.0:29092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LOG_DIRS: /tmp/kraft-combined-logs
+      CLUSTER_ID: 9-fLubcIRYqQaWkrwEThnQ
 
   schema-registry:
     image: confluentinc/cp-schema-registry:{{ site.cprelease }}
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
-      - zookeeper
-      - broker
+      - kafka
     ports:
       - "8081:8081"
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
-      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: PLAINTEXT://kafka:9092
 
   ksqldb-server:
     image: confluentinc/ksqldb-server:{{ site.ksqldbversion }}
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
-      - broker
+      - kafka
       - schema-registry
     ports:
       - "8088:8088"
@@ -500,7 +492,7 @@ services:
       - "./extensions/:/opt/ksqldb-udfs"
     environment:
       KSQL_LISTENERS: "http://0.0.0.0:8088"
-      KSQL_BOOTSTRAP_SERVERS: "broker:9092"
+      KSQL_BOOTSTRAP_SERVERS: "kafka:9092"
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
       KSQL_KSQL_LOGGING_PROCESSING_STREAM_AUTO_CREATE: "true"
       KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: "true"
@@ -512,7 +504,7 @@ services:
     image: confluentinc/ksqldb-cli:{{ site.ksqldbversion }}
     container_name: ksqldb-cli
     depends_on:
-      - broker
+      - kafka
       - ksqldb-server
     entrypoint: /bin/sh
     tty: true

--- a/docs/how-to-guides/use-connector-management.md
+++ b/docs/how-to-guides/use-connector-management.md
@@ -77,53 +77,45 @@ To get started, here is a Docker Compose example with a server configured for em
 version: '2'
 
 services:
-  zookeeper:
-    image: confluentinc/cp-zookeeper:{{ site.cprelease }}
-    hostname: zookeeper
-    container_name: zookeeper
-    ports:
-      - "2181:2181"
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-
-  broker:
-    image: confluentinc/cp-enterprise-kafka:{{ site.cprelease }}
-    hostname: broker
-    container_name: broker
-    depends_on:
-      - zookeeper
+  kafka:
+    image: confluentinc/cp-server:{{ site.cprelease }}
+    hostname: kafka
+    container_name: kafka
     ports:
       - "29092:29092"
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_NODE_ID: 1
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:39093
+      KAFKA_LISTENERS: PLAINTEXT://kafka:9092,CONTROLLER://kafka:39093,PLAINTEXT_HOST://0.0.0.0:29092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LOG_DIRS: /tmp/kraft-combined-logs
+      CLUSTER_ID: 9-fLubcIRYqQaWkrwEThnQ
 
   schema-registry:
     image: confluentinc/cp-schema-registry:{{ site.cprelease }}
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
-      - zookeeper
-      - broker
+      - kafka
     ports:
       - "8081:8081"
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
-      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: PLAINTEXT://kafka:9092
 
   ksqldb-server:
     image: confluentinc/ksqldb-server:{{ site.ksqldbversion }}
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
-      - broker
+      - kafka
       - schema-registry
     ports:
       - "8088:8088"
@@ -131,13 +123,13 @@ services:
       - "./confluent-hub-components:/usr/share/kafka/plugins"
     environment:
       KSQL_LISTENERS: "http://0.0.0.0:8088"
-      KSQL_BOOTSTRAP_SERVERS: "broker:9092"
+      KSQL_BOOTSTRAP_SERVERS: "kafka:9092"
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
       KSQL_KSQL_LOGGING_PROCESSING_STREAM_AUTO_CREATE: "true"
       KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: "true"
       # Configuration to embed Kafka Connect support.
       KSQL_CONNECT_GROUP_ID: "ksql-connect-cluster"
-      KSQL_CONNECT_BOOTSTRAP_SERVERS: "broker:9092"
+      KSQL_CONNECT_BOOTSTRAP_SERVERS: "kafka:9092"
       KSQL_CONNECT_KEY_CONVERTER: "org.apache.kafka.connect.storage.StringConverter"
       KSQL_CONNECT_VALUE_CONVERTER: "io.confluent.connect.avro.AvroConverter"
       KSQL_CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
@@ -155,7 +147,7 @@ services:
     image: confluentinc/ksqldb-cli:{{ site.ksqldbversion }}
     container_name: ksqldb-cli
     depends_on:
-      - broker
+      - kafka
       - ksqldb-server
     entrypoint: /bin/sh
     tty: true

--- a/docs/operate-and-deploy/installation/installing.md
+++ b/docs/operate-and-deploy/installation/installing.md
@@ -40,8 +40,6 @@ for ksqlDB components.
   ksqlDB Server image
 - **[ksqldb-cli](https://hub.docker.com/r/confluentinc/ksqldb-cli/):**
   ksqlDB command-line interface (CLI) image
-- **[cp-zookeeper](https://hub.docker.com/r/confluentinc/cp-zookeeper):**
-  {{ site.zk }} image (Community Version)
 - **[cp-schema-registry](https://hub.docker.com/r/confluentinc/cp-schema-registry):**
   {{ site.sr }} image (Community Version)
 - **[cp-kafka](https://hub.docker.com/r/confluentinc/cp-kafka):**
@@ -185,7 +183,6 @@ Your output should resemble:
 
 ```
 Creating network "ksql_default" with the default driver
-Creating ksql_zookeeper_1 ... done
 Creating ksql_kafka_1     ... done
 Creating ksql_schema-registry_1 ... done
 Creating primary-ksqldb-server  ... done
@@ -207,7 +204,6 @@ Your output should resemble:
 additional-ksqldb-server   /usr/bin/docker/run         Up      0.0.0.0:32768->8090/tcp
 ksql_kafka_1               /etc/confluent/docker/run   Up      0.0.0.0:29092->29092/tcp, 9092/tcp
 ksql_schema-registry_1     /etc/confluent/docker/run   Up      8081/tcp
-ksql_zookeeper_1           /etc/confluent/docker/run   Up      2181/tcp, 2888/tcp, 3888/tcp
 ksqldb-cli                 /bin/sh                     Up
 primary-ksqldb-server      /usr/bin/docker/run         Up      0.0.0.0:8088->8088/tcp
 ```
@@ -308,13 +304,11 @@ Stopping ksqldb-cli               ... done
 Stopping primary-ksqldb-server    ... done
 Stopping ksql_schema-registry_1   ... done
 Stopping ksql_kafka_1             ... done
-Stopping ksql_zookeeper_1         ... done
 Removing additional-ksqldb-server ... done
 Removing ksqldb-cli               ... done
 Removing primary-ksqldb-server    ... done
 Removing ksql_schema-registry_1   ... done
 Removing ksql_kafka_1             ... done
-Removing ksql_zookeeper_1         ... done
 Removing network ksql_default
 ```
 

--- a/docs/tutorials/etl.md
+++ b/docs/tutorials/etl.md
@@ -120,53 +120,45 @@ services:
     environment:
       discovery.type: single-node
 
-  zookeeper:
-    image: confluentinc/cp-zookeeper:{{ site.cprelease }}
-    hostname: zookeeper
-    container_name: zookeeper
-    ports:
-      - "2181:2181"
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-
-  broker:
-    image: confluentinc/cp-kafka:{{ site.cprelease }}
-    hostname: broker
-    container_name: broker
-    depends_on:
-      - zookeeper
+  kafka:
+    image: confluentinc/cp-server:{{ site.cprelease }}
+    hostname: kafka
+    container_name: kafka
     ports:
       - "29092:29092"
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_NODE_ID: 1
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:39093
+      KAFKA_LISTENERS: PLAINTEXT://kafka:9092,CONTROLLER://kafka:39093,PLAINTEXT_HOST://0.0.0.0:29092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LOG_DIRS: /tmp/kraft-combined-logs
+      CLUSTER_ID: 9-fLubcIRYqQaWkrwEThnQ
 
   schema-registry:
     image: confluentinc/cp-schema-registry:{{ site.cprelease }}
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
-      - zookeeper
-      - broker
+      - kafka
     ports:
       - "8081:8081"
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
-      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: "PLAINTEXT://broker:9092"
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: PLAINTEXT://kafka:9092
 
   ksqldb-server:
     image: confluentinc/ksqldb-server:{{ site.ksqldbversion }}
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
-      - broker
+      - kafka
       - schema-registry
     ports:
       - "8088:8088"
@@ -174,12 +166,12 @@ services:
       - "./confluent-hub-components/:/usr/share/kafka/plugins/"
     environment:
       KSQL_LISTENERS: "http://0.0.0.0:8088"
-      KSQL_BOOTSTRAP_SERVERS: "broker:9092"
+      KSQL_BOOTSTRAP_SERVERS: "kafka:9092"
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
       KSQL_KSQL_LOGGING_PROCESSING_STREAM_AUTO_CREATE: "true"
       KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: "true"
       KSQL_CONNECT_GROUP_ID: "ksql-connect-cluster"
-      KSQL_CONNECT_BOOTSTRAP_SERVERS: "broker:9092"
+      KSQL_CONNECT_BOOTSTRAP_SERVERS: "kafka:9092"
       KSQL_CONNECT_KEY_CONVERTER: "org.apache.kafka.connect.storage.StringConverter"
       KSQL_CONNECT_VALUE_CONVERTER: "io.confluent.connect.avro.AvroConverter"
       KSQL_CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
@@ -195,7 +187,7 @@ services:
     image: confluentinc/ksqldb-cli:{{ site.ksqldbversion }}
     container_name: ksqldb-cli
     depends_on:
-      - broker
+      - kafka
       - ksqldb-server
     entrypoint: /bin/sh
     tty: true

--- a/docs/tutorials/event-driven-microservice.md
+++ b/docs/tutorials/event-driven-microservice.md
@@ -39,65 +39,57 @@ To get started, create the following `docker-compose.yml` file. This specifies a
 version: '2'
 
 services:
-  zookeeper:
-    image: confluentinc/cp-zookeeper:{{ site.cprelease }}
-    hostname: zookeeper
-    container_name: zookeeper
-    ports:
-      - "2181:2181"
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-
-  broker:
-    image: confluentinc/cp-kafka:{{ site.cprelease }}
-    hostname: broker
-    container_name: broker
-    depends_on:
-      - zookeeper
+  kafka:
+    image: confluentinc/cp-server:{{ site.cprelease }}
+    hostname: kafka
+    container_name: kafka
     ports:
       - "29092:29092"
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_NODE_ID: 1
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:39093
+      KAFKA_LISTENERS: PLAINTEXT://kafka:9092,CONTROLLER://kafka:39093,PLAINTEXT_HOST://0.0.0.0:29092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LOG_DIRS: /tmp/kraft-combined-logs
+      CLUSTER_ID: 9-fLubcIRYqQaWkrwEThnQ
 
   schema-registry:
     image: confluentinc/cp-schema-registry:{{ site.cprelease }}
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
-      - zookeeper
-      - broker
+      - kafka
     ports:
       - "8081:8081"
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
-      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: "PLAINTEXT://broker:9092"
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: "PLAINTEXT://kafka:9092"
 
   ksqldb-server:
     image: confluentinc/ksqldb-server:{{ site.ksqldbversion }}
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
-      - broker
+      - kafka
       - schema-registry
     ports:
       - "8088:8088"
     environment:
       KSQL_LISTENERS: "http://0.0.0.0:8088"
-      KSQL_BOOTSTRAP_SERVERS: "broker:9092"
+      KSQL_BOOTSTRAP_SERVERS: "kafka:9092"
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
       KSQL_KSQL_LOGGING_PROCESSING_STREAM_AUTO_CREATE: "true"
       KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: "true"
       # Configuration to embed Kafka Connect support.
       KSQL_CONNECT_GROUP_ID: "ksql-connect-cluster"
-      KSQL_CONNECT_BOOTSTRAP_SERVERS: "broker:9092"
+      KSQL_CONNECT_BOOTSTRAP_SERVERS: "kafka:9092"
       KSQL_CONNECT_KEY_CONVERTER: "org.apache.kafka.connect.storage.StringConverter"
       KSQL_CONNECT_VALUE_CONVERTER: "io.confluent.connect.avro.AvroConverter"
       KSQL_CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
@@ -113,7 +105,7 @@ services:
     image: confluentinc/ksqldb-cli:{{ site.ksqldbversion }}
     container_name: ksqldb-cli
     depends_on:
-      - broker
+      - kafka
       - ksqldb-server
     entrypoint: /bin/sh
     tty: true

--- a/docs/tutorials/materialized.md
+++ b/docs/tutorials/materialized.md
@@ -90,53 +90,45 @@ services:
     volumes:
       - "./mysql/custom-config.cnf:/etc/mysql/conf.d/custom-config.cnf"
 
-  zookeeper:
-    image: confluentinc/cp-zookeeper:{{ site.cprelease }}
-    hostname: zookeeper
-    container_name: zookeeper
-    ports:
-      - "2181:2181"
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-
-  broker:
-    image: confluentinc/cp-kafka:{{ site.cprelease }}
-    hostname: broker
-    container_name: broker
-    depends_on:
-      - zookeeper
+  kafka:
+    image: confluentinc/cp-server:{{ site.cprelease }}
+    hostname: kafka
+    container_name: kafka
     ports:
       - "29092:29092"
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_NODE_ID: 1
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:39093
+      KAFKA_LISTENERS: PLAINTEXT://kafka:9092,CONTROLLER://kafka:39093,PLAINTEXT_HOST://0.0.0.0:29092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LOG_DIRS: /tmp/kraft-combined-logs
+      CLUSTER_ID: 9-fLubcIRYqQaWkrwEThnQ
 
   schema-registry:
     image: confluentinc/cp-schema-registry:{{ site.cprelease }}
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
-      - zookeeper
-      - broker
+      - kafka
     ports:
       - "8081:8081"
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
-      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: "PLAINTEXT://broker:9092"
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: "PLAINTEXT://kafka:9092"
 
   ksqldb-server:
     image: confluentinc/ksqldb-server:{{ site.ksqldbversion }}
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
-      - broker
+      - kafka
       - schema-registry
     ports:
       - "8088:8088"
@@ -144,13 +136,13 @@ services:
       - "./confluent-hub-components/:/usr/share/kafka/plugins/"
     environment:
       KSQL_LISTENERS: "http://0.0.0.0:8088"
-      KSQL_BOOTSTRAP_SERVERS: "broker:9092"
+      KSQL_BOOTSTRAP_SERVERS: "kafka:9092"
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
       KSQL_KSQL_LOGGING_PROCESSING_STREAM_AUTO_CREATE: "true"
       KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: "true"
       # Configuration to embed Kafka Connect support.
       KSQL_CONNECT_GROUP_ID: "ksql-connect-cluster"
-      KSQL_CONNECT_BOOTSTRAP_SERVERS: "broker:9092"
+      KSQL_CONNECT_BOOTSTRAP_SERVERS: "kafka:9092"
       KSQL_CONNECT_KEY_CONVERTER: "org.apache.kafka.connect.storage.StringConverter"
       KSQL_CONNECT_VALUE_CONVERTER: "io.confluent.connect.avro.AvroConverter"
       KSQL_CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
@@ -166,7 +158,7 @@ services:
     image: confluentinc/ksqldb-cli:{{ site.ksqldbversion }}
     container_name: ksqldb-cli
     depends_on:
-      - broker
+      - kafka
       - ksqldb-server
     entrypoint: /bin/sh
     tty: true

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
@@ -86,7 +86,7 @@ import org.junit.rules.TemporaryFolder;
 
 
 /**
- * Runs an in-memory, "embedded" Kafka cluster with 1 ZooKeeper instance and 1 Kafka broker.
+ * Runs an in-memory, "embedded" Kafka cluster with 1 Kafka running in combined mode.
  */
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 @SuppressWarnings("UnstableApiUsage")

--- a/licenses/licenses.html
+++ b/licenses/licenses.html
@@ -136,10 +136,6 @@ th {
 <TD>snappy-java-1.1.1.3</TD><TD>jar</TD><TD>1.1.1.3</TD><TD><A HREF="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache 2.0</A><br></TD></TR>
 <TR>
 <TD>xz-1.5</TD><TD>jar</TD><TD>1.5</TD><TD></TD></TR>
-<TR>
-<TD>zkclient-0.10</TD><TD>jar</TD><TD>0.10</TD><TD></TD></TR>
-<TR>
-<TD>zookeeper-3.8.4</TD><TD>jar</TD><TD>3.4.8</TD><TD><A HREF="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache 2.0</A><br></TD></TR>
 </TBODY>
 </TABLE>
 </BODY><HTML>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -260,8 +260,6 @@ extra:
         srlong: Confluent Schema Registry
         sr: Schema Registry
         streaming: Event Streaming Platform
-        zkfull: Apache ZooKeeper™
-        zk: ZooKeeper
 
         # Build-related string tokens
         kafkaversion: 3.5


### PR DESCRIPTION
### Description 
Removes all the zookeeper references from the codebase

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

