### PR TITLE
LOGGING-4227 | Bump log4j2 to 2.25.4 to fix CVE-2026-34478

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
         <multi-threaded-testing.forkCount>3</multi-threaded-testing.forkCount>
         <kafka.version>${ce.kafka.version}</kafka.version>
         <!-- This needs to be removed once the version is populated in common -->
-        <log4j2.version>2.25.3</log4j2.version>
+        <log4j2.version>2.25.4</log4j2.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Summary
- Bumps `log4j2.version` from `2.25.3` to `2.25.4` to remediate CVE-2026-34478 (`org.apache.logging.log4j:log4j-core`)
- Targets the FedRAMP branch `8.0.2-cp7` as required by LOGGING-4227

## Verification
```
mvn dependency:tree -Dincludes=org.apache.logging.log4j:log4j-core
```
All modules resolve to `log4j-core:2.25.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)