### PR TITLE
upgrade jline dependency to address terminal sizing issue (#10869)

### DIFF
--- a/ksqldb-cli/pom.xml
+++ b/ksqldb-cli/pom.xml
@@ -67,6 +67,7 @@
         <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline</artifactId>
+            <version>${jline.version}</version>
         </dependency>
 
         <!-- Required for running tests -->

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/JLineReaderTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/JLineReaderTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.function.Predicate;
 import org.jline.reader.EndOfFileException;
 import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
 import org.jline.terminal.impl.DumbTerminal;
 import org.junit.Before;
 import org.junit.Rule;
@@ -279,7 +280,10 @@ public class JLineReaderTest {
     final InputStream inputStream =
         new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8));
     final OutputStream outputStream = new ByteArrayOutputStream(512);
-    final Terminal terminal = new DumbTerminal(inputStream, outputStream);
+    final Terminal terminal = TerminalBuilder.builder()
+        .streams(inputStream, outputStream)
+        .system(false)
+        .build();
     final File tempHistoryFile = tempFolder.newFile("ksql-history.txt");
     final Path historyFilePath = Paths.get(tempHistoryFile.getAbsolutePath());
     return new JLineReader(terminal, historyFilePath, cliLinePredicate);

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <inject.version>1</inject.version>
         <janino.version>3.1.10</janino.version>
         <javax-validation.version>2.0.1.Final</javax-validation.version>
-        <jline.version>3.13.1</jline.version>
+        <jline.version>3.25.0</jline.version>
         <jna.version>4.4.0</jna.version>
         <jsr305.version>3.0.2</jsr305.version>
         <maven.plugins.version>3.0.0-M1</maven.plugins.version>


### PR DESCRIPTION
* upgrade jline dependency to address terminal sizing issue

* upgrade jline dependency to address terminal sizing issue

* use terminal builder in jline tests

(cherry picked from commit 96e1f07d2e2bfcb3aa1b03c8d33861e42e9ec1b8)

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

