### PR TITLE
KSQL-13451 | fix master 

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -67,7 +67,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-ubuntu24-04-arm64-0
+          type: s1-prod-ubuntu24-04-amd64-0
       env_vars:
         - name: COMPONENT_NAME
           value: ksqldb

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -67,7 +67,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-ubuntu24-04-amd64-0
+          type: s1-prod-ubuntu24-04-arm64-0
       env_vars:
         - name: COMPONENT_NAME
           value: ksqldb

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
@@ -175,6 +175,7 @@ public class RestQueryTranslationTest {
           // but they are capped to 100
           .nameMatches(name -> !name.startsWith("pull-query-coordinator"))
           .nameMatches(name -> !name.startsWith("pull-query-router"))
+          .nameMatches(name -> !name.startsWith("executor-share-coordinator"))
           .build()));
     } else {
       thread.assertSameThreads();

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
@@ -132,14 +132,10 @@ class KafkaEmbedded {
    * @param config The broker configuration settings to be updated.
    */
   private void setupListenerConfiguration(final Map<String, String> config) {
-    final int controllerPort = getFreePort();
-    final int externalPort = getFreePort();
-
-    config.put("listeners", "CONTROLLER://127.0.0.1:" + controllerPort
-        + ",EXTERNAL://127.0.0.1:" + externalPort);
+    config.put("listeners", "CONTROLLER://127.0.0.1:0,EXTERNAL://127.0.0.1:0");
     config.put("inter.broker.listener.name", "EXTERNAL");
     config.put("controller.listener.names", "CONTROLLER");
-    config.put("advertised.listeners", "EXTERNAL://127.0.0.1:" + externalPort);
+    config.put("advertised.listeners", "EXTERNAL://127.0.0.1:0");
 
     if (!config.containsKey("listener.security.protocol.map")) {
       // Default to PLAINTEXT if not set

--- a/pom.xml
+++ b/pom.xml
@@ -789,6 +789,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
### Description
_What behavior do you want to change, why, how does your patch achieve the changes?_  
* fixes the test getting skipped issue by adding junit-vintage-engine dependency to the pom.xml file
* fix the port binding issue by updating the port assignment logic by removing `getFreePort()` with `:0`, so that it gets auto assigned.
* whitelisted `executor-share-coordinator` thread as it is not a case of thread leak and its executors is present.

jiira: https://confluentinc.atlassian.net/browse/KSQL-13451

### Testing done
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

