### PR TITLE
Enhance SqlTestExecutor to capture and restore state from Kafka Streams drivers

### DIFF
--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.test.driver;
 
-import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.tools.test.parser.SqlTestLoader;
 import io.confluent.ksql.tools.test.parser.SqlTestLoader.SqlTest;
 import io.confluent.ksql.tools.test.SqlTestExecutor;
@@ -23,9 +22,7 @@ import io.confluent.ksql.test.util.KsqlTestFolder;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Set;
 import org.junit.After;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,31 +34,15 @@ import org.junit.runners.Parameterized;
 public class KsqlTesterTest {
   private static final String TEST_DIR = "/sql-tests";
 
-  /**
-   * Specific tests skipped pending fix for KIP-1035-affected state-preservation
-   * across CREATE OR REPLACE with Kafka Streams in Apache Kafka 8.3.
-   * Production ksqlDB is unaffected (durability flows via the real changelog
-   * topic). The rest of the suite runs normally.
-   */
-  private static final Set<String> SKIPPED_TESTS = ImmutableSet.of(
-      "(query-upgrades/filters.sql) change filter in StreamAggregate (StreamGroupByKey)",
-      "(query-upgrades/filters.sql) change filter in StreamAggregate (StreamGroupBy)",
-      "(query-upgrades/filters.sql) add filter in StreamAggregate where columns are already in input schema",
-      "(query-upgrades/filters.sql) remove filter in StreamAggregate where columns are already in input schema",
-      "(query-upgrades/filters.sql) change filter in StreamAggregate to another column that already exists in input",
-      "(query-upgrades/projections.sql) add aggregate columns to value"
-  );
-
   // parameterized
-  private final String testCase;
-  private final SqlTest test;
+  private SqlTest test;
 
   @Rule
   public final TemporaryFolder tmpFolder = KsqlTestFolder.temporaryFolder();
   private SqlTestExecutor executor;
 
+  @SuppressWarnings("unused")
   public KsqlTesterTest(final String testCase, final SqlTest test) {
-    this.testCase = testCase;
     this.test = test;
   }
 
@@ -79,18 +60,11 @@ public class KsqlTesterTest {
 
   @After
   public void close() {
-    if (executor != null) {
-      executor.close();
-    }
+    executor.close();
   }
 
   @Before
   public void setUp() {
-    // Skip-check before creating the executor so we don't pay setup cost
-    // for known-skipped cases.
-    Assume.assumeFalse(
-        "Skipping known KIP-1035-affected test pending state-preservation fix: " + testCase,
-        SKIPPED_TESTS.contains(testCase));
     this.executor = SqlTestExecutor.create(tmpFolder.getRoot().toPath());
   }
 

--- a/ksqldb-testing-tool/src/main/java/io/confluent/ksql/tools/test/KsqlTopologyTestDriver.java
+++ b/ksqldb-testing-tool/src/main/java/io/confluent/ksql/tools/test/KsqlTopologyTestDriver.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.tools.test;
+
+import java.util.Properties;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyTestDriver;
+
+/**
+ * Subclass of {@link TopologyTestDriver} that exposes the upstream
+ * {@code protected close(boolean cleanState)} overload so the SQL test harness
+ * can close the driver while preserving the on-disk state directory.
+ */
+public class KsqlTopologyTestDriver extends TopologyTestDriver {
+
+  public KsqlTopologyTestDriver(final Topology topology, final Properties config) {
+    super(topology, config);
+  }
+
+  public void close(final boolean cleanState) {
+    super.close(cleanState);
+  }
+}

--- a/ksqldb-testing-tool/src/main/java/io/confluent/ksql/tools/test/SqlTestExecutor.java
+++ b/ksqldb-testing-tool/src/main/java/io/confluent/ksql/tools/test/SqlTestExecutor.java
@@ -82,9 +82,6 @@ import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import java.io.Closeable;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
@@ -93,21 +90,15 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
-import org.apache.commons.io.FileUtils;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
-import org.apache.kafka.streams.TopologyTestDriver;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 public class SqlTestExecutor implements Closeable {
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
-
-  private static final Logger LOG = LogManager.getLogger(SqlTestExecutor.class);
 
   private static final ImmutableMap<String, Object> BASE_CONFIG = ImmutableMap
       .<String, Object>builder()
@@ -128,7 +119,7 @@ public class SqlTestExecutor implements Closeable {
   private KafkaTopicClient topicClient;
   private Path tmpFolder;
   private final Map<String, Object> overrides;
-  private final Map<QueryId, DriverAndProperties> drivers;
+  private final Map<QueryId, KsqlTopologyTestDriver> drivers;
 
   // populated during execution to handle the expected exception
   // scenario - don't use Matchers because they do not create very
@@ -159,7 +150,7 @@ public class SqlTestExecutor implements Closeable {
         DisabledKsqlClient::instance,
         new StubKafkaConsumerGroupClient()
     );
-    final Map<QueryId, DriverAndProperties> drivers = new HashMap<>();
+    final Map<QueryId, KsqlTopologyTestDriver> drivers = new HashMap<>();
     final KsqlConfig config = new KsqlConfig(BASE_CONFIG);
 
     return new SqlTestExecutor(
@@ -176,15 +167,7 @@ public class SqlTestExecutor implements Closeable {
                 new QueryEventListener() {
                   @Override
                   public void onDeregister(final QueryMetadata query) {
-                    final DriverAndProperties driverAndProperties = drivers.get(
-                        query.getQueryId()
-                    );
-                    closeDriver(
-                        driverAndProperties.driver,
-                        driverAndProperties.properties,
-                        false,
-                        tmpFolder
-                    );
+                    drivers.get(query.getQueryId()).close(false);
                   }
                 }
             ),
@@ -201,7 +184,7 @@ public class SqlTestExecutor implements Closeable {
       final KafkaTopicClient topicClient,
       final KsqlEngine ksqlEngine,
       final KsqlConfig config,
-      final Map<QueryId, DriverAndProperties> drivers,
+      final Map<QueryId, KsqlTopologyTestDriver> drivers,
       final Path tmpFolder
   ) {
     this.serviceContext = requireNonNull(serviceContext, "serviceContext");
@@ -295,7 +278,7 @@ public class SqlTestExecutor implements Closeable {
     properties.putAll(query.getStreamsProperties());
     properties.put(StreamsConfig.STATE_DIR_CONFIG, tmpFolder.toString());
 
-    final TopologyTestDriver driver = new TopologyTestDriver(topology, properties);
+    final KsqlTopologyTestDriver driver = new KsqlTopologyTestDriver(topology, properties);
 
     final List<TopicInfo> inputTopics = query
         .getSourceNames()
@@ -314,7 +297,7 @@ public class SqlTestExecutor implements Closeable {
     );
 
     driverPipeline.addDriver(driver, inputTopics, outputInfo);
-    drivers.put(query.getQueryId(), new DriverAndProperties(driver, properties));
+    drivers.put(query.getQueryId(), driver);
   }
 
   private void pipeInput(final ConfiguredStatement<InsertValues> statement) {
@@ -427,61 +410,6 @@ public class SqlTestExecutor implements Closeable {
 
   private void handleExpectedMessage(final TestDirective directive) {
     expectedMessage = directive.getContents();
-  }
-
-  private static final class DriverAndProperties {
-    final TopologyTestDriver driver;
-    final Properties properties;
-
-    private DriverAndProperties(final TopologyTestDriver driver, final Properties properties) {
-      this.driver = driver;
-      this.properties = properties;
-    }
-  }
-
-  private static void closeDriver(
-      final TopologyTestDriver driver,
-      final Properties properties,
-      final boolean deleteState,
-      final Path tmpFolder
-  ) {
-    // this is a hack that lets us close the driver (releasing the lock on the state
-    // directory) without actually cleaning up the resources. This essentially simulates
-    // the behavior we have in QueryMetadata#close vs QueryMetadata#stop
-    //
-    // in production we have the additional safeguard of changelog topics, but the
-    // test driver doesn't support pre-loading state stores from changelog topics,
-    // so we're stuck with the solution of preserving the state store
-    final String appId = properties.getProperty(StreamsConfig.APPLICATION_ID_CONFIG);
-    final File stateDir = tmpFolder.resolve(appId).toFile();
-    final File tmp = tmpFolder.resolve("tmp_" + appId).toFile();
-
-    if (!deleteState && stateDir.exists()) {
-      try {
-        FileUtils.copyDirectory(stateDir, tmp);
-      } catch (final IOException e) {
-        if (!(e instanceof NoSuchFileException)) {
-          throw new KsqlException(e);
-        } else {
-          // Log a warning instead of throwing an exception when the state directory does not
-          // exist. The file could've been deleted manually by external factors.
-          LOG.warn("The state or temp directory '{}' do not exist. "
-                  + "The test will continue closing the driver.",
-              ((NoSuchFileException) e).getFile());
-        }
-      }
-    }
-
-    try {
-      driver.close();
-
-      if (tmp.exists()) {
-        FileUtils.copyDirectory(tmp, stateDir);
-        FileUtils.deleteDirectory(tmp);
-      }
-    } catch (final IOException e) {
-      throw new KsqlException(e);
-    }
   }
 
   private void createTopics(final PreparedStatement<?> engineStatement) {


### PR DESCRIPTION


### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

Before PR TestTopologyDriver used to clear the state. We hacked around it by copying the state to a file and recovering from there. Due to internal changes the hack stopped working. We now have made a change in ce-kafka to add a close(boolean) method which accepts a boolean value to decide inorder to clear the state.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

