### PR TITLE
MINOR: Harden command topic backup against null records and corrupted backup files

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/BackupReplayFile.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/BackupReplayFile.java
@@ -130,9 +130,28 @@ public final class BackupReplayFile implements Closeable {
 
   public List<Pair<byte[], byte[]>> readRecords() throws IOException {
     final List<Pair<byte[], byte[]>> commands = new ArrayList<>();
-    for (final String line : Files.readAllLines(getFile().toPath(), StandardCharsets.UTF_8)) {
-      final String commandId = line.substring(0, line.indexOf(KEY_VALUE_SEPARATOR_STR));
-      final String command = line.substring(line.indexOf(KEY_VALUE_SEPARATOR_STR) + 1);
+    final List<String> lines = Files.readAllLines(getFile().toPath(), StandardCharsets.UTF_8);
+    for (int i = 0; i < lines.size(); i++) {
+      final String line = lines.get(i);
+
+      // Tolerate stray blank lines (e.g. a hand-edited file or a trailing newline) instead of
+      // failing the whole backup.
+      if (line.isEmpty()) {
+        continue;
+      }
+
+      final int separatorIndex = line.indexOf(KEY_VALUE_SEPARATOR_STR);
+      if (separatorIndex < 0) {
+        // A line with content but no key/value separator means the backup is corrupted or
+        // truncated (e.g. a torn write). Fail with a clear, actionable message rather than an
+        // opaque StringIndexOutOfBoundsException from substring(0, -1).
+        throw new KsqlException(String.format(
+            "Corrupted backup file %s: line %d is missing the '%s' key/value separator.",
+            getPath(), i + 1, KEY_VALUE_SEPARATOR_STR));
+      }
+
+      final String commandId = line.substring(0, separatorIndex);
+      final String command = line.substring(separatorIndex + 1);
 
       commands.add(new Pair<>(
           commandId.getBytes(StandardCharsets.UTF_8),

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicBackupImpl.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicBackupImpl.java
@@ -20,6 +20,7 @@ import io.confluent.ksql.rest.server.computation.InternalTopicSerdes;
 import io.confluent.ksql.rest.server.resources.CommandTopicCorruptionException;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlServerException;
 import io.confluent.ksql.util.Pair;
 import java.io.File;
@@ -86,7 +87,9 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
 
     try {
       latestReplay = replayFile.readRecords();
-    } catch (final IOException e) {
+    } catch (final IOException | KsqlException e) {
+      // KsqlException covers a corrupted/truncated backup line (see BackupReplayFile.readRecords);
+      // like an IOException, fall back to a fresh replay file rather than aborting server startup.
       LOG.warn("Failed to read the latest backup from {}. Continue with a new file. Error = {}",
           replayFile.getPath(), e.getMessage());
 
@@ -146,6 +149,10 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
       LOG.warn(String.format("Can't backup a command topic record with a null key/value:"
               + " partition=%d, offset=%d",
           record.partition(), record.offset()));
+      // Do not attempt to write a null record: BackupReplayFile cannot frame it and would throw
+      // an NPE that is swallowed below, silently leaving the backup out of sync with the topic.
+      // That divergence later surfaces as a misleading CommandTopicCorruptionException.
+      return;
     }
 
     if (Arrays.equals(record.key(), InternalTopicSerdes.serializer().serialize(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/BackupReplayFileTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/BackupReplayFileTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.rest.server.BackupReplayFile.Filesystem;
 import io.confluent.ksql.test.util.KsqlTestFolder;
+import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.Pair;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -212,6 +213,45 @@ public class BackupReplayFileTest {
     assertThat(commands.get(0).right, is(record1.value()));
     assertThat(commands.get(1).left, is(record2.key()));
     assertThat(commands.get(1).right, is(record2.value()));
+  }
+
+  @Test
+  public void shouldSkipBlankLinesWhenReadingCommands() throws IOException {
+    // Given: two valid records with a stray blank line between them
+    final ConsumerRecord<byte[], byte[]> record1 = newStreamRecord("stream1");
+    final ConsumerRecord<byte[], byte[]> record2 = newStreamRecord("stream2");
+    Files.write(internalReplayFile.toPath(),
+        String.format("%s%s%s%n%n%s%s%s",
+            "\"stream/stream1/create\"",
+            KEY_VALUE_SEPARATOR,
+            "{\"statement\":\"CREATE STREAM stream1 (id INT) WITH (kafka_topic='stream1')\"}",
+            "\"stream/stream2/create\"",
+            KEY_VALUE_SEPARATOR,
+            "{\"statement\":\"CREATE STREAM stream2 (id INT) WITH (kafka_topic='stream2')\"}"
+        ).getBytes(StandardCharsets.UTF_8));
+
+    // When
+    final List<Pair<byte[], byte[]>> commands = replayFile.readRecords();
+
+    // Then: the blank line is skipped, both records are read
+    assertThat(commands.size(), is(2));
+    assertThat(commands.get(0).left, is(record1.key()));
+    assertThat(commands.get(1).left, is(record2.key()));
+  }
+
+  @Test
+  public void shouldThrowClearErrorWhenLineIsMissingSeparator() throws IOException {
+    // Given: a corrupted/truncated line with no key/value separator
+    Files.write(internalReplayFile.toPath(),
+        "this-line-has-no-key-value-separator".getBytes(StandardCharsets.UTF_8));
+
+    // When
+    final KsqlException e =
+        Assert.assertThrows(KsqlException.class, () -> replayFile.readRecords());
+
+    // Then: a clear, actionable error instead of an opaque StringIndexOutOfBoundsException
+    assertThat(e.getMessage(), org.hamcrest.Matchers.containsString("missing"));
+    assertThat(e.getMessage(), org.hamcrest.Matchers.containsString("line 1"));
   }
 
   private ConsumerRecord<byte[], byte[]> newStreamRecord(final String streamName) {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicBackupImplTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicBackupImplTest.java
@@ -34,6 +34,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.List;
 import java.util.function.Supplier;
@@ -199,6 +200,51 @@ public class CommandTopicBackupImplTest {
     // Then
     final List<Pair<byte[], byte[]>> commands = commandTopicBackup.getReplayFile().readRecords();
     assertThat(commands.size(), is(0));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void shouldNotCorruptBackupWhenRecordHasNullValue() throws IOException {
+    // Given
+    commandTopicBackup.initialize();
+    final ConsumerRecord<byte[], byte[]> nullValueRecord = mock(ConsumerRecord.class);
+    when(nullValueRecord.key()).thenReturn(new byte[]{});
+    when(nullValueRecord.value()).thenReturn(null);
+
+    // When: a null record is skipped, a subsequent valid record is still backed up
+    commandTopicBackup.writeRecord(nullValueRecord);
+    commandTopicBackup.writeRecord(command1);
+
+    // Then: the null record did not poison the backup or trip corruption detection
+    assertThat(commandTopicBackup.commandTopicCorruption(), is(false));
+    final List<Pair<byte[], byte[]>> commands = commandTopicBackup.getReplayFile().readRecords();
+    assertThat(commands.size(), is(1));
+    assertThat(commands.get(0).left, is(command1.key()));
+    assertThat(commands.get(0).right, is(command1.value()));
+  }
+
+  @Test
+  public void shouldFallBackToNewFileWhenBackupFileIsCorrupted() throws IOException {
+    // Given: a backup file with one valid record followed by a corrupted (separator-less) line.
+    // Distinct ticker values ensure the fall-back creates a genuinely new replay file.
+    when(ticker.get()).thenReturn(1L, 2L);
+    commandTopicBackup.initialize();
+    commandTopicBackup.writeRecord(command1);
+    final File corruptedFile = commandTopicBackup.getReplayFile().getFile();
+    Files.write(
+        corruptedFile.toPath(),
+        "corrupted-line-with-no-separator\n".getBytes(StandardCharsets.UTF_8),
+        StandardOpenOption.APPEND);
+
+    // When: re-initialising reads the corrupted backup
+    commandTopicBackup.initialize();
+
+    // Then: startup does not fail; it falls back to a fresh replay file and keeps working
+    assertThat(commandTopicBackup.commandTopicCorruption(), is(false));
+    commandTopicBackup.writeRecord(command2);
+    final List<Pair<byte[], byte[]>> commands = commandTopicBackup.getReplayFile().readRecords();
+    assertThat(commands.size(), is(1));
+    assertThat(commands.get(0).left, is(command2.key()));
   }
 
   @Test


### PR DESCRIPTION
## Description

Two robustness fixes in the command-topic backup/restore subsystem (`ksqldb-rest-app .../rest/server`). Both are semantics-preserving hardening of existing error paths; **no on-disk backup format change**, so existing backup files remain readable.

### 1. `CommandTopicBackupImpl.writeRecord` — stop falling through on a null record
Previously, when a command-topic record had a `null` key/value, the method logged a warning but **did not return**. It then proceeded to `replayFile.write(record)`, which threw an `NullPointerException` that was swallowed by the broad `catch (Exception)` below. Net effect: the record was silently **not** backed up while still being consumed and executed, leaving the backup out of sync with the topic. That divergence surfaces much later (via `isRecordInLatestReplay`) as a **misleading** `CommandTopicCorruptionException`.

Fix: `return;` immediately after the warning so a null record is not written.

### 2. `BackupReplayFile.readRecords` — graceful handling of malformed/truncated lines
A line missing the `:` key/value separator (e.g. a truncated/torn write or a hand-edited file) caused `line.substring(0, line.indexOf(":"))` → `substring(0, -1)` → an opaque `StringIndexOutOfBoundsException`. Because `CommandTopicBackupImpl.initialize()` only caught `IOException`, that `RuntimeException` propagated and **aborted server startup**.

Fix:
- Skip stray blank lines.
- A content line with no separator now throws a `KsqlException` with a clear, actionable message including the line number.
- `initialize()` catches `KsqlException` alongside `IOException` and falls back to a fresh replay file instead of aborting startup. (The standalone restore tool already reports the message clearly.)

## Testing done
New unit tests (all green locally; `mvn -pl ksqldb-rest-app test`):
- `BackupReplayFileTest.shouldSkipBlankLinesWhenReadingCommands`
- `BackupReplayFileTest.shouldThrowClearErrorWhenLineIsMissingSeparator`
- `CommandTopicBackupImplTest.shouldNotCorruptBackupWhenRecordHasNullValue`
- `CommandTopicBackupImplTest.shouldFallBackToNewFileWhenBackupFileIsCorrupted`

Existing tests in both classes still pass (`BackupReplayFileTest` 9/9, `CommandTopicBackupImplTest` 19/19). Checkstyle passes for the module.

## Reviewer notes
Scope intentionally excludes the on-disk format change (escaping/length-prefix framing) and an atomic-append rewrite: the `write()` path already updates the live file via an atomic rename, and a format change would be backward-incompatible with existing backups on a maintenance branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)