### PR TITLE
fix: [KSQL-14922] wait for degraded state before stopping server in RestoreCommandTopicIntegrationTest (7.5.x)

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/RestoreCommandTopicIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/RestoreCommandTopicIntegrationTest.java
@@ -203,6 +203,7 @@ public class RestoreCommandTopicIntegrationTest {
 
     // Delete the command topic again and restore with skip flag
     TEST_HARNESS.deleteTopics(Collections.singletonList(commandTopic));
+    assertThatEventually("Degraded State", this::isDegradedState, is(true));
     REST_APP.stop();
     KsqlRestoreCommandTopic.mainInternal(
         new String[]{
@@ -269,6 +270,7 @@ public class RestoreCommandTopicIntegrationTest {
 
     // Delete the command topic again and restore with skip flag
     TEST_HARNESS.deleteTopics(Collections.singletonList(commandTopic));
+    assertThatEventually("Degraded State", this::isDegradedState, is(true));
     REST_APP.stop();
     KsqlRestoreCommandTopic.mainInternal(
         new String[]{
@@ -318,6 +320,7 @@ public class RestoreCommandTopicIntegrationTest {
 
     // Delete the command topic again and restore with skip flag
     TEST_HARNESS.deleteTopics(Collections.singletonList(commandTopic));
+    assertThatEventually("Degraded State", this::isDegradedState, is(true));
     REST_APP.stop();
     KsqlRestoreCommandTopic.mainInternal(
         new String[]{


### PR DESCRIPTION
## Summary

- Fixes `shouldSkipIncompatibleCommands`, `shouldSkipIncompatibleCommandsWithExecutionPlan`, and `shouldHandleIncompatibleCommandsWithNoQueryPlan` in `RestoreCommandTopicIntegrationTest`
- Adds `assertThatEventually("Degraded State", ...)` between command topic deletion and `REST_APP.stop()` in all three affected tests
- Backport of KSQL-14922 fix from 7.9.x to 7.5.x

## Root Cause

When the command topic is deleted, the ksqlDB server's transactional producer (transactional ID `default_`) may still be active. Stopping the server immediately after deletion leaves the producer in an uncertain state on the broker. The restore tool then fails when it tries to initialize a new transactional producer with the same transactional ID via `kafkaProducer.initTransactions()`.

The fix waits for the server to enter DEGRADED state (confirming it has detected the missing topic and stabilized) before stopping — exactly the same pattern already used in the passing `shouldBackupAndRestoreCommandTopic` test.

## Test plan

- [ ] `RestoreCommandTopicIntegrationTest.shouldSkipIncompatibleCommands`
- [ ] `RestoreCommandTopicIntegrationTest.shouldSkipIncompatibleCommandsWithExecutionPlan`
- [ ] `RestoreCommandTopicIntegrationTest.shouldHandleIncompatibleCommandsWithNoQueryPlan`

Jira: https://confluentinc.atlassian.net/browse/KSQL-14922

🤖 Generated with [Claude Code](https://claude.com/claude-code)