### PR TITLE
KSQL-13833 | Set the order of timestamp fields to be processed to avoid incorrect modifications for daylight savings. (#10833)

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -7,7 +7,7 @@ version: v1.0
 name: build-test-release
 agent:
   machine:
-    type: s1-prod-ubuntu20-04-amd64-1
+    type: s1-prod-ubuntu24-04-amd64-1
 
 fail_fast:
   cancel:

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/timestamp/StringToTimestampParser.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/timestamp/StringToTimestampParser.java
@@ -26,6 +26,7 @@ import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalField;
 import java.time.temporal.TemporalQueries;
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.function.Function;
 import org.apache.commons.lang3.ObjectUtils;
@@ -35,7 +36,7 @@ public class StringToTimestampParser {
   private static final Function<ZoneId, ZonedDateTime> DEFAULT_ZONED_DATE_TIME =
       zid -> ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, zid);
   private static final long LEAP_DAY_OF_THE_YEAR = 366;
-
+  private final ChronoField[] values = ChronoField.values();
   private final DateTimeFormatter formatter;
 
   public StringToTimestampParser(final String pattern) {
@@ -43,6 +44,9 @@ public class StringToTimestampParser {
         .parseCaseInsensitive()
         .appendPattern(pattern)
         .toFormatter(Locale.ROOT);
+
+    Arrays.sort(values,
+        (a, b) -> b.getBaseUnit().getDuration().compareTo(a.getBaseUnit().getDuration()));
   }
 
   /**
@@ -82,7 +86,7 @@ public class StringToTimestampParser {
     ZonedDateTime resolved = DEFAULT_ZONED_DATE_TIME.apply(
         ObjectUtils.defaultIfNull(parsedZone, zoneId));
 
-    for (final TemporalField override : ChronoField.values()) {
+    for (final TemporalField override : values) {
       if (parsed.isSupported(override)) {
         if (!resolved.isSupported(override)) {
           throw new KsqlException(

--- a/ksqldb-common/src/test/java/io/confluent/ksql/util/timestamp/StringToTimestampParserTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/util/timestamp/StringToTimestampParserTest.java
@@ -16,6 +16,7 @@ public class StringToTimestampParserTest {
 
   private static final ZoneId ZID = ZoneId.systemDefault();
   private static final ZoneId GMT_3 = ZoneId.of("GMT+3");
+  private static final ZoneId ZID_NY = ZoneId.of("America/New_York");
   private static final ZoneId IGNORED = ZID;
 
   private static final ZonedDateTime EPOCH =
@@ -26,6 +27,12 @@ public class StringToTimestampParserTest {
 
   private static final ZonedDateTime NEW_YEARS_EVE_2012 =
       ZonedDateTime.of(2012, 12, 31, 23, 59, 58, 660000000, ZID);
+
+  private static final ZonedDateTime TWENTY_SIXTH_APRIL_2025 =
+      ZonedDateTime.of(2025, 4, 26, 2, 39, 50, 0, ZID_NY);
+
+  private static final ZonedDateTime TWENTY_FIFTH_APRIL_2025 =
+      ZonedDateTime.of(2025, 4, 25, 2, 39, 50, 0, ZID_NY);
 
   @Test
   public void shouldParseBasicLocalDate() {
@@ -59,6 +66,27 @@ public class StringToTimestampParserTest {
             .withZoneSameInstant(ZID)
             .toInstant()
             .toEpochMilli()));
+  }
+
+  @Test
+  public void shouldParseDatesWithCorrectDaylightSavings() {
+    // Given
+    final String format = "yyyy-MM-dd HH:mm:ss";
+    final String timestamp = "2025-04-26 02:39:50";
+
+    // When
+    final ZonedDateTime ts = new StringToTimestampParser(format).parseZoned(timestamp, ZID_NY);
+
+    // Then
+    assertThat(ts, sameInstant(TWENTY_SIXTH_APRIL_2025.withZoneSameInstant(ZID_NY)));
+
+    final String timestamp2 = "2025-04-25 02:39:50";
+
+    // When
+    final ZonedDateTime ts2 = new StringToTimestampParser(format).parseZoned(timestamp2, ZID_NY);
+
+    // Then
+    assertThat(ts2, sameInstant(TWENTY_FIFTH_APRIL_2025.withZoneSameInstant(ZID_NY)));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/ConnectIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/ConnectIntegrationTest.java
@@ -159,8 +159,23 @@ public class ConnectIntegrationTest {
     ));
 
     // When:
-    final RestResponse<KsqlEntityList> response = ksqlRestClient
-        .makeKsqlRequest("SHOW CONNECTORS;");
+    final AtomicReference<RestResponse<KsqlEntityList>> responseHolder = new AtomicReference<>();
+    assertThatEventually(
+        () -> {
+          try {
+            responseHolder
+                .set(ksqlRestClient.makeKsqlRequest("SHOW CONNECTORS;"));
+            return responseHolder.get().getResponse().get(0);
+          } catch (Exception e) {
+            // there is a race condition were create from line 150 may not have gone through.
+            // when this happens, getResponse() above throws an exception. instead, we catch
+            // the exception and return a dummy value to fail the instanceOf() check below.
+            return null;
+          }
+        },
+        instanceOf(ConnectorList.class)
+    );
+    final RestResponse<KsqlEntityList> response = responseHolder.get();
 
     // Then:
     assertThat("expected successful response", response.isSuccessful());

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestConfigTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestConfigTest.java
@@ -193,7 +193,7 @@ public class KsqlRestConfigTest {
   @Test
   public void shouldUseExplicitInterNodeListenerSetToResolvableHost() {
     // Given:
-    final URL expected = url("https://example.com:12345");
+    final URL expected = url("https://confluent.io:12345");
 
     final KsqlRestConfig config = new KsqlRestConfig(ImmutableMap.<String, Object>builder()
         .putAll(MIN_VALID_CONFIGS)
@@ -276,8 +276,8 @@ public class KsqlRestConfigTest {
   @Test
   public void shouldSanitizeInterNodeListenerWithTrailingSlash() {
     // Given:
-    final URL expected = url("https://example.com:12345");
-    final URL configured = url("https://example.com:12345/");
+    final URL expected = url("https://confluent.io:12345");
+    final URL configured = url("https://confluent.io:12345/");
 
     final KsqlRestConfig config = new KsqlRestConfig(ImmutableMap.<String, Object>builder()
         .putAll(MIN_VALID_CONFIGS)
@@ -384,7 +384,7 @@ public class KsqlRestConfigTest {
   @Test
   public void shouldResolveInterNodeListenerToFirstListenerSetToResolvableHost() {
     // Given:
-    final URL expected = url("https://example.com:12345");
+    final URL expected = url("https://confluent.io:12345");
 
     final KsqlRestConfig config = new KsqlRestConfig(ImmutableMap.<String, Object>builder()
         .put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
@@ -467,7 +467,7 @@ public class KsqlRestConfigTest {
   @Test
   public void shouldResolveInterNodeListenerToFirstListenerWithAutoPortAssignment() {
     // Given:
-    final URL autoPort = url("https://example.com:0");
+    final URL autoPort = url("https://confluent.io:0");
 
     when(portResolver.apply(any())).thenReturn(2222);
 
@@ -481,7 +481,7 @@ public class KsqlRestConfigTest {
     final URL actual = config.getInterNodeListener(portResolver, logger);
 
     // Then:
-    final URL expected = url("https://example.com:2222");
+    final URL expected = url("https://confluent.io:2222");
 
     assertThat(actual, is(expected));
     verifyLogsInterNodeListener(expected, QUOTED_FIRST_LISTENER_CONFIG);
@@ -491,7 +491,7 @@ public class KsqlRestConfigTest {
   @Test
   public void shouldResolveInterNodeListenerToFirstListenerWithAutoPortAssignmentAndTrailingSlash() {
     // Given:
-    final URL autoPort = url("https://example.com:0/");
+    final URL autoPort = url("https://confluent.io:0/");
 
     when(portResolver.apply(any())).thenReturn(2222);
 
@@ -505,7 +505,7 @@ public class KsqlRestConfigTest {
     final URL actual = config.getInterNodeListener(portResolver, logger);
 
     // Then:
-    final URL expected = url("https://example.com:2222");
+    final URL expected = url("https://confluent.io:2222");
 
     assertThat(actual, is(expected));
     verifyLogsInterNodeListener(expected, QUOTED_FIRST_LISTENER_CONFIG);
@@ -586,7 +586,7 @@ public class KsqlRestConfigTest {
   @Test
   public void shouldResolveInterNodeListenerToInternalListenerSetToResolvableHost() {
     // Given:
-    final URL expected = url("https://example.com:12345");
+    final URL expected = url("https://confluent.io:12345");
 
     final KsqlRestConfig config = new KsqlRestConfig(ImmutableMap.<String, Object>builder()
         .put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
@@ -669,7 +669,7 @@ public class KsqlRestConfigTest {
   @Test
   public void shouldResolveInterNodeListenerToInternalListenerWithAutoPortAssignment() {
     // Given:
-    final URL autoPort = url("https://example.com:0");
+    final URL autoPort = url("https://confluent.io:0");
 
     when(portResolver.apply(any())).thenReturn(2222);
 
@@ -683,7 +683,7 @@ public class KsqlRestConfigTest {
     final URL actual = config.getInterNodeListener(portResolver, logger);
 
     // Then:
-    final URL expected = url("https://example.com:2222");
+    final URL expected = url("https://confluent.io:2222");
 
     assertThat(actual, is(expected));
     verifyLogsInterNodeListener(expected, QUOTED_INTERNAL_LISTENER_CONFIG);
@@ -693,7 +693,7 @@ public class KsqlRestConfigTest {
   @Test
   public void shouldResolveInterNodeListenerToInternalListenerWithAutoPortAssignmentAndTrailingSlash() {
     // Given:
-    final URL autoPort = url("https://example.com:0/");
+    final URL autoPort = url("https://confluent.io:0/");
 
     when(portResolver.apply(any())).thenReturn(2222);
 
@@ -707,7 +707,7 @@ public class KsqlRestConfigTest {
     final URL actual = config.getInterNodeListener(portResolver, logger);
 
     // Then:
-    final URL expected = url("https://example.com:2222");
+    final URL expected = url("https://confluent.io:2222");
 
     assertThat(actual, is(expected));
     verifyLogsInterNodeListener(expected, QUOTED_INTERNAL_LISTENER_CONFIG);


### PR DESCRIPTION
### Description 
Cherry-pick the fix to hotfix branch.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

