### PR TITLE
Merge Conflict Resolution (from 8.0.x to 8.1.x)

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -611,9 +611,10 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_SHARED_RUNTIME_ENABLED = "ksql.runtime.feature.shared.enabled";
   public static final Boolean KSQL_SHARED_RUNTIME_ENABLED_DEFAULT = false;
   public static final String KSQL_SHARED_RUNTIME_ENABLED_DOC =
-      "Feature flag for sharing streams runtimes. "
+      "Deprecated. Feature flag for sharing streams runtimes. "
           + "Default is false. If false, persistent queries will use separate "
-          + " runtimes, if true, new queries may share streams instances.";
+          + " runtimes, if true, new queries may share streams instances. "
+          + "This configuration is deprecated and will be removed in a future release.";
 
   public static final String KSQL_NEW_QUERY_PLANNER_ENABLED =
       "ksql.new.query.planner.enabled";
@@ -1691,6 +1692,13 @@ public class KsqlConfig extends AbstractConfig {
 
   public KsqlConfig(final Map<?, ?> props) {
     this(ConfigGeneration.CURRENT, props);
+    if (props.containsKey(KSQL_SHARED_RUNTIME_ENABLED)) {
+      LOG.warn(
+          "'{}' is deprecated and will be removed in a future release. "
+              + "Please remove this configuration from your settings.",
+          KSQL_SHARED_RUNTIME_ENABLED
+      );
+    }
   }
 
   private KsqlConfig(final ConfigGeneration generation, final Map<?, ?> props) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/SchemaRegistryUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/SchemaRegistryUtil.java
@@ -28,9 +28,11 @@ import io.confluent.ksql.util.ExecutorUtil;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.kafka.common.acl.AclOperation;
@@ -55,11 +57,29 @@ public final class SchemaRegistryUtil {
   public static void cleanupInternalTopicSchemas(
       final String applicationId,
       final SchemaRegistryClient schemaRegistryClient) {
-    getInternalSubjectNames(applicationId, schemaRegistryClient)
-        .forEach(subject -> tryDeleteInternalSubject(
-            applicationId,
-            schemaRegistryClient,
-            subject));
+    // Materialize once so we can log the matched set in a single line and then
+    // iterate it for deletion. The list is bounded by the topology size of one
+    // query (typically a handful of subjects: key/value of changelog/repartition
+    // per state store), so collecting in memory is fine.
+    final List<String> matchedSubjects =
+        getInternalSubjectNames(applicationId, schemaRegistryClient)
+            .collect(Collectors.toList());
+    if (!matchedSubjects.isEmpty()) {
+      // One INFO line per cleanup invocation lists every subject that will be
+      // soft- and hard-deleted. After KSQL-14907 this is the trace operators
+      // need to verify the prefix filter behaved correctly (no subjects of
+      // larger-numbered queries collected here). Skip when nothing matched:
+      // simple queries (e.g. plain CSAS without aggregation/repartition) have
+      // no internal subjects, so logging "matched 0" on every cleanup would be
+      // pure noise — the caller already logged "Deleting schemas for prefix
+      // <appId>" before invoking us.
+      LOG.info("Matched {} internal schema subject(s) for cleanup of \"{}\": {}",
+          matchedSubjects.size(), applicationId, matchedSubjects);
+      matchedSubjects.forEach(subject -> tryDeleteInternalSubject(
+          applicationId,
+          schemaRegistryClient,
+          subject));
+    }
   }
 
   public static Stream<String> getSubjectNames(final SchemaRegistryClient schemaRegistryClient) {
@@ -235,8 +255,18 @@ public final class SchemaRegistryUtil {
     final Stream<String> allSubjectNames = getSubjectNames(
         schemaRegistryClient,
         "Could not clean up the schema registry for query: " + applicationId);
+    // Append a "-" delimiter so an applicationId ending in a numeric suffix
+    // (e.g. "..._CTAS_FOO_1") does not prefix-match subjects of larger-numbered
+    // queries (e.g. "..._CTAS_FOO_17-..."). Kafka Streams' internal topic names
+    // are always built as "<applicationId>-<rawTopic>" (the "-" is hardcoded in
+    // `InternalTopologyBuilder#decorateTopic`), and SR subjects are derived as
+    // "<topicName>-(key|value)". So every internal subject for a given query
+    // begins with "<applicationId>-". The companion Kafka-topic cleanup path in
+    // `KafkaTopicClientImpl#isInternalTopic` already uses this same prefix
+    // shape; this filter just keeps the SR cleanup consistent with it.
+    final String prefix = applicationId + "-";
     return allSubjectNames
-        .filter(subjectName -> subjectName.startsWith(applicationId))
+        .filter(subjectName -> subjectName.startsWith(prefix))
         .filter(SchemaRegistryUtil::isInternalSubject);
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/schema/registry/SchemaRegistryUtilTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/schema/registry/SchemaRegistryUtilTest.java
@@ -131,44 +131,60 @@ public class SchemaRegistryUtilTest {
     assertThat(schemaAndId.get().getSchema(), equalTo(AVRO_SCHEMA));
   }
 
+  // The fixtures below all follow the canonical internal-subject shape
+  // "<applicationId>-<rawTopic>-(changelog|repartition)-(key|value)".
+  // Rationale (see also SchemaRegistryUtil#getInternalSubjectNames):
+  //  * Kafka Streams' `InternalTopologyBuilder#decorateTopic` unconditionally
+  //    builds internal topic names as "<applicationId>-<rawTopic>" — the "-"
+  //    is hardcoded, so every internal topic (and therefore every internal SR
+  //    subject) begins with "<applicationId>-".
+  //  * `KsqlConstants#getSRSubject` then appends "-key" or "-value", so a full
+  //    internal subject is "<applicationId>-<...>-(changelog|repartition)-(key|value)".
+  //  * The companion Kafka-topic cleanup at
+  //    `KafkaTopicClientImpl#isInternalTopic` already uses
+  //    `topicName.startsWith(applicationId + "-")` — these tests use the same
+  //    shape so the SR-side cleanup is exercised against realistic input.
+  // The pre-fix fixtures used "APP_ID + \"SOME-changelog-key\"" (no separator
+  // after the applicationId), which does not match anything Kafka Streams
+  // would actually emit and is what masked KSQL-14907.
   @Test
   public void shouldDeleteChangeLogTopicSchema() throws Exception {
     // Given:
     when(schemaRegistryClient.getAllSubjects()).thenReturn(ImmutableList.of(
-        APP_ID + "SOME-changelog-key",
-        APP_ID + "SOME-changelog-value"
+        APP_ID + "-SOME-changelog-key",
+        APP_ID + "-SOME-changelog-value"
     ));
 
     // When:
     SchemaRegistryUtil.cleanupInternalTopicSchemas(APP_ID, schemaRegistryClient);
 
     // Then not exception:
-    verify(schemaRegistryClient).deleteSubject(APP_ID + "SOME-changelog-key");
-    verify(schemaRegistryClient).deleteSubject(APP_ID + "SOME-changelog-value");
+    verify(schemaRegistryClient).deleteSubject(APP_ID + "-SOME-changelog-key");
+    verify(schemaRegistryClient).deleteSubject(APP_ID + "-SOME-changelog-value");
   }
 
   @Test
   public void shouldDeleteRepartitionTopicSchema() throws Exception {
     // Given:
     when(schemaRegistryClient.getAllSubjects()).thenReturn(ImmutableList.of(
-        APP_ID + "SOME-repartition-key",
-        APP_ID + "SOME-repartition-value"
+        APP_ID + "-SOME-repartition-key",
+        APP_ID + "-SOME-repartition-value"
     ));
 
     // When:
     SchemaRegistryUtil.cleanupInternalTopicSchemas(APP_ID, schemaRegistryClient);
 
     // Then not exception:
-    verify(schemaRegistryClient).deleteSubject(APP_ID + "SOME-repartition-key");
-    verify(schemaRegistryClient).deleteSubject(APP_ID + "SOME-repartition-value");
+    verify(schemaRegistryClient).deleteSubject(APP_ID + "-SOME-repartition-key");
+    verify(schemaRegistryClient).deleteSubject(APP_ID + "-SOME-repartition-value");
   }
 
   @Test
   public void shouldHardDeleteIfFlagSet() throws Exception {
     // Given:
     when(schemaRegistryClient.getAllSubjects()).thenReturn(ImmutableList.of(
-        APP_ID + "SOME-repartition-key",
-        APP_ID + "SOME-repartition-value"
+        APP_ID + "-SOME-repartition-key",
+        APP_ID + "-SOME-repartition-value"
     ));
 
     // When:
@@ -176,18 +192,18 @@ public class SchemaRegistryUtilTest {
 
     // Then not exception:
     final InOrder inOrder = inOrder(schemaRegistryClient);
-    inOrder.verify(schemaRegistryClient).deleteSubject(APP_ID + "SOME-repartition-key");
-    inOrder.verify(schemaRegistryClient).deleteSubject(APP_ID + "SOME-repartition-key", true);
-    inOrder.verify(schemaRegistryClient).deleteSubject(APP_ID + "SOME-repartition-value");
-    inOrder.verify(schemaRegistryClient).deleteSubject(APP_ID + "SOME-repartition-value", true);
+    inOrder.verify(schemaRegistryClient).deleteSubject(APP_ID + "-SOME-repartition-key");
+    inOrder.verify(schemaRegistryClient).deleteSubject(APP_ID + "-SOME-repartition-key", true);
+    inOrder.verify(schemaRegistryClient).deleteSubject(APP_ID + "-SOME-repartition-value");
+    inOrder.verify(schemaRegistryClient).deleteSubject(APP_ID + "-SOME-repartition-value", true);
   }
 
   @Test
   public void shouldNotDeleteOtherSchemasForThisApplicationId() throws Exception {
     // Given:
     when(schemaRegistryClient.getAllSubjects()).thenReturn(ImmutableList.of(
-        APP_ID + "SOME-other-key",
-        APP_ID + "SOME-other-value"
+        APP_ID + "-SOME-other-key",
+        APP_ID + "-SOME-other-value"
     ));
 
     // When:
@@ -195,6 +211,53 @@ public class SchemaRegistryUtilTest {
 
     // Then not exception:
     verify(schemaRegistryClient, never()).deleteSubject(any());
+  }
+
+  @Test
+  public void shouldNotDeleteSchemasOfLargerNumberedQueryWithSamePrefix() throws Exception {
+    // Regression for KSQL-14907.
+    //
+    // Production scenario this models:
+    //   * A user issued >=10 CREATE OR REPLACE TABLE FOO AS SELECT ..., so KSQL had
+    //     advanced its query name from CTAS_FOO_1 to CTAS_FOO_17.
+    //   * Stale local state from CTAS_FOO_1 lingered on a pod's PV (KSQL logs the
+    //     "race condition when the query was dropped before" WARN in this case).
+    //   * On a subsequent pod restart, QueryCleanupService scheduled cleanup for
+    //     the orphaned single-digit applicationId.
+    //
+    // Pre-fix bug: `getInternalSubjectNames` used `startsWith(applicationId)` with
+    // no terminator, so cleanup for "..._CTAS_FOO_1" matched the four active
+    // subjects of "..._CTAS_FOO_17-..." and proceeded to soft- then hard-delete
+    // them — wiping the running materialized table's schemas.
+    //
+    // Post-fix: `getInternalSubjectNames` uses `startsWith(applicationId + "-")`.
+    // Since "..._CTAS_FOO_17-..." does not start with "..._CTAS_FOO_1-" (the
+    // character after "_FOO_1" is "7", not "-"), nothing is matched and nothing
+    // is deleted. This is the only behavioural change vs. the old filter.
+    //
+    // Given:
+    final String singleDigitAppId = "_confluent-ksql-default_query_CTAS_FOO_1";
+    final String activeAppId = "_confluent-ksql-default_query_CTAS_FOO_17";
+    when(schemaRegistryClient.getAllSubjects()).thenReturn(ImmutableList.of(
+        // Active (running) query's internal subjects — must NOT be deleted.
+        // Shape "<activeAppId>-<storeName>-(changelog|repartition)-(key|value)"
+        // matches what Kafka Streams' `InternalTopologyBuilder#decorateTopic`
+        // actually emits (the "-" between applicationId and storeName is
+        // hardcoded there).
+        activeAppId + "-Aggregate-Aggregate-Materialize-changelog-key",
+        activeAppId + "-Aggregate-Aggregate-Materialize-changelog-value",
+        activeAppId + "-Join-repartition-key",
+        activeAppId + "-Join-repartition-value"
+    ));
+
+    // When: cleanup for the older single-digit query.
+    SchemaRegistryUtil.cleanupInternalTopicSchemas(singleDigitAppId, schemaRegistryClient);
+
+    // Then: nothing deleted — none of the active query's subjects share the
+    // "<singleDigitAppId>-" prefix (because "<singleDigitAppId>" is followed by
+    // "7", not "-", in the active query's subject names).
+    verify(schemaRegistryClient, never()).deleteSubject(any());
+    verify(schemaRegistryClient, never()).deleteSubject(any(), any(Boolean.class));
   }
 
   @Test
@@ -228,8 +291,8 @@ public class SchemaRegistryUtilTest {
   public void shouldNotThrowIfDeleteSubjectThrows() throws Exception {
     // Given:
     when(schemaRegistryClient.getAllSubjects()).thenReturn(ImmutableList.of(
-        APP_ID + "SOME-changelog-key",
-        APP_ID + "SOME-changelog-value"
+        APP_ID + "-SOME-changelog-key",
+        APP_ID + "-SOME-changelog-value"
     ));
 
     when(schemaRegistryClient.deleteSubject(any())).thenThrow(new RuntimeException("Boom!"));
@@ -238,16 +301,16 @@ public class SchemaRegistryUtilTest {
     SchemaRegistryUtil.cleanupInternalTopicSchemas(APP_ID, schemaRegistryClient);
 
     // Then not exception:
-    verify(schemaRegistryClient, times(5)).deleteSubject(APP_ID + "SOME-changelog-key");
-    verify(schemaRegistryClient, times(5)).deleteSubject(APP_ID + "SOME-changelog-value");
+    verify(schemaRegistryClient, times(5)).deleteSubject(APP_ID + "-SOME-changelog-key");
+    verify(schemaRegistryClient, times(5)).deleteSubject(APP_ID + "-SOME-changelog-value");
   }
 
   @Test
   public void shouldNotRetryIf40401() throws Exception {
     // Given:
     when(schemaRegistryClient.getAllSubjects()).thenReturn(ImmutableList.of(
-        APP_ID + "SOME-changelog-key",
-        APP_ID + "SOME-changelog-value"
+        APP_ID + "-SOME-changelog-key",
+        APP_ID + "-SOME-changelog-value"
     ));
 
     when(schemaRegistryClient.deleteSubject(any())).thenThrow(new RestClientException("foo", 404, 40401));
@@ -256,8 +319,8 @@ public class SchemaRegistryUtilTest {
     SchemaRegistryUtil.cleanupInternalTopicSchemas(APP_ID, schemaRegistryClient);
 
     // Then not exception (only tried once):
-    verify(schemaRegistryClient, times(1)).deleteSubject(APP_ID + "SOME-changelog-key");
-    verify(schemaRegistryClient, times(1)).deleteSubject(APP_ID + "SOME-changelog-value");
+    verify(schemaRegistryClient, times(1)).deleteSubject(APP_ID + "-SOME-changelog-key");
+    verify(schemaRegistryClient, times(1)).deleteSubject(APP_ID + "-SOME-changelog-value");
   }
 
   @Test

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
@@ -327,6 +327,17 @@ public final class KsqlTarget {
       final Function<ResponseWithBody, T> mapper
   ) {
     return executeAsync(httpMethod, path, Optional.empty(), jsonEntity, mapper, (resp, vcf) -> {
+      // Vert.x can invoke this handler with a null response when the underlying
+      // HTTP connection is closed before any response is received (e.g. peer pod
+      // restart, TCP reset, idle keepalive timeout). Without this guard the NPE
+      // would propagate up the event loop as an unhandled exception and crash
+      // the JVM.
+      if (resp == null) {
+        vcf.completeExceptionally(new KsqlRestClientException(
+            "Inter-pod HTTP response was null (connection closed before response "
+                + "received) for " + httpMethod + " " + path));
+        return;
+      }
       resp.bodyHandler(buff -> vcf.complete(new ResponseWithBody(resp, buff)));
     });
   }

--- a/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlTargetTest.java
+++ b/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlTargetTest.java
@@ -18,6 +18,8 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.properties.LocalProperties;
 import io.confluent.ksql.rest.client.exception.KsqlRestClientException;
+import io.confluent.ksql.rest.entity.HeartbeatResponse;
+import io.confluent.ksql.rest.entity.KsqlHostInfoEntity;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
@@ -292,6 +294,41 @@ public class KsqlTargetTest {
     assertThatEventually(response::get, notNullValue());
     assertThat(response.get().getResponse(), is (2));
     assertThat(rows.size(), is (2));
+  }
+
+  @Test
+  public void shouldCompleteAsyncRequestExceptionallyWhenResponseIsNull() throws Exception {
+    // Regression for KSQL-14906: when the underlying HTTP connection is closed before any
+    // response is received, Vert.x can invoke the response handler with a null result. The
+    // async path must complete the future exceptionally with a KsqlRestClientException
+    // rather than letting an NPE escape onto the event loop and crash the JVM.
+    when(httpClientRequest.response(any(Handler.class))).thenAnswer(a -> {
+      final Handler<AsyncResult<HttpClientResponse>> handler = a.getArgument(0);
+      vertx.runOnContext(v -> {
+        handler.handle(Future.succeededFuture(null));
+        requestStarted.set(true);
+      });
+      return null;
+    });
+
+    ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST,
+        SUB_PATH, Collections.emptyMap(), RequestOptions.DEFAULT_TIMEOUT);
+
+    final CompletableFuture<RestResponse<HeartbeatResponse>> result =
+        ksqlTarget.postAsyncHeartbeatRequest(new KsqlHostInfoEntity("h", 1), 0L);
+
+    assertThatEventually(requestStarted::get, is(true));
+    assertThatEventually(result::isCompletedExceptionally, is(true));
+
+    Throwable cause = null;
+    try {
+      result.get();
+    } catch (final Exception e) {
+      cause = e.getCause();
+    }
+    assertThat(cause, instanceOf(KsqlRestClientException.class));
+    assertThat(cause.getMessage(), containsString("Inter-pod HTTP response was null"));
+    assertThat(cause.getMessage(), containsString("/heartbeat"));
   }
 
   @Test

--- a/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlTargetTest.java
+++ b/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlTargetTest.java
@@ -18,6 +18,8 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.properties.LocalProperties;
 import io.confluent.ksql.rest.client.exception.KsqlRestClientException;
+import io.confluent.ksql.rest.entity.HeartbeatResponse;
+import io.confluent.ksql.rest.entity.KsqlHostInfoEntity;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
@@ -292,6 +294,41 @@ public class KsqlTargetTest {
     assertThatEventually(response::get, notNullValue());
     assertThat(response.get().getResponse(), is (2));
     assertThat(rows.size(), is (2));
+  }
+
+  @Test
+  public void shouldCompleteAsyncRequestExceptionallyWhenResponseIsNull() throws Exception {
+    // Regression for KSQL-14906: when the underlying HTTP connection is closed before any
+    // response is received, Vert.x can invoke the response handler with a null result. The
+    // async path must complete the future exceptionally with a KsqlRestClientException
+    // rather than letting an NPE escape onto the event loop and crash the JVM.
+    when(httpClientRequest.response(any(Handler.class))).thenAnswer(a -> {
+      final Handler<AsyncResult<HttpClientResponse>> handler = a.getArgument(0);
+      vertx.runOnContext(v -> {
+        handler.handle(Future.succeededFuture(null));
+        requestStarted.set(true);
+      });
+      return null;
+    });
+
+    ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST,
+        SUB_PATH, Collections.emptyMap());
+
+    final CompletableFuture<RestResponse<HeartbeatResponse>> result =
+        ksqlTarget.postAsyncHeartbeatRequest(new KsqlHostInfoEntity("h", 1), 0L);
+
+    assertThatEventually(requestStarted::get, is(true));
+    assertThatEventually(result::isCompletedExceptionally, is(true));
+
+    Throwable cause = null;
+    try {
+      result.get();
+    } catch (final Exception e) {
+      cause = e.getCause();
+    }
+    assertThat(cause, instanceOf(KsqlRestClientException.class));
+    assertThat(cause.getMessage(), containsString("Inter-pod HTTP response was null"));
+    assertThat(cause.getMessage(), containsString("/heartbeat"));
   }
 
   @Test

--- a/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlTargetTest.java
+++ b/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlTargetTest.java
@@ -312,7 +312,7 @@ public class KsqlTargetTest {
     });
 
     ksqlTarget = new KsqlTarget(httpClient, socketAddress, localProperties, authHeader, HOST,
-        SUB_PATH, Collections.emptyMap());
+        SUB_PATH, Collections.emptyMap(), RequestOptions.DEFAULT_TIMEOUT);
 
     final CompletableFuture<RestResponse<HeartbeatResponse>> result =
         ksqlTarget.postAsyncHeartbeatRequest(new KsqlHostInfoEntity("h", 1), 0L);


### PR DESCRIPTION
# What is this pull request?

This PR resolves the failed `pint merge` of 8.0.x → 8.1.x. The pint job ([Semaphore log](https://semaphore.ci.confluent.io/jobs/...)) reported conflicts in `pom.xml` and `ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlTargetTest.java` for 3 commits.

# What's in 8.0.x that needed to come over

The four commits new on 8.0.x since 8.1.x (i.e. `git log 8.1.x..8.0.x`):

1. `61c509ed599` — Merge branch '7.9.x' into 8.0.x (PR #11025)
2. `01b01c1f5c3` — fix(rest-client): pass timeout to KsqlTarget ctor in async-null-resp test
3. `28ad2a9f12b` — Merge remote-tracking branch 'origin/7.9.x' into pr_merge_from_7_9_x_to_8_0_x
4. `4882b520267` — Merge pull request #11025

These represent the cumulative fix for KSQL-14906 / KSQL-14907 (`KsqlTarget` NPE + `SchemaRegistryUtil` prefix-collision) that landed on 7.4.x and forward-ported through 7.5.x..7.9.x..8.0.x via cascade.

# Conflict resolution

When I ran the merge locally as a single 3-way merge from 8.1.x into 8.0.x's tip, **`git merge` auto-resolved with no manual intervention**:

```
$ git merge origin/8.0.x
Merge made by the 'ort' strategy.
 .../io/confluent/ksql/util/KsqlConfig.java          |  12 ++-
 .../ksql/schema/registry/SchemaRegistryUtil.java    |  42 ++++++--
 .../schema/registry/SchemaRegistryUtilTest.java     | 111 ++++++++++++++++-----
 .../io/confluent/ksql/rest/client/KsqlTarget.java   |  11 ++
 .../confluent/ksql/rest/client/KsqlTargetTest.java  |  37 +++++++
 5 files changed, 181 insertions(+), 32 deletions(-)
```

Pint reported conflicts because it tries each root commit in isolation (`git merge X1`, abort, `git merge X2`, abort, ...) — when each commit is merged alone, the cumulative state isn't available, so each one collides with the prior pint "ours" skip-merges on 8.1.x. Doing the merge against 8.0.x's tip (cumulative) gives git enough context to auto-resolve.

# Verified outputs

- **`pom.xml`** is byte-identical to 8.1.x's pre-merge state (no real divergence to resolve).
- **`KsqlTargetTest.java`** has all 10 `new KsqlTarget(...)` calls in 8-arg form with `RequestOptions.DEFAULT_TIMEOUT`. The new `shouldCompleteAsyncRequestExceptionallyWhenResponseIsNull` test landed cleanly with the constructor-arity fix integrated.
- **`SchemaRegistryUtil.java`** preserves 8.1.x's Log4j2 logger imports while incorporating the new `applicationId + "-"` prefix filter and `LOG.info` matched-subject log line.
- **`KsqlTarget.java`** has the `executeRequestAsync` null-resp guard.

# Next Steps

1. Review the resolution.
2. Obtain approvals.
3. **(IMPORTANT)** After approval, click the dropdown on the merge button and select **"Create a merge commit"** — squashing would drop the 4 individual SHAs from 8.1.x's history, breaking the changelog generator and pint's tracking.
4. Click "Merge pull request".
5. Re-run [`pint merge`](http://go/pint-merge-service) to continue cascading 8.1.x → 8.2.x → 8.3.x → master.