### PR TITLE
Updates to use public OAuth APIs

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/security/oauth/CachedOAuthTokenRetriever.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/security/oauth/CachedOAuthTokenRetriever.java
@@ -17,11 +17,11 @@ package io.confluent.ksql.security.oauth;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.security.oauth.exceptions.KsqlOAuthTokenRetrieverException;
-import java.io.IOException;
+import org.apache.kafka.common.security.oauthbearer.JwtRetriever;
+import org.apache.kafka.common.security.oauthbearer.JwtRetrieverException;
+import org.apache.kafka.common.security.oauthbearer.JwtValidator;
+import org.apache.kafka.common.security.oauthbearer.JwtValidatorException;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtRetriever;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtValidator;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.ValidateException;
 
 public class CachedOAuthTokenRetriever {
   private final JwtRetriever accessTokenRetriever;
@@ -42,7 +42,7 @@ public class CachedOAuthTokenRetriever {
       String token = null;
       try {
         token = accessTokenRetriever.retrieve();
-      } catch (IOException | RuntimeException e) {
+      } catch (JwtRetrieverException e) {
         throw new KsqlOAuthTokenRetrieverException(
             "Failed to Retrieve OAuth Token for KSQL", e);
       }
@@ -50,7 +50,7 @@ public class CachedOAuthTokenRetriever {
       final OAuthBearerToken oauthBearerToken;
       try {
         oauthBearerToken = accessTokenValidator.validate(token);
-      } catch (ValidateException e) {
+      } catch (JwtValidatorException e) {
         throw new KsqlOAuthTokenRetrieverException(
             "OAuth Token for KSQL is Invalid", e);
       }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/security/oauth/OAuthBearerCredentials.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/security/oauth/OAuthBearerCredentials.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.security.oauth;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.confluent.kafka.schemaregistry.client.security.bearerauth.oauth.ClientJwtValidator;
 import io.confluent.ksql.security.Credentials;
 import io.confluent.ksql.security.KsqlClientConfig;
 import io.confluent.ksql.security.ssl.HostSslSocketFactory;
@@ -24,12 +25,11 @@ import java.util.Map;
 import javax.net.ssl.SSLSocketFactory;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SaslConfigs;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.ClientJwtValidator;
+import org.apache.kafka.common.security.oauthbearer.JwtRetriever;
+import org.apache.kafka.common.security.oauthbearer.JwtValidator;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.ConfigurationUtils;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.HttpJwtRetriever;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.JaasOptionsUtils;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtRetriever;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtValidator;
 
 public class OAuthBearerCredentials implements Credentials {
 

--- a/ksqldb-common/src/test/java/io/confluent/ksql/security/oauth/CachedOAuthTokenRetrieverTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/security/oauth/CachedOAuthTokenRetrieverTest.java
@@ -25,11 +25,11 @@ import java.io.IOException;
 import java.util.Collections;
 
 import io.confluent.ksql.security.oauth.exceptions.KsqlOAuthTokenRetrieverException;
+import org.apache.kafka.common.security.oauthbearer.JwtRetriever;
+import org.apache.kafka.common.security.oauthbearer.JwtValidator;
+import org.apache.kafka.common.security.oauthbearer.JwtValidatorException;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.BasicOAuthBearerToken;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtRetriever;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtValidator;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.ValidateException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -132,7 +132,7 @@ public class CachedOAuthTokenRetrieverTest {
 
     String validationError = "Malformed JWT provided";
     when(accessTokenValidator.validate(tokenString1)).thenThrow(
-        new ValidateException(validationError));
+        new JwtValidatorException(validationError));
     Assert.assertThrows(validationError, KsqlOAuthTokenRetrieverException.class, () -> {
       cachedOAuthTokenRetriever.getToken();
     });


### PR DESCRIPTION
### Description 

Upstream changes in Apache Kafka to the OAuth plugin for KIP-1139 modified some internal APIs which are in use by classes in this repo.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

