### PR TITLE
Ksql 13436 suppress test spotbugs

### DIFF
--- a/findbugs/findbugs-exclude.xml
+++ b/findbugs/findbugs-exclude.xml
@@ -98,14 +98,8 @@ For a detailed description of findbugs bug categories, see http://findbugs.sourc
         <Bug pattern="FS_BAD_DATE_FORMAT_FLAG_COMBO"/>
     </Match>
     <Match>
-        <Class name="~io.confluent.ksql.test.*"/>
-        <Bug pattern="SS_SHOULD_BE_STATIC"/>
+        <Class name="~.*Test" />
     </Match>
-    <Match>
-        <Class name="~io.confluent.ksql.*"/>
-        <Bug pattern="SIC_INNER_SHOULD_BE_STATIC"/>
-    </Match>
-
     <!--
       DO NOT USE THIS EXCLUSION FILE FOR NON-GENERATED CODE
 

--- a/findbugs/findbugs-exclude.xml
+++ b/findbugs/findbugs-exclude.xml
@@ -101,6 +101,10 @@ For a detailed description of findbugs bug categories, see http://findbugs.sourc
         <Class name="~io.confluent.ksql.test.*"/>
         <Bug pattern="SS_SHOULD_BE_STATIC"/>
     </Match>
+    <Match>
+        <Class name="~io.confluent.ksql.*"/>
+        <Bug pattern="SIC_INNER_SHOULD_BE_STATIC"/>
+    </Match>
 
     <!--
       DO NOT USE THIS EXCLUSION FILE FOR NON-GENERATED CODE

--- a/pom.xml
+++ b/pom.xml
@@ -920,7 +920,7 @@
                     <effort>Max</effort>
                     <threshold>Max</threshold>
                     <failOnError>true</failOnError>
-                    <includeTests>true</includeTests>
+<!--                    <includeTests>true</includeTests>-->
                 </configuration>
                 <executions>
                     <!--


### PR DESCRIPTION
### Description 
This pull request includes updates to improve the configuration of FindBugs and modify its behavior regarding test classes. The most significant changes involve altering the exclusion rules for test classes in the `findbugs-exclude.xml` file and commenting out the `includeTests` configuration in the `pom.xml` file.

### FindBugs Configuration Updates:

* [`findbugs/findbugs-exclude.xml`](diffhunk://#diff-6103f0f51c1c3e4cb11f9c5fad828b086d902e8655b8005477e9c6f8091c447bL101-L104): Updated the exclusion rule to match all test classes using the pattern `~.*Test` instead of the previous `~io.confluent.ksql.test.*`. This broadens the scope of excluded test classes.

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L923-R923): Commented out the `includeTests` configuration in the FindBugs plugin setup, effectively disabling the inclusion of test classes in the analysis.ow does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

