### PR TITLE
KSQL-13839: Bump up tcnative dependency to be in sync with netty.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
         <io.confluent.ksql.version>7.3.14-0</io.confluent.ksql.version>
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
         <io.confluent.confluent-security-plugins.version>${confluent.version.range}</io.confluent.confluent-security-plugins.version>
-        <netty-tcnative-version>2.0.72.Final</netty-tcnative-version>
+        <netty-tcnative-version>2.0.73.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`
              we might need to bump `tcnative`, too.


### PR DESCRIPTION
### Description 
Bump up tcnative dependency to be in sync with netty.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

