### PR TITLE
fix: [KSQL-14906][KSQL-14907] KsqlTarget NPE and SchemaRegistryUtil prefix collision

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/SchemaRegistryUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/SchemaRegistryUtil.java
@@ -228,8 +228,13 @@ public final class SchemaRegistryUtil {
         "Could not clean up the schema registry for query: " + applicationId);
     // Append a "-" delimiter so an applicationId ending in a numeric suffix
     // (e.g. "..._CTAS_FOO_1") does not prefix-match subjects of larger-numbered
-    // queries (e.g. "..._CTAS_FOO_17-..."). Internal subjects are always of the
-    // form "<applicationId>-<topic-suffix>-(key|value)".
+    // queries (e.g. "..._CTAS_FOO_17-..."). Kafka Streams' internal topic names
+    // are always built as "<applicationId>-<rawTopic>" (the "-" is hardcoded in
+    // `InternalTopologyBuilder#decorateTopic`), and SR subjects are derived as
+    // "<topicName>-(key|value)". So every internal subject for a given query
+    // begins with "<applicationId>-". The companion Kafka-topic cleanup path in
+    // `KafkaTopicClientImpl#isInternalTopic` already uses this same prefix
+    // shape; this filter just keeps the SR cleanup consistent with it.
     final String prefix = applicationId + "-";
     return allSubjectNames
         .filter(subjectName -> subjectName.startsWith(prefix))

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/SchemaRegistryUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/SchemaRegistryUtil.java
@@ -28,9 +28,11 @@ import io.confluent.ksql.util.ExecutorUtil;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.kafka.common.acl.AclOperation;
@@ -53,11 +55,31 @@ public final class SchemaRegistryUtil {
   public static void cleanupInternalTopicSchemas(
       final String applicationId,
       final SchemaRegistryClient schemaRegistryClient) {
-    getInternalSubjectNames(applicationId, schemaRegistryClient)
-        .forEach(subject -> tryDeleteInternalSubject(
-            applicationId,
-            schemaRegistryClient,
-            subject));
+    // Materialize once so we can log the matched set in a single line and then
+    // iterate it for deletion. The list is bounded by the topology size of one
+    // query (typically a handful of subjects: key/value of changelog/repartition
+    // per state store), so collecting in memory is fine.
+    final List<String> matchedSubjects =
+        getInternalSubjectNames(applicationId, schemaRegistryClient)
+            .collect(Collectors.toList());
+    if (matchedSubjects.isEmpty()) {
+      // Skip the empty case: this method is called once per query cleanup, and
+      // simple queries (e.g. plain CSAS without aggregation/repartition) have
+      // no internal subjects. Logging "matched 0 subjects" on every cleanup
+      // would spam the log without adding signal — the caller already logged
+      // "Deleting schemas for prefix <appId>" before invoking us.
+      return;
+    }
+    // One INFO line per cleanup invocation lists every subject that will be
+    // soft- and hard-deleted. After KSQL-14907 this is the trace operators
+    // need to verify the prefix filter behaved correctly (no subjects of
+    // larger-numbered queries collected here).
+    LOG.info("Matched {} internal schema subject(s) for cleanup of \"{}\": {}",
+        matchedSubjects.size(), applicationId, matchedSubjects);
+    matchedSubjects.forEach(subject -> tryDeleteInternalSubject(
+        applicationId,
+        schemaRegistryClient,
+        subject));
   }
 
   public static Stream<String> getSubjectNames(final SchemaRegistryClient schemaRegistryClient) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/SchemaRegistryUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/SchemaRegistryUtil.java
@@ -226,8 +226,13 @@ public final class SchemaRegistryUtil {
     final Stream<String> allSubjectNames = getSubjectNames(
         schemaRegistryClient,
         "Could not clean up the schema registry for query: " + applicationId);
+    // Append a "-" delimiter so an applicationId ending in a numeric suffix
+    // (e.g. "..._CTAS_FOO_1") does not prefix-match subjects of larger-numbered
+    // queries (e.g. "..._CTAS_FOO_17-..."). Internal subjects are always of the
+    // form "<applicationId>-<topic-suffix>-(key|value)".
+    final String prefix = applicationId + "-";
     return allSubjectNames
-        .filter(subjectName -> subjectName.startsWith(applicationId))
+        .filter(subjectName -> subjectName.startsWith(prefix))
         .filter(SchemaRegistryUtil::isInternalSubject);
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/SchemaRegistryUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/SchemaRegistryUtil.java
@@ -62,24 +62,22 @@ public final class SchemaRegistryUtil {
     final List<String> matchedSubjects =
         getInternalSubjectNames(applicationId, schemaRegistryClient)
             .collect(Collectors.toList());
-    if (matchedSubjects.isEmpty()) {
-      // Skip the empty case: this method is called once per query cleanup, and
+    if (!matchedSubjects.isEmpty()) {
+      // One INFO line per cleanup invocation lists every subject that will be
+      // soft- and hard-deleted. After KSQL-14907 this is the trace operators
+      // need to verify the prefix filter behaved correctly (no subjects of
+      // larger-numbered queries collected here). Skip when nothing matched:
       // simple queries (e.g. plain CSAS without aggregation/repartition) have
-      // no internal subjects. Logging "matched 0 subjects" on every cleanup
-      // would spam the log without adding signal — the caller already logged
-      // "Deleting schemas for prefix <appId>" before invoking us.
-      return;
+      // no internal subjects, so logging "matched 0" on every cleanup would be
+      // pure noise — the caller already logged "Deleting schemas for prefix
+      // <appId>" before invoking us.
+      LOG.info("Matched {} internal schema subject(s) for cleanup of \"{}\": {}",
+          matchedSubjects.size(), applicationId, matchedSubjects);
+      matchedSubjects.forEach(subject -> tryDeleteInternalSubject(
+          applicationId,
+          schemaRegistryClient,
+          subject));
     }
-    // One INFO line per cleanup invocation lists every subject that will be
-    // soft- and hard-deleted. After KSQL-14907 this is the trace operators
-    // need to verify the prefix filter behaved correctly (no subjects of
-    // larger-numbered queries collected here).
-    LOG.info("Matched {} internal schema subject(s) for cleanup of \"{}\": {}",
-        matchedSubjects.size(), applicationId, matchedSubjects);
-    matchedSubjects.forEach(subject -> tryDeleteInternalSubject(
-        applicationId,
-        schemaRegistryClient,
-        subject));
   }
 
   public static Stream<String> getSubjectNames(final SchemaRegistryClient schemaRegistryClient) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/schema/registry/SchemaRegistryUtilTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/schema/registry/SchemaRegistryUtilTest.java
@@ -135,40 +135,40 @@ public class SchemaRegistryUtilTest {
   public void shouldDeleteChangeLogTopicSchema() throws Exception {
     // Given:
     when(schemaRegistryClient.getAllSubjects()).thenReturn(ImmutableList.of(
-        APP_ID + "SOME-changelog-key",
-        APP_ID + "SOME-changelog-value"
+        APP_ID + "-SOME-changelog-key",
+        APP_ID + "-SOME-changelog-value"
     ));
 
     // When:
     SchemaRegistryUtil.cleanupInternalTopicSchemas(APP_ID, schemaRegistryClient);
 
     // Then not exception:
-    verify(schemaRegistryClient).deleteSubject(APP_ID + "SOME-changelog-key");
-    verify(schemaRegistryClient).deleteSubject(APP_ID + "SOME-changelog-value");
+    verify(schemaRegistryClient).deleteSubject(APP_ID + "-SOME-changelog-key");
+    verify(schemaRegistryClient).deleteSubject(APP_ID + "-SOME-changelog-value");
   }
 
   @Test
   public void shouldDeleteRepartitionTopicSchema() throws Exception {
     // Given:
     when(schemaRegistryClient.getAllSubjects()).thenReturn(ImmutableList.of(
-        APP_ID + "SOME-repartition-key",
-        APP_ID + "SOME-repartition-value"
+        APP_ID + "-SOME-repartition-key",
+        APP_ID + "-SOME-repartition-value"
     ));
 
     // When:
     SchemaRegistryUtil.cleanupInternalTopicSchemas(APP_ID, schemaRegistryClient);
 
     // Then not exception:
-    verify(schemaRegistryClient).deleteSubject(APP_ID + "SOME-repartition-key");
-    verify(schemaRegistryClient).deleteSubject(APP_ID + "SOME-repartition-value");
+    verify(schemaRegistryClient).deleteSubject(APP_ID + "-SOME-repartition-key");
+    verify(schemaRegistryClient).deleteSubject(APP_ID + "-SOME-repartition-value");
   }
 
   @Test
   public void shouldHardDeleteIfFlagSet() throws Exception {
     // Given:
     when(schemaRegistryClient.getAllSubjects()).thenReturn(ImmutableList.of(
-        APP_ID + "SOME-repartition-key",
-        APP_ID + "SOME-repartition-value"
+        APP_ID + "-SOME-repartition-key",
+        APP_ID + "-SOME-repartition-value"
     ));
 
     // When:
@@ -176,18 +176,18 @@ public class SchemaRegistryUtilTest {
 
     // Then not exception:
     final InOrder inOrder = inOrder(schemaRegistryClient);
-    inOrder.verify(schemaRegistryClient).deleteSubject(APP_ID + "SOME-repartition-key");
-    inOrder.verify(schemaRegistryClient).deleteSubject(APP_ID + "SOME-repartition-key", true);
-    inOrder.verify(schemaRegistryClient).deleteSubject(APP_ID + "SOME-repartition-value");
-    inOrder.verify(schemaRegistryClient).deleteSubject(APP_ID + "SOME-repartition-value", true);
+    inOrder.verify(schemaRegistryClient).deleteSubject(APP_ID + "-SOME-repartition-key");
+    inOrder.verify(schemaRegistryClient).deleteSubject(APP_ID + "-SOME-repartition-key", true);
+    inOrder.verify(schemaRegistryClient).deleteSubject(APP_ID + "-SOME-repartition-value");
+    inOrder.verify(schemaRegistryClient).deleteSubject(APP_ID + "-SOME-repartition-value", true);
   }
 
   @Test
   public void shouldNotDeleteOtherSchemasForThisApplicationId() throws Exception {
     // Given:
     when(schemaRegistryClient.getAllSubjects()).thenReturn(ImmutableList.of(
-        APP_ID + "SOME-other-key",
-        APP_ID + "SOME-other-value"
+        APP_ID + "-SOME-other-key",
+        APP_ID + "-SOME-other-value"
     ));
 
     // When:
@@ -195,6 +195,33 @@ public class SchemaRegistryUtilTest {
 
     // Then not exception:
     verify(schemaRegistryClient, never()).deleteSubject(any());
+  }
+
+  @Test
+  public void shouldNotDeleteSchemasOfLargerNumberedQueryWithSamePrefix() throws Exception {
+    // Regression for KSQL-14907: when applicationId ends in a numeric suffix that is
+    // a prefix of a larger number, the cleanup must not match subjects of those
+    // larger-numbered queries. Internal subjects always have a "-" between the
+    // applicationId and the rest of the subject name, so the filter must use that
+    // delimiter.
+    // Given:
+    final String singleDigitAppId = "_confluent-ksql-default_query_CTAS_FOO_1";
+    final String activeAppId = "_confluent-ksql-default_query_CTAS_FOO_17";
+    when(schemaRegistryClient.getAllSubjects()).thenReturn(ImmutableList.of(
+        // Active (running) query's internal subjects — must NOT be deleted.
+        activeAppId + "-Aggregate-Aggregate-Materialize-changelog-key",
+        activeAppId + "-Aggregate-Aggregate-Materialize-changelog-value",
+        activeAppId + "-Join-repartition-key",
+        activeAppId + "-Join-repartition-value"
+    ));
+
+    // When: cleanup for the older single-digit query.
+    SchemaRegistryUtil.cleanupInternalTopicSchemas(singleDigitAppId, schemaRegistryClient);
+
+    // Then: nothing deleted — none of the active query's subjects share the
+    // "<singleDigitAppId>-" prefix.
+    verify(schemaRegistryClient, never()).deleteSubject(any());
+    verify(schemaRegistryClient, never()).deleteSubject(any(), any(Boolean.class));
   }
 
   @Test
@@ -228,8 +255,8 @@ public class SchemaRegistryUtilTest {
   public void shouldNotThrowIfDeleteSubjectThrows() throws Exception {
     // Given:
     when(schemaRegistryClient.getAllSubjects()).thenReturn(ImmutableList.of(
-        APP_ID + "SOME-changelog-key",
-        APP_ID + "SOME-changelog-value"
+        APP_ID + "-SOME-changelog-key",
+        APP_ID + "-SOME-changelog-value"
     ));
 
     when(schemaRegistryClient.deleteSubject(any())).thenThrow(new RuntimeException("Boom!"));
@@ -238,16 +265,16 @@ public class SchemaRegistryUtilTest {
     SchemaRegistryUtil.cleanupInternalTopicSchemas(APP_ID, schemaRegistryClient);
 
     // Then not exception:
-    verify(schemaRegistryClient, times(5)).deleteSubject(APP_ID + "SOME-changelog-key");
-    verify(schemaRegistryClient, times(5)).deleteSubject(APP_ID + "SOME-changelog-value");
+    verify(schemaRegistryClient, times(5)).deleteSubject(APP_ID + "-SOME-changelog-key");
+    verify(schemaRegistryClient, times(5)).deleteSubject(APP_ID + "-SOME-changelog-value");
   }
 
   @Test
   public void shouldNotRetryIf40401() throws Exception {
     // Given:
     when(schemaRegistryClient.getAllSubjects()).thenReturn(ImmutableList.of(
-        APP_ID + "SOME-changelog-key",
-        APP_ID + "SOME-changelog-value"
+        APP_ID + "-SOME-changelog-key",
+        APP_ID + "-SOME-changelog-value"
     ));
 
     when(schemaRegistryClient.deleteSubject(any())).thenThrow(new RestClientException("foo", 404, 40401));
@@ -256,8 +283,8 @@ public class SchemaRegistryUtilTest {
     SchemaRegistryUtil.cleanupInternalTopicSchemas(APP_ID, schemaRegistryClient);
 
     // Then not exception (only tried once):
-    verify(schemaRegistryClient, times(1)).deleteSubject(APP_ID + "SOME-changelog-key");
-    verify(schemaRegistryClient, times(1)).deleteSubject(APP_ID + "SOME-changelog-value");
+    verify(schemaRegistryClient, times(1)).deleteSubject(APP_ID + "-SOME-changelog-key");
+    verify(schemaRegistryClient, times(1)).deleteSubject(APP_ID + "-SOME-changelog-value");
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/schema/registry/SchemaRegistryUtilTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/schema/registry/SchemaRegistryUtilTest.java
@@ -131,6 +131,22 @@ public class SchemaRegistryUtilTest {
     assertThat(schemaAndId.get().getSchema(), equalTo(AVRO_SCHEMA));
   }
 
+  // The fixtures below all follow the canonical internal-subject shape
+  // "<applicationId>-<rawTopic>-(changelog|repartition)-(key|value)".
+  // Rationale (see also SchemaRegistryUtil#getInternalSubjectNames):
+  //  * Kafka Streams' `InternalTopologyBuilder#decorateTopic` unconditionally
+  //    builds internal topic names as "<applicationId>-<rawTopic>" — the "-"
+  //    is hardcoded, so every internal topic (and therefore every internal SR
+  //    subject) begins with "<applicationId>-".
+  //  * `KsqlConstants#getSRSubject` then appends "-key" or "-value", so a full
+  //    internal subject is "<applicationId>-<...>-(changelog|repartition)-(key|value)".
+  //  * The companion Kafka-topic cleanup at
+  //    `KafkaTopicClientImpl#isInternalTopic` already uses
+  //    `topicName.startsWith(applicationId + "-")` — these tests use the same
+  //    shape so the SR-side cleanup is exercised against realistic input.
+  // The pre-fix fixtures used "APP_ID + \"SOME-changelog-key\"" (no separator
+  // after the applicationId), which does not match anything Kafka Streams
+  // would actually emit and is what masked KSQL-14907.
   @Test
   public void shouldDeleteChangeLogTopicSchema() throws Exception {
     // Given:
@@ -199,16 +215,35 @@ public class SchemaRegistryUtilTest {
 
   @Test
   public void shouldNotDeleteSchemasOfLargerNumberedQueryWithSamePrefix() throws Exception {
-    // Regression for KSQL-14907: when applicationId ends in a numeric suffix that is
-    // a prefix of a larger number, the cleanup must not match subjects of those
-    // larger-numbered queries. Internal subjects always have a "-" between the
-    // applicationId and the rest of the subject name, so the filter must use that
-    // delimiter.
+    // Regression for KSQL-14907.
+    //
+    // Production scenario this models:
+    //   * A user issued >=10 CREATE OR REPLACE TABLE FOO AS SELECT ..., so KSQL had
+    //     advanced its query name from CTAS_FOO_1 to CTAS_FOO_17.
+    //   * Stale local state from CTAS_FOO_1 lingered on a pod's PV (KSQL logs the
+    //     "race condition when the query was dropped before" WARN in this case).
+    //   * On a subsequent pod restart, QueryCleanupService scheduled cleanup for
+    //     the orphaned single-digit applicationId.
+    //
+    // Pre-fix bug: `getInternalSubjectNames` used `startsWith(applicationId)` with
+    // no terminator, so cleanup for "..._CTAS_FOO_1" matched the four active
+    // subjects of "..._CTAS_FOO_17-..." and proceeded to soft- then hard-delete
+    // them — wiping the running materialized table's schemas.
+    //
+    // Post-fix: `getInternalSubjectNames` uses `startsWith(applicationId + "-")`.
+    // Since "..._CTAS_FOO_17-..." does not start with "..._CTAS_FOO_1-" (the
+    // character after "_FOO_1" is "7", not "-"), nothing is matched and nothing
+    // is deleted. This is the only behavioural change vs. the old filter.
+    //
     // Given:
     final String singleDigitAppId = "_confluent-ksql-default_query_CTAS_FOO_1";
     final String activeAppId = "_confluent-ksql-default_query_CTAS_FOO_17";
     when(schemaRegistryClient.getAllSubjects()).thenReturn(ImmutableList.of(
         // Active (running) query's internal subjects — must NOT be deleted.
+        // Shape "<activeAppId>-<storeName>-(changelog|repartition)-(key|value)"
+        // matches what Kafka Streams' `InternalTopologyBuilder#decorateTopic`
+        // actually emits (the "-" between applicationId and storeName is
+        // hardcoded there).
         activeAppId + "-Aggregate-Aggregate-Materialize-changelog-key",
         activeAppId + "-Aggregate-Aggregate-Materialize-changelog-value",
         activeAppId + "-Join-repartition-key",
@@ -219,7 +254,8 @@ public class SchemaRegistryUtilTest {
     SchemaRegistryUtil.cleanupInternalTopicSchemas(singleDigitAppId, schemaRegistryClient);
 
     // Then: nothing deleted — none of the active query's subjects share the
-    // "<singleDigitAppId>-" prefix.
+    // "<singleDigitAppId>-" prefix (because "<singleDigitAppId>" is followed by
+    // "7", not "-", in the active query's subject names).
     verify(schemaRegistryClient, never()).deleteSubject(any());
     verify(schemaRegistryClient, never()).deleteSubject(any(), any(Boolean.class));
   }

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
@@ -318,6 +318,17 @@ public final class KsqlTarget {
       final Function<ResponseWithBody, T> mapper
   ) {
     return executeAsync(httpMethod, path, Optional.empty(), jsonEntity, mapper, (resp, vcf) -> {
+      // Vert.x can invoke this handler with a null response when the underlying
+      // HTTP connection is closed before any response is received (e.g. peer pod
+      // restart, TCP reset, idle keepalive timeout). Without this guard the NPE
+      // would propagate up the event loop as an unhandled exception and crash
+      // the JVM.
+      if (resp == null) {
+        vcf.completeExceptionally(new KsqlRestClientException(
+            "Inter-pod HTTP response was null (connection closed before response "
+                + "received) for " + httpMethod + " " + path));
+        return;
+      }
       resp.bodyHandler(buff -> vcf.complete(new ResponseWithBody(resp, buff)));
     });
   }

--- a/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlTargetTest.java
+++ b/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlTargetTest.java
@@ -17,6 +17,8 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.properties.LocalProperties;
 import io.confluent.ksql.rest.client.exception.KsqlRestClientException;
+import io.confluent.ksql.rest.entity.HeartbeatResponse;
+import io.confluent.ksql.rest.entity.KsqlHostInfoEntity;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
@@ -267,6 +269,41 @@ public class KsqlTargetTest {
     assertThatEventually(response::get, notNullValue());
     assertThat(response.get().getResponse(), is (2));
     assertThat(rows.size(), is (2));
+  }
+
+  @Test
+  public void shouldCompleteAsyncRequestExceptionallyWhenResponseIsNull() throws Exception {
+    // Regression for KSQL-14906: when the underlying HTTP connection is closed before any
+    // response is received, Vert.x can invoke the response handler with a null result. The
+    // async path must complete the future exceptionally with a KsqlRestClientException
+    // rather than letting an NPE escape onto the event loop and crash the JVM.
+    when(httpClientRequest.response(any(Handler.class))).thenAnswer(a -> {
+      final Handler<AsyncResult<HttpClientResponse>> handler = a.getArgument(0);
+      vertx.runOnContext(v -> {
+        handler.handle(Future.succeededFuture(null));
+        requestStarted.set(true);
+      });
+      return null;
+    });
+
+    ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST,
+        SUB_PATH, Collections.emptyMap());
+
+    final CompletableFuture<RestResponse<HeartbeatResponse>> result =
+        ksqlTarget.postAsyncHeartbeatRequest(new KsqlHostInfoEntity("h", 1), 0L);
+
+    assertThatEventually(requestStarted::get, is(true));
+    assertThatEventually(result::isCompletedExceptionally, is(true));
+
+    Throwable cause = null;
+    try {
+      result.get();
+    } catch (final Exception e) {
+      cause = e.getCause();
+    }
+    assertThat(cause, instanceOf(KsqlRestClientException.class));
+    assertThat(cause.getMessage(), containsString("Inter-pod HTTP response was null"));
+    assertThat(cause.getMessage(), containsString("/heartbeat"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Two related production bugs that combined to wipe an active query's Schema Registry subjects and cascade through pod restarts on `pksqlc-8v8xdr` (LPL Financial). Each is a tiny defensive fix; they are independent and bundled into one PR for the customer-facing rollout.

### KSQL-14906 — `KsqlTarget.executeRequestAsync` NPE crashes the JVM

`ksqldb-rest-client/.../KsqlTarget.java`'s async response handler called `resp.bodyHandler(...)` without checking that `resp` was non-null. When the inter-pod HTTP connection was closed before any response was received (peer pod restart, TCP reset, idle keepalive timeout), Vert.x invoked the handler with `resp == null` and the resulting NPE escaped onto the event loop, bringing the JVM down.

Fix: complete the future exceptionally with a `KsqlRestClientException` describing the method and path when `resp` is null.

### KSQL-14907 — `SchemaRegistryUtil` prefix-collision deletes active query's schemas

`SchemaRegistryUtil.getInternalSubjectNames` filtered Schema Registry subjects via `subjectName.startsWith(applicationId)` with no terminator. When `applicationId` ended in a numeric suffix that was the prefix of larger numbers (e.g. `..._CTAS_FOO_1` is a `startsWith` match for `..._CTAS_FOO_17-...`), `cleanupInternalTopicSchemas` soft- then hard-deleted every match — wiping the currently-running query's subjects.

Fix: append `-` to the prefix before `startsWith`. Internal subjects are always of the form `<applicationId>-<topic-suffix>-(key|value)`, so the dash is an unambiguous separator.

## Changes

- `ksqldb-rest-client/.../KsqlTarget.java` — null-check `resp` in `executeRequestAsync` lambda, fail with `KsqlRestClientException`
- `ksqldb-rest-client/.../KsqlTargetTest.java` — new test `shouldCompleteAsyncRequestExceptionallyWhenResponseIsNull` simulates the null-response case
- `ksqldb-engine/.../SchemaRegistryUtil.java` — append `"-"` delimiter to prefix before `startsWith`
- `ksqldb-engine/.../SchemaRegistryUtilTest.java`
  - existing test fixtures updated to use realistic `applicationId-suffix` subject names
  - new regression test `shouldNotDeleteSchemasOfLargerNumberedQueryWithSamePrefix` proving `..._FOO_1` cleanup does not match `..._FOO_17-...` subjects

## Test plan

- [x] `./mvnw -pl ksqldb-rest-client test -Dtest=KsqlTargetTest` — 9/9 pass (including new null-resp test)
- [x] `./mvnw -pl ksqldb-engine test -Dtest=SchemaRegistryUtilTest` — 22/22 pass (including new regression test)
- [x] `./mvnw -pl ksqldb-engine test -Dtest='KsqlEngineTest#shouldHardDeleteSchemaOnEngineCloseForTransientQueries+shouldHardDeleteSchemaOnEngineCloseForTransientQueriesSharedRuntimes+shouldCleanUpInternalTopicsOnClose+shouldCleanUpInternalTopicsOnCloseSharedRuntimes'` — all pass; these tests already used realistic `applicationId-suffix` subject names so the prefix change is compatible
- [x] `./mvnw -pl ksqldb-rest-client,ksqldb-engine checkstyle:check` — 0 violations
- [x] Both modules `compile` cleanly

## Tickets

- https://confluentinc.atlassian.net/browse/KSQL-14906
- https://confluentinc.atlassian.net/browse/KSQL-14907

🤖 Generated with [Claude Code](https://claude.com/claude-code)