### PR TITLE
Skip processing of cancelled pull query requests still in the queue

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/HARouting.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/HARouting.java
@@ -165,6 +165,15 @@ public final class HARouting implements AutoCloseable {
       final PullQueryWriteStream pullQueryQueue,
       final CompletableFuture<Void> shouldCancelRequests
   ) {
+    // If the client has already disconnected/cancelled by the time this queued request is
+    // picked up by the coordinator thread pool, skip processing it entirely rather than doing
+    // work whose results no one will read.
+    if (shouldCancelRequests.isDone()) {
+      LOG.debug("Pull query request was cancelled before execution; skipping.");
+      pullQueryQueue.close();
+      return;
+    }
+
     // The remaining partition locations to retrieve without error
     List<KsqlPartitionLocation> remainingLocations = ImmutableList.copyOf(locations);
     final Map<KsqlNode, List<Exception>> exceptionsPerNode = new HashMap<>();
@@ -280,6 +289,13 @@ public final class HARouting implements AutoCloseable {
   ) {
     final Function<StreamedRow, StreamedRow> addHostInfo
         = sr -> sr.withSourceHost(routingOptions.getIsDebugRequest() ? toKsqlHostInfo(node) : null);
+    // If the request was cancelled (e.g. the client disconnected) while this per-host request
+    // was queued in the router thread pool, skip executing it.
+    if (shouldCancelRequests.isDone()) {
+      LOG.debug("Pull query request to node {} was cancelled before execution; skipping.",
+          node.location());
+      return new NodeFetchResult(RoutingResult.SUCCESS, node, Optional.empty());
+    }
     if (node.isLocal()) {
       try {
         LOG.debug("Query {} partitions {} executed locally at host {} at timestamp {}.",

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/execution/pull/HARoutingTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/execution/pull/HARoutingTest.java
@@ -516,6 +516,28 @@ public class HARoutingTest {
   }
 
   @Test
+  public void shouldSkipQueuedRequestWhenAlreadyCancelled()
+      throws ExecutionException, InterruptedException {
+    // Given:
+    locate(location1, location2, location3, location4);
+    // The client has already disconnected/cancelled before the queued request is picked up.
+    when(disconnect.isDone()).thenReturn(true);
+
+    // When:
+    final CompletableFuture<Void> future = haRouting.handlePullQuery(
+        serviceContext, pullPhysicalPlan, statement, routingOptions,
+        pullQueryQueue, disconnect);
+    future.get();
+
+    // Then: no work is performed for the cancelled request and the queue is closed.
+    verify(pullPhysicalPlan, never()).execute(any(), any(), any());
+    verify(ksqlClient, never())
+        .makeQueryRequest(any(), any(), any(), any(), any(), any(), any());
+    assertThat(pullQueryQueue.size(), is(0));
+    assertThat(pullQueryQueue.isDone(), is(true));
+  }
+
+  @Test
   public void forwardingError_noRows() {
     // Given:
     locate(location4);


### PR DESCRIPTION
## Description

Pull query routing submits work to two fixed-size thread pools — the coordinator pool (in `HARouting.handlePullQuery`) and the per-host router pool (in `executeRounds`). Both are `Executors.newFixedThreadPool(...)`, which is backed by an unbounded `LinkedBlockingQueue`, so when the pools are saturated, submitted tasks wait in the executor's work queue.

If the client disconnects/cancels while a task is **still queued**, the cancellation signal (`shouldCancelRequests`) was never checked before the task ran. The server would go on to execute the local materialization and forward to remote hosts anyway, writing rows into a `PullQueryWriteStream` that nobody drains. The only existing cancellation check was reactive — inside the remote-forwarding exception handler (`forwardTo`), after the request had already been attempted.

Under load (when the pools are saturated and the queue is deepest — exactly when you'd most want to drop abandoned requests) this is wasted work.

## Change

- Add a `shouldCancelRequests.isDone()` guard at the top of `executeRounds` (the coordinator task body): if already cancelled, close the queue and return without doing any work.
- Add a `shouldCancelRequests.isDone()` guard at the top of `executeOrRouteQuery` (the per-host task body): if already cancelled, return a `SUCCESS` `NodeFetchResult` so no standby retry is triggered and no local/remote execution happens.

## Test

Adds `HARoutingTest.shouldSkipQueuedRequestWhenAlreadyCancelled`, which asserts that when the request is already cancelled before pickup, neither local execution (`pullPhysicalPlan.execute`) nor remote forwarding (`ksqlClient.makeQueryRequest`) occurs, and the queue is closed.

> Note: the test was not run locally — the internal `io.confluent:common` parent POM for 7.6.x does not resolve in my build environment. Relying on CI to validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)