### PR TITLE
fix(rest-client): pass timeout to KsqlTarget ctor in async-null-resp test

### DIFF
--- a/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlTargetTest.java
+++ b/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlTargetTest.java
@@ -295,7 +295,7 @@ public class KsqlTargetTest {
     });
 
     ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST,
-        SUB_PATH, Collections.emptyMap());
+        SUB_PATH, Collections.emptyMap(), RequestOptions.DEFAULT_TIMEOUT);
 
     final CompletableFuture<RestResponse<HeartbeatResponse>> result =
         ksqlTarget.postAsyncHeartbeatRequest(new KsqlHostInfoEntity("h", 1), 0L);


### PR DESCRIPTION
## Summary

Compile fix for `ksqldb-rest-client` test code. Unblocks CI on `7.5.x` (and via pint forward-port, `7.6.x`–`7.9.x`–`8.0.x`).

## Problem

PR #11023 (for KSQL-14906) was authored on `7.4.x`, where `KsqlTarget`'s package-private constructor takes 7 args. The new regression test `shouldCompleteAsyncRequestExceptionallyWhenResponseIsNull` was written against that 7-arg signature.

On `7.5.x` and forward branches, the constructor was extended with an 8th `long timeout` argument. After pint-merge propagated the test up, the only call site that wasn't updated to the 8-arg form was mine, so the test now fails to compile:

```
[ERROR] /home/semaphore/ksql/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlTargetTest.java:[297,18] constructor KsqlTarget in class io.confluent.ksql.rest.client.KsqlTarget cannot be applied to given types;
[ERROR]   required: ..., java.util.Map<java.lang.String,java.lang.String>, long
[ERROR]   found:    ..., java.util.Map<java.lang.Object,java.lang.Object>
[ERROR]   reason: actual and formal argument lists differ in length
```

This breaks Maven `testCompile` on `ksqldb-rest-client`, taking down the test/packaging pipelines on every release branch from `7.5.x` through `7.9.x`.

## Fix

One-line change at `KsqlTargetTest.java:298` to pass `RequestOptions.DEFAULT_TIMEOUT` for the 8th argument — matching what every other constructor call in the same file does. The `io.vertx.core.http.RequestOptions` import is already present, so nothing else changes.

```diff
     ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST,
-        SUB_PATH, Collections.emptyMap());
+        SUB_PATH, Collections.emptyMap(), RequestOptions.DEFAULT_TIMEOUT);
```

## Verification

```bash
$ grep -nE "new KsqlTarget\(" ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlTargetTest.java
```

All 10 constructor invocations in the file now have the 8th `RequestOptions.DEFAULT_TIMEOUT` arg.

## Forward-port path

Once this lands on `7.5.x`, pint will forward-port through:

`7.5.x` → `7.6.x` → `7.7.x` → `7.8.x` → `7.9.x` → `8.0.x` (via the open #11025 merge-conflict PR)

— unblocking each branch's CI in turn.

## Test plan

- [x] `grep` confirms all 10 ctor calls in `KsqlTargetTest.java` are 8-arg
- [x] No other files reference the 7-arg constructor
- [ ] CI compiles `ksqldb-rest-client` test sources cleanly
- [ ] `KsqlTargetTest` still passes on 7.5.x