### PR TITLE
fix: [KSQL-14915] always retry admin stmts on topic-not-found, even with expectedError

### DIFF
--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
@@ -374,7 +374,6 @@ public class RestTestExecutor implements Closeable {
         () -> {
           final RestResponse<KsqlEntityList> resp = restClient.makeKsqlRequest(sql);
           if (resp.isErroneous()
-              && !testCase.expectedError().isPresent()
               && resp.getErrorMessage().getMessage().contains("does not exist")) {
             throw new RuntimeException(
                 "Topic metadata not yet propagated: " + resp.getErrorMessage().getMessage());


### PR DESCRIPTION
## Summary

- `sendAdminStatements` in `RestTestExecutor` retried transient "topic does not exist" errors (Kafka metadata propagation lag) only when `expectedError` was absent on the test case.
- Tests that expect a *semantic* error (e.g. `"WHERE clause missing key column"`) on a **SELECT** can still hit propagation lag on the preceding **CREATE STREAM**, causing the wrong error to surface and the assertion to fail — seen as a flaky failure in `RestQueryTranslationTestBatch2`.
- Drop the `!testCase.expectedError().isPresent()` guard so any "does not exist" response is always retried, letting setup statements complete before the expected-error statement runs.

## Test plan

- [ ] Existing `RestQueryTranslationTest` batch suite covers this path — the failing test (`pull-queries-against-materialized-aggregates - fail on unsupported query feature: where missing key column`) should now pass reliably.
- [ ] No new tests needed; this is a one-line test-infrastructure fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)