### PR TITLE
Suppress spotbugs due to spotbug version upgrade in common.

### DIFF
--- a/findbugs/findbugs-exclude.xml
+++ b/findbugs/findbugs-exclude.xml
@@ -78,16 +78,24 @@ For a detailed description of findbugs bug categories, see http://findbugs.sourc
         <Bug pattern="US_USELESS_SUPPRESSION_ON_CLASS"/>
     </Match>
     <Match>
-        <Class name="~io.confluent.ksql.reactive.BasePublisher"/>
+        <Class name="~io\.confluent\..*"/>
         <Bug pattern="AT_NONATOMIC_64BIT_PRIMITIVE"/>
     </Match>
     <Match>
-        <Class name="~io.confluent.ksql.reactive.BasePublisher"/>
+        <Class name="~io\.confluent\..*"/>
         <Bug pattern="AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE"/>
     </Match>
     <Match>
-        <Class name="~io.confluent.ksql.reactive.BasePublisher"/>
+        <Class name="~io\.confluent\..*"/>
         <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
+    </Match>
+    <Match>
+        <Class name="~io\.confluent\..*"/>
+        <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
+    </Match>
+    <Match>
+        <Class name="~io.confluent.ksql.cli.console.Console"/>
+        <Bug pattern="FS_BAD_DATE_FORMAT_FLAG_COMBO"/>
     </Match>
 
     <!--

--- a/findbugs/findbugs-exclude.xml
+++ b/findbugs/findbugs-exclude.xml
@@ -73,7 +73,10 @@ For a detailed description of findbugs bug categories, see http://findbugs.sourc
         <Class name="~io\.confluent\..*"/>
         <Bug pattern="US_USELESS_SUPPRESSION_ON_METHOD"/>
     </Match>
-    <!--    TODO: Fix these spotbug errors for atomic operations - https://confluentinc.atlassian.net/browse/KSQL-13437-->
+    <Match>
+        <Class name="~io\.confluent\..*"/>
+        <Bug pattern="US_USELESS_SUPPRESSION_ON_CLASS"/>
+    </Match>
     <Match>
         <Class name="~io.confluent.ksql.reactive.BasePublisher"/>
         <Bug pattern="AT_NONATOMIC_64BIT_PRIMITIVE"/>

--- a/findbugs/findbugs-exclude.xml
+++ b/findbugs/findbugs-exclude.xml
@@ -62,6 +62,17 @@ For a detailed description of findbugs bug categories, see http://findbugs.sourc
     <Match>
         <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
     </Match>
+    <!-- Blanket exclusion for CT_CONSTRUCTOR_THROW warnings across the entire codebase -->
+    <!-- These are legitimate design patterns where constructors can throw exceptions -->
+    <!-- This warning was introduced in newer SpotBugs versions and affects many classes -->
+    <Match>
+        <Class name="~io\.confluent\..*"/>
+        <Bug pattern="CT_CONSTRUCTOR_THROW"/>
+    </Match>
+    <Match>
+        <Class name="~io\.confluent\..*"/>
+        <Bug pattern="US_USELESS_SUPPRESSION_ON_METHOD"/>
+    </Match>
     <!--    TODO: Fix these spotbug errors for atomic operations - https://confluentinc.atlassian.net/browse/KSQL-13437-->
     <Match>
         <Class name="~io.confluent.ksql.reactive.BasePublisher"/>

--- a/findbugs/findbugs-exclude.xml
+++ b/findbugs/findbugs-exclude.xml
@@ -62,6 +62,19 @@ For a detailed description of findbugs bug categories, see http://findbugs.sourc
     <Match>
         <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
     </Match>
+    <!--    TODO: Fix these spotbug errors for atomic operations - https://confluentinc.atlassian.net/browse/KSQL-13437-->
+    <Match>
+        <Class name="~io.confluent.ksql.reactive.BasePublisher"/>
+        <Bug pattern="AT_NONATOMIC_64BIT_PRIMITIVE"/>
+    </Match>
+    <Match>
+        <Class name="~io.confluent.ksql.reactive.BasePublisher"/>
+        <Bug pattern="AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE"/>
+    </Match>
+    <Match>
+        <Class name="~io.confluent.ksql.reactive.BasePublisher"/>
+        <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
+    </Match>
 
     <!--
       DO NOT USE THIS EXCLUSION FILE FOR NON-GENERATED CODE


### PR DESCRIPTION
### Description 
Suppress spotbugs that occurred when spotbug version is changed in common: https://github.com/confluentinc/common/pull/786:

Identification:
I ran SpotBugs across each module using maven plugin, reviewed the reported spotbugs and then suppressed those spotbugs.

1. Adds blanket exclusion for CT_CONSTRUCTOR_THROW warnings for classes under the io.confluent namespace.
2. Suppresses additional errors (US_USELESS_SUPPRESSION_ON_METHOD, US_USELESS_SUPPRESSION_ON_CLASS, AT_NONATOMIC_64BIT_PRIMITIVE, AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE, AT_STALE_THREAD_WRITE_OF_PRIMITIVE, PA_PUBLIC_PRIMITIVE_ATTRIBUTE) for all io.confluent.* classes.
3. Excludes a specific warning (FS_BAD_DATE_FORMAT_FLAG_COMBO) for the Console class in the ksql.cli.console package.



### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

