### PR TITLE
KSQL-14984: demote client-side request failures from ERROR to DEBUG/WARN

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/FailureHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/FailureHandler.java
@@ -41,13 +41,10 @@ public class FailureHandler implements Handler<RoutingContext> {
     final int statusCode = routingContext.statusCode();
     final Throwable failure = routingContext.failure();
     // Don't log the failure, since it may contain sensitive information meant for the user.
-    log.error(
-        String.format(
-            "Failed to handle request %d %s",
-            routingContext.statusCode(),
-            routingContext.request().path()
-        )
-    );
+    // 4xx responses are client errors (auth failures, malformed requests, scanner traffic);
+    // logging them as DEBUG avoids drowning real server errors. Genuine 5xx server errors
+    // remain at ERROR.
+    logRequestFailure(statusCode, routingContext.request().path());
 
 
     if (failure != null) {
@@ -79,6 +76,17 @@ public class FailureHandler implements Handler<RoutingContext> {
       }
     } else {
       routingContext.response().setStatusCode(statusCode).end();
+    }
+  }
+
+  private static void logRequestFailure(final int statusCode, final String path) {
+    final String message = String.format("Failed to handle request %d %s", statusCode, path);
+    if (statusCode >= 500) {
+      log.error(message);
+    } else if (statusCode >= 400) {
+      log.debug(message);
+    } else {
+      log.info(message);
     }
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/LoggingHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/LoggingHandler.java
@@ -136,8 +136,12 @@ public class LoggingHandler implements Handler<RoutingContext> {
   }
 
   private void doLog(final int status, final String message) {
+    // This is the request access log, not the server error log. Even 5xx access-log lines
+    // are routinely emitted for scanner traffic (e.g. Qualys probes hitting unknown paths)
+    // and during boot-time 503s, which doesn't warrant an ERROR-level entry. Genuine server
+    // exceptions are logged separately by FailureHandler and the Vert.x exception handlers.
     if (status >= 500) {
-      logger.error(message);
+      logger.warn(message);
     } else if (status >= 400) {
       logger.warn(message);
     } else {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -30,7 +30,6 @@ import io.confluent.ksql.rest.entity.KsqlMediaType;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.entity.LagReportingMessage;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
-import io.netty.handler.codec.haproxy.HAProxyProtocolException;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
 import io.vertx.core.http.HttpHeaders;
@@ -42,7 +41,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
-import java.nio.channels.ClosedChannelException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -415,13 +413,9 @@ public class ServerVerticle extends AbstractVerticle {
   }
 
   private static void unhandledExceptionHandler(final Throwable t) {
-    if (t instanceof ClosedChannelException) {
-      log.debug("Unhandled ClosedChannelException (connection likely closed early)", t);
-    } else if (t instanceof HAProxyProtocolException) {
-      log.error("Failed to decode proxy protocol header", t);
-    } else {
-      log.error("Unhandled exception", t);
-    }
+    // Delegate to ApiServerUtils so the two Vert.x exception handlers stay in sync
+    // (notably for demoting client-side TLS / HTTP framing failures to DEBUG).
+    io.confluent.ksql.api.util.ApiServerUtils.unhandledExceptionHandler(t);
   }
 
   /**

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/SniHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/SniHandler.java
@@ -39,7 +39,10 @@ public class SniHandler implements Handler<RoutingContext> {
         // sometimes the port is present in the host header, remove it
         final String requestHostNoPort = requestHost.replaceFirst(":\\d+", "");
         if (!requestHostNoPort.equals(indicatedServerName)) {
-          log.error(String.format(
+          // SNI mismatches are client-side misconfigurations (wrong host, IP-based access,
+          // cross-listener traffic). The request is rejected with MISDIRECTED_REQUEST, so
+          // there's nothing for the server operator to act on; log at DEBUG.
+          log.debug(String.format(
               "Sni check failed, host header: %s, sni value %s",
               requestHostNoPort,
               indicatedServerName)

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/util/ApiServerUtils.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/util/ApiServerUtils.java
@@ -24,8 +24,6 @@ import io.confluent.ksql.util.QueryMask;
 import io.confluent.ksql.util.VertxSslOptionsFactory;
 import io.netty.handler.codec.haproxy.HAProxyProtocolException;
 import io.netty.handler.codec.http.InvalidLineSeparatorException;
-import io.netty.handler.ssl.NotSslRecordException;
-import io.netty.handler.ssl.SslHandshakeTimeoutException;
 import io.vertx.core.http.ClientAuth;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerOptions;
@@ -86,9 +84,9 @@ public final class ApiServerUtils {
   }
 
   private static boolean isClientSideConnectionFailure(final Throwable t) {
+    // SSLException covers handshake/protocol failures and netty subclasses
+    // (NotSslRecordException, SslHandshakeTimeoutException, SSLHandshakeException, ...).
     return t instanceof SSLException
-        || t instanceof NotSslRecordException
-        || t instanceof SslHandshakeTimeoutException
         || t instanceof SocketException
         || t instanceof InvalidLineSeparatorException;
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/util/ApiServerUtils.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/util/ApiServerUtils.java
@@ -23,6 +23,9 @@ import io.confluent.ksql.util.FileWatcher.Callback;
 import io.confluent.ksql.util.QueryMask;
 import io.confluent.ksql.util.VertxSslOptionsFactory;
 import io.netty.handler.codec.haproxy.HAProxyProtocolException;
+import io.netty.handler.codec.http.InvalidLineSeparatorException;
+import io.netty.handler.ssl.NotSslRecordException;
+import io.netty.handler.ssl.SslHandshakeTimeoutException;
 import io.vertx.core.http.ClientAuth;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerOptions;
@@ -31,6 +34,7 @@ import io.vertx.core.net.JksOptions;
 import io.vertx.core.net.KeyStoreOptions;
 import io.vertx.core.net.PfxOptions;
 import io.vertx.ext.web.RoutingContext;
+import java.net.SocketException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.channels.ClosedChannelException;
@@ -42,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import javax.net.ssl.SSLException;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.logging.log4j.LogManager;
@@ -68,11 +73,24 @@ public final class ApiServerUtils {
   public static void unhandledExceptionHandler(final Throwable t) {
     if (t instanceof ClosedChannelException) {
       LOG.debug("Unhandled ClosedChannelException (connection likely closed early)", t);
+    } else if (isClientSideConnectionFailure(t)) {
+      // TLS/HTTP framing errors from misconfigured clients, port scanners, or Kafka-protocol
+      // traffic sent to the HTTPS endpoint. There is no server-side action available; logging
+      // these at ERROR floods the error log with internet noise.
+      LOG.debug("Unhandled exception (client-side connection failure)", t);
     } else if (t instanceof HAProxyProtocolException) {
       LOG.error("Failed to decode proxy protocol header", t);
     } else {
       LOG.error("Unhandled exception", t);
     }
+  }
+
+  private static boolean isClientSideConnectionFailure(final Throwable t) {
+    return t instanceof SSLException
+        || t instanceof NotSslRecordException
+        || t instanceof SslHandshakeTimeoutException
+        || t instanceof SocketException
+        || t instanceof InvalidLineSeparatorException;
   }
 
   public static void chcHandler(final RoutingContext routingContext) {


### PR DESCRIPTION
## Summary
reduce the redundant logs

Linked: KSQL-14984.

## Test plan

- [x] `mvn -pl ksqldb-rest-app test -Dtest='LoggingHandlerTest,SniHandlerTest,ApiServerUtilsTest'` — 30/30 passing
- [x] `mvn -pl ksqldb-rest-app checkstyle:check` — clean
- [ ] Full CI run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)