### PR TITLE
KSQL-14999 | TransientQueryCleanup leak-detection ordering + TransientQueryQueue LIMIT-handler null-guard

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/TransientQueryCleanupService.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/TransientQueryCleanupService.java
@@ -173,13 +173,20 @@ public class TransientQueryCleanupService extends AbstractScheduledService {
   }
 
   boolean isLeaked(final String resource) {
+    // Always rule out resources owned by a currently live query — even if the
+    // resource happens to appear in localCommandsQueryAppIds (e.g., a stale
+    // local-commands file referencing a query that has since been restarted).
+    // Without this guard, the local-commands branch returned true uncondition-
+    // ally and the running query's topics / state dirs would be deleted under
+    // it. This is also robust against the substring-based matching inside
+    // foundInLocalCommands.
+    if (!isCorrespondingQueryTerminated(resource)) {
+      return false;
+    }
     if (foundInLocalCommands(resource)) {
       return true;
     }
     if (!internalTopicPrefixPattern.matcher(resource).find()) {
-      return false;
-    }
-    if (!isCorrespondingQueryTerminated(resource)) {
       return false;
     }
     final Matcher appIdMatcher = transientAppIdPattern.matcher(resource);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/TransientQueryQueue.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/TransientQueryQueue.java
@@ -187,9 +187,8 @@ public class TransientQueryQueue implements BlockingRowQueue {
       // streams thread NPE's and the query terminates. setLimitHandler's own
       // passedLimit() block fires limitReached once the handler is finally
       // installed, so dropping it here is safe.
-      final LimitHandler handler = limitHandler;
-      if (handler != null) {
-        handler.limitReached();
+      if (limitHandler != null) {
+        limitHandler.limitReached();
       }
     }
     if (queuedCallback != null) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/TransientQueryQueue.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/TransientQueryQueue.java
@@ -181,7 +181,16 @@ public class TransientQueryQueue implements BlockingRowQueue {
   private void onQueued() {
     if (remaining != null && remaining.decrementAndGet() <= 0) {
       invokedHandler.set(true);
-      limitHandler.limitReached();
+      // limitHandler is set by the REST resource AFTER the query starts
+      // producing rows, so for small LIMITs the streams thread can hit the
+      // limit before setLimitHandler runs. Without this null-check, the
+      // streams thread NPE's and the query terminates. setLimitHandler's own
+      // passedLimit() block fires limitReached once the handler is finally
+      // installed, so dropping it here is safe.
+      final LimitHandler handler = limitHandler;
+      if (handler != null) {
+        handler.limitReached();
+      }
     }
     if (queuedCallback != null) {
       queuedCallback.run();

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/TransientQueryQueue.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/TransientQueryQueue.java
@@ -42,7 +42,11 @@ public class TransientQueryQueue implements BlockingRowQueue {
   private final int offerTimeoutMs;
   private volatile boolean closed = false;
   private final AtomicInteger remaining;
-  private LimitHandler limitHandler;
+  // volatile so the Streams thread reading in onQueued() observes the
+  // assignment done by the REST thread in setLimitHandler(). Without this,
+  // a stale null read could silently skip limitReached() forever in the
+  // race where setLimitHandler ran before the limit was reached.
+  private volatile LimitHandler limitHandler;
   private CompletionHandler completionHandler;
   private Runnable queuedCallback;
   private AtomicLong totalRowsQueued = new AtomicLong(0);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/TransientQueryQueue.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/TransientQueryQueue.java
@@ -42,11 +42,7 @@ public class TransientQueryQueue implements BlockingRowQueue {
   private final int offerTimeoutMs;
   private volatile boolean closed = false;
   private final AtomicInteger remaining;
-  // volatile so the Streams thread reading in onQueued() observes the
-  // assignment done by the REST thread in setLimitHandler(). Without this,
-  // a stale null read could silently skip limitReached() forever in the
-  // race where setLimitHandler ran before the limit was reached.
-  private volatile LimitHandler limitHandler;
+  private LimitHandler limitHandler;
   private CompletionHandler completionHandler;
   private Runnable queuedCallback;
   private AtomicLong totalRowsQueued = new AtomicLong(0);
@@ -191,8 +187,9 @@ public class TransientQueryQueue implements BlockingRowQueue {
       // streams thread NPE's and the query terminates. setLimitHandler's own
       // passedLimit() block fires limitReached once the handler is finally
       // installed, so dropping it here is safe.
-      if (limitHandler != null) {
-        limitHandler.limitReached();
+      final LimitHandler handler = limitHandler;
+      if (handler != null) {
+        handler.limitReached();
       }
     }
     if (queuedCallback != null) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/TransientQueryCleanupServiceTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/TransientQueryCleanupServiceTest.java
@@ -170,6 +170,25 @@ public class TransientQueryCleanupServiceTest {
     }
 
     @Test
+    public void shouldNotConsiderLocalCommandLeakedIfQueryIsStillLive() {
+        // Given: a stale local-commands entry for a query that has since been
+        // restarted and is currently live. The unguarded local-commands branch
+        // previously returned true unconditionally — risking deletion of the
+        // running query's topics and state.
+        service.setLocalCommandsQueryAppIds(ImmutableSet.of(APP_ID_1));
+        when(registry.getAllLiveQueries()).thenReturn(ImmutableList.of(q1));
+
+        // When:
+        Set<String> results = new HashSet<>(service.findLeakedTopics());
+
+        // Then:
+        assertTrue(
+            "live query's topics must never be flagged as leaked, even if its "
+                + "appId is in localCommandsQueryAppIds; got: " + results,
+            results.isEmpty());
+    }
+
+    @Test
     public void shouldDetectTheCorrectLeakedTopics() {
         Set<String> results = new HashSet<>(service.findLeakedTopics());
         assertEquals(results.size(), 0);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/TransientQueryQueueTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/TransientQueryQueueTest.java
@@ -207,4 +207,24 @@ public class TransientQueryQueueTest {
     queue.acceptRow(KEY_TWO, VAL_TWO);
     assertThat(queue.getTotalRowsQueued(), is(2L));
   }
+
+  @Test
+  public void shouldNotNpeWhenLimitReachedBeforeLimitHandlerSet() {
+    // Given: a queue with a small limit and NO limit handler installed yet.
+    // For small LIMITs the Streams thread can produce rows before the REST
+    // resource calls setLimitHandler — onQueued previously NPE'd on
+    // limitHandler.limitReached() and terminated the query.
+    final TransientQueryQueue raw = new TransientQueryQueue(OptionalInt.of(1), MAX_LIMIT, 1);
+
+    // When: enough rows to cross the limit are accepted before setLimitHandler.
+    raw.acceptRow(KEY_ONE, VAL_ONE);
+
+    // Then(don't NPE): the row is queued and the limit is recorded.
+    assertThat(raw.size(), is(1));
+
+    // And: when setLimitHandler is finally called, it observes the already-reached
+    // limit and fires limitReached — the signal is not lost.
+    raw.setLimitHandler(limitHandler);
+    verify(limitHandler).limitReached();
+  }
 }


### PR DESCRIPTION
### Description

First in a series of small, focused backports from PR #11037 onto 7.6.x (epic [KSQL-14548](https://confluentinc.atlassian.net/browse/KSQL-14548)). This PR contains two transient-query safety fixes.

**1. `TransientQueryCleanupService.isLeaked` — never delete a live query's resources (data-loss prevention).**
`isLeaked()` short-circuited on `foundInLocalCommands(resource)` and returned `true` without first verifying the corresponding query was terminated. Combined with the substring-based matching inside `foundInLocalCommands`, a stale `local-commands` entry pointing at a queryId that has since been restarted — or a user-created topic whose name happens to contain a known `local-commands` appId substring — could cause `findLeakedTopics()` / `findLeakedStateDirs()` to flag the live query's topics or state directories for deletion.

Fix: run `isCorrespondingQueryTerminated()` before any other branch so a resource that any currently live query claims (by queryId substring) is never reported as leaked, regardless of what the local-commands set says.

Backport of `a4a7f81f45e` from `pbadani/fix-bugs`.

**2. `TransientQueryQueue.onQueued` — null-check the LIMIT handler.**
`onQueued()` called `limitHandler.limitReached()` with no null guard, but the limit handler is installed by the REST resource *after* the query begins producing rows. For small `LIMIT`s (e.g., `LIMIT 1`) the Streams thread can hit the limit and invoke `onQueued` before the resource ever calls `setLimitHandler` — NPE'ing on the Streams thread and terminating the query.

Fix: null-check the handler. `setLimitHandler`'s own `passedLimit()` branch fires `limitReached` when finally installed against an already-reached limit, so the signal is not lost.

Backport of `5db4f264a02` from `pbadani/fix-bugs`.

### Testing done

`./mvnw -pl ksqldb-engine -am test -Dtest=TransientQueryCleanupServiceTest,TransientQueryQueueTest`
- `TransientQueryCleanupServiceTest`: 8/8 pass (includes new `shouldNotConsiderLocalCommandLeakedIfQueryIsStillLive`)
- `TransientQueryQueueTest`: 11/11 pass (includes new `shouldNotNpeWhenLimitReachedBeforeLimitHandlerSet`)
- Existing `localCommandsShouldBeConsideredLeaked` still passes — its mocked registry returns no live queries, so the new pre-check passes through and the local-commands branch still fires.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback?

[KSQL-14548]: https://confluentinc.atlassian.net/browse/KSQL-14548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ