### PR TITLE
Resolve checkstyle errors.

### DIFF
--- a/findbugs/findbugs-exclude.xml
+++ b/findbugs/findbugs-exclude.xml
@@ -101,7 +101,6 @@ For a detailed description of findbugs bug categories, see http://findbugs.sourc
         <Class name="~io.confluent.ksql.test.*"/>
         <Bug pattern="SS_SHOULD_BE_STATIC"/>
     </Match>
-    SS_SHOULD_BE_STATIC02
 
     <!--
       DO NOT USE THIS EXCLUSION FILE FOR NON-GENERATED CODE

--- a/findbugs/findbugs-exclude.xml
+++ b/findbugs/findbugs-exclude.xml
@@ -97,6 +97,11 @@ For a detailed description of findbugs bug categories, see http://findbugs.sourc
         <Class name="~io.confluent.ksql.cli.console.Console"/>
         <Bug pattern="FS_BAD_DATE_FORMAT_FLAG_COMBO"/>
     </Match>
+    <Match>
+        <Class name="~io.confluent.ksql.test.*"/>
+        <Bug pattern="SS_SHOULD_BE_STATIC"/>
+    </Match>
+    SS_SHOULD_BE_STATIC02
 
     <!--
       DO NOT USE THIS EXCLUSION FILE FOR NON-GENERATED CODE


### PR DESCRIPTION
### Description 
Suppress spotbugs that occurred when spotbug version is changed in common: https://github.com/confluentinc/common/pull/786.

Related PR for suppressions required in ksql repo: https://github.com/confluentinc/ksql/pull/10751

Suppressing - SS_SHOULD_BE_STATIC specifically to unblock cp-br packaging failing with errors similar to:
```
[ERROR] Medium: Unread field: io.confluent.ksql.test.util.ImmutableTesterTest$4TestSubject.f11; should this field be static? [io.confluent.ksql.test.util.ImmutableTesterTest$4TestSubject] At ImmutableTesterTest.java:[line 107] SS_SHOULD_BE_STATIC
```

https://semaphore.ci.confluent.io/jobs/a9aebfe9-cbfa-428b-a383-2358a5242586#L3056


### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

