### PR TITLE
fix(cve): [KSQL-14692] CVE-2026-33870 — bump netty to 4.1.132.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,15 +140,15 @@
         <apache.io.version>2.11.0</apache.io.version>
         <io.confluent.ksql.version>7.4.15-0</io.confluent.ksql.version>
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
-        <netty-tcnative-version>2.0.74.Final</netty-tcnative-version>
+        <netty-tcnative-version>2.0.75.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`
              we might need to bump `tcnative`, too.
              Please check top level `pom.xml` at https://github.com/netty/netty
              for the netty version we bump to (ie, corresponding git tag),
              to find the correct `tcnative` version. -->
-        <netty.version>4.1.130.Final</netty.version>
-        <netty-codec-http2-version>4.1.130.Final</netty-codec-http2-version>
+        <netty.version>4.1.132.Final</netty.version>
+        <netty-codec-http2-version>4.1.132.Final</netty-codec-http2-version>
         <jersey-common>2.46</jersey-common>
         <multi-threaded-testing.forkCount>3</multi-threaded-testing.forkCount>
     </properties>


### PR DESCRIPTION
### Description 
KSQL-14692: CVE-2026-33870 
```
— bump netty to 4.1.132.Final- netty.version: 4.1.130.Final → 4.1.132.Final
- netty-codec-http2-version: 4.1.130.Final → 4.1.132.Final
- netty-tcnative-version: 2.0.74.Final → 2.0.75.Final
```


### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

