### PR TITLE
[KSQL-13829] | Unpin jackson version and upgrade shade plugin (#10841)

### DIFF
--- a/ksqldb-api-client/pom.xml
+++ b/ksqldb-api-client/pom.xml
@@ -176,7 +176,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.5.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -150,8 +150,6 @@
              to find the correct `tcnative` version. -->
         <netty.version>4.1.124.Final</netty.version>
         <netty-codec-http2-version>4.1.124.Final</netty-codec-http2-version>
-        <!-- Override jackson version so that shading doesn't fail -->
-        <jackson.version>2.14.2</jackson.version>
         <jersey-common>2.39.1</jersey-common>
         <multi-threaded-testing.forkCount>3</multi-threaded-testing.forkCount>
     </properties>


### PR DESCRIPTION
* [KSQL-13829] | Unpin jackson version

* [KSQL-13829] | Bump up shade plugin version

(cherry picked from commit d45322338ddd0b8c6d089604afc30dd9aa79427f)

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.



[KSQL-13829]: https://confluentinc.atlassian.net/browse/KSQL-13829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KSQL-13829]: https://confluentinc.atlassian.net/browse/KSQL-13829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ