### PR TITLE
KSQL-13744 Changes to add License Validation plugin from CSP

### DIFF
--- a/config/ksql-production-server.properties
+++ b/config/ksql-production-server.properties
@@ -68,6 +68,11 @@ compression.type=snappy
 # Uncomment and complete the following to enable KSQL's integration to the Confluent Schema Registry:
 #ksql.schema.registry.url=?
 
+#------ Resource Extension -------
+
+# Configure a resource extension class (e.g., for enterprise license validation)
+ksql.resource.extension.class=io.confluent.ksql.security.license.KsqlLicenseValidatorExtension
+
 
 #------ Following configs improve performance and reliability of KSQL for critical/production setups. -------
 

--- a/config/ksql-server.properties
+++ b/config/ksql-server.properties
@@ -79,3 +79,8 @@ compression.type=snappy
 
 # Uncomment and complete the following to enable KSQL's integration to the Confluent Schema Registry:
 # ksql.schema.registry.url=http://localhost:8081
+
+#------ Resource Extension -------
+
+# Configure a resource extension class (e.g., for enterprise license validation)
+ksql.resource.extension.class=io.confluent.ksql.security.license.KsqlLicenseValidatorExtension

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -259,6 +259,12 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_SECURITY_EXTENSION_DOC = "A KSQL security extension class that "
       + "provides authorization to KSQL servers.";
 
+  public static final String KSQL_RESOURCE_EXTENSION_CLASS = "ksql.resource.extension.class";
+  public static final String KSQL_RESOURCE_EXTENSION_DEFAULT = null;
+  public static final String KSQL_RESOURCE_EXTENSION_DOC =
+      "A KSQL resource extension class that "
+      + "provides additional functionality to KSQL servers.";
+
   public static final String KSQL_ENABLE_ACCESS_VALIDATOR = "ksql.access.validator.enable";
   public static final String KSQL_ACCESS_VALIDATOR_ON = "on";
   public static final String KSQL_ACCESS_VALIDATOR_OFF = "off";
@@ -1053,6 +1059,12 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_SECURITY_EXTENSION_DEFAULT,
             ConfigDef.Importance.LOW,
             KSQL_SECURITY_EXTENSION_DOC
+        ).define(
+            KSQL_RESOURCE_EXTENSION_CLASS,
+            Type.CLASS,
+            KSQL_RESOURCE_EXTENSION_DEFAULT,
+            ConfigDef.Importance.LOW,
+            KSQL_RESOURCE_EXTENSION_DOC
         ).define(
             KSQL_DEFAULT_KEY_FORMAT_CONFIG,
             Type.STRING,

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
@@ -54,6 +54,10 @@ public final class KsqlConstants {
   public static final String KSQL_QUERY_PLAN_TYPE_TAG = "query_plan_type";
   public static final String KSQL_QUERY_ROUTING_TYPE_TAG = "query_routing_type";
 
+  public static final String KSQL_RESOURCE_EXTENSION_MISCONFIGURED_LOG_MESSAGE =
+      "No Enterprise license detected. Confluent does not offer Enterprise support any self-managed"
+      + "(Confluent Platform) components without a valid Enterprise license";
+
   public enum KsqlQueryType {
     PERSISTENT,
     PUSH,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlResourceExtension.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlResourceExtension.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ */
+
+package io.confluent.ksql.security;
+
+import io.confluent.ksql.util.KsqlConfig;
+
+/**
+ * Interface for extending ksqlDB with additional resource functionality.
+ */
+public interface KsqlResourceExtension extends AutoCloseable {
+  
+  /**
+   * Registers and initializes the resource extension.
+   * @param ksqlConfig the ksqlDB configuration containing all server settings
+   * @throws Exception if the extension cannot be properly initialized
+   */
+  void register(KsqlConfig ksqlConfig);
+
+  /**
+   * Closes the resource extension and releases any held resources.
+   */
+  @Override
+  void close();
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -55,6 +55,7 @@ import io.confluent.ksql.rest.server.resources.StatusResource;
 import io.confluent.ksql.rest.server.resources.streaming.StreamedQueryResource;
 import io.confluent.ksql.rest.server.state.ServerState;
 import io.confluent.ksql.rest.util.PersistentQueryCleanupImpl;
+import io.confluent.ksql.security.KsqlResourceExtension;
 import io.confluent.ksql.security.KsqlSecurityContext;
 import io.confluent.ksql.security.KsqlSecurityExtension;
 import io.confluent.ksql.services.KafkaTopicClient;
@@ -113,6 +114,8 @@ public class KsqlRestApplicationTest {
   private CommandStore commandQueue;
   @Mock
   private KsqlSecurityExtension securityExtension;
+  @Mock
+  private KsqlResourceExtension ksqlResourceExtension;
   @Mock
   private ProcessingLogContext processingLogContext;
   @Mock
@@ -226,6 +229,15 @@ public class KsqlRestApplicationTest {
 
     // Then:
     verify(securityExtension).close();
+  }
+
+  @Test
+  public void shouldCloseKsqlResourceExtensionOnClose() {
+    // When:
+    app.shutdown();
+
+    // Then:
+    verify(ksqlResourceExtension).close();
   }
 
   @Test
@@ -439,6 +451,7 @@ public class KsqlRestApplicationTest {
         versionCheckerAgent,
         apiSecurityContext -> new KsqlSecurityContext(Optional.empty(), serviceContext),
         securityExtension,
+        Optional.of(ksqlResourceExtension),
         Optional.empty(),
         serverState,
         processingLogContext,


### PR DESCRIPTION
### Description 
Project Lasso - requires KSQL to have license validation logic. The changes here are meant to append a extension for license validation. The extension is written in the confluent-security-plugins.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

