### PR TITLE
KSQL-13839: update netty to 4.1.125

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,8 +148,8 @@
              Please check top level `pom.xml` at https://github.com/netty/netty
              for the netty version we bump to (ie, corresponding git tag),
              to find the correct `tcnative` version. -->
-        <netty.version>4.1.124.Final</netty.version>
-        <netty-codec-http2-version>4.1.124.Final</netty-codec-http2-version>
+        <netty.version>4.1.125.Final</netty.version>
+        <netty-codec-http2-version>4.1.125.Final</netty-codec-http2-version>
         <jersey-common>2.34</jersey-common>
     </properties>
 


### PR DESCRIPTION
### Description 
Update Netty to 4.1.125 to resolve CVE

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

