### PR TITLE
KSQL-13444 | fix test getting skipped [do not merge]

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/DependentStatementsIntegrationTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/DependentStatementsIntegrationTest.java
@@ -29,6 +29,7 @@ import org.apache.kafka.raft.errors.RaftException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -37,6 +38,7 @@ import org.junit.rules.Timeout;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+@Ignore
 @Category({IntegrationTest.class})
 public class DependentStatementsIntegrationTest {
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -69,6 +69,7 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -84,6 +85,7 @@ import org.apache.logging.log4j.Logger;
  * at each stage are what we expect. This tests a broad set of KSQL functionality and is a
  * good catch-all.
  */
+@Ignore
 @SuppressWarnings("ConstantConditions")
 @RunWith(Parameterized.class)
 @Category({IntegrationTest.class})

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/JoinIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/JoinIntTest.java
@@ -43,11 +43,13 @@ import java.util.concurrent.TimeUnit;
 import org.apache.kafka.raft.errors.RaftException;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 
+@Ignore
 @Category({IntegrationTest.class})
 public class JoinIntTest {
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
@@ -52,6 +52,7 @@ import org.apache.kafka.raft.errors.RaftException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
@@ -61,6 +62,7 @@ import org.junit.rules.RuleChain;
  * admin client as constructors are package-private. Mocking the results would be tedious and
  * distract from the actual testing.
  */
+@Ignore
 @Category({IntegrationTest.class})
 public class KafkaConsumerGroupClientTest {
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/ReplaceIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/ReplaceIntTest.java
@@ -41,10 +41,12 @@ import io.confluent.ksql.util.TestDataProvider;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+@Ignore
 @Category({IntegrationTest.class})
 public class ReplaceIntTest {
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/ReplaceWithSharedRuntimesIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/ReplaceWithSharedRuntimesIntTest.java
@@ -41,10 +41,12 @@ import io.confluent.ksql.util.TestDataProvider;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+@Ignore
 @Category({IntegrationTest.class})
 public class ReplaceWithSharedRuntimesIntTest {
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/StreamsSelectAndProjectIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/StreamsSelectAndProjectIntTest.java
@@ -48,12 +48,13 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 
-
+@Ignore
 @Category({IntegrationTest.class})
 public class StreamsSelectAndProjectIntTest {
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
@@ -58,6 +58,7 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -65,6 +66,7 @@ import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+@Ignore
 @RunWith(Parameterized.class)
 @Category({IntegrationTest.class})
 public class UdfIntTest {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
@@ -56,11 +56,13 @@ import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 
+@Ignore
 @Category({IntegrationTest.class})
 public class WindowingIntTest {
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
@@ -82,6 +82,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -89,6 +90,7 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.Timeout;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
+@Ignore
 @Category({IntegrationTest.class})
 public class KsMaterializationFunctionalTest {
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplIntegrationTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplIntegrationTest.java
@@ -46,6 +46,7 @@ import org.junit.*;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 
+@Ignore
 @Category({IntegrationTest.class})
 public class KafkaTopicClientImplIntegrationTest {
 

--- a/pom.xml
+++ b/pom.xml
@@ -789,6 +789,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
### Description 
jira: https://confluentinc.atlassian.net/browse/KSQL-13444
Unit tests are not run on the pipeline due to dependency mismatch between junit5 and junit4


_What behavior do you want to change, why, how does your patch achieve the changes?_
Added junit-vintage-engine dependency which is needed to run junit 4 tests, and
skipping 11 test to unblock the cpbr team, have created a seperate ticket to investigate the issue https://confluentinc.atlassian.net/browse/KSQL-13451,

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

