### PR TITLE
fix(build): bump protobuf-java runtime to 4.34.0 [8.0.x — cascade entry point]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <skip.docker.build>true</skip.docker.build>
         <skip.docker.test>true</skip.docker.test>
-        <protobuf.version>4.32.1</protobuf.version>
+        <protobuf.version>4.34.0</protobuf.version>
         <!-- Temporarily disabling this because it is causing failures in packaging but not CI builds. -->
         <!-- <compile.warnings-flag>-Werror</compile.warnings-flag> -->
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>


### PR DESCRIPTION
## Pipe Triage Fix

**Failure class:** unit-test-regression (cascade from `<clinit>`)

**Root cause:** schema-registry's `MetaProto` is gencode `4.34.0`, but ksql's local `<protobuf.version>` property in `pom.xml` overrides the parent BOM with `4.32.1`. `RuntimeVersion.validateProtobufGencodeVersion` rejects "runtime older than gencode" → all 42 protobuf serde tests fail at static-init with `Could not initialize class io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema`.

**Upstream trigger:** [`confluentinc/common`@a9d06319](https://github.com/confluentinc/common/commit/a9d06319f118c4510fdb5a632cd9866d599448b1) — merged 7.9.x → 8.0.x in `common-parent`, bumping its BOM `<protobuf.version>` from `3.25.5` → `4.34.0` (line 106). That bump cascaded across every 8.x line of common (so SR's MetaProto across all 8.x SR releases is now gencode 4.34.0). ksql's local override never followed, so 8.0.x/8.1.x/8.2.x are still on `4.32.1`. ksql master had already fixed this via [`6f6a4e7`](https://github.com/confluentinc/ksql/commit/6f6a4e7) (PR #10987, KSQL-14553), which is the same one-line bump as this PR.

**Confidence:** MEDIUM
**Files changed:** 1 (`pom.xml`, single property bump — identical to the line on master and 8.3.x)

### Cross-branch state at a glance

| Layer | 7.x | 8.0.x | 8.1.x | 8.2.x | 8.3.x | master |
|---|---|---|---|---|---|---|
| `confluentinc/common` BOM `<protobuf.version>` | 3.25.5 | **4.34.0** | **4.34.0** | **4.34.0** | **4.34.0** | **4.34.0** |
| `confluentinc/ksql` local `<protobuf.version>` override | property not defined | **4.32.1** ❌ | **4.32.1** ❌ | **4.32.1** ❌ | 4.34.0 ✅ | 4.34.0 ✅ |

### Why 8.0.x as the entry point

This repo runs upward forward-merges (`8.0.x → 8.1.x → 8.2.x → 8.3.x → master`). Fixing the lowest still-broken branch lets the cascade-merge bot carry the bump to 8.1.x and 8.2.x in one shot. No fan-out PRs needed.

### Verification
- Upstream evidence stands in for local repro: master and 8.3.x already pass these exact tests with `4.34.0` (and have done so since 2026-03-24, when `6f6a4e7` landed).
- Sanity check that nothing else from common 8.0.5-0 is breaking ksql: the failing 8.1.x pipeline ran 1835 tests and only 42 errored — all in `io.confluent.ksql.serde.protobuf.*` and all cascading from the same `MetaProto.<clinit>`. The other bumps in common 8.0.5-0 (Jetty 9→12, Java 8→11, Jackson 2.18.6→2.16.0, Avro 1.11→1.12, etc.) produced **zero** test failures. Just the protobuf override is what needs to move.

### Failing test signature (from 8.1.x pipeline `8e7bd1ca-596a-4d6a-b0c0-c11a8559000d`)

```
java.lang.NoClassDefFoundError: Could not initialize class
    io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema
  at io.confluent.connect.protobuf.ProtobufData.typeToDynamicSchema(ProtobufData.java:898)
  at io.confluent.ksql.serde.protobuf.ProtobufNoSRConverter.fromConnectData(ProtobufNoSRConverter.java:80)
  at io.confluent.ksql.serde.protobuf.KsqlProtobufNoSRDeserializerTest.givenConnectSerialized(KsqlProtobufNoSRDeserializerTest.java:45)
Caused by: java.lang.ExceptionInInitializerError
  at io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema.<clinit>(ProtobufSchema.java:295)
  at io.confluent.ksql.serde.protobuf.ProtobufSchemaTranslatorTest.<clinit>(ProtobufSchemaTranslatorTest.java:39)
Caused by: com.google.protobuf.RuntimeVersion$ProtobufRuntimeVersionException:
  Detected incompatible Protobuf Gencode/Runtime versions when loading MetaProto:
  gencode 4.34.0, runtime 4.32.1.
```

42 errors / 1835 tests. 6+ consecutive failed pipelines on 8.1.x since 2026-04-29 23:26 UTC with the identical signature.

---
Generated by `ksqldb-pipe-triage` skill.