### PR TITLE
KSQL-13692 | CVE fix for commons-lang3. Bump the version to 3.18.0

### DIFF
--- a/ksqldb-common/pom.xml
+++ b/ksqldb-common/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.5</version>
+            <version>${lang3.version}</version>
         </dependency>
 
         <dependency>

--- a/ksqldb-parser/pom.xml
+++ b/ksqldb-parser/pom.xml
@@ -61,6 +61,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
+            <version>${lang3.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <commons-text.version>1.10.0</commons-text.version>
         <csv.version>1.4</csv.version>
         <commons.compress.version>1.26.0</commons.compress.version>
-        <lang3.version>3.5</lang3.version>
+        <lang3.version>3.18.0</lang3.version>
         <retrying.version>2.0.0</retrying.version>
         <inject.version>1</inject.version>
         <janino.version>3.1.10</janino.version>


### PR DESCRIPTION
### Description 
KSQL-13692 | CVE fix for commons-lang3. Bump the version to 3.18.0

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

