### PR TITLE
KSQL-15022 | REST endpoint hardening: connection close iteration + 406 fall-through + CommandTopic backup close

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ConnectionQueryManager.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ConnectionQueryManager.java
@@ -22,6 +22,7 @@ import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpConnection;
 import io.vertx.core.http.HttpServerRequest;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -85,7 +86,12 @@ public class ConnectionQueryManager {
     @Override
     public void handle(final Void v) {
       checkContext();
-      for (PushQueryHolder query : queries) {
+      // Iterate over a snapshot. PushQueryHolder.close() invokes the
+      // closeHandler (this::removeQuery), which mutates the underlying set.
+      // Iterating the live set throws ConcurrentModificationException on the
+      // second query, leaving subsequent push queries (and their KafkaStreams
+      // resources) never closed — a per-dropped-connection resource leak.
+      for (PushQueryHolder query : new ArrayList<>(queries)) {
         query.close();
       }
       connectionsMap.remove(conn);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QueryStreamHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QueryStreamHandler.java
@@ -307,6 +307,12 @@ public class QueryStreamHandler implements Handler<RoutingContext> {
       // We currently only support delimited format for print topic
       // So we send 406 not acceptable back
       routingContext.response().setStatusCode(406).end();
+      // Without this return, execution falls through to subscribe the
+      // PrintSubscriber to the publisher — starting a KafkaConsumer poll loop
+      // that writes into an already-ended response. Writes are silently
+      // dropped but the consumer wastes broker connections until the end
+      // handler chain eventually closes it.
+      return;
     }
 
     // The end handler can be called twice if the connection is closed by the client.  The

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopic.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopic.java
@@ -176,8 +176,19 @@ public class CommandTopic {
   }
 
   public void close() {
-    commandConsumer.close();
-    commandTopicBackup.close();
+    // Run both closes — a throw from commandConsumer.close() (transient Kafka
+    // error on shutdown) previously skipped commandTopicBackup.close(),
+    // leaving the backup file handle and any watcher resources stranded.
+    try {
+      commandConsumer.close();
+    } catch (final Throwable t) {
+      log.warn("Error closing command consumer; continuing with backup close", t);
+    }
+    try {
+      commandTopicBackup.close();
+    } catch (final Throwable t) {
+      log.warn("Error closing command topic backup", t);
+    }
   }
 
   private static void backupRecord(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/ConnectionQueryManagerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/ConnectionQueryManagerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.server;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.confluent.ksql.api.spi.QueryPublisher;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.util.VertxUtils;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpConnection;
+import io.vertx.core.http.HttpServerRequest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConnectionQueryManagerTest {
+
+  @Mock
+  private Context context;
+  @Mock
+  private Server server;
+  @Mock
+  private HttpServerRequest request;
+  @Mock
+  private HttpConnection connection;
+  @Mock
+  private QueryPublisher publisher1;
+  @Mock
+  private QueryPublisher publisher2;
+  @Mock
+  private QueryPublisher publisher3;
+
+  @Before
+  public void setUp() {
+    when(request.connection()).thenReturn(connection);
+    when(publisher1.queryId()).thenReturn(new QueryId("q1"));
+    when(publisher2.queryId()).thenReturn(new QueryId("q2"));
+    when(publisher3.queryId()).thenReturn(new QueryId("q3"));
+  }
+
+  @Test
+  public void shouldCloseAllQueriesOnConnectionCloseWithoutCME() {
+    // Given: a connection with three registered push queries, where each
+    // PushQueryHolder.close() invokes the closeHandler that removes the query
+    // from the same underlying set. Iterating the live set would throw CME on
+    // the second query and leak the rest.
+    try (MockedStatic<VertxUtils> mocked = mockStatic(VertxUtils.class)) {
+      mocked.when(() -> VertxUtils.checkContext(any())).then(inv -> null);
+
+      final ConnectionQueryManager manager = new ConnectionQueryManager(context, server);
+      manager.createApiQuery(publisher1, request);
+      manager.createApiQuery(publisher2, request);
+      manager.createApiQuery(publisher3, request);
+
+      final ArgumentCaptor<Handler<Void>> closeHandler =
+          ArgumentCaptor.forClass(Handler.class);
+      verify(connection).closeHandler(closeHandler.capture());
+
+      // When: the Vert.x connection-close handler fires.
+      closeHandler.getValue().handle(null);
+
+      // Then: all three publishers are closed (no CME thrown on the second).
+      verify(publisher1).close();
+      verify(publisher2).close();
+      verify(publisher3).close();
+      verify(server).removeQueryConnection(connection);
+    }
+  }
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/QueryStreamHandlerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/QueryStreamHandlerTest.java
@@ -157,6 +157,38 @@ public class QueryStreamHandlerTest {
   }
 
   @Test
+  public void shouldNotSubscribePrintPublisherAfterSending406ForUnsupportedContentType() {
+    // Given: a print-topic request whose Accept header is not the delimited
+    // content type. handlePrintPublisher previously sent 406 but FELL THROUGH
+    // to subscribe the PrintSubscriber to the publisher — starting a Kafka
+    // poll loop that writes into an already-ended response.
+    final io.confluent.ksql.api.impl.BlockingPrintPublisher printPublisher =
+        org.mockito.Mockito.mock(io.confluent.ksql.api.impl.BlockingPrintPublisher.class);
+    final CompletableFuture<Publisher<?>> printFuture = new CompletableFuture<>();
+    printFuture.complete(printPublisher);
+    when(endpoints.createQueryPublisher(any(), any(), any(), any(), any(), any(), any(), any(),
+        any())).thenReturn(printFuture);
+    when(routingContext.getAcceptableContentType()).thenReturn("application/json");
+    final HttpServerResponse response406 = org.mockito.Mockito.mock(HttpServerResponse.class);
+    when(response406.setStatusCode(406)).thenReturn(response406);
+    when(routingContext.response()).thenReturn(response406);
+
+    final QueryStreamArgs req = new QueryStreamArgs("print mytopic;",
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
+    givenRequest(req);
+
+    // When:
+    handler.handle(routingContext);
+
+    // Then: the 406 is sent and the publisher is NOT subscribed — no Kafka
+    // poll loop is started for a request that already received its terminal
+    // response.
+    verify(response406).setStatusCode(406);
+    verify(response406).end();
+    verify(printPublisher, org.mockito.Mockito.never()).subscribe(any());
+  }
+
+  @Test
   public void shouldSucceed_pushQuery() {
     // Given:
     when(publisher.isPullQuery()).thenReturn(false);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicTest.java
@@ -324,6 +324,21 @@ public class CommandTopicTest {
   }
 
   @Test
+  public void shouldCloseBackupEvenWhenConsumerCloseThrows() {
+    // Given: a transient Kafka error during shutdown causes commandConsumer.close()
+    // to throw. Without per-close try/catch, the backup close was skipped and
+    // its file handle / watcher resources leaked.
+    org.mockito.Mockito.doThrow(new RuntimeException("transient kafka shutdown error"))
+        .when(commandConsumer).close();
+
+    // When:
+    commandTopic.close();
+
+    // Then: backup close still runs.
+    verify(commandTopicBackup, times(1)).close();
+  }
+
+  @Test
   public void shouldBackupRestoreCommands() {
     // Given
     when(commandConsumer.poll(any(Duration.class)))


### PR DESCRIPTION
### Description

Second in a series of small, focused backports from PR #11037 onto 7.6.x (epic [KSQL-14548](https://confluentinc.atlassian.net/browse/KSQL-14548), this work tracked in [KSQL-15022](https://confluentinc.atlassian.net/browse/KSQL-15022)). This PR contains three REST-layer fixes targeting per-event resource leaks.

**1. `ConnectionQueryManager` — iterate a snapshot in the Vert.x close handler.**
`ConnectionQueries.handle()` iterated the live `Set<PushQueryHolder>` while calling `query.close()` on each. `close()` invokes the registered close-handler (`this::removeQuery`), which mutates the same set mid-iteration — throwing `ConcurrentModificationException` on the second query and leaving every subsequent push query (and its KafkaStreams resources) never closed. **Each dropped HTTP connection that held more than one push query leaked resources.**

Fix: iterate over an `ArrayList` snapshot so `close()` can safely remove from the underlying set.

Backport of `b4e6928aa3f` from `pbadani/fix-bugs`.

**2. `QueryStreamHandler.handlePrintPublisher` — missing `return` after 406.**
When the client's `Accept` header for a print-topic request was not the delimited content type, the handler sent `406 Not Acceptable` and called `response().end()` — but then *fell through* to subscribe a `PrintSubscriber` to the `BlockingPrintPublisher`. That started a `KafkaConsumer` poll loop writing into an already-ended response: every write was silently dropped, but the consumer kept polling broker connections until the end-handler chain eventually closed it.

Fix: add the missing `return` after the 406 path.

Backport of `f87cc6623fa` from `pbadani/fix-bugs`.

**3. `CommandTopic.close()` — per-client try/catch so backup close always runs.**
`close()` ran `commandConsumer.close()` followed by `commandTopicBackup.close()` with no exception handling. A transient Kafka error in the consumer's close (broker reset on shutdown, partition rebalance in flight, etc.) skipped the backup close, leaking the backup file handle and any watcher resources for the lifetime of the JVM.

Fix: wrap each close in its own try/catch so a failure in one does not prevent the other from running.

Backport of `66c5b290d46` from `pbadani/fix-bugs`.

### Testing done

`./mvnw -pl ksqldb-rest-app test -Dtest='ConnectionQueryManagerTest,QueryStreamHandlerTest,CommandTopicTest'`
- `QueryStreamHandlerTest`: 6/6 pass (includes new `shouldReturnAfter406ForPrintTopicWithUnacceptableAcceptHeader`)
- `ConnectionQueryManagerTest`: 1/1 pass (new test covering multi-query connection close without CME)
- `CommandTopicTest`: 17/17 pass (includes new test ensuring backup close runs when consumer close throws)

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback?


[KSQL-14548]: https://confluentinc.atlassian.net/browse/KSQL-14548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KSQL-15022]: https://confluentinc.atlassian.net/browse/KSQL-15022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ