### PR TITLE
[KSQL-14553] fix: RecordFormatterTest Bytes null, protobuf version, and KsMaterialization window/session store failures

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatterTest.java
@@ -50,7 +50,6 @@ import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer;
 import io.confluent.ksql.rest.server.resources.streaming.RecordFormatter.Deserializers;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -192,19 +191,6 @@ public class RecordFormatterTest {
     }
 
     @Test
-    public void shouldFormatNullsBytes() {
-      // Given:
-      final Bytes nullBytes = null;
-
-      // When:
-      formatSingle(consumerRecord(nullBytes, nullBytes));
-
-      // Then:
-      verify(keyDeserializers).format(nullBytes);
-      verify(valueDeserializers).format(nullBytes);
-    }
-
-    @Test
     public void shouldFormatRowTime() {
       // When:
       final String formatted = formatSingle(consumerRecord(null, null));
@@ -315,8 +301,6 @@ public class RecordFormatterTest {
         JSON_BOOLEAN,
         JSON_NULL
     );
-
-    private static final List<Bytes> NULL_VARIANTS = Collections.singletonList(null);
 
     private static final int SERIALIZED_INT_SIZE = 4;
     private static final int SERIALIZED_BIGINT_SIZE = 8;
@@ -432,13 +416,11 @@ public class RecordFormatterTest {
       // Given:
       final List<String> expected = ImmutableList.copyOf(deserializers.getPossibleFormats());
 
-      NULL_VARIANTS.forEach(nullVariant -> {
-        // When:
-        deserializers.format(nullVariant);
+      // When:
+      deserializers.format(null);
 
-        // Then:
-        assertThat(deserializers.getPossibleFormats(), is(expected));
-      });
+      // Then:
+      assertThat(deserializers.getPossibleFormats(), is(expected));
     }
 
     @Test
@@ -1155,9 +1137,7 @@ public class RecordFormatterTest {
 
     @Test
     public void shouldFormatNull() {
-      NULL_VARIANTS.forEach(nullVariant ->
-          assertThat(deserializers.format(null), is("<null>"))
-      );
+      assertThat(deserializers.format(null), is("<null>"));
     }
 
     private void givenAvroSchemaRegistered() {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatterTest.java
@@ -48,7 +48,6 @@ import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer;
 import io.confluent.ksql.rest.server.resources.streaming.RecordFormatter.Deserializers;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -195,7 +194,7 @@ public class RecordFormatterTest {
     @Test
     public void shouldFormatNullsBytes() {
       // Given:
-      final Bytes nullBytes = new Bytes(null);
+      final Bytes nullBytes = null;
 
       // When:
       formatSingle(consumerRecord(nullBytes, nullBytes));
@@ -317,14 +316,7 @@ public class RecordFormatterTest {
         JSON_NULL
     );
 
-    private static final List<Bytes> NULL_VARIANTS;
-
-    static {
-      final List<Bytes> nullVariants = new ArrayList<>();
-      nullVariants.add(new Bytes(null));
-      nullVariants.add(null);
-      NULL_VARIANTS = Collections.unmodifiableList(nullVariants);
-    }
+    private static final List<Bytes> NULL_VARIANTS = Collections.singletonList(null);
 
     private static final int SERIALIZED_INT_SIZE = 4;
     private static final int SERIALIZED_BIGINT_SIZE = 8;

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypass.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypass.java
@@ -43,6 +43,8 @@ public final class SessionStoreCacheBypass {
   private static final Field STORE_NAME_FIELD;
   private static final Field STORE_TYPE_FIELD;
   static final Field SERDES_FIELD;
+  // Nullable: only present in Kafka versions that introduced ReadOnlySessionStoreFacade
+  private static final Field SESSION_FACADE_INNER_FIELD;
   private static final String STORE_UNAVAILABLE_MESSAGE = "State store is not available anymore "
           + "and may have been migrated to another instance; "
           + "please re-discover its location from the state metadata.";
@@ -61,6 +63,17 @@ public final class SessionStoreCacheBypass {
     } catch (final NoSuchFieldException e) {
       throw new RuntimeException("Stream internals changed unexpectedly!", e);
     }
+
+    Field sessionFacadeInnerField = null;
+    try {
+      final Class<?> facadeClass = Class.forName(
+          "org.apache.kafka.streams.state.internals.ReadOnlySessionStoreFacade");
+      sessionFacadeInnerField = facadeClass.getDeclaredField("inner");
+      sessionFacadeInnerField.setAccessible(true);
+    } catch (final ClassNotFoundException | NoSuchFieldException e) {
+      // Facade class not present in this Kafka version — no unwrapping needed
+    }
+    SESSION_FACADE_INNER_FIELD = sessionFacadeInnerField;
   }
 
   private SessionStoreCacheBypass() {
@@ -106,12 +119,14 @@ public final class SessionStoreCacheBypass {
       final ReadOnlySessionStore<GenericKey, GenericRow> sessionStore,
       final GenericKey key
   ) {
-    if (!(sessionStore instanceof MeteredSessionStore)) {
+    final ReadOnlySessionStore<GenericKey, GenericRow> unwrapped
+        = unwrapSessionFacade(sessionStore);
+    if (!(unwrapped instanceof MeteredSessionStore)) {
       throw new IllegalStateException("Expecting a MeteredSessionStore");
     } else {
-      final StateSerdes<GenericKey, GenericRow> serdes = getSerdes(sessionStore);
+      final StateSerdes<GenericKey, GenericRow> serdes = getSerdes(unwrapped);
       final Bytes rawKey = Bytes.wrap(serdes.rawKey(key));
-      final SessionStore<Bytes, byte[]> wrapped = getInnermostStore(sessionStore);
+      final SessionStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
       final KeyValueIterator<Windowed<Bytes>, byte[]> fetch = wrapped.fetch(rawKey);
       return new DeserializingIterator(fetch, serdes);
     }
@@ -143,14 +158,15 @@ public final class SessionStoreCacheBypass {
           final GenericKey keyFrom,
           final GenericKey keyTo
   ) {
-    if (!(sessionStore instanceof MeteredSessionStore)) {
+    final ReadOnlySessionStore<GenericKey, GenericRow> unwrapped
+        = unwrapSessionFacade(sessionStore);
+    if (!(unwrapped instanceof MeteredSessionStore)) {
       throw new IllegalStateException("Expecting a MeteredSessionStore");
     } else {
-
-      final StateSerdes<GenericKey, GenericRow> serdes = getSerdes(sessionStore);
+      final StateSerdes<GenericKey, GenericRow> serdes = getSerdes(unwrapped);
       final Bytes rawKeyFrom = Bytes.wrap(serdes.rawKey(keyFrom));
       final Bytes rawKeyTo = Bytes.wrap(serdes.rawKey(keyTo));
-      final SessionStore<Bytes, byte[]> wrapped = getInnermostStore(sessionStore);
+      final SessionStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
       final KeyValueIterator<Windowed<Bytes>, byte[]> fetch = wrapped.fetch(rawKeyFrom, rawKeyTo);
       return new DeserializingIterator(fetch, serdes);
     }
@@ -176,6 +192,22 @@ public final class SessionStoreCacheBypass {
       }
     }
     return new EmptyKeyValueIterator();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static ReadOnlySessionStore<GenericKey, GenericRow> unwrapSessionFacade(
+      final ReadOnlySessionStore<GenericKey, GenericRow> sessionStore
+  ) {
+    if (SESSION_FACADE_INNER_FIELD != null
+        && SESSION_FACADE_INNER_FIELD.getDeclaringClass().isInstance(sessionStore)) {
+      try {
+        return (ReadOnlySessionStore<GenericKey, GenericRow>)
+            SESSION_FACADE_INNER_FIELD.get(sessionStore);
+      } catch (final IllegalAccessException e) {
+        throw new RuntimeException("Stream internals changed unexpectedly!", e);
+      }
+    }
+    return sessionStore;
   }
 
   @SuppressWarnings("unchecked")

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypass.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypass.java
@@ -45,6 +45,7 @@ public final class SessionStoreCacheBypass {
   static final Field SERDES_FIELD;
   // Nullable: only present in Kafka versions that introduced ReadOnlySessionStoreFacade
   private static final Field SESSION_FACADE_INNER_FIELD;
+  private static final Field SESSION_FACADE_VALUE_CONVERTER_FIELD;
   private static final String STORE_UNAVAILABLE_MESSAGE = "State store is not available anymore "
           + "and may have been migrated to another instance; "
           + "please re-discover its location from the state metadata.";
@@ -65,15 +66,19 @@ public final class SessionStoreCacheBypass {
     }
 
     Field sessionFacadeInnerField = null;
+    Field sessionFacadeValueConverterField = null;
     try {
       final Class<?> facadeClass = Class.forName(
           "org.apache.kafka.streams.state.internals.ReadOnlySessionStoreFacade");
       sessionFacadeInnerField = facadeClass.getDeclaredField("inner");
       sessionFacadeInnerField.setAccessible(true);
+      sessionFacadeValueConverterField = facadeClass.getDeclaredField("valueConverter");
+      sessionFacadeValueConverterField.setAccessible(true);
     } catch (final ClassNotFoundException | NoSuchFieldException e) {
       // Facade class not present in this Kafka version — no unwrapping needed
     }
     SESSION_FACADE_INNER_FIELD = sessionFacadeInnerField;
+    SESSION_FACADE_VALUE_CONVERTER_FIELD = sessionFacadeValueConverterField;
   }
 
   private SessionStoreCacheBypass() {
@@ -119,6 +124,7 @@ public final class SessionStoreCacheBypass {
       final ReadOnlySessionStore<GenericKey, GenericRow> sessionStore,
       final GenericKey key
   ) {
+    final Function<Object, GenericRow> valueConverter = getSessionValueConverter(sessionStore);
     final ReadOnlySessionStore<GenericKey, GenericRow> unwrapped
         = unwrapSessionFacade(sessionStore);
     if (!(unwrapped instanceof MeteredSessionStore)) {
@@ -128,7 +134,7 @@ public final class SessionStoreCacheBypass {
       final Bytes rawKey = Bytes.wrap(serdes.rawKey(key));
       final SessionStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
       final KeyValueIterator<Windowed<Bytes>, byte[]> fetch = wrapped.fetch(rawKey);
-      return new DeserializingIterator(fetch, serdes);
+      return new DeserializingIterator(fetch, serdes, valueConverter);
     }
   }
 
@@ -158,6 +164,7 @@ public final class SessionStoreCacheBypass {
           final GenericKey keyFrom,
           final GenericKey keyTo
   ) {
+    final Function<Object, GenericRow> valueConverter = getSessionValueConverter(sessionStore);
     final ReadOnlySessionStore<GenericKey, GenericRow> unwrapped
         = unwrapSessionFacade(sessionStore);
     if (!(unwrapped instanceof MeteredSessionStore)) {
@@ -168,7 +175,7 @@ public final class SessionStoreCacheBypass {
       final Bytes rawKeyTo = Bytes.wrap(serdes.rawKey(keyTo));
       final SessionStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
       final KeyValueIterator<Windowed<Bytes>, byte[]> fetch = wrapped.fetch(rawKeyFrom, rawKeyTo);
-      return new DeserializingIterator(fetch, serdes);
+      return new DeserializingIterator(fetch, serdes, valueConverter);
     }
   }
 
@@ -208,6 +215,22 @@ public final class SessionStoreCacheBypass {
       }
     }
     return sessionStore;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Function<Object, GenericRow> getSessionValueConverter(
+      final ReadOnlySessionStore<GenericKey, GenericRow> sessionStore
+  ) {
+    if (SESSION_FACADE_VALUE_CONVERTER_FIELD != null
+        && SESSION_FACADE_VALUE_CONVERTER_FIELD.getDeclaringClass().isInstance(sessionStore)) {
+      try {
+        return (Function<Object, GenericRow>)
+            SESSION_FACADE_VALUE_CONVERTER_FIELD.get(sessionStore);
+      } catch (final IllegalAccessException e) {
+        throw new RuntimeException("Stream internals changed unexpectedly!", e);
+      }
+    }
+    return x -> (GenericRow) x;
   }
 
   @SuppressWarnings("unchecked")
@@ -262,11 +285,14 @@ public final class SessionStoreCacheBypass {
       implements KeyValueIterator<Windowed<GenericKey>, GenericRow> {
     private final KeyValueIterator<Windowed<Bytes>, byte[]> fetch;
     private final StateSerdes<GenericKey, GenericRow> serdes;
+    private final Function<Object, GenericRow> valueConverter;
 
     private DeserializingIterator(final KeyValueIterator<Windowed<Bytes>, byte[]> fetch,
-        final StateSerdes<GenericKey, GenericRow> serdes) {
+        final StateSerdes<GenericKey, GenericRow> serdes,
+        final Function<Object, GenericRow> valueConverter) {
       this.fetch = fetch;
       this.serdes = serdes;
+      this.valueConverter = valueConverter;
     }
 
     @Override
@@ -289,7 +315,7 @@ public final class SessionStoreCacheBypass {
     public KeyValue<Windowed<GenericKey>, GenericRow> next() {
       final Windowed<GenericKey> key = peekNextKey();
       final KeyValue<Windowed<Bytes>, byte[]> next = fetch.next();
-      return KeyValue.pair(key, serdes.valueFrom(next.value));
+      return KeyValue.pair(key, valueConverter.apply(serdes.valueFrom(next.value)));
     }
   }
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypass.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypass.java
@@ -134,7 +134,7 @@ public final class SessionStoreCacheBypass {
     if (!(unwrapped instanceof MeteredSessionStore)) {
       throw new IllegalStateException("Expecting a MeteredSessionStore");
     } else {
-      final StateSerdes<GenericKey, GenericRow> serdes = getSerdes(unwrapped);
+      final StateSerdes<GenericKey, ?> serdes = getSerdes(unwrapped);
       final Bytes rawKey = Bytes.wrap(serdes.rawKey(key));
       final SessionStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
       final KeyValueIterator<Windowed<Bytes>, byte[]> fetch = wrapped.fetch(rawKey);
@@ -174,7 +174,7 @@ public final class SessionStoreCacheBypass {
     if (!(unwrapped instanceof MeteredSessionStore)) {
       throw new IllegalStateException("Expecting a MeteredSessionStore");
     } else {
-      final StateSerdes<GenericKey, GenericRow> serdes = getSerdes(unwrapped);
+      final StateSerdes<GenericKey, ?> serdes = getSerdes(unwrapped);
       final Bytes rawKeyFrom = Bytes.wrap(serdes.rawKey(keyFrom));
       final Bytes rawKeyTo = Bytes.wrap(serdes.rawKey(keyTo));
       final SessionStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
@@ -240,11 +240,11 @@ public final class SessionStoreCacheBypass {
   }
 
   @SuppressWarnings("unchecked")
-  private static StateSerdes<GenericKey, GenericRow> getSerdes(
+  private static StateSerdes<GenericKey, ?> getSerdes(
           final ReadOnlySessionStore<GenericKey, GenericRow> sessionStore
   ) throws RuntimeException {
     try {
-      return (StateSerdes<GenericKey, GenericRow>) SERDES_FIELD.get(sessionStore);
+      return (StateSerdes<GenericKey, ?>) SERDES_FIELD.get(sessionStore);
     } catch (final IllegalAccessException e) {
       throw new RuntimeException("Stream internals changed unexpectedly!", e);
     }
@@ -290,11 +290,11 @@ public final class SessionStoreCacheBypass {
   private static final class DeserializingIterator
       implements KeyValueIterator<Windowed<GenericKey>, GenericRow> {
     private final KeyValueIterator<Windowed<Bytes>, byte[]> fetch;
-    private final StateSerdes<GenericKey, GenericRow> serdes;
+    private final StateSerdes<GenericKey, ?> serdes;
     private final Function<Object, GenericRow> valueConverter;
 
     private DeserializingIterator(final KeyValueIterator<Windowed<Bytes>, byte[]> fetch,
-        final StateSerdes<GenericKey, GenericRow> serdes,
+        final StateSerdes<GenericKey, ?> serdes,
         final Function<Object, GenericRow> valueConverter) {
       this.fetch = fetch;
       this.serdes = serdes;

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypass.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypass.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.execution.streams.materialization.ks;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -45,7 +46,8 @@ public final class SessionStoreCacheBypass {
   static final Field SERDES_FIELD;
   // Nullable: only present in Kafka versions that introduced ReadOnlySessionStoreFacade
   private static final Field SESSION_FACADE_INNER_FIELD;
-  private static final Field SESSION_FACADE_VALUE_CONVERTER_FIELD;
+  // Nullable: AggregationWithHeaders.getAggregationOrNull — used when session facade is present
+  private static final Method AGGREGATION_GET_AGGREGATION_METHOD;
   private static final String STORE_UNAVAILABLE_MESSAGE = "State store is not available anymore "
           + "and may have been migrated to another instance; "
           + "please re-discover its location from the state metadata.";
@@ -66,19 +68,21 @@ public final class SessionStoreCacheBypass {
     }
 
     Field sessionFacadeInnerField = null;
-    Field sessionFacadeValueConverterField = null;
+    Method aggregationGetAggregationMethod = null;
     try {
       final Class<?> facadeClass = Class.forName(
           "org.apache.kafka.streams.state.internals.ReadOnlySessionStoreFacade");
       sessionFacadeInnerField = facadeClass.getDeclaredField("inner");
       sessionFacadeInnerField.setAccessible(true);
-      sessionFacadeValueConverterField = facadeClass.getDeclaredField("valueConverter");
-      sessionFacadeValueConverterField.setAccessible(true);
-    } catch (final ClassNotFoundException | NoSuchFieldException e) {
+      final Class<?> aggregationClass = Class.forName(
+          "org.apache.kafka.streams.state.AggregationWithHeaders");
+      aggregationGetAggregationMethod = aggregationClass.getMethod(
+          "getAggregationOrNull", aggregationClass);
+    } catch (final ClassNotFoundException | NoSuchFieldException | NoSuchMethodException e) {
       // Facade class not present in this Kafka version — no unwrapping needed
     }
     SESSION_FACADE_INNER_FIELD = sessionFacadeInnerField;
-    SESSION_FACADE_VALUE_CONVERTER_FIELD = sessionFacadeValueConverterField;
+    AGGREGATION_GET_AGGREGATION_METHOD = aggregationGetAggregationMethod;
   }
 
   private SessionStoreCacheBypass() {
@@ -221,14 +225,16 @@ public final class SessionStoreCacheBypass {
   private static Function<Object, GenericRow> getSessionValueConverter(
       final ReadOnlySessionStore<GenericKey, GenericRow> sessionStore
   ) {
-    if (SESSION_FACADE_VALUE_CONVERTER_FIELD != null
-        && SESSION_FACADE_VALUE_CONVERTER_FIELD.getDeclaringClass().isInstance(sessionStore)) {
-      try {
-        return (Function<Object, GenericRow>)
-            SESSION_FACADE_VALUE_CONVERTER_FIELD.get(sessionStore);
-      } catch (final IllegalAccessException e) {
-        throw new RuntimeException("Stream internals changed unexpectedly!", e);
-      }
+    if (AGGREGATION_GET_AGGREGATION_METHOD != null
+        && SESSION_FACADE_INNER_FIELD != null
+        && SESSION_FACADE_INNER_FIELD.getDeclaringClass().isInstance(sessionStore)) {
+      return x -> {
+        try {
+          return (GenericRow) AGGREGATION_GET_AGGREGATION_METHOD.invoke(null, x);
+        } catch (final Exception e) {
+          throw new RuntimeException("Stream internals changed unexpectedly!", e);
+        }
+      };
     }
     return x -> (GenericRow) x;
   }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypass.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypass.java
@@ -78,8 +78,10 @@ public final class SessionStoreCacheBypass {
           "org.apache.kafka.streams.state.AggregationWithHeaders");
       aggregationGetAggregationMethod = aggregationClass.getMethod(
           "getAggregationOrNull", aggregationClass);
-    } catch (final ClassNotFoundException | NoSuchFieldException | NoSuchMethodException e) {
+    } catch (final ClassNotFoundException e) {
       // Facade class not present in this Kafka version — no unwrapping needed
+    } catch (final NoSuchFieldException | NoSuchMethodException e) {
+      throw new RuntimeException("Stream internals changed unexpectedly!", e);
     }
     SESSION_FACADE_INNER_FIELD = sessionFacadeInnerField;
     AGGREGATION_GET_AGGREGATION_METHOD = aggregationGetAggregationMethod;

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypass.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypass.java
@@ -48,6 +48,7 @@ public final class WindowStoreCacheBypass {
   static final Field SERDES_FIELD;
   // Nullable: only present in Kafka versions that introduced GenericReadOnlyWindowStoreFacade
   private static final Field GENERIC_WINDOW_FACADE_INNER_FIELD;
+  private static final Field GENERIC_WINDOW_FACADE_VALUE_CONVERTER_FIELD;
   private static final String STORE_UNAVAILABLE_MESSAGE = "State store is not available anymore "
           + "and may have been migrated to another instance; "
           + "please re-discover its location from the state metadata.";
@@ -68,15 +69,19 @@ public final class WindowStoreCacheBypass {
     }
 
     Field genericWindowFacadeInnerField = null;
+    Field genericWindowFacadeValueConverterField = null;
     try {
       final Class<?> facadeClass = Class.forName(
           "org.apache.kafka.streams.state.internals.GenericReadOnlyWindowStoreFacade");
       genericWindowFacadeInnerField = facadeClass.getDeclaredField("inner");
       genericWindowFacadeInnerField.setAccessible(true);
+      genericWindowFacadeValueConverterField = facadeClass.getDeclaredField("valueConverter");
+      genericWindowFacadeValueConverterField.setAccessible(true);
     } catch (final ClassNotFoundException | NoSuchFieldException e) {
       // Facade class not present in this Kafka version — no unwrapping needed
     }
     GENERIC_WINDOW_FACADE_INNER_FIELD = genericWindowFacadeInnerField;
+    GENERIC_WINDOW_FACADE_VALUE_CONVERTER_FIELD = genericWindowFacadeValueConverterField;
   }
 
   private WindowStoreCacheBypass() {
@@ -143,6 +148,8 @@ public final class WindowStoreCacheBypass {
       final Instant lower,
       final Instant upper
   ) {
+    final Function<Object, ValueAndTimestamp<GenericRow>> valueConverter
+        = getWindowValueConverter(windowStore);
     final ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>> unwrapped
         = unwrapWindowFacade(windowStore);
     if (!(unwrapped instanceof MeteredWindowStore)) {
@@ -152,7 +159,7 @@ public final class WindowStoreCacheBypass {
     final WindowStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
     final Bytes rawKey = Bytes.wrap(serdes.rawKey(key));
     final WindowStoreIterator<byte[]> fetch = wrapped.fetch(rawKey, lower, upper);
-    return new DeserializingIterator(fetch, serdes);
+    return new DeserializingIterator(fetch, serdes, valueConverter);
   }
 
   /*
@@ -186,6 +193,8 @@ public final class WindowStoreCacheBypass {
           final Instant lower,
           final Instant upper
   ) {
+    final Function<Object, ValueAndTimestamp<GenericRow>> valueConverter
+        = getWindowValueConverter(windowStore);
     final ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>> unwrapped
         = unwrapWindowFacade(windowStore);
     if (!(unwrapped instanceof MeteredWindowStore)) {
@@ -197,7 +206,7 @@ public final class WindowStoreCacheBypass {
     final Bytes rawKeyTo = Bytes.wrap(serdes.rawKey(keyTo));
     final KeyValueIterator<Windowed<Bytes>, byte[]> fetch = wrapped
             .fetch(rawKeyFrom, rawKeyTo, lower, upper);
-    return new DeserializingKeyValueIterator(fetch, serdes);
+    return new DeserializingKeyValueIterator(fetch, serdes, valueConverter);
   }
 
   /*
@@ -225,6 +234,8 @@ public final class WindowStoreCacheBypass {
           final Instant lower,
           final Instant upper
   ) {
+    final Function<Object, ValueAndTimestamp<GenericRow>> valueConverter
+        = getWindowValueConverter(windowStore);
     final ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>> unwrapped
         = unwrapWindowFacade(windowStore);
     if (!(unwrapped instanceof MeteredWindowStore)) {
@@ -233,7 +244,7 @@ public final class WindowStoreCacheBypass {
     final StateSerdes<GenericKey, ValueAndTimestamp<GenericRow>> serdes = getSerdes(unwrapped);
     final WindowStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
     final KeyValueIterator<Windowed<Bytes>, byte[]> fetch = wrapped.fetchAll(lower, upper);
-    return new DeserializingKeyValueIterator(fetch, serdes);
+    return new DeserializingKeyValueIterator(fetch, serdes, valueConverter);
   }
 
   @SuppressWarnings("unchecked")
@@ -273,6 +284,23 @@ public final class WindowStoreCacheBypass {
       }
     }
     return windowStore;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Function<Object, ValueAndTimestamp<GenericRow>> getWindowValueConverter(
+      final ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>> windowStore
+  ) {
+    if (GENERIC_WINDOW_FACADE_VALUE_CONVERTER_FIELD != null
+        && GENERIC_WINDOW_FACADE_VALUE_CONVERTER_FIELD.getDeclaringClass()
+            .isInstance(windowStore)) {
+      try {
+        return (Function<Object, ValueAndTimestamp<GenericRow>>)
+            GENERIC_WINDOW_FACADE_VALUE_CONVERTER_FIELD.get(windowStore);
+      } catch (final IllegalAccessException e) {
+        throw new RuntimeException("Stream internals changed unexpectedly!", e);
+      }
+    }
+    return x -> (ValueAndTimestamp<GenericRow>) x;
   }
 
   @SuppressWarnings("unchecked")
@@ -332,12 +360,15 @@ public final class WindowStoreCacheBypass {
           implements KeyValueIterator<Windowed<GenericKey>, ValueAndTimestamp<GenericRow>> {
     private final KeyValueIterator<Windowed<Bytes>, byte[]> fetch;
     private final StateSerdes<GenericKey, ValueAndTimestamp<GenericRow>> serdes;
+    private final Function<Object, ValueAndTimestamp<GenericRow>> valueConverter;
 
     private DeserializingKeyValueIterator(
             final KeyValueIterator<Windowed<Bytes>, byte[]> fetch,
-            final StateSerdes<GenericKey, ValueAndTimestamp<GenericRow>> serdes) {
+            final StateSerdes<GenericKey, ValueAndTimestamp<GenericRow>> serdes,
+            final Function<Object, ValueAndTimestamp<GenericRow>> valueConverter) {
       this.fetch = fetch;
       this.serdes = serdes;
+      this.valueConverter = valueConverter;
     }
 
     @Override
@@ -361,7 +392,7 @@ public final class WindowStoreCacheBypass {
       final KeyValue<Windowed<Bytes>, byte[]> next = fetch.next();
       final Windowed<GenericKey> windowedKey = new Windowed<>(
               serdes.keyFrom(next.key.key().get()), next.key.window());
-      return KeyValue.pair(windowedKey, serdes.valueFrom(next.value));
+      return KeyValue.pair(windowedKey, valueConverter.apply(serdes.valueFrom(next.value)));
     }
   }
 
@@ -372,12 +403,15 @@ public final class WindowStoreCacheBypass {
           implements WindowStoreIterator<ValueAndTimestamp<GenericRow>> {
     private final WindowStoreIterator<byte[]> fetch;
     private final StateSerdes<GenericKey, ValueAndTimestamp<GenericRow>> serdes;
+    private final Function<Object, ValueAndTimestamp<GenericRow>> valueConverter;
 
     private DeserializingIterator(
             final WindowStoreIterator<byte[]> fetch,
-            final StateSerdes<GenericKey, ValueAndTimestamp<GenericRow>> serdes) {
+            final StateSerdes<GenericKey, ValueAndTimestamp<GenericRow>> serdes,
+            final Function<Object, ValueAndTimestamp<GenericRow>> valueConverter) {
       this.fetch = fetch;
       this.serdes = serdes;
+      this.valueConverter = valueConverter;
     }
 
     @Override
@@ -398,7 +432,7 @@ public final class WindowStoreCacheBypass {
     @Override
     public KeyValue<Long, ValueAndTimestamp<GenericRow>> next() {
       final KeyValue<Long, byte[]> next = fetch.next();
-      return KeyValue.pair(next.key, serdes.valueFrom(next.value));
+      return KeyValue.pair(next.key, valueConverter.apply(serdes.valueFrom(next.value)));
     }
   }
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypass.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypass.java
@@ -46,6 +46,8 @@ public final class WindowStoreCacheBypass {
   private static final Field STORE_NAME_FIELD;
   private static final Field WINDOW_STORE_TYPE_FIELD;
   static final Field SERDES_FIELD;
+  // Nullable: only present in Kafka versions that introduced GenericReadOnlyWindowStoreFacade
+  private static final Field GENERIC_WINDOW_FACADE_INNER_FIELD;
   private static final String STORE_UNAVAILABLE_MESSAGE = "State store is not available anymore "
           + "and may have been migrated to another instance; "
           + "please re-discover its location from the state metadata.";
@@ -64,6 +66,17 @@ public final class WindowStoreCacheBypass {
     } catch (final NoSuchFieldException e) {
       throw new RuntimeException("Stream internals changed unexpectedly!", e);
     }
+
+    Field genericWindowFacadeInnerField = null;
+    try {
+      final Class<?> facadeClass = Class.forName(
+          "org.apache.kafka.streams.state.internals.GenericReadOnlyWindowStoreFacade");
+      genericWindowFacadeInnerField = facadeClass.getDeclaredField("inner");
+      genericWindowFacadeInnerField.setAccessible(true);
+    } catch (final ClassNotFoundException | NoSuchFieldException e) {
+      // Facade class not present in this Kafka version — no unwrapping needed
+    }
+    GENERIC_WINDOW_FACADE_INNER_FIELD = genericWindowFacadeInnerField;
   }
 
   private WindowStoreCacheBypass() {
@@ -130,11 +143,13 @@ public final class WindowStoreCacheBypass {
       final Instant lower,
       final Instant upper
   ) {
-    if (!(windowStore instanceof MeteredWindowStore)) {
+    final ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>> unwrapped
+        = unwrapWindowFacade(windowStore);
+    if (!(unwrapped instanceof MeteredWindowStore)) {
       throw new IllegalStateException("Expecting a MeteredWindowStore");
     }
-    final StateSerdes<GenericKey, ValueAndTimestamp<GenericRow>> serdes = getSerdes(windowStore);
-    final WindowStore<Bytes, byte[]> wrapped = getInnermostStore(windowStore);
+    final StateSerdes<GenericKey, ValueAndTimestamp<GenericRow>> serdes = getSerdes(unwrapped);
+    final WindowStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
     final Bytes rawKey = Bytes.wrap(serdes.rawKey(key));
     final WindowStoreIterator<byte[]> fetch = wrapped.fetch(rawKey, lower, upper);
     return new DeserializingIterator(fetch, serdes);
@@ -171,11 +186,13 @@ public final class WindowStoreCacheBypass {
           final Instant lower,
           final Instant upper
   ) {
-    if (!(windowStore instanceof MeteredWindowStore)) {
+    final ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>> unwrapped
+        = unwrapWindowFacade(windowStore);
+    if (!(unwrapped instanceof MeteredWindowStore)) {
       throw new IllegalStateException("Expecting a MeteredWindowStore");
     }
-    final StateSerdes<GenericKey, ValueAndTimestamp<GenericRow>> serdes = getSerdes(windowStore);
-    final WindowStore<Bytes, byte[]> wrapped = getInnermostStore(windowStore);
+    final StateSerdes<GenericKey, ValueAndTimestamp<GenericRow>> serdes = getSerdes(unwrapped);
+    final WindowStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
     final Bytes rawKeyFrom = Bytes.wrap(serdes.rawKey(keyFrom));
     final Bytes rawKeyTo = Bytes.wrap(serdes.rawKey(keyTo));
     final KeyValueIterator<Windowed<Bytes>, byte[]> fetch = wrapped
@@ -208,11 +225,13 @@ public final class WindowStoreCacheBypass {
           final Instant lower,
           final Instant upper
   ) {
-    if (!(windowStore instanceof MeteredWindowStore)) {
+    final ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>> unwrapped
+        = unwrapWindowFacade(windowStore);
+    if (!(unwrapped instanceof MeteredWindowStore)) {
       throw new IllegalStateException("Expecting a MeteredWindowStore");
     }
-    final StateSerdes<GenericKey, ValueAndTimestamp<GenericRow>> serdes = getSerdes(windowStore);
-    final WindowStore<Bytes, byte[]> wrapped = getInnermostStore(windowStore);
+    final StateSerdes<GenericKey, ValueAndTimestamp<GenericRow>> serdes = getSerdes(unwrapped);
+    final WindowStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
     final KeyValueIterator<Windowed<Bytes>, byte[]> fetch = wrapped.fetchAll(lower, upper);
     return new DeserializingKeyValueIterator(fetch, serdes);
   }
@@ -238,6 +257,22 @@ public final class WindowStoreCacheBypass {
     }
     return (T) (result instanceof WindowStoreIterator
             ? new EmptyWindowStoreIterator() : new EmptyKeyValueIterator());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>> unwrapWindowFacade(
+      final ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>> windowStore
+  ) {
+    if (GENERIC_WINDOW_FACADE_INNER_FIELD != null
+        && GENERIC_WINDOW_FACADE_INNER_FIELD.getDeclaringClass().isInstance(windowStore)) {
+      try {
+        return (ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>>)
+            GENERIC_WINDOW_FACADE_INNER_FIELD.get(windowStore);
+      } catch (final IllegalAccessException e) {
+        throw new RuntimeException("Stream internals changed unexpectedly!", e);
+      }
+    }
+    return windowStore;
   }
 
   @SuppressWarnings("unchecked")

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypass.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypass.java
@@ -77,8 +77,10 @@ public final class WindowStoreCacheBypass {
       genericWindowFacadeInnerField.setAccessible(true);
       genericWindowFacadeValueConverterField = facadeClass.getDeclaredField("valueConverter");
       genericWindowFacadeValueConverterField.setAccessible(true);
-    } catch (final ClassNotFoundException | NoSuchFieldException e) {
+    } catch (final ClassNotFoundException e) {
       // Facade class not present in this Kafka version — no unwrapping needed
+    } catch (final NoSuchFieldException e) {
+      throw new RuntimeException("Stream internals changed unexpectedly!", e);
     }
     GENERIC_WINDOW_FACADE_INNER_FIELD = genericWindowFacadeInnerField;
     GENERIC_WINDOW_FACADE_VALUE_CONVERTER_FIELD = genericWindowFacadeValueConverterField;

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypass.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypass.java
@@ -155,7 +155,7 @@ public final class WindowStoreCacheBypass {
     if (!(unwrapped instanceof MeteredWindowStore)) {
       throw new IllegalStateException("Expecting a MeteredWindowStore");
     }
-    final StateSerdes<GenericKey, ValueAndTimestamp<GenericRow>> serdes = getSerdes(unwrapped);
+    final StateSerdes<GenericKey, ?> serdes = getSerdes(unwrapped);
     final WindowStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
     final Bytes rawKey = Bytes.wrap(serdes.rawKey(key));
     final WindowStoreIterator<byte[]> fetch = wrapped.fetch(rawKey, lower, upper);
@@ -200,7 +200,7 @@ public final class WindowStoreCacheBypass {
     if (!(unwrapped instanceof MeteredWindowStore)) {
       throw new IllegalStateException("Expecting a MeteredWindowStore");
     }
-    final StateSerdes<GenericKey, ValueAndTimestamp<GenericRow>> serdes = getSerdes(unwrapped);
+    final StateSerdes<GenericKey, ?> serdes = getSerdes(unwrapped);
     final WindowStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
     final Bytes rawKeyFrom = Bytes.wrap(serdes.rawKey(keyFrom));
     final Bytes rawKeyTo = Bytes.wrap(serdes.rawKey(keyTo));
@@ -241,7 +241,7 @@ public final class WindowStoreCacheBypass {
     if (!(unwrapped instanceof MeteredWindowStore)) {
       throw new IllegalStateException("Expecting a MeteredWindowStore");
     }
-    final StateSerdes<GenericKey, ValueAndTimestamp<GenericRow>> serdes = getSerdes(unwrapped);
+    final StateSerdes<GenericKey, ?> serdes = getSerdes(unwrapped);
     final WindowStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
     final KeyValueIterator<Windowed<Bytes>, byte[]> fetch = wrapped.fetchAll(lower, upper);
     return new DeserializingKeyValueIterator(fetch, serdes, valueConverter);
@@ -304,11 +304,11 @@ public final class WindowStoreCacheBypass {
   }
 
   @SuppressWarnings("unchecked")
-  private static StateSerdes<GenericKey, ValueAndTimestamp<GenericRow>> getSerdes(
+  private static StateSerdes<GenericKey, ?> getSerdes(
           final ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>> windowStore
   ) throws RuntimeException {
     try {
-      return (StateSerdes<GenericKey, ValueAndTimestamp<GenericRow>>) SERDES_FIELD.get(windowStore);
+      return (StateSerdes<GenericKey, ?>) SERDES_FIELD.get(windowStore);
     } catch (final IllegalAccessException e) {
       throw new RuntimeException("Stream internals changed unexpectedly!", e);
     }
@@ -359,12 +359,12 @@ public final class WindowStoreCacheBypass {
   private static final class DeserializingKeyValueIterator
           implements KeyValueIterator<Windowed<GenericKey>, ValueAndTimestamp<GenericRow>> {
     private final KeyValueIterator<Windowed<Bytes>, byte[]> fetch;
-    private final StateSerdes<GenericKey, ValueAndTimestamp<GenericRow>> serdes;
+    private final StateSerdes<GenericKey, ?> serdes;
     private final Function<Object, ValueAndTimestamp<GenericRow>> valueConverter;
 
     private DeserializingKeyValueIterator(
             final KeyValueIterator<Windowed<Bytes>, byte[]> fetch,
-            final StateSerdes<GenericKey, ValueAndTimestamp<GenericRow>> serdes,
+            final StateSerdes<GenericKey, ?> serdes,
             final Function<Object, ValueAndTimestamp<GenericRow>> valueConverter) {
       this.fetch = fetch;
       this.serdes = serdes;
@@ -402,12 +402,12 @@ public final class WindowStoreCacheBypass {
   private static final class DeserializingIterator
           implements WindowStoreIterator<ValueAndTimestamp<GenericRow>> {
     private final WindowStoreIterator<byte[]> fetch;
-    private final StateSerdes<GenericKey, ValueAndTimestamp<GenericRow>> serdes;
+    private final StateSerdes<GenericKey, ?> serdes;
     private final Function<Object, ValueAndTimestamp<GenericRow>> valueConverter;
 
     private DeserializingIterator(
             final WindowStoreIterator<byte[]> fetch,
-            final StateSerdes<GenericKey, ValueAndTimestamp<GenericRow>> serdes,
+            final StateSerdes<GenericKey, ?> serdes,
             final Function<Object, ValueAndTimestamp<GenericRow>> valueConverter) {
       this.fetch = fetch;
       this.serdes = serdes;

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypassTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypassTest.java
@@ -16,6 +16,9 @@
 package io.confluent.ksql.execution.streams.materialization.ks;
 
 import static io.confluent.ksql.execution.streams.materialization.ks.SessionStoreCacheBypass.SERDES_FIELD;
+import org.apache.kafka.streams.state.SessionStoreWithHeaders;
+import org.apache.kafka.streams.state.internals.MeteredSessionStoreWithHeaders;
+import org.apache.kafka.streams.state.internals.ReadOnlySessionStoreFacade;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThrows;
@@ -72,6 +75,8 @@ public class SessionStoreCacheBypassTest {
   private KeyValueIterator<Windowed<Bytes>, byte[]> storeIterator;
   @Mock
   private StateSerdes<GenericKey, ValueAndTimestamp<GenericRow>> serdes;
+  @Mock
+  private MeteredSessionStoreWithHeaders<GenericKey, GenericRow> meteredSessionStoreWithHeaders;
 
   private CompositeReadOnlySessionStore<GenericKey, GenericRow> store;
 
@@ -141,6 +146,40 @@ public class SessionStoreCacheBypassTest {
   }
 
   @Test
+  public void shouldUnwrapSessionFacadeAndCallUnderlyingStoreSingleKey()
+      throws IllegalAccessException {
+    final TestSessionStoreFacade facade =
+        new TestSessionStoreFacade(meteredSessionStoreWithHeaders);
+    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade));
+    SERDES_FIELD.set(meteredSessionStoreWithHeaders, serdes);
+    when(serdes.rawKey(any())).thenReturn(BYTES);
+    when(meteredSessionStoreWithHeaders.wrapped()).thenReturn(wrappedSessionStore);
+    when(wrappedSessionStore.wrapped()).thenReturn(sessionStore);
+    when(sessionStore.fetch(any())).thenReturn(storeIterator);
+    when(storeIterator.hasNext()).thenReturn(false);
+
+    SessionStoreCacheBypass.fetch(store, SOME_KEY);
+    verify(sessionStore).fetch(new Bytes(BYTES));
+  }
+
+  @Test
+  public void shouldUnwrapSessionFacadeAndCallUnderlyingStoreRangeQuery()
+      throws IllegalAccessException {
+    final TestSessionStoreFacade facade =
+        new TestSessionStoreFacade(meteredSessionStoreWithHeaders);
+    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade));
+    SERDES_FIELD.set(meteredSessionStoreWithHeaders, serdes);
+    when(serdes.rawKey(any())).thenReturn(BYTES, OTHER_BYTES);
+    when(meteredSessionStoreWithHeaders.wrapped()).thenReturn(wrappedSessionStore);
+    when(wrappedSessionStore.wrapped()).thenReturn(sessionStore);
+    when(sessionStore.fetch(any(), any())).thenReturn(storeIterator);
+    when(storeIterator.hasNext()).thenReturn(false);
+
+    SessionStoreCacheBypass.fetchRange(store, SOME_KEY, SOME_OTHER_KEY);
+    verify(sessionStore).fetch(new Bytes(BYTES), new Bytes(OTHER_BYTES));
+  }
+
+  @Test
   public void shouldThrowException_wrongStateStore() {
     when(provider.stores(any(), any())).thenReturn(ImmutableList.of(sessionStore));
 
@@ -156,6 +195,13 @@ public class SessionStoreCacheBypassTest {
       extends WrappedStateStore<StateStore, K, V> implements SessionStore<K, V> {
     public WrappedSessionStore(StateStore wrapped) {
       super(wrapped);
+    }
+  }
+
+  private static class TestSessionStoreFacade
+      extends ReadOnlySessionStoreFacade<GenericKey, GenericRow> {
+    TestSessionStoreFacade(final SessionStoreWithHeaders<GenericKey, GenericRow> inner) {
+      super(inner);
     }
   }
 }

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypassTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypassTest.java
@@ -204,7 +204,7 @@ public class SessionStoreCacheBypassTest {
     final Windowed<Bytes> windowedKey =
         new Windowed<>(new Bytes(BYTES), new SessionWindow(0, 100));
     when(sessionStore.fetch(any())).thenReturn(storeIterator);
-    when(storeIterator.hasNext()).thenReturn(true);
+    when(storeIterator.hasNext()).thenReturn(true, false);
     when(storeIterator.peekNextKey()).thenReturn(windowedKey);
     when(storeIterator.next()).thenReturn(KeyValue.pair(windowedKey, VALUE_BYTES));
 

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypassTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypassTest.java
@@ -21,18 +21,24 @@ import org.apache.kafka.streams.state.internals.MeteredSessionStoreWithHeaders;
 import org.apache.kafka.streams.state.internals.ReadOnlySessionStoreFacade;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.kstream.internals.SessionWindow;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.state.AggregationWithHeaders;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.ReadOnlySessionStore;
@@ -57,6 +63,8 @@ public class SessionStoreCacheBypassTest {
 
   private static final byte[] BYTES = new byte[] {'a', 'b'};
   private static final byte[] OTHER_BYTES = new byte[] {'c', 'd'};
+  private static final byte[] VALUE_BYTES = new byte[] {'e', 'f'};
+  private static final GenericRow EXPECTED_ROW = GenericRow.genericRow("v1");
 
   @Mock
   private QueryableStoreType<ReadOnlySessionStore<GenericKey, GenericRow>>
@@ -177,6 +185,32 @@ public class SessionStoreCacheBypassTest {
 
     SessionStoreCacheBypass.fetchRange(store, SOME_KEY, SOME_OTHER_KEY);
     verify(sessionStore).fetch(new Bytes(BYTES), new Bytes(OTHER_BYTES));
+  }
+
+  @Test
+  public void shouldUnwrapSessionFacadeAndConvertValueViaAggregationMethod()
+      throws IllegalAccessException {
+    final TestSessionStoreFacade facade =
+        new TestSessionStoreFacade(meteredSessionStoreWithHeaders);
+    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade));
+    SERDES_FIELD.set(meteredSessionStoreWithHeaders, serdes);
+    when(serdes.rawKey(any())).thenReturn(BYTES);
+    when(serdes.keyFrom(any())).thenReturn(SOME_KEY);
+    final AggregationWithHeaders<GenericRow> aggregation =
+        AggregationWithHeaders.make(EXPECTED_ROW, new RecordHeaders());
+    doReturn(aggregation).when(serdes).valueFrom(any());
+    when(meteredSessionStoreWithHeaders.wrapped()).thenReturn(wrappedSessionStore);
+    when(wrappedSessionStore.wrapped()).thenReturn(sessionStore);
+    final Windowed<Bytes> windowedKey =
+        new Windowed<>(new Bytes(BYTES), new SessionWindow(0, 100));
+    when(sessionStore.fetch(any())).thenReturn(storeIterator);
+    when(storeIterator.hasNext()).thenReturn(true);
+    when(storeIterator.peekNextKey()).thenReturn(windowedKey);
+    when(storeIterator.next()).thenReturn(KeyValue.pair(windowedKey, VALUE_BYTES));
+
+    final KeyValueIterator<Windowed<GenericKey>, GenericRow> result =
+        SessionStoreCacheBypass.fetch(store, SOME_KEY);
+    assertThat(result.next().value, is(EXPECTED_ROW));
   }
 
   @Test

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypassTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypassTest.java
@@ -237,7 +237,7 @@ public class WindowStoreCacheBypassTest {
     when(meteredWindowStore.wrapped()).thenReturn(wrappedWindowStore);
     when(wrappedWindowStore.wrapped()).thenReturn(windowStore);
     when(windowStore.fetch(any(), any(), any())).thenReturn(windowStoreIterator);
-    when(windowStoreIterator.hasNext()).thenReturn(true);
+    when(windowStoreIterator.hasNext()).thenReturn(true, false);
     when(windowStoreIterator.next()).thenReturn(KeyValue.pair(100L, VALUE_BYTES));
 
     final WindowStoreIterator<ValueAndTimestamp<GenericRow>> result =

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypassTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypassTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.internals.GenericReadOnlyWindowStoreFacade;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
@@ -31,6 +32,7 @@ import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
 import java.time.Instant;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.QueryableStoreType;
@@ -56,6 +58,9 @@ public class WindowStoreCacheBypassTest {
   private static final GenericKey SOME_OTHER_KEY = GenericKey.genericKey(2);
   private static final byte[] BYTES = new byte[] {'a', 'b'};
   private static final byte[] OTHER_BYTES = new byte[] {'c', 'd'};
+  private static final byte[] VALUE_BYTES = new byte[] {'e', 'f'};
+  private static final ValueAndTimestamp<GenericRow> VALUE_AND_TIMESTAMP =
+      ValueAndTimestamp.make(GenericRow.genericRow("v1"), 1000L);
 
   @Mock
   private QueryableStoreType<ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>>>
@@ -217,6 +222,28 @@ public class WindowStoreCacheBypassTest {
     WindowStoreCacheBypass.fetchAll(
         store, Instant.ofEpochMilli(100), Instant.ofEpochMilli(200));
     verify(windowStore).fetchAll(Instant.ofEpochMilli(100L), Instant.ofEpochMilli(200L));
+  }
+
+  @Test
+  public void shouldUnwrapWindowFacadeAndApplyValueConverterForSingleKey()
+      throws IllegalAccessException {
+    final GenericReadOnlyWindowStoreFacade<GenericKey, ValueAndTimestamp<GenericRow>,
+        ValueAndTimestamp<GenericRow>> facade =
+        new GenericReadOnlyWindowStoreFacade<>(meteredWindowStore, x -> x);
+    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade));
+    SERDES_FIELD.set(meteredWindowStore, serdes);
+    when(serdes.rawKey(any())).thenReturn(BYTES);
+    when(serdes.valueFrom(any())).thenReturn(VALUE_AND_TIMESTAMP);
+    when(meteredWindowStore.wrapped()).thenReturn(wrappedWindowStore);
+    when(wrappedWindowStore.wrapped()).thenReturn(windowStore);
+    when(windowStore.fetch(any(), any(), any())).thenReturn(windowStoreIterator);
+    when(windowStoreIterator.hasNext()).thenReturn(true);
+    when(windowStoreIterator.next()).thenReturn(KeyValue.pair(100L, VALUE_BYTES));
+
+    final WindowStoreIterator<ValueAndTimestamp<GenericRow>> result =
+        WindowStoreCacheBypass.fetch(
+            store, SOME_KEY, Instant.ofEpochMilli(100), Instant.ofEpochMilli(200));
+    assertThat(result.next().value, is(VALUE_AND_TIMESTAMP));
   }
 
   @Test

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypassTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypassTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.execution.streams.materialization.ks;
 import static io.confluent.ksql.execution.streams.materialization.ks.WindowStoreCacheBypass.SERDES_FIELD;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.internals.GenericReadOnlyWindowStoreFacade;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThrows;
@@ -157,6 +158,65 @@ public class WindowStoreCacheBypassTest {
 
     assertThat(e.getMessage(), containsString("State store is not "
         + "available anymore and may have been migrated to another instance"));
+  }
+
+  @Test
+  public void shouldUnwrapWindowFacadeAndCallUnderlyingStoreSingleKey()
+      throws IllegalAccessException {
+    final GenericReadOnlyWindowStoreFacade<GenericKey, ValueAndTimestamp<GenericRow>,
+        ValueAndTimestamp<GenericRow>> facade =
+        new GenericReadOnlyWindowStoreFacade<>(meteredWindowStore, x -> x);
+    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade));
+    SERDES_FIELD.set(meteredWindowStore, serdes);
+    when(serdes.rawKey(any())).thenReturn(BYTES);
+    when(meteredWindowStore.wrapped()).thenReturn(wrappedWindowStore);
+    when(wrappedWindowStore.wrapped()).thenReturn(windowStore);
+    when(windowStore.fetch(any(), any(), any())).thenReturn(windowStoreIterator);
+    when(windowStoreIterator.hasNext()).thenReturn(false);
+
+    WindowStoreCacheBypass.fetch(
+        store, SOME_KEY, Instant.ofEpochMilli(100), Instant.ofEpochMilli(200));
+    verify(windowStore).fetch(
+        new Bytes(BYTES), Instant.ofEpochMilli(100L), Instant.ofEpochMilli(200L));
+  }
+
+  @Test
+  public void shouldUnwrapWindowFacadeAndCallUnderlyingStoreRangeQuery()
+      throws IllegalAccessException {
+    final GenericReadOnlyWindowStoreFacade<GenericKey, ValueAndTimestamp<GenericRow>,
+        ValueAndTimestamp<GenericRow>> facade =
+        new GenericReadOnlyWindowStoreFacade<>(meteredWindowStore, x -> x);
+    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade));
+    SERDES_FIELD.set(meteredWindowStore, serdes);
+    when(serdes.rawKey(any())).thenReturn(BYTES, OTHER_BYTES);
+    when(meteredWindowStore.wrapped()).thenReturn(wrappedWindowStore);
+    when(wrappedWindowStore.wrapped()).thenReturn(windowStore);
+    when(windowStore.fetch(any(), any(), any(), any())).thenReturn(keyValueIterator);
+    when(keyValueIterator.hasNext()).thenReturn(false);
+
+    WindowStoreCacheBypass.fetchRange(
+        store, SOME_KEY, SOME_OTHER_KEY, Instant.ofEpochMilli(100), Instant.ofEpochMilli(200));
+    verify(windowStore).fetch(
+        new Bytes(BYTES), new Bytes(OTHER_BYTES),
+        Instant.ofEpochMilli(100L), Instant.ofEpochMilli(200L));
+  }
+
+  @Test
+  public void shouldUnwrapWindowFacadeAndCallUnderlyingStoreTableScan()
+      throws IllegalAccessException {
+    final GenericReadOnlyWindowStoreFacade<GenericKey, ValueAndTimestamp<GenericRow>,
+        ValueAndTimestamp<GenericRow>> facade =
+        new GenericReadOnlyWindowStoreFacade<>(meteredWindowStore, x -> x);
+    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade));
+    SERDES_FIELD.set(meteredWindowStore, serdes);
+    when(meteredWindowStore.wrapped()).thenReturn(wrappedWindowStore);
+    when(wrappedWindowStore.wrapped()).thenReturn(windowStore);
+    when(windowStore.fetchAll(any(), any())).thenReturn(keyValueIterator);
+    when(keyValueIterator.hasNext()).thenReturn(false);
+
+    WindowStoreCacheBypass.fetchAll(
+        store, Instant.ofEpochMilli(100), Instant.ofEpochMilli(200));
+    verify(windowStore).fetchAll(Instant.ofEpochMilli(100L), Instant.ofEpochMilli(200L));
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <skip.docker.build>true</skip.docker.build>
         <skip.docker.test>true</skip.docker.test>
-        <protobuf.version>4.32.1</protobuf.version>
+        <protobuf.version>4.34.0</protobuf.version>
         <!-- Temporarily disabling this because it is causing failures in packaging but not CI builds. -->
         <!-- <compile.warnings-flag>-Werror</compile.warnings-flag> -->
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>


### PR DESCRIPTION
### Description

This PR fixes three CI test failures on master:

---

**1. RecordFormatterTest — Kafka Bytes non-null constraint**

Kafka's \`Bytes\` constructor now enforces non-null via \`Objects.requireNonNull\`, causing:
- \`ExceptionInInitializerError\` in \`DeserializersTest\` (62 cascading failures) due to \`new Bytes(null)\` in the static \`NULL_VARIANTS\` initializer
- NPE in \`shouldFormatNullsBytes\` due to \`new Bytes(null)\` in the test body

Fix: replace \`new Bytes(null)\` with \`null\` in both locations.

Follow-up cleanup (per PR review): removed the now-redundant \`shouldFormatNullsBytes\` test (identical to \`shouldFormatNulls\`), inlined the \`NULL_VARIANTS\` singleton list, and removed the unused \`Collections\` import.

---

**2. ConnectIntegrationTest — Protobuf gencode/runtime version mismatch**

\`ConnectIntegrationTest\` was failing with:
```
ProtobufRuntimeVersionException: gencode version 4.34.0 is newer than the runtime version 4.32.1
```

Root cause: \`broker-plugins:8.3.0-1128-0-ce\` (pulled in transitively via \`ksqldb-common → ksqldb-udf → broker-plugins\`) was compiled against protobuf gencode 4.34.0, but the \`protobuf.version\` property in the root POM overrode the runtime to 4.32.1. Protobuf enforces a hard check that gencode version ≤ runtime version.

Fix: bump \`protobuf.version\` from \`4.32.1\` to \`4.34.0\` to match the gencode version used by \`broker-plugins\`.

---

**3. KsMaterializationFunctionalTest — window/session store cache bypass broken by Kafka internal API changes**

Six tests were failing (`shouldQueryTumblingWindowMaterializedTableWithRetention`, `shouldQueryHoppingWindowMaterializedTableWithRetention`, `shouldQuerySessionWindowMaterializedTableWithRetention`, `shouldQueryMaterializedTableForTumblingWindowed`, `shouldQueryMaterializedTableForHoppingWindowed`, `shouldQueryMaterializedTableForSessionWindowed`).

Root cause: Kafka 8.3.0-1149-0-ce changed \`StreamThreadStateStoreProvider.validateAndCastStores\` to wrap window and session stores in new facade classes before returning them from \`provider.stores()\`:

- **Window stores**: wrapped in \`GenericReadOnlyWindowStoreFacade\`, which implements \`ReadOnlyWindowStore\` but is not a \`MeteredWindowStore\`. Its \`inner\` field holds the actual \`MeteredTimestampedWindowStoreWithHeaders\` (which IS a \`MeteredWindowStore\`, but whose serdes produce \`ValueTimestampHeaders\` instead of \`ValueAndTimestamp<GenericRow>\`). The facade carries a \`valueConverter: Function<ValueTimestampHeaders, ValueAndTimestamp<GenericRow>>\` that does the final conversion.

- **Session stores**: wrapped in \`ReadOnlySessionStoreFacade\`, which implements \`ReadOnlySessionStore\` but is not a \`MeteredSessionStore\`. Its \`inner\` field holds \`MeteredSessionStoreWithHeaders\` (which IS a \`MeteredSessionStore\`, but whose serdes produce \`AggregationWithHeaders<GenericRow>\` instead of \`GenericRow\`). The conversion is done via the static method \`AggregationWithHeaders.getAggregationOrNull()\`.

The existing \`WindowStoreCacheBypass\` and \`SessionStoreCacheBypass\` classes access Kafka internals via reflection to bypass the in-memory cache layer for pull queries. They were written assuming stores returned from \`provider.stores()\` were always \`MeteredWindowStore\`/\`MeteredSessionStore\` directly.

Fix (both bypass classes):
1. **Detect facades**: use \`Class.forName\` + \`getDeclaredField("inner")\` at class-load time to detect the new facade classes (nullable for older Kafka versions).
2. **Unwrap to inner metered store**: before the \`instanceof Metered*Store\` check, unwrap the facade to access its inner store and obtain the raw-bytes store via \`getInnermostStore()\`.
3. **Apply value converter**: after \`serdes.valueFrom(bytes)\` in the deserializing iterators, apply the appropriate converter to produce the correct external type:
   - Window: \`GenericReadOnlyWindowStoreFacade.valueConverter\` (a \`Function\` field, obtained via reflection).
   - Session: \`AggregationWithHeaders.getAggregationOrNull()\` (a static method, obtained via reflection since \`AggregationWithHeaders\` did not exist in older Kafka versions).

All reflection is done once at class-load time. Older Kafka versions without these facade classes see null fields and fall through to identity casts, preserving backward compatibility.

---

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.