### PR TITLE
KSQL-13763 | Filter out security.protocol and sasl.mechanism as configs to be passed to ksql query overrides.

### DIFF
--- a/ksqldb-cli/src/main/java/io/confluent/ksql/Ksql.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/Ksql.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
 public final class Ksql {
   private static final Logger LOGGER = LoggerFactory.getLogger(Ksql.class);
   private static final Predicate<String> NOT_CLIENT_SIDE_CONFIG = key -> !key.startsWith("ssl.")
-      && !key.equals("security.protocol") && !key.equals("sasl.mechanism") ;
+      && !key.equals("security.protocol") && !key.startsWith("sasl.") ;
 
   private final Options options;
   private final KsqlClientBuilder clientBuilder;

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/Ksql.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/Ksql.java
@@ -38,7 +38,8 @@ import org.slf4j.LoggerFactory;
 
 public final class Ksql {
   private static final Logger LOGGER = LoggerFactory.getLogger(Ksql.class);
-  private static final Predicate<String> NOT_CLIENT_SIDE_CONFIG = key -> !key.startsWith("ssl.");
+  private static final Predicate<String> NOT_CLIENT_SIDE_CONFIG = key -> !key.startsWith("ssl.")
+      && !key.equals("security.protocol") && !key.equals("sasl.mechanism") ;
 
   private final Options options;
   private final KsqlClientBuilder clientBuilder;

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/KsqlTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/KsqlTest.java
@@ -194,6 +194,22 @@ public class KsqlTest {
     verify(clientBuilder).build(any(), eq(ImmutableMap.of("some.other.setting", "value")), any(), any(), any());
   }
 
+  @Test
+  public void shouldStripSecurityConfigFromConfigFileWhenMakingLocalProperties() throws Exception {
+    // Given:
+    givenConfigFile(
+        "security.protocol=SASL_SSL" + System.lineSeparator()
+            + "sasl.mechanism=PLAIN" + System.lineSeparator()
+            + "some.other.setting=value"
+    );
+
+    // When:
+    ksql.run();
+
+    // Then:
+    verify(clientBuilder).build(any(), eq(ImmutableMap.of("some.other.setting", "value")), any(), any(), any());
+  }
+
   private void givenConfigFile(final String content) throws Exception {
     final File file = TMP.newFile();
     when(options.getConfigFile()).thenReturn(Optional.of(file.getAbsolutePath()));


### PR DESCRIPTION
### Description 
Addresses the issue linked at https://github.com/confluentinc/ksql/issues/5547
sasl.* and security. protocol are not passed over to ksql server for all the persistent queries. They are treated as configs only used for the cli to connect to the ksql server.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

