### PR TITLE
[KSQL-13529] | Adds apache kafka logger to rolling log4j2 yaml file

### DIFF
--- a/config/ksql-migrations-log4j2.yaml
+++ b/config/ksql-migrations-log4j2.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2025 Confluent Inc.
+#
+# Licensed under the Confluent Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+# http://www.confluent.io/confluent-community-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
 Configuration:
   Appenders:
     Console:

--- a/config/log4j2-file.yaml
+++ b/config/log4j2-file.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2025 Confluent Inc.
+#
+# Licensed under the Confluent Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+# http://www.confluent.io/confluent-community-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
 Configuration:
   Properties:
     Property:

--- a/config/log4j2-rolling.yaml
+++ b/config/log4j2-rolling.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2025 Confluent Inc.
+#
+# Licensed under the Confluent Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+# http://www.confluent.io/confluent-community-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
 Configuration:
   Properties:
     Property:
@@ -64,6 +79,15 @@ Configuration:
         AppenderRef:
           - ref: main
 
+      # Uncomment the following to stop KSQL from logging out each request it receives:
+      #- name: io.confluent.ksql.rest.server.resources.KsqlResource
+      #  level: warn
+
+      # And this one to avoid the logs being spammed with KsqlConfig values.
+      # Though these can be useful for debugging / investigations.
+      #- name: io.confluent.ksql.util.KsqlConfig
+      #  level: warn
+
       - name: processing
         level: warn
         additivity: false
@@ -89,6 +113,12 @@ Configuration:
           - ref: connect
 
       - name: kafka
+        level: warn
+        additivity: false
+        AppenderRef:
+          - ref: kafka
+
+      - name: org.apache.kafka
         level: warn
         additivity: false
         AppenderRef:

--- a/config/log4j2-silent.yaml
+++ b/config/log4j2-silent.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2025 Confluent Inc.
+#
+# Licensed under the Confluent Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+# http://www.confluent.io/confluent-community-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
 Configuration:
   Loggers:
     Root:

--- a/config/log4j2-sql-test.yaml
+++ b/config/log4j2-sql-test.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2025 Confluent Inc.
+#
+# Licensed under the Confluent Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+# http://www.confluent.io/confluent-community-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
 Configuration:
   Appenders:
     Console:

--- a/config/log4j2.yaml
+++ b/config/log4j2.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2025 Confluent Inc.
+#
+# Licensed under the Confluent Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+# http://www.confluent.io/confluent-community-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
 Configuration:
   Appenders:
     Console:
@@ -59,3 +74,12 @@ Configuration:
         additivity: false
         AppenderRef:
           - ref: stdout
+
+      # Uncomment the following to stop KSQL from logging out each request it receives:
+      #- name: io.confluent.ksql.rest.server.resources.KsqlResource
+      #  level: warn
+
+      # And this one to avoid the logs being spammed with KsqlConfig values.
+      # Though these can be useful for debugging / investigations.
+      #- name: io.confluent.ksql.util.KsqlConfig
+      #  level: warn


### PR DESCRIPTION
### Description 
Update the log4 rolling config file with org.apache.kafka logger.
Add license text to log4j2 files.

### Testing done 
Tested locally

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

