### PR TITLE
fix: [KSQL-14915] retry admin statements on transient topic-not-found errors

### DIFF
--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
@@ -80,6 +80,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import joptsimple.internal.Strings;
@@ -362,15 +363,33 @@ public class RestTestExecutor implements Closeable {
     final String sql = statements.stream()
         .collect(Collectors.joining(System.lineSeparator()));
 
-    final RestResponse<KsqlEntityList> resp = restClient.makeKsqlRequest(sql);
+    // Retry on transient "topic does not exist" errors caused by Kafka metadata propagation lag:
+    // topic creation succeeds from the test's perspective but ksqlDB's admin client may not see
+    // it yet when executing CREATE STREAM/TABLE without explicit PARTITIONS.
+    final AtomicReference<RestResponse<KsqlEntityList>> responseRef = new AtomicReference<>();
+    RetryUtil.retryWithBackoff(
+        10,
+        500,
+        (int) TimeUnit.SECONDS.toMillis(5),
+        () -> {
+          final RestResponse<KsqlEntityList> resp = restClient.makeKsqlRequest(sql);
+          if (resp.isErroneous()
+              && !testCase.expectedError().isPresent()
+              && resp.getErrorMessage().getMessage().contains("does not exist")) {
+            throw new RuntimeException(
+                "Topic metadata not yet propagated: " + resp.getErrorMessage().getMessage());
+          }
+          responseRef.set(resp);
+        }
+    );
 
+    final RestResponse<KsqlEntityList> resp = responseRef.get();
     if (resp.isErroneous()) {
       handleErrorResponse(testCase, resp);
       return Optional.empty();
     }
 
-    final KsqlEntityList entity = resp.getResponse();
-    return Optional.of(RqttResponse.admin(entity));
+    return Optional.of(RqttResponse.admin(resp.getResponse()));
   }
 
   private List<RqttResponse> sendQueryStatements(


### PR DESCRIPTION
## Summary

- `RestQueryTranslationTest` was flaky because `initializeTopics` creates Kafka topics via the test's admin client, but ksqlDB's own Kafka admin client can lag on metadata propagation — causing `CREATE STREAM/TABLE` to fail with `Topic does not exist`
- Added retry logic in `sendAdminStatements` using `RetryUtil.retryWithBackoff` (10 retries, 500ms→5s backoff), consistent with how `initializeTopics` already handles topic-deletion lag
- Retries are skipped when the test case expects an error, so expected-error test paths are unaffected

## Jira

[KSQL-14915](https://confluentinc.atlassian.net/browse/KSQL-14915)

## Test plan

- [ ] Existing `RestQueryTranslationTestBatch*` tests cover this path — the fix prevents the race rather than adding new cases
- [ ] Verified retry only triggers on "does not exist" errors with no expected error in the test case

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KSQL-14915]: https://confluentinc.atlassian.net/browse/KSQL-14915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ