### PR TITLE
Pin kotlin-stdlib via kotlin-bom to fix runtime crash in ksqldb

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,18 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Pin Kotlin stdlib via BOM. Kafka's connect-runtime publishes a POM
+                 (via Gradle's maven-publish) that lists kotlin-stdlib:1.6.0 as a direct
+                 runtime dep, which wins Maven nearest-wins and lands kotlin-stdlib-1.6.0.jar
+                 in share/java/ksqldb. That breaks json-sKema (compiled against 1.9.10) with
+                 NoClassDefFoundError: kotlin/enums/EnumEntriesKt at runtime. -->
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-bom</artifactId>
+                <version>1.9.10</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- Cross-submodule dependencies -->
             <dependency>
                 <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
## Summary

Pin `kotlin-stdlib` to `1.9.10` via `kotlin-bom` import in the root `dependencyManagement`. This makes the KSQL assembly resilient to `connect-runtime`'s POM declaring `kotlin-stdlib:1.6.0` as a direct runtime dependency (artifact of Gradle's `maven-publish` runtime-classpath flattening).

## Symptom

KSQL crashes the JVM on the first call into `json-sKema` (used by `kafka-json-schema-provider` for JSON schema validation):

```
java.lang.NoClassDefFoundError: kotlin/enums/EnumEntriesKt
    at com.github.erosb.jsonsKema.SpecificationVersion.<clinit>(Keyword.kt:4)
    at com.github.erosb.jsonsKema.Keyword.<init>(Keyword.kt:10)
    at com.github.erosb.jsonsKema.SchemaLoader.<init>(SchemaLoader.kt:152)
```

`kotlin.enums.EnumEntriesKt` was introduced in `kotlin-stdlib:1.9.0`; the deb ships only `1.6.0`, so any code compiled against `1.9.10` (such as `json-sKema`) blows up.

Customer-reported, reproduces on every 7.9.6 / 7.9.7 KSQL install and on the latest 7.9.x nightly.

## Root cause

`connect-runtime-7.9.7-ce.pom` contains:

```xml
<dependency>
  <groupId>org.jetbrains.kotlin</groupId>
  <artifactId>kotlin-stdlib</artifactId>
  <version>1.6.0</version>
  <scope>runtime</scope>
</dependency>
```

Emitted by Gradle's `maven-publish` plugin (note `published-with-gradle-metadata` marker) flattening kafka's runtime classpath. By Maven nearest-wins, the depth-1 declaration of `1.6.0` from `connect-runtime` beats the depth-3+ `1.9.10` declarations from `kafka-json-schema-provider` and `kafka-protobuf-provider`. The assembly therefore copies `kotlin-stdlib-1.6.0.jar` into `share/java/ksqldb/`.

Note: a parallel BOM fix in `confluent-security-plugins/pom.xml` resolves the same kind of conflict within security-plugins' own build hierarchy but does not reach the KSQL assembly — KSQL's POM doesn't inherit from or import security-plugins' BOM. The connect-runtime transitive remains uncontained until this PR.

## Fix

Import `kotlin-bom:1.9.10` in the root `dependencyManagement`. Maven applies BOM-imported versions before nearest-wins, so every `kotlin-stdlib*` artifact resolves to `1.9.10` regardless of which transitive declared it.

## Verification

**1. dep:tree before/after on the 7.9.6 GA tag (still has the bug):**

```
Before fix:
  kotlin-stdlib:1.6.0  ← winner
  kotlin-stdlib:1.8.21 (omitted for conflict with 1.6.0)
  kotlin-stdlib:1.9.10 (omitted for conflict with 1.6.0)

After fix:
  kotlin-stdlib:1.9.10  (version managed from 1.6.0)
  (every other path omitted-for-duplicate)
```

**2. Worst-case validation on this branch with kafka.version forced to broken 7.9.7-ce:**

```bash
mvn -pl ksqldb-package -am dependency:tree \
    -Dincludes=org.jetbrains.kotlin:kotlin-stdlib \
    -Dverbose=true -Dkafka.version=7.9.7-ce
```

Output:
```
\- org.apache.kafka:connect-runtime:jar:7.9.7-ce:compile
   \- org.jetbrains.kotlin:kotlin-stdlib:jar:1.9.10:compile (version managed from 1.6.0)
```

**3. End-to-end:** `mvn package -pl ksqldb-package -am` produces `share/java/ksqldb/kotlin-stdlib-1.9.10.jar` (was `1.6.0` in the broken nightly). A SchemaLoader load+validate reproducer that crashed with `NoClassDefFoundError` against the broken classpath runs clean against the built-with-fix classpath:

```
Constructed SchemaLoader OK
Loaded schema = com.github.erosb.jsonsKema.CompositeSchema
Got validator = com.github.erosb.jsonsKema.DefaultValidator
Validate (string OK) = null
```

## Test plan

- [x] `mvn package -pl ksqldb-package -am` succeeds
- [x] Resulting assembly contains `kotlin-stdlib-1.9.10.jar` (not `1.6.0`)
- [x] SchemaLoader reproducer passes against the built classpath
- [x] dep:tree with `-Dkafka.version=7.9.7-ce` confirms BOM overrides broken kafka POM
- [ ] CI green
- [ ] Smoke test against a real KSQL server image after 7.9.7-cp1 is cut

## Backport / forward-port plan

This PR targets `7.9.x`. The same fix should be forward-ported to `master`, `8.0.x`, `8.1.x`, `8.2.x` once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)