### PR TITLE
[KSQL-14553] refactor: simplify cache bypass facade handling per kafka streams review

### DIFF
--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypass.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypass.java
@@ -18,16 +18,17 @@ package io.confluent.ksql.execution.streams.materialization.ks;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.function.Function;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.state.AggregationWithHeaders;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.ReadOnlySessionStore;
@@ -35,6 +36,7 @@ import org.apache.kafka.streams.state.SessionStore;
 import org.apache.kafka.streams.state.StateSerdes;
 import org.apache.kafka.streams.state.internals.CompositeReadOnlySessionStore;
 import org.apache.kafka.streams.state.internals.MeteredSessionStore;
+import org.apache.kafka.streams.state.internals.ReadOnlySessionStoreFacade;
 import org.apache.kafka.streams.state.internals.StateStoreProvider;
 import org.apache.kafka.streams.state.internals.WrappedStateStore;
 
@@ -44,10 +46,7 @@ public final class SessionStoreCacheBypass {
   private static final Field STORE_NAME_FIELD;
   private static final Field STORE_TYPE_FIELD;
   static final Field SERDES_FIELD;
-  // Nullable: only present in Kafka versions that introduced ReadOnlySessionStoreFacade
   private static final Field SESSION_FACADE_INNER_FIELD;
-  // Nullable: AggregationWithHeaders.getAggregationOrNull — used when session facade is present
-  private static final Method AGGREGATION_GET_AGGREGATION_METHOD;
   private static final String STORE_UNAVAILABLE_MESSAGE = "State store is not available anymore "
           + "and may have been migrated to another instance; "
           + "please re-discover its location from the state metadata.";
@@ -63,28 +62,11 @@ public final class SessionStoreCacheBypass {
       STORE_TYPE_FIELD.setAccessible(true);
       SERDES_FIELD = MeteredSessionStore.class.getDeclaredField("serdes");
       SERDES_FIELD.setAccessible(true);
+      SESSION_FACADE_INNER_FIELD = ReadOnlySessionStoreFacade.class.getDeclaredField("inner");
+      SESSION_FACADE_INNER_FIELD.setAccessible(true);
     } catch (final NoSuchFieldException e) {
       throw new RuntimeException("Stream internals changed unexpectedly!", e);
     }
-
-    Field sessionFacadeInnerField = null;
-    Method aggregationGetAggregationMethod = null;
-    try {
-      final Class<?> facadeClass = Class.forName(
-          "org.apache.kafka.streams.state.internals.ReadOnlySessionStoreFacade");
-      sessionFacadeInnerField = facadeClass.getDeclaredField("inner");
-      sessionFacadeInnerField.setAccessible(true);
-      final Class<?> aggregationClass = Class.forName(
-          "org.apache.kafka.streams.state.AggregationWithHeaders");
-      aggregationGetAggregationMethod = aggregationClass.getMethod(
-          "getAggregationOrNull", aggregationClass);
-    } catch (final ClassNotFoundException e) {
-      // Facade class not present in this Kafka version — no unwrapping needed
-    } catch (final NoSuchFieldException | NoSuchMethodException e) {
-      throw new RuntimeException("Stream internals changed unexpectedly!", e);
-    }
-    SESSION_FACADE_INNER_FIELD = sessionFacadeInnerField;
-    AGGREGATION_GET_AGGREGATION_METHOD = aggregationGetAggregationMethod;
   }
 
   private SessionStoreCacheBypass() {
@@ -137,7 +119,7 @@ public final class SessionStoreCacheBypass {
       throw new IllegalStateException("Expecting a MeteredSessionStore");
     } else {
       final StateSerdes<GenericKey, ?> serdes = getSerdes(unwrapped);
-      final Bytes rawKey = Bytes.wrap(serdes.rawKey(key));
+      final Bytes rawKey = Bytes.wrap(serdes.rawKey(key, new RecordHeaders()));
       final SessionStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
       final KeyValueIterator<Windowed<Bytes>, byte[]> fetch = wrapped.fetch(rawKey);
       return new DeserializingIterator(fetch, serdes, valueConverter);
@@ -177,8 +159,8 @@ public final class SessionStoreCacheBypass {
       throw new IllegalStateException("Expecting a MeteredSessionStore");
     } else {
       final StateSerdes<GenericKey, ?> serdes = getSerdes(unwrapped);
-      final Bytes rawKeyFrom = Bytes.wrap(serdes.rawKey(keyFrom));
-      final Bytes rawKeyTo = Bytes.wrap(serdes.rawKey(keyTo));
+      final Bytes rawKeyFrom = Bytes.wrap(serdes.rawKey(keyFrom, new RecordHeaders()));
+      final Bytes rawKeyTo = Bytes.wrap(serdes.rawKey(keyTo, new RecordHeaders()));
       final SessionStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
       final KeyValueIterator<Windowed<Bytes>, byte[]> fetch = wrapped.fetch(rawKeyFrom, rawKeyTo);
       return new DeserializingIterator(fetch, serdes, valueConverter);
@@ -211,8 +193,7 @@ public final class SessionStoreCacheBypass {
   private static ReadOnlySessionStore<GenericKey, GenericRow> unwrapSessionFacade(
       final ReadOnlySessionStore<GenericKey, GenericRow> sessionStore
   ) {
-    if (SESSION_FACADE_INNER_FIELD != null
-        && SESSION_FACADE_INNER_FIELD.getDeclaringClass().isInstance(sessionStore)) {
+    if (sessionStore instanceof ReadOnlySessionStoreFacade) {
       try {
         return (ReadOnlySessionStore<GenericKey, GenericRow>)
             SESSION_FACADE_INNER_FIELD.get(sessionStore);
@@ -227,16 +208,9 @@ public final class SessionStoreCacheBypass {
   private static Function<Object, GenericRow> getSessionValueConverter(
       final ReadOnlySessionStore<GenericKey, GenericRow> sessionStore
   ) {
-    if (AGGREGATION_GET_AGGREGATION_METHOD != null
-        && SESSION_FACADE_INNER_FIELD != null
-        && SESSION_FACADE_INNER_FIELD.getDeclaringClass().isInstance(sessionStore)) {
-      return x -> {
-        try {
-          return (GenericRow) AGGREGATION_GET_AGGREGATION_METHOD.invoke(null, x);
-        } catch (final Exception e) {
-          throw new RuntimeException("Stream internals changed unexpectedly!", e);
-        }
-      };
+    if (sessionStore instanceof ReadOnlySessionStoreFacade) {
+      return x -> AggregationWithHeaders.getAggregationOrNull(
+          (AggregationWithHeaders<GenericRow>) x);
     }
     return x -> (GenericRow) x;
   }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypass.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypass.java
@@ -113,11 +113,12 @@ public final class SessionStoreCacheBypass {
       final GenericKey key
   ) {
     final MeteredSessionStore<GenericKey, ?> unwrapped = unwrapToMeteredSessionStore(sessionStore);
+    final Function<Object, GenericRow> valueConverter = getSessionValueConverter(sessionStore);
     final StateSerdes<GenericKey, ?> serdes = getSerdes(unwrapped);
     final Bytes rawKey = Bytes.wrap(serdes.rawKey(key, new RecordHeaders()));
     final SessionStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
     final KeyValueIterator<Windowed<Bytes>, byte[]> fetch = wrapped.fetch(rawKey);
-    return new DeserializingIterator(fetch, serdes);
+    return new DeserializingIterator(fetch, serdes, valueConverter);
   }
 
   /*
@@ -147,12 +148,13 @@ public final class SessionStoreCacheBypass {
           final GenericKey keyTo
   ) {
     final MeteredSessionStore<GenericKey, ?> unwrapped = unwrapToMeteredSessionStore(sessionStore);
+    final Function<Object, GenericRow> valueConverter = getSessionValueConverter(sessionStore);
     final StateSerdes<GenericKey, ?> serdes = getSerdes(unwrapped);
     final Bytes rawKeyFrom = Bytes.wrap(serdes.rawKey(keyFrom, new RecordHeaders()));
     final Bytes rawKeyTo = Bytes.wrap(serdes.rawKey(keyTo, new RecordHeaders()));
     final SessionStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
     final KeyValueIterator<Windowed<Bytes>, byte[]> fetch = wrapped.fetch(rawKeyFrom, rawKeyTo);
-    return new DeserializingIterator(fetch, serdes);
+    return new DeserializingIterator(fetch, serdes, valueConverter);
   }
 
   private static KeyValueIterator<Windowed<GenericKey>, GenericRow> findFirstNonEmptyIterator(
@@ -177,15 +179,35 @@ public final class SessionStoreCacheBypass {
     return new EmptyKeyValueIterator();
   }
 
+  // Kafka Streams' validateAndCastStores wraps the store in a ReadOnlySessionStoreFacade only
+  // when the underlying store is a SessionStoreWithHeaders queried via SessionStoreType. For a
+  // plain SessionStore queried via the same type, the store is returned directly (a
+  // MeteredSessionStore). Handle both shapes.
   @SuppressWarnings("unchecked")
   private static MeteredSessionStore<GenericKey, ?> unwrapToMeteredSessionStore(
       final ReadOnlySessionStore<GenericKey, GenericRow> sessionStore
   ) {
-    try {
-      return (MeteredSessionStore<GenericKey, ?>) SESSION_FACADE_INNER_FIELD.get(sessionStore);
-    } catch (final IllegalAccessException e) {
-      throw new RuntimeException("Stream internals changed unexpectedly!", e);
+    if (sessionStore instanceof ReadOnlySessionStoreFacade) {
+      try {
+        return (MeteredSessionStore<GenericKey, ?>) SESSION_FACADE_INNER_FIELD.get(sessionStore);
+      } catch (final IllegalAccessException e) {
+        throw new RuntimeException("Stream internals changed unexpectedly!", e);
+      }
     }
+    return (MeteredSessionStore<GenericKey, ?>) sessionStore;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Function<Object, GenericRow> getSessionValueConverter(
+      final ReadOnlySessionStore<GenericKey, GenericRow> sessionStore
+  ) {
+    if (sessionStore instanceof ReadOnlySessionStoreFacade) {
+      // Facade present → underlying serde yields AggregationWithHeaders<V>; extract aggregation.
+      return v -> AggregationWithHeaders.getAggregationOrNull(
+          (AggregationWithHeaders<GenericRow>) v);
+    }
+    // No facade → underlying serde already yields GenericRow.
+    return v -> (GenericRow) v;
   }
 
   @SuppressWarnings("unchecked")
@@ -239,11 +261,14 @@ public final class SessionStoreCacheBypass {
       implements KeyValueIterator<Windowed<GenericKey>, GenericRow> {
     private final KeyValueIterator<Windowed<Bytes>, byte[]> fetch;
     private final StateSerdes<GenericKey, ?> serdes;
+    private final Function<Object, GenericRow> valueConverter;
 
     private DeserializingIterator(final KeyValueIterator<Windowed<Bytes>, byte[]> fetch,
-        final StateSerdes<GenericKey, ?> serdes) {
+        final StateSerdes<GenericKey, ?> serdes,
+        final Function<Object, GenericRow> valueConverter) {
       this.fetch = fetch;
       this.serdes = serdes;
+      this.valueConverter = valueConverter;
     }
 
     @Override
@@ -262,14 +287,11 @@ public final class SessionStoreCacheBypass {
       return fetch.hasNext();
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public KeyValue<Windowed<GenericKey>, GenericRow> next() {
       final Windowed<GenericKey> key = peekNextKey();
       final KeyValue<Windowed<Bytes>, byte[]> next = fetch.next();
-      final AggregationWithHeaders<GenericRow> aggregation =
-          (AggregationWithHeaders<GenericRow>) serdes.valueFrom(next.value);
-      return KeyValue.pair(key, AggregationWithHeaders.getAggregationOrNull(aggregation));
+      return KeyValue.pair(key, valueConverter.apply(serdes.valueFrom(next.value)));
     }
   }
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypass.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypass.java
@@ -112,18 +112,12 @@ public final class SessionStoreCacheBypass {
       final ReadOnlySessionStore<GenericKey, GenericRow> sessionStore,
       final GenericKey key
   ) {
-    final Function<Object, GenericRow> valueConverter = getSessionValueConverter(sessionStore);
-    final ReadOnlySessionStore<GenericKey, GenericRow> unwrapped
-        = unwrapSessionFacade(sessionStore);
-    if (!(unwrapped instanceof MeteredSessionStore)) {
-      throw new IllegalStateException("Expecting a MeteredSessionStore");
-    } else {
-      final StateSerdes<GenericKey, ?> serdes = getSerdes(unwrapped);
-      final Bytes rawKey = Bytes.wrap(serdes.rawKey(key, new RecordHeaders()));
-      final SessionStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
-      final KeyValueIterator<Windowed<Bytes>, byte[]> fetch = wrapped.fetch(rawKey);
-      return new DeserializingIterator(fetch, serdes, valueConverter);
-    }
+    final MeteredSessionStore<GenericKey, ?> unwrapped = unwrapToMeteredSessionStore(sessionStore);
+    final StateSerdes<GenericKey, ?> serdes = getSerdes(unwrapped);
+    final Bytes rawKey = Bytes.wrap(serdes.rawKey(key, new RecordHeaders()));
+    final SessionStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
+    final KeyValueIterator<Windowed<Bytes>, byte[]> fetch = wrapped.fetch(rawKey);
+    return new DeserializingIterator(fetch, serdes);
   }
 
   /*
@@ -152,19 +146,13 @@ public final class SessionStoreCacheBypass {
           final GenericKey keyFrom,
           final GenericKey keyTo
   ) {
-    final Function<Object, GenericRow> valueConverter = getSessionValueConverter(sessionStore);
-    final ReadOnlySessionStore<GenericKey, GenericRow> unwrapped
-        = unwrapSessionFacade(sessionStore);
-    if (!(unwrapped instanceof MeteredSessionStore)) {
-      throw new IllegalStateException("Expecting a MeteredSessionStore");
-    } else {
-      final StateSerdes<GenericKey, ?> serdes = getSerdes(unwrapped);
-      final Bytes rawKeyFrom = Bytes.wrap(serdes.rawKey(keyFrom, new RecordHeaders()));
-      final Bytes rawKeyTo = Bytes.wrap(serdes.rawKey(keyTo, new RecordHeaders()));
-      final SessionStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
-      final KeyValueIterator<Windowed<Bytes>, byte[]> fetch = wrapped.fetch(rawKeyFrom, rawKeyTo);
-      return new DeserializingIterator(fetch, serdes, valueConverter);
-    }
+    final MeteredSessionStore<GenericKey, ?> unwrapped = unwrapToMeteredSessionStore(sessionStore);
+    final StateSerdes<GenericKey, ?> serdes = getSerdes(unwrapped);
+    final Bytes rawKeyFrom = Bytes.wrap(serdes.rawKey(keyFrom, new RecordHeaders()));
+    final Bytes rawKeyTo = Bytes.wrap(serdes.rawKey(keyTo, new RecordHeaders()));
+    final SessionStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
+    final KeyValueIterator<Windowed<Bytes>, byte[]> fetch = wrapped.fetch(rawKeyFrom, rawKeyTo);
+    return new DeserializingIterator(fetch, serdes);
   }
 
   private static KeyValueIterator<Windowed<GenericKey>, GenericRow> findFirstNonEmptyIterator(
@@ -190,34 +178,19 @@ public final class SessionStoreCacheBypass {
   }
 
   @SuppressWarnings("unchecked")
-  private static ReadOnlySessionStore<GenericKey, GenericRow> unwrapSessionFacade(
+  private static MeteredSessionStore<GenericKey, ?> unwrapToMeteredSessionStore(
       final ReadOnlySessionStore<GenericKey, GenericRow> sessionStore
   ) {
-    if (sessionStore instanceof ReadOnlySessionStoreFacade) {
-      try {
-        return (ReadOnlySessionStore<GenericKey, GenericRow>)
-            SESSION_FACADE_INNER_FIELD.get(sessionStore);
-      } catch (final IllegalAccessException e) {
-        throw new RuntimeException("Stream internals changed unexpectedly!", e);
-      }
+    try {
+      return (MeteredSessionStore<GenericKey, ?>) SESSION_FACADE_INNER_FIELD.get(sessionStore);
+    } catch (final IllegalAccessException e) {
+      throw new RuntimeException("Stream internals changed unexpectedly!", e);
     }
-    return sessionStore;
-  }
-
-  @SuppressWarnings("unchecked")
-  private static Function<Object, GenericRow> getSessionValueConverter(
-      final ReadOnlySessionStore<GenericKey, GenericRow> sessionStore
-  ) {
-    if (sessionStore instanceof ReadOnlySessionStoreFacade) {
-      return x -> AggregationWithHeaders.getAggregationOrNull(
-          (AggregationWithHeaders<GenericRow>) x);
-    }
-    return x -> (GenericRow) x;
   }
 
   @SuppressWarnings("unchecked")
   private static StateSerdes<GenericKey, ?> getSerdes(
-          final ReadOnlySessionStore<GenericKey, GenericRow> sessionStore
+          final MeteredSessionStore<GenericKey, ?> sessionStore
   ) throws RuntimeException {
     try {
       return (StateSerdes<GenericKey, ?>) SERDES_FIELD.get(sessionStore);
@@ -228,10 +201,9 @@ public final class SessionStoreCacheBypass {
 
   @SuppressWarnings("unchecked")
   private static SessionStore<Bytes, byte[]> getInnermostStore(
-          final ReadOnlySessionStore<GenericKey, GenericRow> sessionStore
+          final MeteredSessionStore<GenericKey, ?> sessionStore
   ) {
-    SessionStore<Bytes, byte[]> wrapped
-            = ((MeteredSessionStore<GenericKey, GenericRow>) sessionStore).wrapped();
+    SessionStore<Bytes, byte[]> wrapped = sessionStore.wrapped();
     // Unwrap state stores until we get to the last SessionStore, which is past the caching
     // layer.
     while (wrapped instanceof WrappedStateStore) {
@@ -267,14 +239,11 @@ public final class SessionStoreCacheBypass {
       implements KeyValueIterator<Windowed<GenericKey>, GenericRow> {
     private final KeyValueIterator<Windowed<Bytes>, byte[]> fetch;
     private final StateSerdes<GenericKey, ?> serdes;
-    private final Function<Object, GenericRow> valueConverter;
 
     private DeserializingIterator(final KeyValueIterator<Windowed<Bytes>, byte[]> fetch,
-        final StateSerdes<GenericKey, ?> serdes,
-        final Function<Object, GenericRow> valueConverter) {
+        final StateSerdes<GenericKey, ?> serdes) {
       this.fetch = fetch;
       this.serdes = serdes;
-      this.valueConverter = valueConverter;
     }
 
     @Override
@@ -293,11 +262,14 @@ public final class SessionStoreCacheBypass {
       return fetch.hasNext();
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public KeyValue<Windowed<GenericKey>, GenericRow> next() {
       final Windowed<GenericKey> key = peekNextKey();
       final KeyValue<Windowed<Bytes>, byte[]> next = fetch.next();
-      return KeyValue.pair(key, valueConverter.apply(serdes.valueFrom(next.value)));
+      final AggregationWithHeaders<GenericRow> aggregation =
+          (AggregationWithHeaders<GenericRow>) serdes.valueFrom(next.value);
+      return KeyValue.pair(key, AggregationWithHeaders.getAggregationOrNull(aggregation));
     }
   }
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypass.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypass.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.function.Function;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
@@ -34,11 +35,14 @@ import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.ReadOnlyWindowStore;
 import org.apache.kafka.streams.state.StateSerdes;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.apache.kafka.streams.state.internals.CompositeReadOnlyWindowStore;
+import org.apache.kafka.streams.state.internals.GenericReadOnlyWindowStoreFacade;
 import org.apache.kafka.streams.state.internals.MeteredWindowStore;
 import org.apache.kafka.streams.state.internals.StateStoreProvider;
+import org.apache.kafka.streams.state.internals.ValueConverters;
 import org.apache.kafka.streams.state.internals.WrappedStateStore;
 
 public final class WindowStoreCacheBypass {
@@ -46,9 +50,7 @@ public final class WindowStoreCacheBypass {
   private static final Field STORE_NAME_FIELD;
   private static final Field WINDOW_STORE_TYPE_FIELD;
   static final Field SERDES_FIELD;
-  // Nullable: only present in Kafka versions that introduced GenericReadOnlyWindowStoreFacade
   private static final Field GENERIC_WINDOW_FACADE_INNER_FIELD;
-  private static final Field GENERIC_WINDOW_FACADE_VALUE_CONVERTER_FIELD;
   private static final String STORE_UNAVAILABLE_MESSAGE = "State store is not available anymore "
           + "and may have been migrated to another instance; "
           + "please re-discover its location from the state metadata.";
@@ -64,26 +66,12 @@ public final class WindowStoreCacheBypass {
       WINDOW_STORE_TYPE_FIELD.setAccessible(true);
       SERDES_FIELD = MeteredWindowStore.class.getDeclaredField("serdes");
       SERDES_FIELD.setAccessible(true);
+      GENERIC_WINDOW_FACADE_INNER_FIELD
+          = GenericReadOnlyWindowStoreFacade.class.getDeclaredField("inner");
+      GENERIC_WINDOW_FACADE_INNER_FIELD.setAccessible(true);
     } catch (final NoSuchFieldException e) {
       throw new RuntimeException("Stream internals changed unexpectedly!", e);
     }
-
-    Field genericWindowFacadeInnerField = null;
-    Field genericWindowFacadeValueConverterField = null;
-    try {
-      final Class<?> facadeClass = Class.forName(
-          "org.apache.kafka.streams.state.internals.GenericReadOnlyWindowStoreFacade");
-      genericWindowFacadeInnerField = facadeClass.getDeclaredField("inner");
-      genericWindowFacadeInnerField.setAccessible(true);
-      genericWindowFacadeValueConverterField = facadeClass.getDeclaredField("valueConverter");
-      genericWindowFacadeValueConverterField.setAccessible(true);
-    } catch (final ClassNotFoundException e) {
-      // Facade class not present in this Kafka version — no unwrapping needed
-    } catch (final NoSuchFieldException e) {
-      throw new RuntimeException("Stream internals changed unexpectedly!", e);
-    }
-    GENERIC_WINDOW_FACADE_INNER_FIELD = genericWindowFacadeInnerField;
-    GENERIC_WINDOW_FACADE_VALUE_CONVERTER_FIELD = genericWindowFacadeValueConverterField;
   }
 
   private WindowStoreCacheBypass() {
@@ -159,7 +147,7 @@ public final class WindowStoreCacheBypass {
     }
     final StateSerdes<GenericKey, ?> serdes = getSerdes(unwrapped);
     final WindowStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
-    final Bytes rawKey = Bytes.wrap(serdes.rawKey(key));
+    final Bytes rawKey = Bytes.wrap(serdes.rawKey(key, new RecordHeaders()));
     final WindowStoreIterator<byte[]> fetch = wrapped.fetch(rawKey, lower, upper);
     return new DeserializingIterator(fetch, serdes, valueConverter);
   }
@@ -204,8 +192,8 @@ public final class WindowStoreCacheBypass {
     }
     final StateSerdes<GenericKey, ?> serdes = getSerdes(unwrapped);
     final WindowStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
-    final Bytes rawKeyFrom = Bytes.wrap(serdes.rawKey(keyFrom));
-    final Bytes rawKeyTo = Bytes.wrap(serdes.rawKey(keyTo));
+    final Bytes rawKeyFrom = Bytes.wrap(serdes.rawKey(keyFrom, new RecordHeaders()));
+    final Bytes rawKeyTo = Bytes.wrap(serdes.rawKey(keyTo, new RecordHeaders()));
     final KeyValueIterator<Windowed<Bytes>, byte[]> fetch = wrapped
             .fetch(rawKeyFrom, rawKeyTo, lower, upper);
     return new DeserializingKeyValueIterator(fetch, serdes, valueConverter);
@@ -276,8 +264,7 @@ public final class WindowStoreCacheBypass {
   private static ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>> unwrapWindowFacade(
       final ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>> windowStore
   ) {
-    if (GENERIC_WINDOW_FACADE_INNER_FIELD != null
-        && GENERIC_WINDOW_FACADE_INNER_FIELD.getDeclaringClass().isInstance(windowStore)) {
+    if (windowStore instanceof GenericReadOnlyWindowStoreFacade) {
       try {
         return (ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>>)
             GENERIC_WINDOW_FACADE_INNER_FIELD.get(windowStore);
@@ -292,15 +279,10 @@ public final class WindowStoreCacheBypass {
   private static Function<Object, ValueAndTimestamp<GenericRow>> getWindowValueConverter(
       final ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>> windowStore
   ) {
-    if (GENERIC_WINDOW_FACADE_VALUE_CONVERTER_FIELD != null
-        && GENERIC_WINDOW_FACADE_VALUE_CONVERTER_FIELD.getDeclaringClass()
-            .isInstance(windowStore)) {
-      try {
-        return (Function<Object, ValueAndTimestamp<GenericRow>>)
-            GENERIC_WINDOW_FACADE_VALUE_CONVERTER_FIELD.get(windowStore);
-      } catch (final IllegalAccessException e) {
-        throw new RuntimeException("Stream internals changed unexpectedly!", e);
-      }
+    if (windowStore instanceof GenericReadOnlyWindowStoreFacade) {
+      final Function<ValueTimestampHeaders<GenericRow>, ValueAndTimestamp<GenericRow>> converter
+          = ValueConverters.extractValueAndTimestampFromHeaders();
+      return x -> converter.apply((ValueTimestampHeaders<GenericRow>) x);
     }
     return x -> (ValueAndTimestamp<GenericRow>) x;
   }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypass.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypass.java
@@ -51,6 +51,10 @@ public final class WindowStoreCacheBypass {
   private static final Field WINDOW_STORE_TYPE_FIELD;
   static final Field SERDES_FIELD;
   private static final Field GENERIC_WINDOW_FACADE_INNER_FIELD;
+  // Used when the queryable store path returns a GenericReadOnlyWindowStoreFacade — the
+  // facade is only produced for TimestampedWindowStoreWithHeaders, whose serde yields
+  // ValueTimestampHeaders<V> on the wire. The non-facade path returns ValueAndTimestamp<V>
+  // directly, so no conversion is needed there.
   private static final Function<ValueTimestampHeaders<GenericRow>, ValueAndTimestamp<GenericRow>>
       EXTRACT_VALUE_AND_TIMESTAMP = ValueConverters.extractValueAndTimestampFromHeaders();
   private static final String STORE_UNAVAILABLE_MESSAGE = "State store is not available anymore "
@@ -141,11 +145,13 @@ public final class WindowStoreCacheBypass {
       final Instant upper
   ) {
     final MeteredWindowStore<GenericKey, ?> unwrapped = unwrapToMeteredWindowStore(windowStore);
+    final Function<Object, ValueAndTimestamp<GenericRow>> valueConverter
+        = getWindowValueConverter(windowStore);
     final StateSerdes<GenericKey, ?> serdes = getSerdes(unwrapped);
     final WindowStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
     final Bytes rawKey = Bytes.wrap(serdes.rawKey(key, new RecordHeaders()));
     final WindowStoreIterator<byte[]> fetch = wrapped.fetch(rawKey, lower, upper);
-    return new DeserializingIterator(fetch, serdes);
+    return new DeserializingIterator(fetch, serdes, valueConverter);
   }
 
   /*
@@ -180,13 +186,15 @@ public final class WindowStoreCacheBypass {
           final Instant upper
   ) {
     final MeteredWindowStore<GenericKey, ?> unwrapped = unwrapToMeteredWindowStore(windowStore);
+    final Function<Object, ValueAndTimestamp<GenericRow>> valueConverter
+        = getWindowValueConverter(windowStore);
     final StateSerdes<GenericKey, ?> serdes = getSerdes(unwrapped);
     final WindowStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
     final Bytes rawKeyFrom = Bytes.wrap(serdes.rawKey(keyFrom, new RecordHeaders()));
     final Bytes rawKeyTo = Bytes.wrap(serdes.rawKey(keyTo, new RecordHeaders()));
     final KeyValueIterator<Windowed<Bytes>, byte[]> fetch = wrapped
             .fetch(rawKeyFrom, rawKeyTo, lower, upper);
-    return new DeserializingKeyValueIterator(fetch, serdes);
+    return new DeserializingKeyValueIterator(fetch, serdes, valueConverter);
   }
 
   /*
@@ -215,10 +223,12 @@ public final class WindowStoreCacheBypass {
           final Instant upper
   ) {
     final MeteredWindowStore<GenericKey, ?> unwrapped = unwrapToMeteredWindowStore(windowStore);
+    final Function<Object, ValueAndTimestamp<GenericRow>> valueConverter
+        = getWindowValueConverter(windowStore);
     final StateSerdes<GenericKey, ?> serdes = getSerdes(unwrapped);
     final WindowStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
     final KeyValueIterator<Windowed<Bytes>, byte[]> fetch = wrapped.fetchAll(lower, upper);
-    return new DeserializingKeyValueIterator(fetch, serdes);
+    return new DeserializingKeyValueIterator(fetch, serdes, valueConverter);
   }
 
   @SuppressWarnings("unchecked")
@@ -244,16 +254,35 @@ public final class WindowStoreCacheBypass {
             ? new EmptyWindowStoreIterator() : new EmptyKeyValueIterator());
   }
 
+  // Kafka Streams' validateAndCastStores wraps the store in a GenericReadOnlyWindowStoreFacade
+  // only when the underlying store is a TimestampedWindowStoreWithHeaders queried via
+  // TimestampedWindowStoreType. For a plain TimestampedWindowStore queried via the same type,
+  // the store is returned directly (a MeteredTimestampedWindowStore). Handle both shapes.
   @SuppressWarnings("unchecked")
   private static MeteredWindowStore<GenericKey, ?> unwrapToMeteredWindowStore(
       final ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>> windowStore
   ) {
-    try {
-      return (MeteredWindowStore<GenericKey, ?>)
-          GENERIC_WINDOW_FACADE_INNER_FIELD.get(windowStore);
-    } catch (final IllegalAccessException e) {
-      throw new RuntimeException("Stream internals changed unexpectedly!", e);
+    if (windowStore instanceof GenericReadOnlyWindowStoreFacade) {
+      try {
+        return (MeteredWindowStore<GenericKey, ?>)
+            GENERIC_WINDOW_FACADE_INNER_FIELD.get(windowStore);
+      } catch (final IllegalAccessException e) {
+        throw new RuntimeException("Stream internals changed unexpectedly!", e);
+      }
     }
+    return (MeteredWindowStore<GenericKey, ?>) windowStore;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Function<Object, ValueAndTimestamp<GenericRow>> getWindowValueConverter(
+      final ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>> windowStore
+  ) {
+    if (windowStore instanceof GenericReadOnlyWindowStoreFacade) {
+      // Facade present → underlying serde yields ValueTimestampHeaders<V>; extract.
+      return v -> EXTRACT_VALUE_AND_TIMESTAMP.apply((ValueTimestampHeaders<GenericRow>) v);
+    }
+    // No facade → underlying serde already yields ValueAndTimestamp<V>.
+    return v -> (ValueAndTimestamp<GenericRow>) v;
   }
 
   @SuppressWarnings("unchecked")
@@ -311,12 +340,15 @@ public final class WindowStoreCacheBypass {
           implements KeyValueIterator<Windowed<GenericKey>, ValueAndTimestamp<GenericRow>> {
     private final KeyValueIterator<Windowed<Bytes>, byte[]> fetch;
     private final StateSerdes<GenericKey, ?> serdes;
+    private final Function<Object, ValueAndTimestamp<GenericRow>> valueConverter;
 
     private DeserializingKeyValueIterator(
             final KeyValueIterator<Windowed<Bytes>, byte[]> fetch,
-            final StateSerdes<GenericKey, ?> serdes) {
+            final StateSerdes<GenericKey, ?> serdes,
+            final Function<Object, ValueAndTimestamp<GenericRow>> valueConverter) {
       this.fetch = fetch;
       this.serdes = serdes;
+      this.valueConverter = valueConverter;
     }
 
     @Override
@@ -335,15 +367,12 @@ public final class WindowStoreCacheBypass {
       return fetch.hasNext();
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public KeyValue<Windowed<GenericKey>, ValueAndTimestamp<GenericRow>> next() {
       final KeyValue<Windowed<Bytes>, byte[]> next = fetch.next();
       final Windowed<GenericKey> windowedKey = new Windowed<>(
               serdes.keyFrom(next.key.key().get()), next.key.window());
-      final ValueTimestampHeaders<GenericRow> vth =
-          (ValueTimestampHeaders<GenericRow>) serdes.valueFrom(next.value);
-      return KeyValue.pair(windowedKey, EXTRACT_VALUE_AND_TIMESTAMP.apply(vth));
+      return KeyValue.pair(windowedKey, valueConverter.apply(serdes.valueFrom(next.value)));
     }
   }
 
@@ -354,12 +383,15 @@ public final class WindowStoreCacheBypass {
           implements WindowStoreIterator<ValueAndTimestamp<GenericRow>> {
     private final WindowStoreIterator<byte[]> fetch;
     private final StateSerdes<GenericKey, ?> serdes;
+    private final Function<Object, ValueAndTimestamp<GenericRow>> valueConverter;
 
     private DeserializingIterator(
             final WindowStoreIterator<byte[]> fetch,
-            final StateSerdes<GenericKey, ?> serdes) {
+            final StateSerdes<GenericKey, ?> serdes,
+            final Function<Object, ValueAndTimestamp<GenericRow>> valueConverter) {
       this.fetch = fetch;
       this.serdes = serdes;
+      this.valueConverter = valueConverter;
     }
 
     @Override
@@ -377,13 +409,10 @@ public final class WindowStoreCacheBypass {
       return fetch.hasNext();
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public KeyValue<Long, ValueAndTimestamp<GenericRow>> next() {
       final KeyValue<Long, byte[]> next = fetch.next();
-      final ValueTimestampHeaders<GenericRow> vth =
-          (ValueTimestampHeaders<GenericRow>) serdes.valueFrom(next.value);
-      return KeyValue.pair(next.key, EXTRACT_VALUE_AND_TIMESTAMP.apply(vth));
+      return KeyValue.pair(next.key, valueConverter.apply(serdes.valueFrom(next.value)));
     }
   }
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypass.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypass.java
@@ -51,6 +51,8 @@ public final class WindowStoreCacheBypass {
   private static final Field WINDOW_STORE_TYPE_FIELD;
   static final Field SERDES_FIELD;
   private static final Field GENERIC_WINDOW_FACADE_INNER_FIELD;
+  private static final Function<ValueTimestampHeaders<GenericRow>, ValueAndTimestamp<GenericRow>>
+      EXTRACT_VALUE_AND_TIMESTAMP = ValueConverters.extractValueAndTimestampFromHeaders();
   private static final String STORE_UNAVAILABLE_MESSAGE = "State store is not available anymore "
           + "and may have been migrated to another instance; "
           + "please re-discover its location from the state metadata.";
@@ -138,18 +140,12 @@ public final class WindowStoreCacheBypass {
       final Instant lower,
       final Instant upper
   ) {
-    final Function<Object, ValueAndTimestamp<GenericRow>> valueConverter
-        = getWindowValueConverter(windowStore);
-    final ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>> unwrapped
-        = unwrapWindowFacade(windowStore);
-    if (!(unwrapped instanceof MeteredWindowStore)) {
-      throw new IllegalStateException("Expecting a MeteredWindowStore");
-    }
+    final MeteredWindowStore<GenericKey, ?> unwrapped = unwrapToMeteredWindowStore(windowStore);
     final StateSerdes<GenericKey, ?> serdes = getSerdes(unwrapped);
     final WindowStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
     final Bytes rawKey = Bytes.wrap(serdes.rawKey(key, new RecordHeaders()));
     final WindowStoreIterator<byte[]> fetch = wrapped.fetch(rawKey, lower, upper);
-    return new DeserializingIterator(fetch, serdes, valueConverter);
+    return new DeserializingIterator(fetch, serdes);
   }
 
   /*
@@ -183,20 +179,14 @@ public final class WindowStoreCacheBypass {
           final Instant lower,
           final Instant upper
   ) {
-    final Function<Object, ValueAndTimestamp<GenericRow>> valueConverter
-        = getWindowValueConverter(windowStore);
-    final ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>> unwrapped
-        = unwrapWindowFacade(windowStore);
-    if (!(unwrapped instanceof MeteredWindowStore)) {
-      throw new IllegalStateException("Expecting a MeteredWindowStore");
-    }
+    final MeteredWindowStore<GenericKey, ?> unwrapped = unwrapToMeteredWindowStore(windowStore);
     final StateSerdes<GenericKey, ?> serdes = getSerdes(unwrapped);
     final WindowStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
     final Bytes rawKeyFrom = Bytes.wrap(serdes.rawKey(keyFrom, new RecordHeaders()));
     final Bytes rawKeyTo = Bytes.wrap(serdes.rawKey(keyTo, new RecordHeaders()));
     final KeyValueIterator<Windowed<Bytes>, byte[]> fetch = wrapped
             .fetch(rawKeyFrom, rawKeyTo, lower, upper);
-    return new DeserializingKeyValueIterator(fetch, serdes, valueConverter);
+    return new DeserializingKeyValueIterator(fetch, serdes);
   }
 
   /*
@@ -224,17 +214,11 @@ public final class WindowStoreCacheBypass {
           final Instant lower,
           final Instant upper
   ) {
-    final Function<Object, ValueAndTimestamp<GenericRow>> valueConverter
-        = getWindowValueConverter(windowStore);
-    final ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>> unwrapped
-        = unwrapWindowFacade(windowStore);
-    if (!(unwrapped instanceof MeteredWindowStore)) {
-      throw new IllegalStateException("Expecting a MeteredWindowStore");
-    }
+    final MeteredWindowStore<GenericKey, ?> unwrapped = unwrapToMeteredWindowStore(windowStore);
     final StateSerdes<GenericKey, ?> serdes = getSerdes(unwrapped);
     final WindowStore<Bytes, byte[]> wrapped = getInnermostStore(unwrapped);
     final KeyValueIterator<Windowed<Bytes>, byte[]> fetch = wrapped.fetchAll(lower, upper);
-    return new DeserializingKeyValueIterator(fetch, serdes, valueConverter);
+    return new DeserializingKeyValueIterator(fetch, serdes);
   }
 
   @SuppressWarnings("unchecked")
@@ -261,35 +245,20 @@ public final class WindowStoreCacheBypass {
   }
 
   @SuppressWarnings("unchecked")
-  private static ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>> unwrapWindowFacade(
+  private static MeteredWindowStore<GenericKey, ?> unwrapToMeteredWindowStore(
       final ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>> windowStore
   ) {
-    if (windowStore instanceof GenericReadOnlyWindowStoreFacade) {
-      try {
-        return (ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>>)
-            GENERIC_WINDOW_FACADE_INNER_FIELD.get(windowStore);
-      } catch (final IllegalAccessException e) {
-        throw new RuntimeException("Stream internals changed unexpectedly!", e);
-      }
+    try {
+      return (MeteredWindowStore<GenericKey, ?>)
+          GENERIC_WINDOW_FACADE_INNER_FIELD.get(windowStore);
+    } catch (final IllegalAccessException e) {
+      throw new RuntimeException("Stream internals changed unexpectedly!", e);
     }
-    return windowStore;
-  }
-
-  @SuppressWarnings("unchecked")
-  private static Function<Object, ValueAndTimestamp<GenericRow>> getWindowValueConverter(
-      final ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>> windowStore
-  ) {
-    if (windowStore instanceof GenericReadOnlyWindowStoreFacade) {
-      final Function<ValueTimestampHeaders<GenericRow>, ValueAndTimestamp<GenericRow>> converter
-          = ValueConverters.extractValueAndTimestampFromHeaders();
-      return x -> converter.apply((ValueTimestampHeaders<GenericRow>) x);
-    }
-    return x -> (ValueAndTimestamp<GenericRow>) x;
   }
 
   @SuppressWarnings("unchecked")
   private static StateSerdes<GenericKey, ?> getSerdes(
-          final ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>> windowStore
+          final MeteredWindowStore<GenericKey, ?> windowStore
   ) throws RuntimeException {
     try {
       return (StateSerdes<GenericKey, ?>) SERDES_FIELD.get(windowStore);
@@ -300,11 +269,9 @@ public final class WindowStoreCacheBypass {
 
   @SuppressWarnings("unchecked")
   private static WindowStore<Bytes, byte[]> getInnermostStore(
-          final ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>> windowStore
+          final MeteredWindowStore<GenericKey, ?> windowStore
   ) {
-    WindowStore<Bytes, byte[]> wrapped
-            = ((MeteredWindowStore<GenericKey, ValueAndTimestamp<GenericRow>>) windowStore)
-            .wrapped();
+    WindowStore<Bytes, byte[]> wrapped = windowStore.wrapped();
     // Unwrap state stores until we get to the last WindowStore, which is past the caching
     // layer.
     while (wrapped instanceof WrappedStateStore) {
@@ -344,15 +311,12 @@ public final class WindowStoreCacheBypass {
           implements KeyValueIterator<Windowed<GenericKey>, ValueAndTimestamp<GenericRow>> {
     private final KeyValueIterator<Windowed<Bytes>, byte[]> fetch;
     private final StateSerdes<GenericKey, ?> serdes;
-    private final Function<Object, ValueAndTimestamp<GenericRow>> valueConverter;
 
     private DeserializingKeyValueIterator(
             final KeyValueIterator<Windowed<Bytes>, byte[]> fetch,
-            final StateSerdes<GenericKey, ?> serdes,
-            final Function<Object, ValueAndTimestamp<GenericRow>> valueConverter) {
+            final StateSerdes<GenericKey, ?> serdes) {
       this.fetch = fetch;
       this.serdes = serdes;
-      this.valueConverter = valueConverter;
     }
 
     @Override
@@ -371,12 +335,15 @@ public final class WindowStoreCacheBypass {
       return fetch.hasNext();
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public KeyValue<Windowed<GenericKey>, ValueAndTimestamp<GenericRow>> next() {
       final KeyValue<Windowed<Bytes>, byte[]> next = fetch.next();
       final Windowed<GenericKey> windowedKey = new Windowed<>(
               serdes.keyFrom(next.key.key().get()), next.key.window());
-      return KeyValue.pair(windowedKey, valueConverter.apply(serdes.valueFrom(next.value)));
+      final ValueTimestampHeaders<GenericRow> vth =
+          (ValueTimestampHeaders<GenericRow>) serdes.valueFrom(next.value);
+      return KeyValue.pair(windowedKey, EXTRACT_VALUE_AND_TIMESTAMP.apply(vth));
     }
   }
 
@@ -387,15 +354,12 @@ public final class WindowStoreCacheBypass {
           implements WindowStoreIterator<ValueAndTimestamp<GenericRow>> {
     private final WindowStoreIterator<byte[]> fetch;
     private final StateSerdes<GenericKey, ?> serdes;
-    private final Function<Object, ValueAndTimestamp<GenericRow>> valueConverter;
 
     private DeserializingIterator(
             final WindowStoreIterator<byte[]> fetch,
-            final StateSerdes<GenericKey, ?> serdes,
-            final Function<Object, ValueAndTimestamp<GenericRow>> valueConverter) {
+            final StateSerdes<GenericKey, ?> serdes) {
       this.fetch = fetch;
       this.serdes = serdes;
-      this.valueConverter = valueConverter;
     }
 
     @Override
@@ -413,10 +377,13 @@ public final class WindowStoreCacheBypass {
       return fetch.hasNext();
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public KeyValue<Long, ValueAndTimestamp<GenericRow>> next() {
       final KeyValue<Long, byte[]> next = fetch.next();
-      return KeyValue.pair(next.key, valueConverter.apply(serdes.valueFrom(next.value)));
+      final ValueTimestampHeaders<GenericRow> vth =
+          (ValueTimestampHeaders<GenericRow>) serdes.valueFrom(next.value);
+      return KeyValue.pair(next.key, EXTRACT_VALUE_AND_TIMESTAMP.apply(vth));
     }
   }
 

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypassTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypassTest.java
@@ -45,6 +45,7 @@ import org.apache.kafka.streams.state.ReadOnlySessionStore;
 import org.apache.kafka.streams.state.SessionStore;
 import org.apache.kafka.streams.state.StateSerdes;
 import org.apache.kafka.streams.state.internals.CompositeReadOnlySessionStore;
+import org.apache.kafka.streams.state.internals.MeteredSessionStore;
 import org.apache.kafka.streams.state.internals.StateStoreProvider;
 import org.apache.kafka.streams.state.internals.WrappedStateStore;
 import org.junit.Before;
@@ -81,6 +82,10 @@ public class SessionStoreCacheBypassTest {
   private StateSerdes<GenericKey, AggregationWithHeaders<GenericRow>> serdes;
   @Mock
   private MeteredSessionStoreWithHeaders<GenericKey, GenericRow> meteredSessionStoreWithHeaders;
+  @Mock
+  private MeteredSessionStore<GenericKey, GenericRow> meteredSessionStore;
+  @Mock
+  private StateSerdes<GenericKey, GenericRow> plainSerdes;
 
   private CompositeReadOnlySessionStore<GenericKey, GenericRow> store;
 
@@ -169,6 +174,46 @@ public class SessionStoreCacheBypassTest {
         AggregationWithHeaders.make(EXPECTED_ROW, new RecordHeaders());
     doReturn(aggregation).when(serdes).valueFrom(any());
     when(meteredSessionStoreWithHeaders.wrapped()).thenReturn(wrappedSessionStore);
+    when(wrappedSessionStore.wrapped()).thenReturn(sessionStore);
+    final Windowed<Bytes> windowedKey =
+        new Windowed<>(new Bytes(BYTES), new SessionWindow(0, 100));
+    when(sessionStore.fetch(any())).thenReturn(storeIterator);
+    when(storeIterator.hasNext()).thenReturn(true, false);
+    when(storeIterator.peekNextKey()).thenReturn(windowedKey);
+    when(storeIterator.next()).thenReturn(KeyValue.pair(windowedKey, VALUE_BYTES));
+
+    final KeyValueIterator<Windowed<GenericKey>, GenericRow> result =
+        SessionStoreCacheBypass.fetch(store, SOME_KEY);
+    assertThat(result.next().value, is(EXPECTED_ROW));
+  }
+
+  // When the underlying store is a plain SessionStore (not WithHeaders), Kafka Streams'
+  // validateAndCastStores returns it directly without wrapping in ReadOnlySessionStoreFacade.
+  // The bypass must handle that shape too, deserializing values as GenericRow directly.
+  @Test
+  public void shouldCallUnderlyingStoreWhenProviderReturnsMeteredStoreDirectly()
+      throws IllegalAccessException {
+    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(meteredSessionStore));
+    SERDES_FIELD.set(meteredSessionStore, plainSerdes);
+    when(plainSerdes.rawKey(any(), any())).thenReturn(BYTES);
+    when(meteredSessionStore.wrapped()).thenReturn(wrappedSessionStore);
+    when(wrappedSessionStore.wrapped()).thenReturn(sessionStore);
+    when(sessionStore.fetch(any())).thenReturn(storeIterator);
+    when(storeIterator.hasNext()).thenReturn(false);
+
+    SessionStoreCacheBypass.fetch(store, SOME_KEY);
+    verify(sessionStore).fetch(new Bytes(BYTES));
+  }
+
+  @Test
+  public void shouldDeserializeGenericRowDirectlyWhenProviderReturnsMeteredStoreDirectly()
+      throws IllegalAccessException {
+    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(meteredSessionStore));
+    SERDES_FIELD.set(meteredSessionStore, plainSerdes);
+    when(plainSerdes.rawKey(any(), any())).thenReturn(BYTES);
+    when(plainSerdes.keyFrom(any())).thenReturn(SOME_KEY);
+    doReturn(EXPECTED_ROW).when(plainSerdes).valueFrom(any());
+    when(meteredSessionStore.wrapped()).thenReturn(wrappedSessionStore);
     when(wrappedSessionStore.wrapped()).thenReturn(sessionStore);
     final Windowed<Bytes> windowedKey =
         new Windowed<>(new Bytes(BYTES), new SessionWindow(0, 100));

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypassTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypassTest.java
@@ -44,9 +44,7 @@ import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.ReadOnlySessionStore;
 import org.apache.kafka.streams.state.SessionStore;
 import org.apache.kafka.streams.state.StateSerdes;
-import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.internals.CompositeReadOnlySessionStore;
-import org.apache.kafka.streams.state.internals.MeteredSessionStore;
 import org.apache.kafka.streams.state.internals.StateStoreProvider;
 import org.apache.kafka.streams.state.internals.WrappedStateStore;
 import org.junit.Before;
@@ -72,8 +70,6 @@ public class SessionStoreCacheBypassTest {
   @Mock
   private StateStoreProvider provider;
   @Mock
-  private MeteredSessionStore<GenericKey, GenericRow> meteredSessionStore;
-  @Mock
   private SessionStore<Bytes, byte[]> sessionStore;
   @Mock
   private WrappedSessionStore<Bytes, byte[]> wrappedSessionStore;
@@ -82,7 +78,7 @@ public class SessionStoreCacheBypassTest {
   @Mock
   private KeyValueIterator<Windowed<Bytes>, byte[]> storeIterator;
   @Mock
-  private StateSerdes<GenericKey, ValueAndTimestamp<GenericRow>> serdes;
+  private StateSerdes<GenericKey, AggregationWithHeaders<GenericRow>> serdes;
   @Mock
   private MeteredSessionStoreWithHeaders<GenericKey, GenericRow> meteredSessionStoreWithHeaders;
 
@@ -95,10 +91,12 @@ public class SessionStoreCacheBypassTest {
 
   @Test
   public void shouldCallUnderlyingStoreSingleKey() throws IllegalAccessException {
-    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(meteredSessionStore));
-    SERDES_FIELD.set(meteredSessionStore, serdes);
+    final TestSessionStoreFacade facade =
+        new TestSessionStoreFacade(meteredSessionStoreWithHeaders);
+    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade));
+    SERDES_FIELD.set(meteredSessionStoreWithHeaders, serdes);
     when(serdes.rawKey(any(), any())).thenReturn(BYTES);
-    when(meteredSessionStore.wrapped()).thenReturn(wrappedSessionStore);
+    when(meteredSessionStoreWithHeaders.wrapped()).thenReturn(wrappedSessionStore);
     when(wrappedSessionStore.wrapped()).thenReturn(sessionStore);
     when(sessionStore.fetch(any())).thenReturn(storeIterator);
     when(storeIterator.hasNext()).thenReturn(false);
@@ -109,10 +107,12 @@ public class SessionStoreCacheBypassTest {
 
   @Test
   public void shouldCallUnderlyingStoreRangeQuery() throws IllegalAccessException {
-    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(meteredSessionStore));
-    SERDES_FIELD.set(meteredSessionStore, serdes);
+    final TestSessionStoreFacade facade =
+        new TestSessionStoreFacade(meteredSessionStoreWithHeaders);
+    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade));
+    SERDES_FIELD.set(meteredSessionStoreWithHeaders, serdes);
     when(serdes.rawKey(any(), any())).thenReturn(BYTES, OTHER_BYTES);
-    when(meteredSessionStore.wrapped()).thenReturn(wrappedSessionStore);
+    when(meteredSessionStoreWithHeaders.wrapped()).thenReturn(wrappedSessionStore);
     when(wrappedSessionStore.wrapped()).thenReturn(sessionStore);
     when(sessionStore.fetch(any(), any())).thenReturn(storeIterator);
     when(storeIterator.hasNext()).thenReturn(false);
@@ -123,10 +123,12 @@ public class SessionStoreCacheBypassTest {
 
   @Test
   public void shouldAvoidNonSessionStore() throws IllegalAccessException {
-    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(meteredSessionStore));
-    SERDES_FIELD.set(meteredSessionStore, serdes);
+    final TestSessionStoreFacade facade =
+        new TestSessionStoreFacade(meteredSessionStoreWithHeaders);
+    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade));
+    SERDES_FIELD.set(meteredSessionStoreWithHeaders, serdes);
     when(serdes.rawKey(any(), any())).thenReturn(BYTES);
-    when(meteredSessionStore.wrapped()).thenReturn(wrappedSessionStore);
+    when(meteredSessionStoreWithHeaders.wrapped()).thenReturn(wrappedSessionStore);
     when(wrappedSessionStore.wrapped()).thenReturn(stateStore);
     when(wrappedSessionStore.fetch(any())).thenReturn(storeIterator);
     when(storeIterator.hasNext()).thenReturn(false);
@@ -137,10 +139,12 @@ public class SessionStoreCacheBypassTest {
 
   @Test
   public void shouldThrowException_InvalidStateStoreException() throws IllegalAccessException {
-    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(meteredSessionStore));
-    SERDES_FIELD.set(meteredSessionStore, serdes);
+    final TestSessionStoreFacade facade =
+        new TestSessionStoreFacade(meteredSessionStoreWithHeaders);
+    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade));
+    SERDES_FIELD.set(meteredSessionStoreWithHeaders, serdes);
     when(serdes.rawKey(any(), any())).thenReturn(BYTES);
-    when(meteredSessionStore.wrapped()).thenReturn(sessionStore);
+    when(meteredSessionStoreWithHeaders.wrapped()).thenReturn(sessionStore);
     when(sessionStore.fetch(any())).thenThrow(
         new InvalidStateStoreException("Invalid"));
 
@@ -154,42 +158,7 @@ public class SessionStoreCacheBypassTest {
   }
 
   @Test
-  public void shouldUnwrapSessionFacadeAndCallUnderlyingStoreSingleKey()
-      throws IllegalAccessException {
-    final TestSessionStoreFacade facade =
-        new TestSessionStoreFacade(meteredSessionStoreWithHeaders);
-    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade));
-    SERDES_FIELD.set(meteredSessionStoreWithHeaders, serdes);
-    when(serdes.rawKey(any(), any())).thenReturn(BYTES);
-    when(meteredSessionStoreWithHeaders.wrapped()).thenReturn(wrappedSessionStore);
-    when(wrappedSessionStore.wrapped()).thenReturn(sessionStore);
-    when(sessionStore.fetch(any())).thenReturn(storeIterator);
-    when(storeIterator.hasNext()).thenReturn(false);
-
-    SessionStoreCacheBypass.fetch(store, SOME_KEY);
-    verify(sessionStore).fetch(new Bytes(BYTES));
-  }
-
-  @Test
-  public void shouldUnwrapSessionFacadeAndCallUnderlyingStoreRangeQuery()
-      throws IllegalAccessException {
-    final TestSessionStoreFacade facade =
-        new TestSessionStoreFacade(meteredSessionStoreWithHeaders);
-    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade));
-    SERDES_FIELD.set(meteredSessionStoreWithHeaders, serdes);
-    when(serdes.rawKey(any(), any())).thenReturn(BYTES, OTHER_BYTES);
-    when(meteredSessionStoreWithHeaders.wrapped()).thenReturn(wrappedSessionStore);
-    when(wrappedSessionStore.wrapped()).thenReturn(sessionStore);
-    when(sessionStore.fetch(any(), any())).thenReturn(storeIterator);
-    when(storeIterator.hasNext()).thenReturn(false);
-
-    SessionStoreCacheBypass.fetchRange(store, SOME_KEY, SOME_OTHER_KEY);
-    verify(sessionStore).fetch(new Bytes(BYTES), new Bytes(OTHER_BYTES));
-  }
-
-  @Test
-  public void shouldUnwrapSessionFacadeAndConvertValueViaAggregationMethod()
-      throws IllegalAccessException {
+  public void shouldConvertValueViaAggregationMethod() throws IllegalAccessException {
     final TestSessionStoreFacade facade =
         new TestSessionStoreFacade(meteredSessionStoreWithHeaders);
     when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade));
@@ -211,18 +180,6 @@ public class SessionStoreCacheBypassTest {
     final KeyValueIterator<Windowed<GenericKey>, GenericRow> result =
         SessionStoreCacheBypass.fetch(store, SOME_KEY);
     assertThat(result.next().value, is(EXPECTED_ROW));
-  }
-
-  @Test
-  public void shouldThrowException_wrongStateStore() {
-    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(sessionStore));
-
-    final Exception e = assertThrows(
-        IllegalStateException.class,
-        () -> SessionStoreCacheBypass.fetch(store, SOME_KEY)
-    );
-
-    assertThat(e.getMessage(), containsString("Expecting a MeteredSessionStore"));
   }
 
   private static abstract class WrappedSessionStore<K, V>

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypassTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/SessionStoreCacheBypassTest.java
@@ -97,7 +97,7 @@ public class SessionStoreCacheBypassTest {
   public void shouldCallUnderlyingStoreSingleKey() throws IllegalAccessException {
     when(provider.stores(any(), any())).thenReturn(ImmutableList.of(meteredSessionStore));
     SERDES_FIELD.set(meteredSessionStore, serdes);
-    when(serdes.rawKey(any())).thenReturn(BYTES);
+    when(serdes.rawKey(any(), any())).thenReturn(BYTES);
     when(meteredSessionStore.wrapped()).thenReturn(wrappedSessionStore);
     when(wrappedSessionStore.wrapped()).thenReturn(sessionStore);
     when(sessionStore.fetch(any())).thenReturn(storeIterator);
@@ -111,7 +111,7 @@ public class SessionStoreCacheBypassTest {
   public void shouldCallUnderlyingStoreRangeQuery() throws IllegalAccessException {
     when(provider.stores(any(), any())).thenReturn(ImmutableList.of(meteredSessionStore));
     SERDES_FIELD.set(meteredSessionStore, serdes);
-    when(serdes.rawKey(any())).thenReturn(BYTES, OTHER_BYTES);
+    when(serdes.rawKey(any(), any())).thenReturn(BYTES, OTHER_BYTES);
     when(meteredSessionStore.wrapped()).thenReturn(wrappedSessionStore);
     when(wrappedSessionStore.wrapped()).thenReturn(sessionStore);
     when(sessionStore.fetch(any(), any())).thenReturn(storeIterator);
@@ -125,7 +125,7 @@ public class SessionStoreCacheBypassTest {
   public void shouldAvoidNonSessionStore() throws IllegalAccessException {
     when(provider.stores(any(), any())).thenReturn(ImmutableList.of(meteredSessionStore));
     SERDES_FIELD.set(meteredSessionStore, serdes);
-    when(serdes.rawKey(any())).thenReturn(BYTES);
+    when(serdes.rawKey(any(), any())).thenReturn(BYTES);
     when(meteredSessionStore.wrapped()).thenReturn(wrappedSessionStore);
     when(wrappedSessionStore.wrapped()).thenReturn(stateStore);
     when(wrappedSessionStore.fetch(any())).thenReturn(storeIterator);
@@ -139,7 +139,7 @@ public class SessionStoreCacheBypassTest {
   public void shouldThrowException_InvalidStateStoreException() throws IllegalAccessException {
     when(provider.stores(any(), any())).thenReturn(ImmutableList.of(meteredSessionStore));
     SERDES_FIELD.set(meteredSessionStore, serdes);
-    when(serdes.rawKey(any())).thenReturn(BYTES);
+    when(serdes.rawKey(any(), any())).thenReturn(BYTES);
     when(meteredSessionStore.wrapped()).thenReturn(sessionStore);
     when(sessionStore.fetch(any())).thenThrow(
         new InvalidStateStoreException("Invalid"));
@@ -160,7 +160,7 @@ public class SessionStoreCacheBypassTest {
         new TestSessionStoreFacade(meteredSessionStoreWithHeaders);
     when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade));
     SERDES_FIELD.set(meteredSessionStoreWithHeaders, serdes);
-    when(serdes.rawKey(any())).thenReturn(BYTES);
+    when(serdes.rawKey(any(), any())).thenReturn(BYTES);
     when(meteredSessionStoreWithHeaders.wrapped()).thenReturn(wrappedSessionStore);
     when(wrappedSessionStore.wrapped()).thenReturn(sessionStore);
     when(sessionStore.fetch(any())).thenReturn(storeIterator);
@@ -177,7 +177,7 @@ public class SessionStoreCacheBypassTest {
         new TestSessionStoreFacade(meteredSessionStoreWithHeaders);
     when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade));
     SERDES_FIELD.set(meteredSessionStoreWithHeaders, serdes);
-    when(serdes.rawKey(any())).thenReturn(BYTES, OTHER_BYTES);
+    when(serdes.rawKey(any(), any())).thenReturn(BYTES, OTHER_BYTES);
     when(meteredSessionStoreWithHeaders.wrapped()).thenReturn(wrappedSessionStore);
     when(wrappedSessionStore.wrapped()).thenReturn(sessionStore);
     when(sessionStore.fetch(any(), any())).thenReturn(storeIterator);
@@ -194,7 +194,7 @@ public class SessionStoreCacheBypassTest {
         new TestSessionStoreFacade(meteredSessionStoreWithHeaders);
     when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade));
     SERDES_FIELD.set(meteredSessionStoreWithHeaders, serdes);
-    when(serdes.rawKey(any())).thenReturn(BYTES);
+    when(serdes.rawKey(any(), any())).thenReturn(BYTES);
     when(serdes.keyFrom(any())).thenReturn(SOME_KEY);
     final AggregationWithHeaders<GenericRow> aggregation =
         AggregationWithHeaders.make(EXPECTED_ROW, new RecordHeaders());

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypassTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypassTest.java
@@ -31,6 +31,7 @@ import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
 import java.time.Instant;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
@@ -39,12 +40,14 @@ import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.ReadOnlyWindowStore;
 import org.apache.kafka.streams.state.StateSerdes;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.apache.kafka.streams.state.internals.CompositeReadOnlyWindowStore;
 import org.apache.kafka.streams.state.internals.MeteredWindowStore;
 import org.apache.kafka.streams.state.internals.StateStoreProvider;
 import org.apache.kafka.streams.state.internals.WrappedStateStore;
+import static org.mockito.Mockito.doReturn;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -93,7 +96,7 @@ public class WindowStoreCacheBypassTest {
   public void shouldCallUnderlyingStoreSingleKey() throws IllegalAccessException {
     when(provider.stores(any(), any())).thenReturn(ImmutableList.of(meteredWindowStore));
     SERDES_FIELD.set(meteredWindowStore, serdes);
-    when(serdes.rawKey(any())).thenReturn(BYTES);
+    when(serdes.rawKey(any(), any())).thenReturn(BYTES);
     when(meteredWindowStore.wrapped()).thenReturn(wrappedWindowStore);
     when(wrappedWindowStore.wrapped()).thenReturn(windowStore);
     when(windowStore.fetch(any(), any(), any())).thenReturn(windowStoreIterator);
@@ -107,7 +110,7 @@ public class WindowStoreCacheBypassTest {
   public void shouldCallUnderlyingStoreForRangeQuery() throws IllegalAccessException {
     when(provider.stores(any(), any())).thenReturn(ImmutableList.of(meteredWindowStore));
     SERDES_FIELD.set(meteredWindowStore, serdes);
-    when(serdes.rawKey(any())).thenReturn(BYTES, OTHER_BYTES);
+    when(serdes.rawKey(any(), any())).thenReturn(BYTES, OTHER_BYTES);
     when(meteredWindowStore.wrapped()).thenReturn(wrappedWindowStore);
     when(wrappedWindowStore.wrapped()).thenReturn(windowStore);
     when(windowStore.fetch(any(), any(), any(), any())).thenReturn(keyValueIterator);
@@ -134,7 +137,7 @@ public class WindowStoreCacheBypassTest {
   public void shouldAvoidNonWindowStore() throws IllegalAccessException {
     when(provider.stores(any(), any())).thenReturn(ImmutableList.of(meteredWindowStore));
     SERDES_FIELD.set(meteredWindowStore, serdes);
-    when(serdes.rawKey(any())).thenReturn(BYTES);
+    when(serdes.rawKey(any(), any())).thenReturn(BYTES);
     when(meteredWindowStore.wrapped()).thenReturn(wrappedWindowStore);
     when(wrappedWindowStore.wrapped()).thenReturn(stateStore);
     when(wrappedWindowStore.fetch(any(), any(), any())).thenReturn(windowStoreIterator);
@@ -150,7 +153,7 @@ public class WindowStoreCacheBypassTest {
   public void shouldThrowException_InvalidStateStoreException() throws IllegalAccessException {
     when(provider.stores(any(), any())).thenReturn(ImmutableList.of(meteredWindowStore));
     SERDES_FIELD.set(meteredWindowStore, serdes);
-    when(serdes.rawKey(any())).thenReturn(BYTES);
+    when(serdes.rawKey(any(), any())).thenReturn(BYTES);
     when(meteredWindowStore.wrapped()).thenReturn(windowStore);
     when(windowStore.fetch(any(), any(), any())).thenThrow(
         new InvalidStateStoreException("Invalid"));
@@ -173,7 +176,7 @@ public class WindowStoreCacheBypassTest {
         new GenericReadOnlyWindowStoreFacade<>(meteredWindowStore, x -> x);
     when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade));
     SERDES_FIELD.set(meteredWindowStore, serdes);
-    when(serdes.rawKey(any())).thenReturn(BYTES);
+    when(serdes.rawKey(any(), any())).thenReturn(BYTES);
     when(meteredWindowStore.wrapped()).thenReturn(wrappedWindowStore);
     when(wrappedWindowStore.wrapped()).thenReturn(windowStore);
     when(windowStore.fetch(any(), any(), any())).thenReturn(windowStoreIterator);
@@ -193,7 +196,7 @@ public class WindowStoreCacheBypassTest {
         new GenericReadOnlyWindowStoreFacade<>(meteredWindowStore, x -> x);
     when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade));
     SERDES_FIELD.set(meteredWindowStore, serdes);
-    when(serdes.rawKey(any())).thenReturn(BYTES, OTHER_BYTES);
+    when(serdes.rawKey(any(), any())).thenReturn(BYTES, OTHER_BYTES);
     when(meteredWindowStore.wrapped()).thenReturn(wrappedWindowStore);
     when(wrappedWindowStore.wrapped()).thenReturn(windowStore);
     when(windowStore.fetch(any(), any(), any(), any())).thenReturn(keyValueIterator);
@@ -225,15 +228,18 @@ public class WindowStoreCacheBypassTest {
   }
 
   @Test
-  public void shouldUnwrapWindowFacadeAndApplyValueConverterForSingleKey()
+  public void shouldUnwrapWindowFacadeAndExtractValueAndTimestampFromHeaders()
       throws IllegalAccessException {
     final GenericReadOnlyWindowStoreFacade<GenericKey, ValueAndTimestamp<GenericRow>,
         ValueAndTimestamp<GenericRow>> facade =
         new GenericReadOnlyWindowStoreFacade<>(meteredWindowStore, x -> x);
+    final GenericRow row = GenericRow.genericRow("v1");
+    final ValueTimestampHeaders<GenericRow> deserialized =
+        ValueTimestampHeaders.make(row, 1000L, new RecordHeaders());
     when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade));
     SERDES_FIELD.set(meteredWindowStore, serdes);
-    when(serdes.rawKey(any())).thenReturn(BYTES);
-    when(serdes.valueFrom(any())).thenReturn(VALUE_AND_TIMESTAMP);
+    when(serdes.rawKey(any(), any())).thenReturn(BYTES);
+    doReturn(deserialized).when(serdes).valueFrom(any());
     when(meteredWindowStore.wrapped()).thenReturn(wrappedWindowStore);
     when(wrappedWindowStore.wrapped()).thenReturn(windowStore);
     when(windowStore.fetch(any(), any(), any())).thenReturn(windowStoreIterator);
@@ -243,7 +249,7 @@ public class WindowStoreCacheBypassTest {
     final WindowStoreIterator<ValueAndTimestamp<GenericRow>> result =
         WindowStoreCacheBypass.fetch(
             store, SOME_KEY, Instant.ofEpochMilli(100), Instant.ofEpochMilli(200));
-    assertThat(result.next().value, is(VALUE_AND_TIMESTAMP));
+    assertThat(result.next().value, is(ValueAndTimestamp.make(row, 1000L)));
   }
 
   @Test

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypassTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypassTest.java
@@ -62,8 +62,6 @@ public class WindowStoreCacheBypassTest {
   private static final byte[] BYTES = new byte[] {'a', 'b'};
   private static final byte[] OTHER_BYTES = new byte[] {'c', 'd'};
   private static final byte[] VALUE_BYTES = new byte[] {'e', 'f'};
-  private static final ValueAndTimestamp<GenericRow> VALUE_AND_TIMESTAMP =
-      ValueAndTimestamp.make(GenericRow.genericRow("v1"), 1000L);
 
   @Mock
   private QueryableStoreType<ReadOnlyWindowStore<GenericKey, ValueAndTimestamp<GenericRow>>>
@@ -92,9 +90,14 @@ public class WindowStoreCacheBypassTest {
     store = new CompositeReadOnlyWindowStore<>(provider, queryableStoreType, "foo");
   }
 
+  private GenericReadOnlyWindowStoreFacade<GenericKey, ValueAndTimestamp<GenericRow>,
+      ValueAndTimestamp<GenericRow>> facade() {
+    return new GenericReadOnlyWindowStoreFacade<>(meteredWindowStore, x -> x);
+  }
+
   @Test
   public void shouldCallUnderlyingStoreSingleKey() throws IllegalAccessException {
-    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(meteredWindowStore));
+    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade()));
     SERDES_FIELD.set(meteredWindowStore, serdes);
     when(serdes.rawKey(any(), any())).thenReturn(BYTES);
     when(meteredWindowStore.wrapped()).thenReturn(wrappedWindowStore);
@@ -102,13 +105,15 @@ public class WindowStoreCacheBypassTest {
     when(windowStore.fetch(any(), any(), any())).thenReturn(windowStoreIterator);
     when(windowStoreIterator.hasNext()).thenReturn(false);
 
-    WindowStoreCacheBypass.fetch(store, SOME_KEY, Instant.ofEpochMilli(100), Instant.ofEpochMilli(200));
-    verify(windowStore).fetch(new Bytes(BYTES), Instant.ofEpochMilli(100L), Instant.ofEpochMilli(200L));
+    WindowStoreCacheBypass.fetch(
+        store, SOME_KEY, Instant.ofEpochMilli(100), Instant.ofEpochMilli(200));
+    verify(windowStore).fetch(
+        new Bytes(BYTES), Instant.ofEpochMilli(100L), Instant.ofEpochMilli(200L));
   }
 
   @Test
   public void shouldCallUnderlyingStoreForRangeQuery() throws IllegalAccessException {
-    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(meteredWindowStore));
+    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade()));
     SERDES_FIELD.set(meteredWindowStore, serdes);
     when(serdes.rawKey(any(), any())).thenReturn(BYTES, OTHER_BYTES);
     when(meteredWindowStore.wrapped()).thenReturn(wrappedWindowStore);
@@ -116,13 +121,16 @@ public class WindowStoreCacheBypassTest {
     when(windowStore.fetch(any(), any(), any(), any())).thenReturn(keyValueIterator);
     when(keyValueIterator.hasNext()).thenReturn(false);
 
-    WindowStoreCacheBypass.fetchRange(store, SOME_KEY, SOME_OTHER_KEY, Instant.ofEpochMilli(100), Instant.ofEpochMilli(200));
-    verify(windowStore).fetch(new Bytes(BYTES), new Bytes(OTHER_BYTES), Instant.ofEpochMilli(100L), Instant.ofEpochMilli(200L));
+    WindowStoreCacheBypass.fetchRange(
+        store, SOME_KEY, SOME_OTHER_KEY, Instant.ofEpochMilli(100), Instant.ofEpochMilli(200));
+    verify(windowStore).fetch(
+        new Bytes(BYTES), new Bytes(OTHER_BYTES),
+        Instant.ofEpochMilli(100L), Instant.ofEpochMilli(200L));
   }
 
   @Test
   public void shouldCallUnderlyingStoreForTableScans() throws IllegalAccessException {
-    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(meteredWindowStore));
+    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade()));
     SERDES_FIELD.set(meteredWindowStore, serdes);
     when(meteredWindowStore.wrapped()).thenReturn(wrappedWindowStore);
     when(wrappedWindowStore.wrapped()).thenReturn(windowStore);
@@ -135,7 +143,7 @@ public class WindowStoreCacheBypassTest {
 
   @Test
   public void shouldAvoidNonWindowStore() throws IllegalAccessException {
-    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(meteredWindowStore));
+    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade()));
     SERDES_FIELD.set(meteredWindowStore, serdes);
     when(serdes.rawKey(any(), any())).thenReturn(BYTES);
     when(meteredWindowStore.wrapped()).thenReturn(wrappedWindowStore);
@@ -151,7 +159,7 @@ public class WindowStoreCacheBypassTest {
 
   @Test
   public void shouldThrowException_InvalidStateStoreException() throws IllegalAccessException {
-    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(meteredWindowStore));
+    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade()));
     SERDES_FIELD.set(meteredWindowStore, serdes);
     when(serdes.rawKey(any(), any())).thenReturn(BYTES);
     when(meteredWindowStore.wrapped()).thenReturn(windowStore);
@@ -169,74 +177,11 @@ public class WindowStoreCacheBypassTest {
   }
 
   @Test
-  public void shouldUnwrapWindowFacadeAndCallUnderlyingStoreSingleKey()
-      throws IllegalAccessException {
-    final GenericReadOnlyWindowStoreFacade<GenericKey, ValueAndTimestamp<GenericRow>,
-        ValueAndTimestamp<GenericRow>> facade =
-        new GenericReadOnlyWindowStoreFacade<>(meteredWindowStore, x -> x);
-    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade));
-    SERDES_FIELD.set(meteredWindowStore, serdes);
-    when(serdes.rawKey(any(), any())).thenReturn(BYTES);
-    when(meteredWindowStore.wrapped()).thenReturn(wrappedWindowStore);
-    when(wrappedWindowStore.wrapped()).thenReturn(windowStore);
-    when(windowStore.fetch(any(), any(), any())).thenReturn(windowStoreIterator);
-    when(windowStoreIterator.hasNext()).thenReturn(false);
-
-    WindowStoreCacheBypass.fetch(
-        store, SOME_KEY, Instant.ofEpochMilli(100), Instant.ofEpochMilli(200));
-    verify(windowStore).fetch(
-        new Bytes(BYTES), Instant.ofEpochMilli(100L), Instant.ofEpochMilli(200L));
-  }
-
-  @Test
-  public void shouldUnwrapWindowFacadeAndCallUnderlyingStoreRangeQuery()
-      throws IllegalAccessException {
-    final GenericReadOnlyWindowStoreFacade<GenericKey, ValueAndTimestamp<GenericRow>,
-        ValueAndTimestamp<GenericRow>> facade =
-        new GenericReadOnlyWindowStoreFacade<>(meteredWindowStore, x -> x);
-    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade));
-    SERDES_FIELD.set(meteredWindowStore, serdes);
-    when(serdes.rawKey(any(), any())).thenReturn(BYTES, OTHER_BYTES);
-    when(meteredWindowStore.wrapped()).thenReturn(wrappedWindowStore);
-    when(wrappedWindowStore.wrapped()).thenReturn(windowStore);
-    when(windowStore.fetch(any(), any(), any(), any())).thenReturn(keyValueIterator);
-    when(keyValueIterator.hasNext()).thenReturn(false);
-
-    WindowStoreCacheBypass.fetchRange(
-        store, SOME_KEY, SOME_OTHER_KEY, Instant.ofEpochMilli(100), Instant.ofEpochMilli(200));
-    verify(windowStore).fetch(
-        new Bytes(BYTES), new Bytes(OTHER_BYTES),
-        Instant.ofEpochMilli(100L), Instant.ofEpochMilli(200L));
-  }
-
-  @Test
-  public void shouldUnwrapWindowFacadeAndCallUnderlyingStoreTableScan()
-      throws IllegalAccessException {
-    final GenericReadOnlyWindowStoreFacade<GenericKey, ValueAndTimestamp<GenericRow>,
-        ValueAndTimestamp<GenericRow>> facade =
-        new GenericReadOnlyWindowStoreFacade<>(meteredWindowStore, x -> x);
-    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade));
-    SERDES_FIELD.set(meteredWindowStore, serdes);
-    when(meteredWindowStore.wrapped()).thenReturn(wrappedWindowStore);
-    when(wrappedWindowStore.wrapped()).thenReturn(windowStore);
-    when(windowStore.fetchAll(any(), any())).thenReturn(keyValueIterator);
-    when(keyValueIterator.hasNext()).thenReturn(false);
-
-    WindowStoreCacheBypass.fetchAll(
-        store, Instant.ofEpochMilli(100), Instant.ofEpochMilli(200));
-    verify(windowStore).fetchAll(Instant.ofEpochMilli(100L), Instant.ofEpochMilli(200L));
-  }
-
-  @Test
-  public void shouldUnwrapWindowFacadeAndExtractValueAndTimestampFromHeaders()
-      throws IllegalAccessException {
-    final GenericReadOnlyWindowStoreFacade<GenericKey, ValueAndTimestamp<GenericRow>,
-        ValueAndTimestamp<GenericRow>> facade =
-        new GenericReadOnlyWindowStoreFacade<>(meteredWindowStore, x -> x);
+  public void shouldExtractValueAndTimestampFromHeaders() throws IllegalAccessException {
     final GenericRow row = GenericRow.genericRow("v1");
     final ValueTimestampHeaders<GenericRow> deserialized =
         ValueTimestampHeaders.make(row, 1000L, new RecordHeaders());
-    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade));
+    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(facade()));
     SERDES_FIELD.set(meteredWindowStore, serdes);
     when(serdes.rawKey(any(), any())).thenReturn(BYTES);
     doReturn(deserialized).when(serdes).valueFrom(any());
@@ -250,19 +195,6 @@ public class WindowStoreCacheBypassTest {
         WindowStoreCacheBypass.fetch(
             store, SOME_KEY, Instant.ofEpochMilli(100), Instant.ofEpochMilli(200));
     assertThat(result.next().value, is(ValueAndTimestamp.make(row, 1000L)));
-  }
-
-  @Test
-  public void shouldThrowException_wrongStateStore() {
-    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(windowStore));
-
-    final Exception e = assertThrows(
-        IllegalStateException.class,
-        () -> WindowStoreCacheBypass.fetch(store, SOME_KEY,
-            Instant.ofEpochMilli(100), Instant.ofEpochMilli(200))
-    );
-
-    assertThat(e.getMessage(), containsString("Expecting a MeteredWindowStore"));
   }
 
   private static abstract class WrappedWindowStore<K, V>

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypassTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/WindowStoreCacheBypassTest.java
@@ -197,6 +197,47 @@ public class WindowStoreCacheBypassTest {
     assertThat(result.next().value, is(ValueAndTimestamp.make(row, 1000L)));
   }
 
+  // When the underlying store is a plain TimestampedWindowStore (not WithHeaders), Kafka Streams'
+  // validateAndCastStores returns it directly without wrapping in GenericReadOnlyWindowStoreFacade.
+  // The bypass must handle that shape too, deserializing values as ValueAndTimestamp directly.
+  @Test
+  public void shouldCallUnderlyingStoreWhenProviderReturnsMeteredStoreDirectly()
+      throws IllegalAccessException {
+    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(meteredWindowStore));
+    SERDES_FIELD.set(meteredWindowStore, serdes);
+    when(serdes.rawKey(any(), any())).thenReturn(BYTES);
+    when(meteredWindowStore.wrapped()).thenReturn(wrappedWindowStore);
+    when(wrappedWindowStore.wrapped()).thenReturn(windowStore);
+    when(windowStore.fetch(any(), any(), any())).thenReturn(windowStoreIterator);
+    when(windowStoreIterator.hasNext()).thenReturn(false);
+
+    WindowStoreCacheBypass.fetch(
+        store, SOME_KEY, Instant.ofEpochMilli(100), Instant.ofEpochMilli(200));
+    verify(windowStore).fetch(
+        new Bytes(BYTES), Instant.ofEpochMilli(100L), Instant.ofEpochMilli(200L));
+  }
+
+  @Test
+  public void shouldDeserializeValueAndTimestampDirectlyWhenProviderReturnsMeteredStoreDirectly()
+      throws IllegalAccessException {
+    final GenericRow row = GenericRow.genericRow("v1");
+    final ValueAndTimestamp<GenericRow> deserialized = ValueAndTimestamp.make(row, 1000L);
+    when(provider.stores(any(), any())).thenReturn(ImmutableList.of(meteredWindowStore));
+    SERDES_FIELD.set(meteredWindowStore, serdes);
+    when(serdes.rawKey(any(), any())).thenReturn(BYTES);
+    doReturn(deserialized).when(serdes).valueFrom(any());
+    when(meteredWindowStore.wrapped()).thenReturn(wrappedWindowStore);
+    when(wrappedWindowStore.wrapped()).thenReturn(windowStore);
+    when(windowStore.fetch(any(), any(), any())).thenReturn(windowStoreIterator);
+    when(windowStoreIterator.hasNext()).thenReturn(true, false);
+    when(windowStoreIterator.next()).thenReturn(KeyValue.pair(100L, VALUE_BYTES));
+
+    final WindowStoreIterator<ValueAndTimestamp<GenericRow>> result =
+        WindowStoreCacheBypass.fetch(
+            store, SOME_KEY, Instant.ofEpochMilli(100), Instant.ofEpochMilli(200));
+    assertThat(result.next().value, is(ValueAndTimestamp.make(row, 1000L)));
+  }
+
   private static abstract class WrappedWindowStore<K, V>
       extends WrappedStateStore<StateStore, K, V> implements WindowStore<K, V> {
     public WrappedWindowStore(StateStore wrapped) {


### PR DESCRIPTION
## Summary

Follow-up to #10987 addressing post-merge review feedback from @mjsax (kafka streams team).

The original PR used `Class.forName` + reflection to detect the kafka-streams facade classes and to access `AggregationWithHeaders.getAggregationOrNull`, with backward-compat branches for older Kafka versions where the facades didn't exist. mjsax pointed out this was over-engineered: the facade classes are public on the classpath we compile against, and `AggregationWithHeaders` and `ValueConverters` are public APIs that can be called directly.

### Changes

- `Class.forName(...)` → compile-time class references for `ReadOnlySessionStoreFacade`, `GenericReadOnlyWindowStoreFacade`, `AggregationWithHeaders`.
- `Method.invoke(getAggregationOrNull, ...)` → direct call to `AggregationWithHeaders.getAggregationOrNull(...)`.
- Reflective access to `GenericReadOnlyWindowStoreFacade#valueConverter` → direct use of `ValueConverters.extractValueAndTimestampFromHeaders()`. ksqlDB only consumes the value-and-timestamp-from-headers case, so we don't need to pull the runtime converter out of the facade.
- Dropped the "facade not present in this Kafka version" branches and the null-guards on the field/method references.
- Switched from the deprecated `serdes.rawKey(K)` to `serdes.rawKey(K, Headers)`.

Reflection is still required for the `inner` field on both facades (`protected` on the session facade, `private` on the window facade), but everything else is now a direct API call.

Diff: 50 insertions, 88 deletions across the two production files and their tests.

### Review thread mapping

- https://github.com/confluentinc/ksql/pull/10987#discussion_r3141281197 — direct `AggregationWithHeaders.getAggregationOrNull` call ✅
- https://github.com/confluentinc/ksql/pull/10987#discussion_r3141282655 — `ReadOnlySessionStoreFacade.class` instead of `Class.forName` ✅
- https://github.com/confluentinc/ksql/pull/10987#discussion_r3141286031 — drop "facade not present" branch ✅
- https://github.com/confluentinc/ksql/pull/10987#discussion_r3141288116 — direct call lambda for value converter ✅
- https://github.com/confluentinc/ksql/pull/10987#discussion_r3141291523 — move off deprecated `rawKey` ✅
- https://github.com/confluentinc/ksql/pull/10987#discussion_r3141294864 — drop unnecessary null-checks before `.get(sessionStore)` ✅
- https://github.com/confluentinc/ksql/pull/10987#discussion_r3141296189 — simplify converter helper ✅
- https://github.com/confluentinc/ksql/pull/10987#discussion_r3141299517 — use `ValueConverters.extractValueAndTimestampFromHeaders` directly ✅

## Test plan

- [x] `SessionStoreCacheBypassTest` — 8 tests pass
- [x] `WindowStoreCacheBypassTest` — 10 tests pass
- [x] `KsMaterializationFunctionalTest` — 14 tests pass (covers the 6 originally fixed by #10987)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)