### PR TITLE
MINOR: Fix BytesUtils.arrayEquals byte comparison and loop bounds

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/BytesUtils.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/BytesUtils.java
@@ -211,8 +211,8 @@ public final class BytesUtils {
       return false;
     }
 
-    for (int i = aFromIndex, j = bFromIndex; i < length && j < b.length; i++, j++) {
-      if (a[i] != b[i]) {
+    for (int i = aFromIndex, j = bFromIndex; j < bFromIndex + length; i++, j++) {
+      if (a[i] != b[j]) {
         return false;
       }
     }

--- a/ksqldb-common/src/test/java/io/confluent/ksql/util/BytesUtilTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/util/BytesUtilTest.java
@@ -19,8 +19,10 @@ import io.confluent.ksql.util.BytesUtils.Encoding;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -107,5 +109,59 @@ public class BytesUtilTest {
         assertThat(BytesUtils.decode(null, Encoding.BASE64), nullValue());
         assertThat(BytesUtils.decode(null, Encoding.ASCII), nullValue());
         assertThat(BytesUtils.decode(null, Encoding.HEX), nullValue());
+    }
+
+    @Test
+    public void shouldSplitOnSingleByteDelimiter() {
+        // Given
+        final byte[] value = new byte[]{1, 9, 2, 9, 3};
+        final byte[] delim = new byte[]{9};
+
+        // When
+        final List<byte[]> parts = BytesUtils.split(value, delim);
+
+        // Then
+        assertThat(parts, contains(new byte[]{1}, new byte[]{2}, new byte[]{3}));
+    }
+
+    @Test
+    public void shouldSplitOnMultiByteDelimiter() {
+        // Given
+        final byte[] value = new byte[]{1, 8, 9, 2, 8, 9, 3};
+        final byte[] delim = new byte[]{8, 9};
+
+        // When
+        final List<byte[]> parts = BytesUtils.split(value, delim);
+
+        // Then
+        assertThat(parts, contains(new byte[]{1}, new byte[]{2}, new byte[]{3}));
+    }
+
+    @Test
+    public void shouldNotMatchMultiByteDelimiterOnPartialMatch() {
+        // Given: the delimiter's first byte (8) appears repeatedly but the full two-byte
+        // delimiter [8, 9] never does, so nothing should be split off.
+        final byte[] value = new byte[]{1, 8, 7, 8, 7, 8};
+        final byte[] delim = new byte[]{8, 9};
+
+        // When
+        final List<byte[]> parts = BytesUtils.split(value, delim);
+
+        // Then
+        assertThat(parts, contains(value));
+    }
+
+    @Test
+    public void shouldFindMultiByteDelimiterPastDelimiterLength() {
+        // Given: the only full delimiter match starts at an index >= delim.length, which the
+        // previous buggy comparison reported as a match at every first-byte occurrence.
+        final byte[] value = new byte[]{1, 2, 3, 4, 5, 6};
+        final byte[] delim = new byte[]{4, 5};
+
+        // When
+        final int idx = BytesUtils.indexOf(value, delim, 0);
+
+        // Then
+        assertThat(idx, is(3));
     }
 }


### PR DESCRIPTION
## Description

`BytesUtils.arrayEquals` had two bugs in its comparison loop:

```java
for (int i = aFromIndex, j = bFromIndex; i < length && j < b.length; i++, j++) {
  if (a[i] != b[i]) {   // compared b[i] instead of b[j]
    return false;
  }
}
```

1. **Wrong byte compared** — `a[i] != b[i]` should be `a[i] != b[j]`. `b` is meant to be indexed by `j` (which starts at `bFromIndex`), not by `i`.
2. **Wrong loop bound** — `i` starts at `aFromIndex`, so the condition `i < length` does not run `length` iterations. When `aFromIndex >= length` the loop body never executes and the method returns `true` unconditionally.

### Impact

`arrayEquals` backs `indexOf`, which backs `BytesUtils.split` (the `SPLIT` UDF on `BYTES`).

- **Single-byte delimiters were unaffected**: `indexOf` already confirms the first byte matches before calling `arrayEquals`, so there is nothing left to compare and the buggy loop is harmless.
- **Multi-byte `BYTES` delimiters were broken**: any first-byte match at an index `>= delimiter.length` was reported as a full delimiter match without checking the remaining bytes (false positive), and partial matches were compared against the wrong delimiter byte.

### Fix

Run the loop exactly `length` times and compare `a[i]` against `b[j]`.

## Testing

Added regression tests to `BytesUtilTest`:
- multi-byte delimiter split
- partial-match rejection (delimiter first byte recurs but full delimiter never does)
- delimiter match occurring at an index past the delimiter length

`./mvnw -pl ksqldb-common test -Dtest=BytesUtilTest` → 11 run, 0 failures.

Found during a codebase audit; this is a standalone correctness fix with no behavior change for single-byte delimiters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)