### PR TITLE
KSQL-14540 | Cherry-pick: Define spotbugs-annotations in parent pom (8.0.2-cp7)

### DIFF
--- a/ksqldb-api-client/pom.xml
+++ b/ksqldb-api-client/pom.xml
@@ -100,10 +100,6 @@
             <artifactId>guava</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-        </dependency>
 
         <!-- Required for running tests -->
 

--- a/ksqldb-common/pom.xml
+++ b/ksqldb-common/pom.xml
@@ -78,10 +78,6 @@
             <artifactId>avro</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/ksqldb-test-util/pom.xml
+++ b/ksqldb-test-util/pom.xml
@@ -97,10 +97,6 @@
       <artifactId>guava</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/ksqldb-tools/pom.xml
+++ b/ksqldb-tools/pom.xml
@@ -47,10 +47,6 @@
             <artifactId>airline</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>io.confluent.ksql</groupId>

--- a/ksqldb-udf/pom.xml
+++ b/ksqldb-udf/pom.xml
@@ -52,10 +52,6 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-        </dependency>
 
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -818,6 +818,8 @@
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
+            <version>${spotbugs.version}</version>
+            <scope>provided</scope>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -756,13 +756,20 @@
                 <version>${wiremock.version}</version>
                 <scope>test</scope>
             </dependency>
-            
+
             <!-- Override vulnerable json-smart 2.5.0/2.5.1 to fix CVE-2024-57699
                  TODO: Remove when all transitive deps use json-smart 2.5.2+ -->
             <dependency>
                 <groupId>net.minidev</groupId>
                 <artifactId>json-smart</artifactId>
                 <version>2.5.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-annotations</artifactId>
+                <version>${spotbugs.version}</version>
+                <scope>provided</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -807,6 +814,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Summary

Cherry-picks PR #11010 (commit 7d2c6a880dc) onto `8.0.2-cp7` to fix a `Build ksqldb jar` CI failure.

## Root cause

The `Build ksqldb jar` Semaphore job ([failed run](https://semaphore.ci.confluent.io/jobs/8283188b-394c-49f0-a4d8-75a0185b8202)) on `8.0.2-cp7` (HEAD `6e435cf3752`) fails with `mvn -B -Pcp-build -DskipTests ... clean install` returning non-zero exit, due to compile errors in `ksqldb-serde` (16 source files):

```
[ERROR] .../ksqldb-serde/.../AvroFormat.java:[20,39] package edu.umd.cs.findbugs.annotations does not exist
[ERROR] .../ksqldb-serde/.../AvroFormat.java:[48,4] cannot find symbol
[ERROR]   symbol:   class SuppressFBWarnings
```

`ksqldb-serde` (and several other modules) use `@SuppressFBWarnings` from `edu.umd.cs.findbugs.annotations` but do not declare `spotbugs-annotations` themselves — they previously relied on transitive resolution via `ksqldb-common`. On `master` / `8.0.x` / `8.1.x` / `8.2.x` / `8.3.x`, PR #11010 already centralized the annotation dependency in the parent pom. That fix was never backported to `8.0.2-cp7`, so a recent change in the resolved `spotbugs-annotations` scope (transitively via `io.confluent:common:8.0.2`) broke the latent transitive path.

## What this PR does

Mirrors PR #11010 exactly:

- Adds `spotbugs-annotations` to the parent pom's `<dependencyManagement>` (version pinned, `scope=provided`) and to the parent's `<dependencies>` block so every child module inherits it.
- Removes the now-redundant per-module declarations from `ksqldb-api-client`, `ksqldb-common`, `ksqldb-test-util`, `ksqldb-tools`, `ksqldb-udf`.

## Verification

Locally on this branch:

```
./mvnw -B -Pcp-build -DskipTests -DskipIntegrationTests -Ddependency-check.skip=true \
  -pl ksqldb-engine,ksqldb-execution,ksqldb-streams,ksqldb-rest-app,ksqldb-rest-client -am compile
```

All 18 modules in the dependency closure (including `ksqldb-serde`, `ksqldb-engine`, `ksqldb-rest-app`) compile cleanly, with the spotbugs `analyze-compile` check passing on every module. The `cp-build` profile warning ("could not be activated because it does not exist") is unrelated and is also present on green builds upstream.

## Test plan

- [ ] CI `Build ksqldb jar` step turns green on this branch
- [ ] No new spotbugs / checkstyle violations introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)