### PR TITLE
fix: update Kafka internal utils imports broken by KAFKA-20297

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -56,7 +56,7 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.config.internals.ConfluentConfigs;
-import org.apache.kafka.common.utils.AppInfoParser;
+import org.apache.kafka.common.utils.internals.AppInfoParser;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
@@ -32,7 +32,7 @@ import javax.net.ssl.SSLContext;
 import org.apache.kafka.common.config.internals.ConfluentConfigs;
 import org.apache.kafka.common.security.auth.SslEngineFactory;
 import org.apache.kafka.common.security.ssl.DefaultSslEngineFactory;
-import org.apache.kafka.common.utils.SecurityUtils;
+import org.apache.kafka.common.utils.internals.SecurityUtils;
 
 /**
  * Configurable Schema Registry client factory, enabling SSL.


### PR DESCRIPTION
### Description

Fixes compilation failures caused by [apache/kafka@10805c9](https://github.com/apache/kafka/commit/10805c9782a2285a77fb0bf922db05590afb2704) (**KAFKA-20297: Move SecurityUtils, ConfigUtils, LogContext, AppInfoParser into internal package**).

That upstream Kafka change relocated several utility classes from the public `org.apache.kafka.common.utils` package into `org.apache.kafka.common.utils.internals` to clarify they were never intended as external API. This broke two ksqldb compilation targets.

**Changes:**

1. **`ksqldb-common` — `KsqlConfig.java`**
   - Updated import: `org.apache.kafka.common.utils.AppInfoParser` → `org.apache.kafka.common.utils.internals.AppInfoParser`

2. **`ksqldb-engine` — `KsqlSchemaRegistryClientFactory.java`**
   - Updated import: `org.apache.kafka.common.utils.SecurityUtils` → `org.apache.kafka.common.utils.internals.SecurityUtils`
   - No call-site changes needed; `addConfiguredSecurityProviders` signature is unchanged.

The other two classes moved by KAFKA-20297 (`ConfigUtils`, `LogContext`) were verified to have no usages in this codebase from the old package path.

