### PR TITLE
feat(config): [KSQL-13078] deprecate ksql.runtime.feature.shared.enabled

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -566,9 +566,10 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_SHARED_RUNTIME_ENABLED = "ksql.runtime.feature.shared.enabled";
   public static final Boolean KSQL_SHARED_RUNTIME_ENABLED_DEFAULT = false;
   public static final String KSQL_SHARED_RUNTIME_ENABLED_DOC =
-      "Feature flag for sharing streams runtimes. "
+      "Deprecated. Feature flag for sharing streams runtimes. "
           + "Default is false. If false, persistent queries will use separate "
-          + " runtimes, if true, new queries may share streams instances.";
+          + " runtimes, if true, new queries may share streams instances. "
+          + "This configuration is deprecated and will be removed in a future release.";
 
   public static final String KSQL_NEW_QUERY_PLANNER_ENABLED =
       "ksql.new.query.planner.enabled";
@@ -1575,6 +1576,13 @@ public class KsqlConfig extends AbstractConfig {
 
   public KsqlConfig(final Map<?, ?> props) {
     this(ConfigGeneration.CURRENT, props);
+    if (props.containsKey(KSQL_SHARED_RUNTIME_ENABLED)) {
+      LOG.warn(
+          "'{}' is deprecated and will be removed in a future release. "
+              + "Please remove this configuration from your settings.",
+          KSQL_SHARED_RUNTIME_ENABLED
+      );
+    }
   }
 
   private KsqlConfig(final ConfigGeneration generation, final Map<?, ?> props) {


### PR DESCRIPTION
Add a runtime deprecation warning log when ksql.runtime.feature.shared.enabled is explicitly configured. Update the config documentation to mark it as deprecated and note it will be removed in a future release.

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

