### PR TITLE
KSQL-13946 | Fix the usage of MockSchemaRegistryClient in tests.

### DIFF
--- a/ksqldb-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
+++ b/ksqldb-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
@@ -15,11 +15,15 @@
 
 package io.confluent.ksql.benchmark;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.avro.random.generator.Generator;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.datagen.RowGenerator;
@@ -217,7 +221,10 @@ public class SerdeBenchmark {
     ) {
       final FormatInfo formatInfo = getFormatInfo(formatName);
 
-      final SchemaRegistryClient srClient = new MockSchemaRegistryClient();
+      final SchemaRegistryClient srClient = new MockSchemaRegistryClient(ImmutableList.of(
+          new AvroSchemaProvider(),
+          new ProtobufSchemaProvider(),
+          new JsonSchemaProvider()));
 
       final PersistenceSchema persistenceSchema = PersistenceSchema
           .from(schema.key(), SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
@@ -239,7 +246,10 @@ public class SerdeBenchmark {
     ) {
       final FormatInfo format = getFormatInfo(formatName);
 
-      final SchemaRegistryClient srClient = new MockSchemaRegistryClient();
+      final SchemaRegistryClient srClient = new MockSchemaRegistryClient(ImmutableList.of(
+          new AvroSchemaProvider(),
+          new ProtobufSchemaProvider(),
+          new JsonSchemaProvider()));
 
       return GenericRowSerDe.from(
           format,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
@@ -16,14 +16,18 @@
 package io.confluent.ksql.services;
 
 import com.google.common.base.Ticker;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
@@ -55,7 +59,11 @@ final class SandboxedSchemaRegistryClient {
     // we use `MockSchemaRegistryClient` as a cache inside the sandbox to store
     // newly registered schemas (without polluting the actual SR)
     // this allows dependent statements to execute successfully inside the sandbox
-    private final MockSchemaRegistryClient sandboxCacheClient = new MockSchemaRegistryClient();
+    private final MockSchemaRegistryClient sandboxCacheClient = new MockSchemaRegistryClient(
+        ImmutableList.of(
+            new AvroSchemaProvider(),
+            new ProtobufSchemaProvider(),
+            new JsonSchemaProvider()));
     // client to talk to the actual SR
     private final SchemaRegistryClient srClient;
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -46,12 +46,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import io.confluent.ksql.KsqlConfigTestUtil;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.KsqlExecutionContext.ExecuteResult;
@@ -134,7 +138,11 @@ public class KsqlEngineTest {
   private final Map<String, Object> sharedRuntimeDisabled = new HashMap<>();
   private MutableMetaStore metaStore;
   @Spy
-  private final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
+  private final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient(
+      ImmutableList.of(
+          new AvroSchemaProvider(),
+          new ProtobufSchemaProvider(),
+          new JsonSchemaProvider()));
   private final Supplier<SchemaRegistryClient> schemaRegistryClientFactory =
       () -> schemaRegistryClient;
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
@@ -27,9 +27,12 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.KsqlConfigTestUtil;
@@ -834,7 +837,11 @@ public final class IntegrationTestHarness extends ExternalResource {
 
   public static final class Builder {
 
-    private final SchemaRegistryClient schemaRegistry = new MockSchemaRegistryClient();
+    private final SchemaRegistryClient schemaRegistry = new MockSchemaRegistryClient(
+        ImmutableList.of(
+            new AvroSchemaProvider(),
+            new ProtobufSchemaProvider(),
+            new JsonSchemaProvider()));
     private EmbeddedSingleNodeKafkaCluster.Builder kafkaCluster
         = EmbeddedSingleNodeKafkaCluster.newBuilder();
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -32,9 +32,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.function.FunctionRegistry;
@@ -607,7 +610,11 @@ public class TestExecutor implements Closeable {
   private static ServiceContext getServiceContext(
       final StubKafkaClientSupplier kafkaClientSupplier
   ) {
-    final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
+    final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient(
+        ImmutableList.of(
+            new AvroSchemaProvider(),
+            new ProtobufSchemaProvider(),
+            new JsonSchemaProvider()));
 
     return new DefaultServiceContext(
         kafkaClientSupplier,

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/serde/json/ValueSpecJsonSchemaSerdeSupplierTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/serde/json/ValueSpecJsonSchemaSerdeSupplierTest.java
@@ -17,11 +17,15 @@ package io.confluent.ksql.test.serde.json;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.schemaregistry.json.JsonSchema;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import java.io.IOException;
 import java.math.BigDecimal;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -35,7 +39,10 @@ public class ValueSpecJsonSchemaSerdeSupplierTest {
 
   @Before
   public void setUp() {
-    srClient = new MockSchemaRegistryClient();
+    srClient = new MockSchemaRegistryClient(ImmutableList.of(
+        new AvroSchemaProvider(),
+        new ProtobufSchemaProvider(),
+        new JsonSchemaProvider()));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatterTest.java
@@ -37,10 +37,13 @@ import com.google.protobuf.Message;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.connect.protobuf.ProtobufData;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.json.JsonSchema;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer;
@@ -1227,7 +1230,10 @@ public class RecordFormatterTest {
       final Map<String, String> props = new HashMap<>();
       props.put("schema.registry.url", "localhost:9092");
 
-      return new KafkaAvroSerializer(new MockSchemaRegistryClient(), props);
+      MockSchemaRegistryClient mockSchemaRegistryClient = new MockSchemaRegistryClient(
+          ImmutableList.of(new AvroSchemaProvider()));
+
+      return new KafkaAvroSerializer(mockSchemaRegistryClient, props);
     }
 
     private static Message protobufRecord() {
@@ -1247,7 +1253,10 @@ public class RecordFormatterTest {
       final Map<String, String> props = new HashMap<>();
       props.put("schema.registry.url", "localhost:9092");
 
-      return new KafkaProtobufSerializer<>(new MockSchemaRegistryClient(), props);
+      MockSchemaRegistryClient mockSchemaRegistryClient = new MockSchemaRegistryClient(
+          ImmutableList.of(new ProtobufSchemaProvider()));
+
+      return new KafkaProtobufSerializer<>(mockSchemaRegistryClient, props);
     }
 
     private static Serializer<Object> jsonSrSerializer() {
@@ -1255,7 +1264,11 @@ public class RecordFormatterTest {
       props.put("schema.registry.url", "localhost:9092");
       props.put("json.schema.scan.packages", "io.confluent.ksql.serde.json");
 
-      return new KafkaJsonSchemaSerializer<>(new MockSchemaRegistryClient(), props);
+
+      MockSchemaRegistryClient mockSchemaRegistryClient = new MockSchemaRegistryClient(
+          ImmutableList.of(new JsonSchemaProvider()));
+
+      return new KafkaJsonSchemaSerializer<>(mockSchemaRegistryClient, props);
     }
   }
 

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroDeserializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroDeserializerTest.java
@@ -31,6 +31,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.connect.avro.AvroConverter;
 import io.confluent.connect.avro.AvroDataConfig;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
@@ -217,7 +218,8 @@ public class KsqlAvroDeserializerTest {
         AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, ""
     );
 
-    schemaRegistryClient = new MockSchemaRegistryClient();
+    schemaRegistryClient = new MockSchemaRegistryClient(ImmutableList.of(
+        new AvroSchemaProvider()));
 
     converter = new AvroConverter(schemaRegistryClient);
     converter.configure(configs, false);

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroSerializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroSerializerTest.java
@@ -41,6 +41,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.connect.avro.AvroData;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
@@ -305,7 +306,9 @@ public class KsqlAvroSerializerTest {
           .map(STRING_SCHEMA, OPTIONAL_FLOAT64_SCHEMA).build())
       .build();
 
-  private final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
+  private final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient(
+      ImmutableList.of(
+          new AvroSchemaProvider()));
 
   private final KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of());
 

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSchemaDeserializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSchemaDeserializerTest.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
 import io.confluent.ksql.serde.connect.ConnectKsqlSchemaTranslator;
 import io.confluent.ksql.util.KsqlConfig;
 import java.nio.ByteBuffer;
@@ -82,7 +83,8 @@ public class KsqlJsonSchemaDeserializerTest {
   public void before() throws Exception {
     schema = (new JsonSchemaTranslator()).fromConnectSchema(ORDER_SCHEMA.schema());
 
-    schemaRegistryClient = new MockSchemaRegistryClient();
+    schemaRegistryClient = new MockSchemaRegistryClient(ImmutableList.of(
+        new JsonSchemaProvider()));
     schemaRegistryClient.register(SOME_TOPIC, schema);
 
     final KsqlJsonSerdeFactory jsonSerdeFactory =

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSerializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSerializerTest.java
@@ -35,6 +35,7 @@ import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.schemaregistry.json.JsonSchema;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
 import io.confluent.ksql.serde.connect.ConnectProperties;
 import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlConfig;
@@ -229,7 +230,8 @@ public class KsqlJsonSerializerTest {
   @Before
   public void before() {
     config = new KsqlConfig(ImmutableMap.of());
-    srClient = new MockSchemaRegistryClient();
+    srClient = new MockSchemaRegistryClient(ImmutableList.of(
+        new JsonSchemaProvider()));
   }
 
   @SuppressWarnings("unchecked")

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufDeserializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufDeserializerTest.java
@@ -15,10 +15,12 @@
 
 package io.confluent.ksql.serde.protobuf;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.connect.protobuf.ProtobufConverter;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Collections;
@@ -49,7 +51,8 @@ public class KsqlProtobufDeserializerTest extends AbstractKsqlProtobufDeserializ
         AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, ""
     );
 
-    schemaRegistryClient = new MockSchemaRegistryClient();
+    schemaRegistryClient = new MockSchemaRegistryClient(ImmutableList.of(
+        new ProtobufSchemaProvider()));
 
     converter = new ProtobufConverter(schemaRegistryClient);
     converter.configure(configs, false);

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufSerializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufSerializerTest.java
@@ -23,6 +23,7 @@ import com.google.protobuf.Message;
 import com.google.protobuf.Timestamp;
 import com.google.type.Date;
 import com.google.type.TimeOfDay;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import io.confluent.ksql.serde.connect.ConnectProperties;
 import java.nio.ByteBuffer;
 import java.util.Optional;
@@ -154,7 +155,9 @@ public class KsqlProtobufSerializerTest {
 
   private static final String SOME_TOPIC = "bob";
 
-  private final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
+  private final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient(
+      ImmutableList.of(
+          new ProtobufSchemaProvider()));
 
   private final KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of());
 

--- a/ksqldb-testing-tool/src/main/java/io/confluent/ksql/tools/test/SqlTestExecutor.java
+++ b/ksqldb-testing-tool/src/main/java/io/confluent/ksql/tools/test/SqlTestExecutor.java
@@ -18,10 +18,14 @@ package io.confluent.ksql.tools.test;
 import static io.confluent.ksql.util.KsqlConfig.CONNECT_REQUEST_TIMEOUT_DEFAULT;
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.KsqlExecutionContext.ExecuteResult;
 import io.confluent.ksql.ServiceInfo;
@@ -135,7 +139,10 @@ public class SqlTestExecutor implements Closeable {
   public static SqlTestExecutor create(final Path tmpFolder) {
     final KafkaTopicClient topicClient = new StubKafkaTopicClient();
     final KafkaClientSupplier kafkaClientSupplier = new StubKafkaClientSupplier();
-    final SchemaRegistryClient srClient = new MockSchemaRegistryClient();
+    final SchemaRegistryClient srClient = new MockSchemaRegistryClient(ImmutableList.of(
+        new AvroSchemaProvider(),
+        new ProtobufSchemaProvider(),
+        new JsonSchemaProvider()));
     final ServiceContext serviceContext = new DefaultServiceContext(
         kafkaClientSupplier,
         () -> kafkaClientSupplier.getAdmin(Collections.emptyMap()),


### PR DESCRIPTION
### Description 
Fix the usage of MockSchemaRegistryClient in tests.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

