### PR TITLE
KSQL-13833 | Set the order of timestamp fields to be processed to avoid incorrect modifications for daylight savings.

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/timestamp/StringToTimestampParser.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/timestamp/StringToTimestampParser.java
@@ -26,6 +26,7 @@ import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalField;
 import java.time.temporal.TemporalQueries;
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.function.Function;
 import org.apache.commons.lang3.ObjectUtils;
@@ -35,7 +36,7 @@ public class StringToTimestampParser {
   private static final Function<ZoneId, ZonedDateTime> DEFAULT_ZONED_DATE_TIME =
       zid -> ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, zid);
   private static final long LEAP_DAY_OF_THE_YEAR = 366;
-
+  private final ChronoField[] values = ChronoField.values();
   private final DateTimeFormatter formatter;
 
   public StringToTimestampParser(final String pattern) {
@@ -43,6 +44,9 @@ public class StringToTimestampParser {
         .parseCaseInsensitive()
         .appendPattern(pattern)
         .toFormatter(Locale.ROOT);
+
+    Arrays.sort(values,
+        (a, b) -> b.getBaseUnit().getDuration().compareTo(a.getBaseUnit().getDuration()));
   }
 
   /**
@@ -82,7 +86,7 @@ public class StringToTimestampParser {
     ZonedDateTime resolved = DEFAULT_ZONED_DATE_TIME.apply(
         ObjectUtils.defaultIfNull(parsedZone, zoneId));
 
-    for (final TemporalField override : ChronoField.values()) {
+    for (final TemporalField override : values) {
       if (parsed.isSupported(override)) {
         if (!resolved.isSupported(override)) {
           throw new KsqlException(

--- a/ksqldb-common/src/test/java/io/confluent/ksql/util/timestamp/StringToTimestampParserTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/util/timestamp/StringToTimestampParserTest.java
@@ -16,6 +16,7 @@ public class StringToTimestampParserTest {
 
   private static final ZoneId ZID = ZoneId.systemDefault();
   private static final ZoneId GMT_3 = ZoneId.of("GMT+3");
+  private static final ZoneId ZID_NY = ZoneId.of("America/New_York");
   private static final ZoneId IGNORED = ZID;
 
   private static final ZonedDateTime EPOCH =
@@ -26,6 +27,12 @@ public class StringToTimestampParserTest {
 
   private static final ZonedDateTime NEW_YEARS_EVE_2012 =
       ZonedDateTime.of(2012, 12, 31, 23, 59, 58, 660000000, ZID);
+
+  private static final ZonedDateTime TWENTY_SIXTH_APRIL_2025 =
+      ZonedDateTime.of(2025, 4, 26, 2, 39, 50, 0, ZID_NY);
+
+  private static final ZonedDateTime TWENTY_FIFTH_APRIL_2025 =
+      ZonedDateTime.of(2025, 4, 25, 2, 39, 50, 0, ZID_NY);
 
   @Test
   public void shouldParseBasicLocalDate() {
@@ -59,6 +66,27 @@ public class StringToTimestampParserTest {
             .withZoneSameInstant(ZID)
             .toInstant()
             .toEpochMilli()));
+  }
+
+  @Test
+  public void shouldParseDatesWithCorrectDaylightSavings() {
+    // Given
+    final String format = "yyyy-MM-dd HH:mm:ss";
+    final String timestamp = "2025-04-26 02:39:50";
+
+    // When
+    final ZonedDateTime ts = new StringToTimestampParser(format).parseZoned(timestamp, ZID_NY);
+
+    // Then
+    assertThat(ts, sameInstant(TWENTY_SIXTH_APRIL_2025.withZoneSameInstant(ZID_NY)));
+
+    final String timestamp2 = "2025-04-25 02:39:50";
+
+    // When
+    final ZonedDateTime ts2 = new StringToTimestampParser(format).parseZoned(timestamp2, ZID_NY);
+
+    // Then
+    assertThat(ts2, sameInstant(TWENTY_FIFTH_APRIL_2025.withZoneSameInstant(ZID_NY)));
   }
 
   @Test


### PR DESCRIPTION
### Description 
Set the order of timestamp fields to be processed to avoid incorrect modifications for daylight savings.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

