### PR TITLE
Address CVE-2024-57699 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -746,6 +746,15 @@
                 <version>${wiremock.version}</version>
                 <scope>test</scope>
             </dependency>
+            
+            <!-- Override vulnerable json-smart version to fix CVE-2024-57699.
+                 TODO: Remove this override when com.jayway.jsonpath:json-path 
+                 updates to use json-smart 2.5.2+ (currently 2.9.0 uses 2.5.0) -->
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>2.5.2</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -747,9 +747,8 @@
                 <scope>test</scope>
             </dependency>
             
-            <!-- Override vulnerable json-smart version to fix CVE-2024-57699.
-                 TODO: Remove this override when com.jayway.jsonpath:json-path 
-                 updates to use json-smart 2.5.2+ (currently 2.9.0 uses 2.5.0) -->
+            <!-- Override vulnerable json-smart 2.5.0/2.5.1 to fix CVE-2024-57699
+                 TODO: Remove when all transitive deps use json-smart 2.5.2+ -->
             <dependency>
                 <groupId>net.minidev</groupId>
                 <artifactId>json-smart</artifactId>


### PR DESCRIPTION
## Summary
Addresses CVE-2024-57699 (DoS via stack exhaustion) in json-smart versions 2.5.0-2.5.1 by overriding transitive dependencies with secure version 2.5.2. Check https://confluentinc.atlassian.net/browse/CVE-4846 for details.

## Vulnerability Details
- **CVE**: CVE-2024-57699
- **Impact**: Potential DoS via stack exhaustion when processing specially crafted JSON with many opening curly braces
- **Affected versions**: net.minidev:json-smart 2.5.0 through 2.5.1
- **Fixed version**: 2.5.2

## Root Cause Analysis
Multiple dependencies in ksqlDB 8.0.x pull in vulnerable json-smart versions:
- `com.jayway.jsonpath:json-path:2.9.0` → `json-smart:2.5.0` (PRIMARY)
- `org.apache.kafka:kafka_2.13` → `json-smart:2.x.x` (SECONDARY)

## Solution
Added dependency management override in root `pom.xml`:

## Verification
```bash
./mvnw dependency:tree -Dincludes=net.minidev:json-smart
# Should show json-smart:2.5.2 across all modules
```

## Maintenance
TODO: Remove this override when ALL upstream dependencies use json-smart 2.5.2+