### PR TITLE
fix: resolve JSON_SR schema doc mismatch in ConnectSRSchemaDataTranslator

### DIFF
--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectSRSchemaDataTranslator.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectSRSchemaDataTranslator.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.serde.connect;
 
 import io.confluent.ksql.util.KsqlException;
+import java.util.Optional;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
@@ -52,26 +53,34 @@ public class ConnectSRSchemaDataTranslator extends ConnectDataTranslator {
 
   @Override
   public Object toConnectRow(final Object ksqlData) {
-    /*
-     * Reconstruct ksqlData struct with given schema and try to put original data in it.
-     * Schema may have more fields than ksqlData, don't put those field by default. If needed by
-     * some format like Avro, create new subclass to handle
-     */
-    if (ksqlData instanceof Struct) {
-      final Schema schema = getSchema();
-      validate(((Struct) ksqlData).schema(), schema);
-
-      final Struct struct = new Struct(schema);
-      final Struct source = (Struct) ksqlData;
-
-      for (final Field sourceField : source.schema().fields()) {
-        final Object value = source.get(sourceField);
-        struct.put(sourceField.name(), value);
-      }
-
-      return struct;
+    if (!(ksqlData instanceof Struct)) {
+      return ksqlData;
     }
 
-    return ksqlData;
+    final Schema schema = getSchema();
+    final Struct source = (Struct) ksqlData;
+    validate(source.schema(), schema);
+
+    final Struct struct = new Struct(schema);
+    final Schema originalSchema = source.schema();
+
+    for (final Field field : schema.fields()) {
+      final Optional<Field> originalField = originalSchema.fields().stream()
+          .filter(f -> field.name().equals(f.name())).findFirst();
+
+      if (originalField.isPresent()) {
+        final Object originalValue = source.get(originalField.get());
+        struct.put(field, ConnectSchemas.withCompatibleSchema(field.schema(), originalValue));
+      } else {
+        if (field.schema().defaultValue() != null || field.schema().isOptional()) {
+          struct.put(field, field.schema().defaultValue());
+        } else {
+          throw new KsqlException("Missing default value for required field: ["
+              + field.name() + "]. This field appears in JSON_SR schema in Schema Registry");
+        }
+      }
+    }
+
+    return struct;
   }
 }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectSRSchemaDataTranslatorTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectSRSchemaDataTranslatorTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertThrows;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -103,5 +104,169 @@ public class ConnectSRSchemaDataTranslatorTest {
     // Then:
     assertThat(e.getMessage(), is("Invalid value: null used for required field: \"f1\", "
         + "schema type: STRING"));
+  }
+
+  @Test
+  public void shouldTransformStructWithDocMismatch() {
+    // Given:
+    final Schema sourceSchema = SchemaBuilder.struct()
+        .field("f1", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .build();
+    final Schema targetSchema = SchemaBuilder.struct()
+        .field("f1", SchemaBuilder.string().optional().doc("some doc").build())
+        .build();
+    final Struct source = new Struct(sourceSchema).put("f1", "hello");
+
+    // When:
+    final Object result = new ConnectSRSchemaDataTranslator(targetSchema).toConnectRow(source);
+
+    // Then:
+    assertThat(result, instanceOf(Struct.class));
+    final Struct resultStruct = (Struct) result;
+    assertThat(resultStruct.schema(), sameInstance(targetSchema));
+    assertThat(resultStruct.get("f1"), is("hello"));
+  }
+
+  @Test
+  public void shouldTransformNestedStructWithDocMismatch() {
+    // Given:
+    final Schema sourceInnerSchema = SchemaBuilder.struct()
+        .field("val", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .build();
+    final Schema targetInnerSchema = SchemaBuilder.struct()
+        .doc("inner doc")
+        .field("val", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .build();
+    final Schema sourceSchema = SchemaBuilder.struct()
+        .field("nested", sourceInnerSchema)
+        .build();
+    final Schema targetSchema = SchemaBuilder.struct()
+        .field("nested", targetInnerSchema)
+        .build();
+
+    final Struct innerSource = new Struct(sourceInnerSchema).put("val", "hello");
+    final Struct source = new Struct(sourceSchema).put("nested", innerSource);
+
+    // When:
+    final Object result = new ConnectSRSchemaDataTranslator(targetSchema).toConnectRow(source);
+
+    // Then:
+    assertThat(result, instanceOf(Struct.class));
+    final Struct resultStruct = (Struct) result;
+    assertThat(resultStruct.schema(), sameInstance(targetSchema));
+    final Struct nested = (Struct) resultStruct.get("nested");
+    assertThat(nested.get("val"), is("hello"));
+  }
+
+  @Test
+  public void shouldTransformArrayOfStructsWithDocMismatch() {
+    // Given:
+    final Schema sourceItemSchema = SchemaBuilder.struct()
+        .field("val", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .build();
+    final Schema targetItemSchema = SchemaBuilder.struct()
+        .doc("item doc")
+        .field("val", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .build();
+    final Schema sourceSchema = SchemaBuilder.struct()
+        .field("items", SchemaBuilder.array(sourceItemSchema).optional().build())
+        .build();
+    final Schema targetSchema = SchemaBuilder.struct()
+        .field("items", SchemaBuilder.array(targetItemSchema).optional().build())
+        .build();
+
+    final Struct itemSource = new Struct(sourceItemSchema).put("val", "a");
+    final Struct source = new Struct(sourceSchema)
+        .put("items", Collections.singletonList(itemSource));
+
+    // When:
+    final Object result = new ConnectSRSchemaDataTranslator(targetSchema).toConnectRow(source);
+
+    // Then:
+    assertThat(result, instanceOf(Struct.class));
+    final Struct resultStruct = (Struct) result;
+    @SuppressWarnings("unchecked")
+    final List<Struct> items = (List<Struct>) resultStruct.get("items");
+    assertThat(items.size(), is(1));
+    assertThat(items.get(0).get("val"), is("a"));
+  }
+
+  @Test
+  public void shouldTransformMapWithStructValueAndDocMismatch() {
+    // Given:
+    final Schema sourceValueSchema = SchemaBuilder.struct()
+        .field("val", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .build();
+    final Schema targetValueSchema = SchemaBuilder.struct()
+        .doc("value doc")
+        .field("val", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .build();
+    final Schema sourceSchema = SchemaBuilder.struct()
+        .field("data", SchemaBuilder.map(Schema.STRING_SCHEMA, sourceValueSchema).optional().build())
+        .build();
+    final Schema targetSchema = SchemaBuilder.struct()
+        .field("data", SchemaBuilder.map(Schema.STRING_SCHEMA, targetValueSchema).optional().build())
+        .build();
+
+    final Struct valueSource = new Struct(sourceValueSchema).put("val", "hello");
+    final Struct source = new Struct(sourceSchema)
+        .put("data", Collections.singletonMap("key", valueSource));
+
+    // When:
+    final Object result = new ConnectSRSchemaDataTranslator(targetSchema).toConnectRow(source);
+
+    // Then:
+    assertThat(result, instanceOf(Struct.class));
+    final Struct resultStruct = (Struct) result;
+    @SuppressWarnings("unchecked")
+    final Map<String, Struct> data = (Map<String, Struct>) resultStruct.get("data");
+    assertThat(data.get("key").get("val"), is("hello"));
+  }
+
+  @Test
+  public void shouldHandleExtraOptionalFieldInTargetSchema() {
+    // Given:
+    final Schema sourceSchema = SchemaBuilder.struct()
+        .field("f1", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .build();
+    final Schema targetSchema = SchemaBuilder.struct()
+        .field("f1", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .field("f2", SchemaBuilder.OPTIONAL_INT32_SCHEMA)
+        .build();
+    final Struct source = new Struct(sourceSchema).put("f1", "hello");
+
+    // When:
+    final Object result = new ConnectSRSchemaDataTranslator(targetSchema).toConnectRow(source);
+
+    // Then:
+    assertThat(result, instanceOf(Struct.class));
+    final Struct resultStruct = (Struct) result;
+    assertThat(resultStruct.schema(), sameInstance(targetSchema));
+    assertThat(resultStruct.get("f1"), is("hello"));
+    assertThat(resultStruct.get("f2"), is(nullValue()));
+  }
+
+  @Test
+  public void shouldThrowForExtraRequiredFieldInTargetSchemaWithNoDefault() {
+    // Given:
+    final Schema sourceSchema = SchemaBuilder.struct()
+        .field("f1", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .build();
+    final Schema targetSchema = SchemaBuilder.struct()
+        .field("f1", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .field("f2", SchemaBuilder.STRING_SCHEMA)
+        .build();
+    final Struct source = new Struct(sourceSchema).put("f1", "hello");
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> new ConnectSRSchemaDataTranslator(targetSchema).toConnectRow(source)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), is(
+        "Missing default value for required field: [f2]."
+            + " This field appears in JSON_SR schema in Schema Registry"));
   }
 }


### PR DESCRIPTION
### Description

Fixes #11011

`ConnectSRSchemaDataTranslator.toConnectRow()` fails with `DataException: Struct schemas do not match` when the JSON Schema in Schema Registry contains a `description` annotation (mapped to Connect Schema's `doc` property). The ksqlDB logical schema has `doc=null`, while the SR physical schema has `doc="<description text>"`, causing `ConnectSchema.equals()` to fail inside `Struct.put()`.

**Root cause:** The method iterates the **source** (ksqlDB) schema fields and puts raw values into the **target** (SR) struct without schema reconciliation. The Avro variant was fixed in PR #9575 via `copyStruct()`, and the Protobuf variant was fixed independently using `ConnectSchemas.withCompatibleSchema()`. The parent class (used by JSON_SR) was never updated.

**Fix:** Changed `toConnectRow()` to:
1. Iterate the **target** (SR physical) schema fields instead of source fields
2. Use `ConnectSchemas.withCompatibleSchema(field.schema(), originalValue)` to re-root each value onto the physical schema
3. Handle extra target fields: optional → null, has default → default value, required with no default → `KsqlException`

This follows the same pattern as `ProtobufSRSchemaDataTranslator.toConnectRow()`.

### Testing done

Added 6 new test cases to `ConnectSRSchemaDataTranslatorTest`:

1. `shouldTransformStructWithDocMismatch` — field-level doc mismatch
2. `shouldTransformNestedStructWithDocMismatch` — nested STRUCT with doc mismatch
3. `shouldTransformArrayOfStructsWithDocMismatch` — ARRAY element struct doc mismatch
4. `shouldTransformMapWithStructValueAndDocMismatch` — MAP value struct doc mismatch
5. `shouldHandleExtraOptionalFieldInTargetSchema` — extra SR field (optional) → null
6. `shouldThrowForExtraRequiredFieldInTargetSchemaWithNoDefault` — extra required field → KsqlException

All 4 existing tests preserved and pass (verified by code review; local build blocked by private `telemetry-client` dependency — see #10713).

### Reviewer checklist
- [x] Ensure docs are updated if necessary. (No docs changes needed — internal serialization fix)
- [x] Ensure relevant issues are linked: Fixes #11011
- [ ] Do these changes have compatibility implications for rollback? **No** — the Avro and Protobuf subclasses both override `toConnectRow()` independently, so this change only affects JSON_SR (which uses the parent class directly).