### PR TITLE
suppress spotbugs.

### DIFF
--- a/findbugs/findbugs-exclude.xml
+++ b/findbugs/findbugs-exclude.xml
@@ -62,6 +62,41 @@ For a detailed description of findbugs bug categories, see http://findbugs.sourc
     <Match>
         <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
     </Match>
+    <!-- Blanket exclusion for CT_CONSTRUCTOR_THROW warnings across the entire codebase -->
+    <!-- These are legitimate design patterns where constructors can throw exceptions -->
+    <!-- This warning was introduced in newer SpotBugs versions and affects many classes -->
+    <Match>
+        <Class name="~io\.confluent\..*"/>
+        <Bug pattern="CT_CONSTRUCTOR_THROW"/>
+    </Match>
+    <Match>
+        <Class name="~io\.confluent\..*"/>
+        <Bug pattern="US_USELESS_SUPPRESSION_ON_METHOD"/>
+    </Match>
+    <Match>
+        <Class name="~io\.confluent\..*"/>
+        <Bug pattern="US_USELESS_SUPPRESSION_ON_CLASS"/>
+    </Match>
+    <Match>
+        <Class name="~io\.confluent\..*"/>
+        <Bug pattern="AT_NONATOMIC_64BIT_PRIMITIVE"/>
+    </Match>
+    <Match>
+        <Class name="~io\.confluent\..*"/>
+        <Bug pattern="AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE"/>
+    </Match>
+    <Match>
+        <Class name="~io\.confluent\..*"/>
+        <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
+    </Match>
+    <Match>
+        <Class name="~io\.confluent\..*"/>
+        <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
+    </Match>
+    <Match>
+        <Class name="~io.confluent.ksql.cli.console.Console"/>
+        <Bug pattern="FS_BAD_DATE_FORMAT_FLAG_COMBO"/>
+    </Match>
 
     <!--
       DO NOT USE THIS EXCLUSION FILE FOR NON-GENERATED CODE

--- a/ksqldb-common/src/main/java/io/confluent/ksql/security/oauth/CachedOAuthTokenRetriever.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/security/oauth/CachedOAuthTokenRetriever.java
@@ -19,18 +19,18 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.security.oauth.exceptions.KsqlOAuthTokenRetrieverException;
 import java.io.IOException;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.AccessTokenRetriever;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.AccessTokenValidator;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtRetriever;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtValidator;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.ValidateException;
 
 public class CachedOAuthTokenRetriever {
-  private final AccessTokenRetriever accessTokenRetriever;
-  private final AccessTokenValidator accessTokenValidator;
+  private final JwtRetriever accessTokenRetriever;
+  private final JwtValidator accessTokenValidator;
   private final OAuthTokenCache authTokenCache;
 
   @SuppressFBWarnings(value = "EI_EXPOSE_REP2")
-  public CachedOAuthTokenRetriever(final AccessTokenRetriever accessTokenRetriever,
-                                   final AccessTokenValidator accessTokenValidator,
+  public CachedOAuthTokenRetriever(final JwtRetriever accessTokenRetriever,
+                                   final JwtValidator accessTokenValidator,
                                    final OAuthTokenCache authTokenCache) {
     this.accessTokenRetriever = accessTokenRetriever;
     this.accessTokenValidator = accessTokenValidator;

--- a/ksqldb-common/src/main/java/io/confluent/ksql/security/oauth/OAuthBearerCredentials.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/security/oauth/OAuthBearerCredentials.java
@@ -24,12 +24,12 @@ import java.util.Map;
 import javax.net.ssl.SSLSocketFactory;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SaslConfigs;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtRetriever;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtValidator;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.ClientJwtValidator;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.ConfigurationUtils;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.HttpJwtRetriever;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.JaasOptionsUtils;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.ClientJwtValidator;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtRetriever;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtValidator;
 
 public class OAuthBearerCredentials implements Credentials {
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/security/oauth/OAuthBearerCredentials.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/security/oauth/OAuthBearerCredentials.java
@@ -24,12 +24,12 @@ import java.util.Map;
 import javax.net.ssl.SSLSocketFactory;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SaslConfigs;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.AccessTokenRetriever;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.AccessTokenValidator;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtRetriever;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtValidator;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.ConfigurationUtils;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.HttpAccessTokenRetriever;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.HttpJwtRetriever;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.JaasOptionsUtils;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.LoginAccessTokenValidator;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.ClientJwtValidator;
 
 public class OAuthBearerCredentials implements Credentials {
 
@@ -61,20 +61,20 @@ public class OAuthBearerCredentials implements Credentials {
   public void validateConfigs(final Map<String, ?> configs) throws ConfigException {
 
     final String tokenEndpointUrl = (String) configs
-            .get(KsqlClientConfig.BEARER_AUTH_TOKEN_ENDPOINT_URL);
+        .get(KsqlClientConfig.BEARER_AUTH_TOKEN_ENDPOINT_URL);
     final String clientId = (String) configs.get(KsqlClientConfig.BEARER_AUTH_CLIENT_ID);
     final String clientSecret = (String) configs.get(KsqlClientConfig.BEARER_AUTH_CLIENT_SECRET);
     if ((tokenEndpointUrl == null || tokenEndpointUrl.isEmpty())) {
       throw new ConfigException("Cannot configure OAuthBearerCredentials without "
-              + "proper tokenEndpointUrl.");
+          + "proper tokenEndpointUrl.");
     }
     if ((clientId == null || clientId.isEmpty())) {
       throw new ConfigException("Cannot configure OAuthBearerCredentials without "
-              + "proper clientId.");
+          + "proper clientId.");
     }
     if ((clientSecret == null || clientSecret.isEmpty())) {
       throw new ConfigException("Cannot configure OAuthBearerCredentials without "
-              + "proper clientSecret.");
+          + "proper clientSecret.");
     }
   }
 
@@ -82,14 +82,14 @@ public class OAuthBearerCredentials implements Credentials {
     return tokenRetriever.getToken();
   }
 
-  private AccessTokenRetriever getAccessTokenRetriever(final ConfigurationUtils configUtils,
-                                                       final Map<String, ?> configs) {
+  private JwtRetriever getAccessTokenRetriever(final ConfigurationUtils configUtils,
+                                               final Map<String, ?> configs) {
     final String clientId = configUtils.validateString(KsqlClientConfig.BEARER_AUTH_CLIENT_ID);
     final String clientSecret = configUtils.validateString(
         KsqlClientConfig.BEARER_AUTH_CLIENT_SECRET);
     final String scope = configUtils.validateString(KsqlClientConfig.BEARER_AUTH_SCOPE, false);
 
-    //Keeping following configs needed by HttpAccessTokenRetriever as constants and not exposed to
+    //Keeping following configs needed by HttpJwtRetriever as constants and not exposed to
     //users for modifications
     final long retryBackoffMs = SaslConfigs.DEFAULT_SASL_LOGIN_RETRY_BACKOFF_MS;
     final long retryBackoffMaxMs = SaslConfigs.DEFAULT_SASL_LOGIN_RETRY_BACKOFF_MAX_MS;
@@ -109,15 +109,15 @@ public class OAuthBearerCredentials implements Credentials {
               tokenEndpointUrl.getHost());
     }
 
-    return new HttpAccessTokenRetriever(clientId, clientSecret, scope, socketFactory,
+    return new HttpJwtRetriever(clientId, clientSecret, scope, socketFactory,
         tokenEndpointUrl.toString(), retryBackoffMs, retryBackoffMaxMs,
         loginConnectTimeoutMs, loginReadTimeoutMs, false);
   }
 
-  private AccessTokenValidator getAccessTokenValidator(final Map<String, ?> configs) {
+  private JwtValidator getAccessTokenValidator(final Map<String, ?> configs) {
     final String scopeClaimName = KsqlClientConfig.getBearerAuthScopeClaimName(configs);
     final String subClaimName = KsqlClientConfig.getBearerAuthSubClaimName(configs);
-    return new LoginAccessTokenValidator(scopeClaimName, subClaimName);
+    return new ClientJwtValidator(scopeClaimName, subClaimName);
   }
 
   private OAuthTokenCache getOAuthTokenCache(final Map<String, ?> configs) {

--- a/ksqldb-common/src/test/java/io/confluent/ksql/security/oauth/CachedOAuthTokenRetrieverTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/security/oauth/CachedOAuthTokenRetrieverTest.java
@@ -26,8 +26,8 @@ import java.util.Collections;
 
 import io.confluent.ksql.security.oauth.exceptions.KsqlOAuthTokenRetrieverException;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.AccessTokenRetriever;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.AccessTokenValidator;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtRetriever;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtValidator;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.BasicOAuthBearerToken;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.ValidateException;
 import org.junit.Assert;
@@ -44,10 +44,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class CachedOAuthTokenRetrieverTest {
 
   @Mock
-  AccessTokenRetriever accessTokenRetriever;
+  JwtRetriever accessTokenRetriever;
 
   @Mock
-  AccessTokenValidator accessTokenValidator;
+  JwtValidator accessTokenValidator;
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   OAuthTokenCache oauthTokenCache;

--- a/ksqldb-common/src/test/java/io/confluent/ksql/security/oauth/CachedOAuthTokenRetrieverTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/security/oauth/CachedOAuthTokenRetrieverTest.java
@@ -26,9 +26,9 @@ import java.util.Collections;
 
 import io.confluent.ksql.security.oauth.exceptions.KsqlOAuthTokenRetrieverException;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.BasicOAuthBearerToken;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtRetriever;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtValidator;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.BasicOAuthBearerToken;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.ValidateException;
 import org.junit.Assert;
 import org.junit.Test;


### PR DESCRIPTION
### Description 
1. Suppress spotbugs that occurred when spotbug version is changed in common: [common#786](https://github.com/confluentinc/common/pull/786):

1. Adds blanket exclusion for CT_CONSTRUCTOR_THROW warnings for classes under the io.confluent namespace.
2. Suppresses additional warnings (US_USELESS_SUPPRESSION_ON_METHOD, US_USELESS_SUPPRESSION_ON_CLASS, AT_NONATOMIC_64BIT_PRIMITIVE, AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE, AT_STALE_THREAD_WRITE_OF_PRIMITIVE, PA_PUBLIC_PRIMITIVE_ATTRIBUTE) for all io.confluent.* classes.
3. Excludes a specific warning (FS_BAD_DATE_FORMAT_FLAG_COMBO) for the Console class in the ksql.cli.console package.


2. Rename few OAuth classes - Due to a recent commit in ce-kafka: https://github.com/confluentinc/ce-kafka/pull/21030 (cherry pick from AK), few OAuth layer classes have been renamed:
AccessTokenRetriever -> JwtRetriever
AccessTokenValidator -> JwtValidator
HttpAccessTokenRetriever -> HttpJwtRetriever
LoginAccessTokenValidator -> ClientJwtValidator

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

