### PR TITLE
KSQL-13699 | Pass the proxy protocol headers to admin, producer and consumer clients if the user principal is available.

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
@@ -34,7 +34,6 @@ import org.apache.kafka.common.network.ProxyProtocol;
 import org.apache.kafka.common.network.ProxyProtocolCommand;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
-import org.jetbrains.annotations.NotNull;
 
 public final class ServiceContextFactory {
 
@@ -159,7 +158,7 @@ public final class ServiceContextFactory {
       return kafkaClientSupplier.getGlobalConsumer(configsWithProxyProtocol);
     }
 
-    private @NotNull Map<String, Object> applyProducerProxyProtocolConfigs(
+    private Map<String, Object> applyProducerProxyProtocolConfigs(
         Map<String, Object> config) {
       final Map<String, Object> configsWithProxyProtocol = new HashMap<>(config);
       configsWithProxyProtocol.put(ProducerConfig.PROXY_PROTOCOL_CLIENT_MODE,
@@ -173,7 +172,7 @@ public final class ServiceContextFactory {
       return configsWithProxyProtocol;
     }
 
-    private @NotNull Map<String, Object> applyConsumerProxyProtocolConfigs(
+    private Map<String, Object> applyConsumerProxyProtocolConfigs(
         Map<String, Object> config) {
       final Map<String, Object> configsWithProxyProtocol = new HashMap<>(config);
       configsWithProxyProtocol.put(ConsumerConfig.PROXY_PROTOCOL_CLIENT_MODE,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
@@ -102,7 +102,8 @@ public final class ServiceContextFactory {
     );
   }
 
-  private static void applyAdminProxyProtocolLocalConfigs(Map<String, Object> topicAdminConfig) {
+  private static void applyAdminProxyProtocolLocalConfigs(
+      final Map<String, Object> topicAdminConfig) {
     // Set proxy protocol client mode to local for topicAdminClientSupplier
     // if user principal doesn't exist
     topicAdminConfig.put(AdminClientConfig.PROXY_PROTOCOL_CLIENT_MODE,
@@ -128,38 +129,42 @@ public final class ServiceContextFactory {
     private final KsqlPrincipal userPrincipal;
     private final KafkaClientSupplier kafkaClientSupplier;
 
-    public KafkaClientSupplierWithProxyConfigs(KsqlPrincipal userPrincipal,
-        KafkaClientSupplier kafkaClientSupplier) {
+    public KafkaClientSupplierWithProxyConfigs(final KsqlPrincipal userPrincipal,
+        final KafkaClientSupplier kafkaClientSupplier) {
       this.userPrincipal = userPrincipal;
       this.kafkaClientSupplier = kafkaClientSupplier;
     }
 
     @Override
-    public Producer<byte[], byte[]> getProducer(Map<String, Object> config) {
-      final Map<String, Object> configsWithProxyProtocol = applyProducerProxyProtocolConfigs(config);
+    public Producer<byte[], byte[]> getProducer(final Map<String, Object> config) {
+      final Map<String, Object> configsWithProxyProtocol =
+          applyProducerProxyProtocolConfigs(config);
       return kafkaClientSupplier.getProducer(configsWithProxyProtocol);
     }
 
     @Override
-    public Consumer<byte[], byte[]> getConsumer(Map<String, Object> config) {
-      final Map<String, Object> configsWithProxyProtocol = applyConsumerProxyProtocolConfigs(config);
+    public Consumer<byte[], byte[]> getConsumer(final Map<String, Object> config) {
+      final Map<String, Object> configsWithProxyProtocol =
+          applyConsumerProxyProtocolConfigs(config);
       return kafkaClientSupplier.getConsumer(configsWithProxyProtocol);
     }
 
     @Override
-    public Consumer<byte[], byte[]> getRestoreConsumer(Map<String, Object> config) {
-      final Map<String, Object> configsWithProxyProtocol = applyConsumerProxyProtocolConfigs(config);
+    public Consumer<byte[], byte[]> getRestoreConsumer(final Map<String, Object> config) {
+      final Map<String, Object> configsWithProxyProtocol =
+          applyConsumerProxyProtocolConfigs(config);
       return kafkaClientSupplier.getRestoreConsumer(configsWithProxyProtocol);
     }
 
     @Override
-    public Consumer<byte[], byte[]> getGlobalConsumer(Map<String, Object> config) {
-      final Map<String, Object> configsWithProxyProtocol = applyConsumerProxyProtocolConfigs(config);
+    public Consumer<byte[], byte[]> getGlobalConsumer(final Map<String, Object> config) {
+      final Map<String, Object> configsWithProxyProtocol =
+          applyConsumerProxyProtocolConfigs(config);
       return kafkaClientSupplier.getGlobalConsumer(configsWithProxyProtocol);
     }
 
     private Map<String, Object> applyProducerProxyProtocolConfigs(
-        Map<String, Object> config) {
+        final Map<String, Object> config) {
       final Map<String, Object> configsWithProxyProtocol = new HashMap<>(config);
       configsWithProxyProtocol.put(ProducerConfig.PROXY_PROTOCOL_CLIENT_MODE,
           ProxyProtocolCommand.PROXY.name());
@@ -173,7 +178,7 @@ public final class ServiceContextFactory {
     }
 
     private Map<String, Object> applyConsumerProxyProtocolConfigs(
-        Map<String, Object> config) {
+        final Map<String, Object> config) {
       final Map<String, Object> configsWithProxyProtocol = new HashMap<>(config);
       configsWithProxyProtocol.put(ConsumerConfig.PROXY_PROTOCOL_CLIENT_MODE,
           ProxyProtocolCommand.PROXY.name());

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
@@ -86,10 +86,8 @@ public final class ServiceContextFactory {
     } else {
       finalKafkaClientSupplier = kafkaClientSupplier;
 
-      final Map<String, Object> adminConfig =
-          new HashMap<>(ksqlConfig.getKsqlAdminClientConfigProps());
-      applyAdminProxyProtocolLocalConfigs(adminConfig);
-      adminClientSupplier = () -> kafkaClientSupplier.getAdmin(adminConfig);
+      adminClientSupplier = () -> kafkaClientSupplier
+          .getAdmin(ksqlConfig.getKsqlAdminClientConfigProps());
     }
 
     return new DefaultServiceContext(
@@ -100,15 +98,6 @@ public final class ServiceContextFactory {
         connectClientSupplier,
         ksqlClientSupplier
     );
-  }
-
-  private static void applyAdminProxyProtocolLocalConfigs(
-      final Map<String, Object> topicAdminConfig) {
-    // Set proxy protocol client mode to local for topicAdminClientSupplier
-    // if user principal doesn't exist
-    topicAdminConfig.put(AdminClientConfig.PROXY_PROTOCOL_CLIENT_MODE,
-        ProxyProtocolCommand.LOCAL.name());
-    topicAdminConfig.put(AdminClientConfig.PROXY_PROTOCOL_CLIENT_VERSION, ProxyProtocol.V2.name);
   }
 
   private static void applyAdminProxyProtocolConfigs(
@@ -129,7 +118,7 @@ public final class ServiceContextFactory {
     private final KsqlPrincipal userPrincipal;
     private final KafkaClientSupplier kafkaClientSupplier;
 
-    public KafkaClientSupplierWithProxyConfigs(final KsqlPrincipal userPrincipal,
+    KafkaClientSupplierWithProxyConfigs(final KsqlPrincipal userPrincipal,
         final KafkaClientSupplier kafkaClientSupplier) {
       this.userPrincipal = userPrincipal;
       this.kafkaClientSupplier = kafkaClientSupplier;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
@@ -26,15 +26,20 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.network.ProxyProtocol;
 import org.apache.kafka.common.network.ProxyProtocolCommand;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
+import org.jetbrains.annotations.NotNull;
 
 public final class ServiceContextFactory {
 
   private ServiceContextFactory() {
-
+    super();
   }
 
   public static ServiceContext create(
@@ -64,35 +69,122 @@ public final class ServiceContextFactory {
       final Supplier<SimpleKsqlClient> ksqlClientSupplier,
       final Optional<KsqlPrincipal> userPrincipal
   ) {
-    final Supplier<Admin> topicAdminClientSupplier;
+    final Supplier<Admin> adminClientSupplier;
+    final KafkaClientSupplier finalKafkaClientSupplier;
+
     if (ksqlConfig.getBoolean(KsqlConfig.KSQL_CLIENT_IP_PORT_CONFIGURATION_ENABLED)
         && userPrincipal.isPresent()) {
-      // Create new map to make it modifiable
-      final Map<String, Object> topicAdminConfig = new HashMap<>(
-          ksqlConfig.getKsqlAdminClientConfigProps());
+      final KsqlPrincipal principal = userPrincipal.get();
 
-      // Set Client address config for topicAdminClientSupplier if user principal exists
-      topicAdminConfig.put(AdminClientConfig.PROXY_PROTOCOL_CLIENT_MODE,
-          ProxyProtocolCommand.PROXY.name());
-      topicAdminConfig.put(AdminClientConfig.PROXY_PROTOCOL_CLIENT_ADDRESS,
-          userPrincipal.get().getIpAddress());
-      topicAdminConfig.put(AdminClientConfig.PROXY_PROTOCOL_CLIENT_PORT,
-          userPrincipal.get().getPort());
-      topicAdminConfig.put(AdminClientConfig.PROXY_PROTOCOL_CLIENT_VERSION, ProxyProtocol.V2.name);
-      topicAdminClientSupplier = () -> kafkaClientSupplier.getAdmin(topicAdminConfig);
+      // Create new map to make it modifiable
+      final Map<String, Object> adminConfig =
+          new HashMap<>(ksqlConfig.getKsqlAdminClientConfigProps());
+      applyAdminProxyProtocolConfigs(principal, adminConfig);
+      adminClientSupplier = () -> kafkaClientSupplier.getAdmin(adminConfig);
+
+      finalKafkaClientSupplier =
+          new KafkaClientSupplierWithProxyConfigs(principal, kafkaClientSupplier);
     } else {
-      topicAdminClientSupplier = () -> kafkaClientSupplier.getAdmin(
-          ksqlConfig.getKsqlAdminClientConfigProps());
+      finalKafkaClientSupplier = kafkaClientSupplier;
+
+      final Map<String, Object> adminConfig =
+          new HashMap<>(ksqlConfig.getKsqlAdminClientConfigProps());
+      applyAdminProxyProtocolLocalConfigs(adminConfig);
+      adminClientSupplier = () -> kafkaClientSupplier.getAdmin(adminConfig);
     }
 
     return new DefaultServiceContext(
-        kafkaClientSupplier,
-        () -> kafkaClientSupplier
-            .getAdmin(ksqlConfig.getKsqlAdminClientConfigProps()),
-        topicAdminClientSupplier,
+        finalKafkaClientSupplier,
+        adminClientSupplier,
+        adminClientSupplier,
         srClientFactory,
         connectClientSupplier,
         ksqlClientSupplier
     );
+  }
+
+  private static void applyAdminProxyProtocolLocalConfigs(Map<String, Object> topicAdminConfig) {
+    // Set proxy protocol client mode to local for topicAdminClientSupplier
+    // if user principal doesn't exist
+    topicAdminConfig.put(AdminClientConfig.PROXY_PROTOCOL_CLIENT_MODE,
+        ProxyProtocolCommand.LOCAL.name());
+    topicAdminConfig.put(AdminClientConfig.PROXY_PROTOCOL_CLIENT_VERSION, ProxyProtocol.V2.name);
+  }
+
+  private static void applyAdminProxyProtocolConfigs(
+      final KsqlPrincipal userPrincipal,
+      final Map<String, Object> topicAdminConfig) {
+    // Set Client address config for topicAdminClientSupplier if user principal exists
+    topicAdminConfig.put(AdminClientConfig.PROXY_PROTOCOL_CLIENT_MODE,
+        ProxyProtocolCommand.PROXY.name());
+    topicAdminConfig.put(AdminClientConfig.PROXY_PROTOCOL_CLIENT_ADDRESS,
+        userPrincipal.getIpAddress());
+    topicAdminConfig.put(AdminClientConfig.PROXY_PROTOCOL_CLIENT_PORT,
+        userPrincipal.getPort());
+    topicAdminConfig.put(AdminClientConfig.PROXY_PROTOCOL_CLIENT_VERSION, ProxyProtocol.V2.name);
+  }
+
+  private static class KafkaClientSupplierWithProxyConfigs implements KafkaClientSupplier {
+
+    private final KsqlPrincipal userPrincipal;
+    private final KafkaClientSupplier kafkaClientSupplier;
+
+    public KafkaClientSupplierWithProxyConfigs(KsqlPrincipal userPrincipal,
+        KafkaClientSupplier kafkaClientSupplier) {
+      this.userPrincipal = userPrincipal;
+      this.kafkaClientSupplier = kafkaClientSupplier;
+    }
+
+    @Override
+    public Producer<byte[], byte[]> getProducer(Map<String, Object> config) {
+      final Map<String, Object> configsWithProxyProtocol = applyProducerProxyProtocolConfigs(config);
+      return kafkaClientSupplier.getProducer(configsWithProxyProtocol);
+    }
+
+    @Override
+    public Consumer<byte[], byte[]> getConsumer(Map<String, Object> config) {
+      final Map<String, Object> configsWithProxyProtocol = applyConsumerProxyProtocolConfigs(config);
+      return kafkaClientSupplier.getConsumer(configsWithProxyProtocol);
+    }
+
+    @Override
+    public Consumer<byte[], byte[]> getRestoreConsumer(Map<String, Object> config) {
+      final Map<String, Object> configsWithProxyProtocol = applyConsumerProxyProtocolConfigs(config);
+      return kafkaClientSupplier.getRestoreConsumer(configsWithProxyProtocol);
+    }
+
+    @Override
+    public Consumer<byte[], byte[]> getGlobalConsumer(Map<String, Object> config) {
+      final Map<String, Object> configsWithProxyProtocol = applyConsumerProxyProtocolConfigs(config);
+      return kafkaClientSupplier.getGlobalConsumer(configsWithProxyProtocol);
+    }
+
+    private @NotNull Map<String, Object> applyProducerProxyProtocolConfigs(
+        Map<String, Object> config) {
+      final Map<String, Object> configsWithProxyProtocol = new HashMap<>(config);
+      configsWithProxyProtocol.put(ProducerConfig.PROXY_PROTOCOL_CLIENT_MODE,
+          ProxyProtocolCommand.PROXY.name());
+      configsWithProxyProtocol.put(ProducerConfig.PROXY_PROTOCOL_CLIENT_ADDRESS,
+          userPrincipal.getIpAddress());
+      configsWithProxyProtocol.put(ProducerConfig.PROXY_PROTOCOL_CLIENT_PORT,
+          userPrincipal.getPort());
+      configsWithProxyProtocol.put(ProducerConfig.PROXY_PROTOCOL_CLIENT_VERSION,
+          ProxyProtocol.V2.name);
+      return configsWithProxyProtocol;
+    }
+
+    private @NotNull Map<String, Object> applyConsumerProxyProtocolConfigs(
+        Map<String, Object> config) {
+      final Map<String, Object> configsWithProxyProtocol = new HashMap<>(config);
+      configsWithProxyProtocol.put(ConsumerConfig.PROXY_PROTOCOL_CLIENT_MODE,
+          ProxyProtocolCommand.PROXY.name());
+      configsWithProxyProtocol.put(ConsumerConfig.PROXY_PROTOCOL_CLIENT_ADDRESS,
+          userPrincipal.getIpAddress());
+      configsWithProxyProtocol.put(ConsumerConfig.PROXY_PROTOCOL_CLIENT_PORT,
+          userPrincipal.getPort());
+      configsWithProxyProtocol.put(ConsumerConfig.PROXY_PROTOCOL_CLIENT_VERSION,
+          ProxyProtocol.V2.name);
+      return configsWithProxyProtocol;
+    }
   }
 }


### PR DESCRIPTION
### Description 
This PR makes changes to pass the user's IP address and port in proxy protocol configs to the Kafka clients instantiated.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

