### PR TITLE
feat: Support allowlist

### DIFF
--- a/docs/developer-guide/ksqldb-rest-api/is_valid_property-endpoint.md
+++ b/docs/developer-guide/ksqldb-rest-api/is_valid_property-endpoint.md
@@ -20,6 +20,6 @@ output should resemble:
 {
   "@type": "generic_error",
   "error_code": 40000,
-  "message": "One or more properties overrides set locally are prohibited by the KSQL server (use UNSET to reset their default value): [ksql.service.id]"
+  "message": "One or more properties overrides set locally are prohibited by the KSQL server denylist (use UNSET to reset their default value): [ksql.service.id]"
 }
 ```

--- a/docs/developer-guide/ksqldb-rest-api/is_valid_property-endpoint.md
+++ b/docs/developer-guide/ksqldb-rest-api/is_valid_property-endpoint.md
@@ -20,6 +20,6 @@ output should resemble:
 {
   "@type": "generic_error",
   "error_code": 40000,
-  "message": "One or more properties overrides set locally are prohibited by the KSQL server denylist (use UNSET to reset their default value): [ksql.service.id]"
+  "message": "One or more properties overrides set locally are prohibited by the KSQL server (use UNSET to reset their default value): [ksql.service.id]"
 }
 ```

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/AllowListPropertyValidator.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/AllowListPropertyValidator.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.properties;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Validates property overrides against an allowlist: any property whose name is not in the
+ * configured allowlist is rejected (deny-by-default). This is the inverse of
+ * {@link DenyListPropertyValidator} and the stricter of the two policies.
+ *
+ * <p>Notes on behavior:
+ * <ul>
+ *   <li><b>Exact-name matching only.</b> Membership is tested against the raw property name, the
+ *       same way the denylist works today. Prefixed variants (e.g. {@code auto.offset.reset} vs.
+ *       {@code ksql.streams.auto.offset.reset}) are distinct entries. Canonicalization is tracked
+ *       separately and not done here.</li>
+ *   <li><b>No wildcards.</b> Allowlist entries must be exact property names; entries containing
+ *       glob/regex meta-characters ({@code *} or {@code ?}) are rejected at construction time so a
+ *       broad pattern cannot silently re-open the "allow arbitrary prefix" hole.</li>
+ *   <li><b>Always-denied floor.</b> A small set of server-owned keys (the service id and the
+ *       {@code ksql.properties.overrides.*} policy knobs) is removed from the effective allowlist
+ *       so they can never be permitted, even if listed by mistake. Mirrors how the denylist
+ *       force-adds the service id.</li>
+ *   <li><b>Empty allowlist is fail-closed.</b> An empty allowlist rejects every override.</li>
+ * </ul>
+ */
+public class AllowListPropertyValidator implements ConfigOverrideValidator {
+
+  /** Server-owned keys that must never be permitted as overrides, even if allowlisted. */
+  private static final Set<String> ALWAYS_DENIED = ImmutableSet.of(
+      KsqlConfig.KSQL_SERVICE_ID_CONFIG,
+      KsqlConfig.KSQL_PROPERTIES_OVERRIDES_DENYLIST,
+      KsqlConfig.KSQL_PROPERTIES_OVERRIDES_ALLOWLIST,
+      KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE,
+      KsqlConfig.KSQL_PROPERTIES_OVERRIDES_LOG
+  );
+
+  private final Set<String> allowed;
+
+  public AllowListPropertyValidator(final Collection<String> allowlist) {
+    Objects.requireNonNull(allowlist, "allowlist");
+    rejectWildcards(allowlist);
+    this.allowed = Sets.difference(ImmutableSet.copyOf(allowlist), ALWAYS_DENIED).immutableCopy();
+  }
+
+  /**
+   * Validates that every property override is present in the allowlist.
+   * @throws KsqlException if at least one property is not on the allowlist.
+   */
+  @Override
+  public void validateAll(final Map<String, Object> properties) {
+    final Set<String> notAllowed = Sets.difference(properties.keySet(), allowed);
+    if (!notAllowed.isEmpty()) {
+      throw new KsqlException(String.format("One or more property overrides set locally are "
+          + "not permitted by the KSQL server allowlist (use UNSET to reset their default "
+          + "value): %s", notAllowed));
+    }
+  }
+
+  private static void rejectWildcards(final Collection<String> allowlist) {
+    final List<String> withWildcards = allowlist.stream()
+        .filter(name -> name.indexOf('*') >= 0 || name.indexOf('?') >= 0)
+        .collect(Collectors.toList());
+    if (!withWildcards.isEmpty()) {
+      throw new KsqlException("Allowlist entries must be exact property names; wildcard or glob "
+          + "entries are not permitted: " + withWildcards);
+    }
+  }
+}

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/AllowListPropertyValidator.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/AllowListPropertyValidator.java
@@ -33,9 +33,9 @@ import java.util.stream.Collectors;
  *
  * <p>Notes on behavior:
  * <ul>
- *   <li><b>Exact-name matching only.</li>
+ *   <li><b>Exact-name matching only.</b></li>
  *   <li><b>No wildcards.</b> </li>
- *   <li><b>Empty allowlist is fail-closed.</li>
+ *   <li><b>Empty allowlist is fail-closed.</b> </li>
  * </ul>
  */
 public class AllowListPropertyValidator implements ConfigOverrideValidator {
@@ -54,7 +54,8 @@ public class AllowListPropertyValidator implements ConfigOverrideValidator {
   public AllowListPropertyValidator(final Collection<String> allowlist) {
     Objects.requireNonNull(allowlist, "allowlist");
     rejectWildcards(allowlist);
-    this.allowedProps = Sets.difference(ImmutableSet.copyOf(allowlist), ALWAYS_DENIED).immutableCopy();
+    this.allowedProps = Sets.difference(ImmutableSet.copyOf(allowlist), ALWAYS_DENIED)
+                        .immutableCopy();
   }
 
   /**

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/AllowListPropertyValidator.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/AllowListPropertyValidator.java
@@ -27,24 +27,15 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Validates property overrides against an allowlist: any property whose name is not in the
- * configured allowlist is rejected (deny-by-default). This is the inverse of
- * {@link DenyListPropertyValidator} and the stricter of the two policies.
+ * Class that validates if a property, or list of property overrides are part of allowed properties:
+ * any property whose name is not in the configured allowlist is rejected (deny-by-default).
+ * This is the inverse of {@link DenyListPropertyValidator} and the stricter of the two policies.
  *
  * <p>Notes on behavior:
  * <ul>
- *   <li><b>Exact-name matching only.</b> Membership is tested against the raw property name, the
- *       same way the denylist works today. Prefixed variants (e.g. {@code auto.offset.reset} vs.
- *       {@code ksql.streams.auto.offset.reset}) are distinct entries. Canonicalization is tracked
- *       separately and not done here.</li>
- *   <li><b>No wildcards.</b> Allowlist entries must be exact property names; entries containing
- *       glob/regex meta-characters ({@code *} or {@code ?}) are rejected at construction time so a
- *       broad pattern cannot silently re-open the "allow arbitrary prefix" hole.</li>
- *   <li><b>Always-denied floor.</b> A small set of server-owned keys (the service id and the
- *       {@code ksql.properties.overrides.*} policy knobs) is removed from the effective allowlist
- *       so they can never be permitted, even if listed by mistake. Mirrors how the denylist
- *       force-adds the service id.</li>
- *   <li><b>Empty allowlist is fail-closed.</b> An empty allowlist rejects every override.</li>
+ *   <li><b>Exact-name matching only.</li>
+ *   <li><b>No wildcards.</b> </li>
+ *   <li><b>Empty allowlist is fail-closed.</li>
  * </ul>
  */
 public class AllowListPropertyValidator implements ConfigOverrideValidator {
@@ -58,12 +49,12 @@ public class AllowListPropertyValidator implements ConfigOverrideValidator {
       KsqlConfig.KSQL_PROPERTIES_OVERRIDES_LOG
   );
 
-  private final Set<String> allowed;
+  private final Set<String> allowedProps;
 
   public AllowListPropertyValidator(final Collection<String> allowlist) {
     Objects.requireNonNull(allowlist, "allowlist");
     rejectWildcards(allowlist);
-    this.allowed = Sets.difference(ImmutableSet.copyOf(allowlist), ALWAYS_DENIED).immutableCopy();
+    this.allowedProps = Sets.difference(ImmutableSet.copyOf(allowlist), ALWAYS_DENIED).immutableCopy();
   }
 
   /**
@@ -72,11 +63,11 @@ public class AllowListPropertyValidator implements ConfigOverrideValidator {
    */
   @Override
   public void validateAll(final Map<String, Object> properties) {
-    final Set<String> notAllowed = Sets.difference(properties.keySet(), allowed);
-    if (!notAllowed.isEmpty()) {
+    final Set<String> notAllowedProps = Sets.difference(properties.keySet(), allowedProps);
+    if (!notAllowedProps.isEmpty()) {
       throw new KsqlException(String.format("One or more property overrides set locally are "
           + "not permitted by the KSQL server allowlist (use UNSET to reset their default "
-          + "value): %s", notAllowed));
+          + "value): %s", notAllowedProps));
     }
   }
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/ConfigOverrideValidator.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/ConfigOverrideValidator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.properties;
+
+import java.util.Map;
+
+/**
+ * Validates the property overrides a user supplies on a request against server policy.
+ *
+ * <p>Two implementations exist and exactly one is active per server, selected at startup by
+ * {@link ConfigOverrideValidatorFactory} from
+ * {@code ksql.properties.overrides.validation.mode}:
+ * <ul>
+ *   <li>{@link DenyListPropertyValidator} &mdash; rejects a fixed set of prohibited names
+ *       (default, today's behavior).</li>
+ *   <li>{@link AllowListPropertyValidator} &mdash; rejects anything not explicitly permitted
+ *       (deny-by-default).</li>
+ * </ul>
+ */
+public interface ConfigOverrideValidator {
+
+  /**
+   * Validates every property override in {@code properties}.
+   *
+   * @param properties the user-supplied overrides (keys are property names)
+   * @throws io.confluent.ksql.util.KsqlException if at least one property is not permitted
+   */
+  void validateAll(Map<String, Object> properties);
+}

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/ConfigOverrideValidator.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/ConfigOverrideValidator.java
@@ -25,7 +25,7 @@ import java.util.Map;
  * {@code ksql.properties.overrides.validation.mode}:
  * <ul>
  *   <li>{@link DenyListPropertyValidator} &mdash; rejects a fixed set of prohibited names
- *       (default, today's behavior).</li>
+ *       (default).</li>
  *   <li>{@link AllowListPropertyValidator} &mdash; rejects anything not explicitly permitted
  *       (deny-by-default).</li>
  * </ul>

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/ConfigOverrideValidatorFactory.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/ConfigOverrideValidatorFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.properties;
+
+import io.confluent.ksql.util.KsqlConfig;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Selects the active {@link ConfigOverrideValidator} for a server from
+ * {@code ksql.properties.overrides.validation.mode}.
+ *
+ * <p>Exactly one validator runs per server. When the mode is {@code allowlist} the denylist is not
+ * consulted at all (allowlist wins); when it is {@code denylist} (the default) the allowlist is not
+ * consulted. Selection is driven solely by the mode &mdash; a populated allowlist does not
+ * implicitly activate allowlist enforcement.
+ */
+public final class ConfigOverrideValidatorFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ConfigOverrideValidatorFactory.class);
+
+  private ConfigOverrideValidatorFactory() {
+  }
+
+  public static ConfigOverrideValidator forMode(final KsqlConfig config) {
+    final String mode = config.getString(KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE);
+
+    if (KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE_ALLOWLIST.equals(mode)) {
+      final List<String> allowlist =
+          config.getList(KsqlConfig.KSQL_PROPERTIES_OVERRIDES_ALLOWLIST);
+      if (allowlist.isEmpty()) {
+        LOG.warn("Property override validation mode is '{}' but '{}' is empty; all property "
+                + "overrides will be rejected.",
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE_ALLOWLIST,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_ALLOWLIST);
+      }
+      return new AllowListPropertyValidator(allowlist);
+    }
+
+    return new DenyListPropertyValidator(
+        config.getList(KsqlConfig.KSQL_PROPERTIES_OVERRIDES_DENYLIST));
+  }
+}

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/ConfigOverrideValidatorFactory.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/ConfigOverrideValidatorFactory.java
@@ -24,10 +24,10 @@ import org.slf4j.LoggerFactory;
  * Selects the active {@link ConfigOverrideValidator} for a server from
  * {@code ksql.properties.overrides.validation.mode}.
  *
- * <p>Exactly one validator runs per server. When the mode is {@code allowlist} the denylist is not
- * consulted at all (allowlist wins); when it is {@code denylist} (the default) the allowlist is not
- * consulted. Selection is driven solely by the mode &mdash; a populated allowlist does not
- * implicitly activate allowlist enforcement.
+ * <p>Exactly one validator runs per server. Selection is driven solely by the mode.
+ * Default mode is {@link KsqlConfig#KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE_DENYLIST}, which
+ * uses {@link DenyListPropertyValidator}.
+ * </p>
  */
 public final class ConfigOverrideValidatorFactory {
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/DenyListPropertyValidator.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/DenyListPropertyValidator.java
@@ -46,7 +46,7 @@ public class DenyListPropertyValidator implements ConfigOverrideValidator {
     final Set<String> propsDenied = Sets.intersection(immutableProps, properties.keySet());
     if (!propsDenied.isEmpty()) {
       throw new KsqlException(String.format("One or more properties overrides set locally are "
-          + "prohibited by the KSQL server (use UNSET to reset their default value): %s",
+          + "prohibited by the KSQL server denylist (use UNSET to reset their default value): %s",
           propsDenied));
     }
   }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/DenyListPropertyValidator.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/DenyListPropertyValidator.java
@@ -28,7 +28,7 @@ import java.util.Set;
  * Class that validates if a property, or list of properties, is part of a list of denied
  * properties.
  */
-public class DenyListPropertyValidator {
+public class DenyListPropertyValidator implements ConfigOverrideValidator {
   private final Set<String> immutableProps;
 
   public DenyListPropertyValidator(final Collection<String> immutableProps) {
@@ -41,6 +41,7 @@ public class DenyListPropertyValidator {
    * Validates if a list of properties are part of the list of denied properties.
    * @throws if at least one property is part of the denied list.
    */
+  @Override
   public void validateAll(final Map<String, Object> properties) {
     final Set<String> propsDenied = Sets.intersection(immutableProps, properties.keySet());
     if (!propsDenied.isEmpty()) {

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/PropertyNotFoundException.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/PropertyNotFoundException.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.properties;
 
 public class PropertyNotFoundException extends IllegalArgumentException {
-  PropertyNotFoundException(final String property) {
+  public PropertyNotFoundException(final String property) {
     super(String.format(
         "Not recognizable as ksql, streams, consumer, or producer property: '%s'",
         property

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -662,12 +662,14 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_PROPERTIES_OVERRIDES_DENYLIST =
       "ksql.properties.overrides.denylist";
   private static final String KSQL_PROPERTIES_OVERRIDES_DENYLIST_DOC = "Comma-separated list of "
-      + "properties that KSQL users cannot override when ksql.properties.overrides.validation.mode = denylist";
+      + "properties that KSQL users cannot override "
+      + "when ksql.properties.overrides.validation.mode = denylist";
 
   public static final String KSQL_PROPERTIES_OVERRIDES_ALLOWLIST =
       "ksql.properties.overrides.allowlist";
   private static final String KSQL_PROPERTIES_OVERRIDES_ALLOWLIST_DOC = "Comma-separated list of "
-      + "properties permitted as overrides when ksql.properties.overrides.validation.mode = allowlist. "
+      + "properties permitted as overrides "
+      + "when ksql.properties.overrides.validation.mode = allowlist. "
       + "Entries must be exact names, wildcard/glob entries are rejected." ;
 
   public static final String KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE =

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -662,14 +662,13 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_PROPERTIES_OVERRIDES_DENYLIST =
       "ksql.properties.overrides.denylist";
   private static final String KSQL_PROPERTIES_OVERRIDES_DENYLIST_DOC = "Comma-separated list of "
-      + "properties that KSQL users cannot override.";
+      + "properties that KSQL users cannot override when ksql.properties.overrides.validation.mode = denylist";
 
   public static final String KSQL_PROPERTIES_OVERRIDES_ALLOWLIST =
       "ksql.properties.overrides.allowlist";
   private static final String KSQL_PROPERTIES_OVERRIDES_ALLOWLIST_DOC = "Comma-separated list of "
-      + "property names permitted as overrides when "
-      + "ksql.properties.overrides.validation.mode = allowlist. "
-      + "Note: this list is not currently consulted; 'allowlist' mode is not enforced.";
+      + "properties permitted as overrides when ksql.properties.overrides.validation.mode = allowlist. "
+      + "Entries must be exact names, wildcard/glob entries are rejected." ;
 
   public static final String KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE =
       "ksql.properties.overrides.validation.mode";
@@ -681,9 +680,7 @@ public class KsqlConfig extends AbstractConfig {
       "Validation mode for property overrides on REST endpoints. Allowed values: 'denylist' "
           + "(default behavior - reject names listed in "
           + KSQL_PROPERTIES_OVERRIDES_DENYLIST + "), 'allowlist' (only permit names listed in "
-          + KSQL_PROPERTIES_OVERRIDES_ALLOWLIST + "). "
-          + "Note: only 'denylist' mode is currently enforced; setting this to 'allowlist' "
-          + "has no effect on validation.";
+          + KSQL_PROPERTIES_OVERRIDES_ALLOWLIST + ").";
 
   public static final String KSQL_PROPERTIES_OVERRIDES_LOG =
       "ksql.properties.overrides.log";

--- a/ksqldb-common/src/test/java/io/confluent/ksql/properties/AllowListPropertyValidatorTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/properties/AllowListPropertyValidatorTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.properties;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import java.util.Arrays;
+import org.junit.Test;
+
+public class AllowListPropertyValidatorTest {
+
+  @Test
+  public void shouldNotThrowWhenAllPropertiesAreAllowlisted() {
+    // Given:
+    final AllowListPropertyValidator validator = new AllowListPropertyValidator(Arrays.asList(
+        "auto.offset.reset",
+        "ksql.streams.num.standby.replicas"
+    ));
+
+    // When/Then (no throw):
+    validator.validateAll(ImmutableMap.of(
+        "auto.offset.reset", "earliest",
+        "ksql.streams.num.standby.replicas", "1"
+    ));
+  }
+
+  @Test
+  public void shouldThrowOnPropertyNotOnAllowlist() {
+    // Given:
+    final AllowListPropertyValidator validator = new AllowListPropertyValidator(Arrays.asList(
+        "auto.offset.reset"
+    ));
+
+    // When:
+    final KsqlException e = assertThrows(
+        KsqlException.class,
+        () -> validator.validateAll(ImmutableMap.of(
+            "auto.offset.reset", "earliest",
+            "sasl.jaas.config", "boom"
+        ))
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString(
+        "One or more property overrides set locally are not permitted by the KSQL server "
+            + "allowlist (use UNSET to reset their default value): [sasl.jaas.config]"));
+  }
+
+  @Test
+  public void shouldRejectEveryPropertyWhenAllowlistEmpty() {
+    // Given:
+    final AllowListPropertyValidator validator =
+        new AllowListPropertyValidator(Arrays.asList());
+
+    // When:
+    final KsqlException e = assertThrows(
+        KsqlException.class,
+        () -> validator.validateAll(ImmutableMap.of("auto.offset.reset", "earliest"))
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString("[auto.offset.reset]"));
+  }
+
+  @Test
+  public void shouldNotThrowOnEmptyOverrides() {
+    // Given:
+    final AllowListPropertyValidator validator =
+        new AllowListPropertyValidator(Arrays.asList());
+
+    // When/Then (no throw):
+    validator.validateAll(ImmutableMap.of());
+  }
+
+  @Test
+  public void shouldRejectServiceIdEvenWhenAllowlisted() {
+    // Given: an admin mistakenly allowlists the service id
+    final AllowListPropertyValidator validator = new AllowListPropertyValidator(Arrays.asList(
+        KsqlConfig.KSQL_SERVICE_ID_CONFIG
+    ));
+
+    // When:
+    final KsqlException e = assertThrows(
+        KsqlException.class,
+        () -> validator.validateAll(ImmutableMap.of(KsqlConfig.KSQL_SERVICE_ID_CONFIG, "x"))
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString(KsqlConfig.KSQL_SERVICE_ID_CONFIG));
+  }
+
+  @Test
+  public void shouldRejectOverridePolicyKnobsEvenWhenAllowlisted() {
+    // Given: an admin mistakenly allowlists the policy knobs
+    final AllowListPropertyValidator validator = new AllowListPropertyValidator(Arrays.asList(
+        KsqlConfig.KSQL_PROPERTIES_OVERRIDES_ALLOWLIST,
+        KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE
+    ));
+
+    // When:
+    final KsqlException e = assertThrows(
+        KsqlException.class,
+        () -> validator.validateAll(ImmutableMap.of(
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE, "denylist"))
+    );
+
+    // Then:
+    assertThat(e.getMessage(),
+        containsString(KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE));
+  }
+
+  @Test
+  public void shouldRejectWildcardAllowlistEntryAtConstruction() {
+    // When:
+    final KsqlException e = assertThrows(
+        KsqlException.class,
+        () -> new AllowListPropertyValidator(Arrays.asList("ksql.functions.*"))
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString("wildcard"));
+    assertThat(e.getMessage(), containsString("ksql.functions.*"));
+  }
+
+  @Test
+  public void shouldRejectQuestionMarkAllowlistEntryAtConstruction() {
+    // When:
+    final KsqlException e = assertThrows(
+        KsqlException.class,
+        () -> new AllowListPropertyValidator(Arrays.asList("auto.offset.rese?"))
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString("wildcard"));
+  }
+}

--- a/ksqldb-common/src/test/java/io/confluent/ksql/properties/AllowListPropertyValidatorTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/properties/AllowListPropertyValidatorTest.java
@@ -91,26 +91,10 @@ public class AllowListPropertyValidatorTest {
   }
 
   @Test
-  public void shouldRejectServiceIdEvenWhenAllowlisted() {
-    // Given: an admin mistakenly allowlists the service id
+  public void shouldRejectAlwaysDeniedFloorKeysEvenWhenAllowlisted() {
+    // Given: an admin mistakenly allowlists the service id and the override policy knobs
     final AllowListPropertyValidator validator = new AllowListPropertyValidator(Arrays.asList(
-        KsqlConfig.KSQL_SERVICE_ID_CONFIG
-    ));
-
-    // When:
-    final KsqlException e = assertThrows(
-        KsqlException.class,
-        () -> validator.validateAll(ImmutableMap.of(KsqlConfig.KSQL_SERVICE_ID_CONFIG, "x"))
-    );
-
-    // Then:
-    assertThat(e.getMessage(), containsString(KsqlConfig.KSQL_SERVICE_ID_CONFIG));
-  }
-
-  @Test
-  public void shouldRejectOverridePolicyKnobsEvenWhenAllowlisted() {
-    // Given: an admin mistakenly allowlists the policy knobs
-    final AllowListPropertyValidator validator = new AllowListPropertyValidator(Arrays.asList(
+        KsqlConfig.KSQL_SERVICE_ID_CONFIG,
         KsqlConfig.KSQL_PROPERTIES_OVERRIDES_ALLOWLIST,
         KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE
     ));
@@ -119,36 +103,30 @@ public class AllowListPropertyValidatorTest {
     final KsqlException e = assertThrows(
         KsqlException.class,
         () -> validator.validateAll(ImmutableMap.of(
+            KsqlConfig.KSQL_SERVICE_ID_CONFIG, "x",
             KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE, "denylist"))
     );
 
     // Then:
+    assertThat(e.getMessage(), containsString(KsqlConfig.KSQL_SERVICE_ID_CONFIG));
     assertThat(e.getMessage(),
         containsString(KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE));
   }
 
   @Test
-  public void shouldRejectWildcardAllowlistEntryAtConstruction() {
+  public void shouldRejectWildcardOrGlobAllowlistEntriesAtConstruction() {
     // When:
     final KsqlException e = assertThrows(
         KsqlException.class,
-        () -> new AllowListPropertyValidator(Arrays.asList("ksql.functions.*"))
+        () -> new AllowListPropertyValidator(Arrays.asList(
+            "ksql.functions.*",
+            "auto.offset.rese?"
+        ))
     );
 
     // Then:
     assertThat(e.getMessage(), containsString("wildcard"));
     assertThat(e.getMessage(), containsString("ksql.functions.*"));
-  }
-
-  @Test
-  public void shouldRejectQuestionMarkAllowlistEntryAtConstruction() {
-    // When:
-    final KsqlException e = assertThrows(
-        KsqlException.class,
-        () -> new AllowListPropertyValidator(Arrays.asList("auto.offset.rese?"))
-    );
-
-    // Then:
-    assertThat(e.getMessage(), containsString("wildcard"));
+    assertThat(e.getMessage(), containsString("auto.offset.rese?"));
   }
 }

--- a/ksqldb-common/src/test/java/io/confluent/ksql/properties/ConfigOverrideValidatorFactoryTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/properties/ConfigOverrideValidatorFactoryTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.properties;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import java.util.Map;
+import org.junit.Test;
+
+public class ConfigOverrideValidatorFactoryTest {
+
+  private static KsqlConfig config(final Map<String, Object> overrides) {
+    return new KsqlConfig(overrides);
+  }
+
+  @Test
+  public void shouldReturnDenyListValidatorByDefault() {
+    // Given: no mode set (defaults to denylist)
+    final ConfigOverrideValidator validator = ConfigOverrideValidatorFactory.forMode(
+        config(ImmutableMap.of()));
+
+    // Then:
+    assertThat(validator, instanceOf(DenyListPropertyValidator.class));
+  }
+
+  @Test
+  public void shouldReturnDenyListValidatorWhenModeIsDenylist() {
+    // Given:
+    final ConfigOverrideValidator validator = ConfigOverrideValidatorFactory.forMode(config(
+        ImmutableMap.of(
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE, "denylist",
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_DENYLIST, "sasl.jaas.config")));
+
+    // Then:
+    assertThat(validator, instanceOf(DenyListPropertyValidator.class));
+    assertThrows(
+        KsqlException.class,
+        () -> validator.validateAll(ImmutableMap.of("sasl.jaas.config", "x")));
+  }
+
+  @Test
+  public void shouldReturnAllowListValidatorWhenModeIsAllowlist() {
+    // Given:
+    final ConfigOverrideValidator validator = ConfigOverrideValidatorFactory.forMode(config(
+        ImmutableMap.of(
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE, "allowlist",
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_ALLOWLIST, "auto.offset.reset")));
+
+    // Then:
+    assertThat(validator, instanceOf(AllowListPropertyValidator.class));
+    // allowlisted property passes:
+    validator.validateAll(ImmutableMap.of("auto.offset.reset", "earliest"));
+    // non-allowlisted property is rejected:
+    assertThrows(
+        KsqlException.class,
+        () -> validator.validateAll(ImmutableMap.of("sasl.jaas.config", "x")));
+  }
+
+  @Test
+  public void shouldReturnAllowListThatRejectsAllWhenAllowlistEmpty() {
+    // Given: allowlist mode with no allowlist configured (fail-closed)
+    final ConfigOverrideValidator validator = ConfigOverrideValidatorFactory.forMode(config(
+        ImmutableMap.of(
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE, "allowlist")));
+
+    // Then:
+    assertThat(validator, instanceOf(AllowListPropertyValidator.class));
+    assertThrows(
+        KsqlException.class,
+        () -> validator.validateAll(ImmutableMap.of("auto.offset.reset", "earliest")));
+  }
+}

--- a/ksqldb-common/src/test/java/io/confluent/ksql/properties/DenyListPropertyValidatorTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/properties/DenyListPropertyValidatorTest.java
@@ -50,7 +50,7 @@ public class DenyListPropertyValidatorTest {
 
     // Then:
     assertThat(e.getMessage(), containsString(
-        "One or more properties overrides set locally are prohibited by the KSQL server "
+        "One or more properties overrides set locally are prohibited by the KSQL server denylist "
             + "(use UNSET to reset their default value): "
             + "[immutable-property-1, immutable-property-2]"
     ));
@@ -77,7 +77,7 @@ public class DenyListPropertyValidatorTest {
 
     // Then:
     assertThat(e.getMessage(), containsString(
-        "One or more properties overrides set locally are prohibited by the KSQL server "
+        "One or more properties overrides set locally are prohibited by the KSQL server denylist "
             + "(use UNSET to reset their default value): [ksql.service.id]"
     ));
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/properties/PropertyOverrider.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/properties/PropertyOverrider.java
@@ -21,7 +21,6 @@ import io.confluent.ksql.config.KsqlConfigResolver;
 import io.confluent.ksql.parser.tree.SetProperty;
 import io.confluent.ksql.parser.tree.UnsetProperty;
 import io.confluent.ksql.statement.ConfiguredStatement;
-import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
 import java.util.Map;
@@ -39,7 +38,7 @@ public final class PropertyOverrider {
     throwIfInvalidProperty(setProperty.getPropertyName(), statement.getMaskedStatementText());
     ConfigOverrideLogger.logOverrides(
             "SET", ImmutableMap.of(setProperty.getPropertyName(), ""));
-    throwIfDeniedProperty(setProperty, statement);
+    throwIfDisallowedProperty(setProperty, statement);
     throwIfInvalidPropertyValues(setProperty, statement);
     mutableProperties.put(setProperty.getPropertyName(), setProperty.getPropertyValue());
   }
@@ -79,22 +78,21 @@ public final class PropertyOverrider {
         .orElseThrow(() -> new KsqlStatementException("Unknown property: " + propertyName, text));
   }
 
-  private static void throwIfDeniedProperty(
+  private static void throwIfDisallowedProperty(
       final SetProperty setProperty,
       final ConfiguredStatement<SetProperty> statement
   ) {
-    // Build the validator from the system config (getConfig(false)), never the override-applied
-    // config, so that a user-supplied override of the denylist itself cannot unlock a denied
-    // property. The validator is stateless and cheap, so constructing it per SET (a rare,
-    // interactive control statement) keeps this security rule local to PropertyOverrider and
+    // Build the validator (denylist or allowlist, per ksql.properties.overrides.validation.mode)
+    // from the system config (getConfig(false)), never the override-applied config, so that a
+    // user-supplied override of the denylist/allowlist or the validation mode itself cannot unlock
+    // a disallowed property. The validator is stateless and cheap, so constructing it per SET (a
+    // rare, interactive control statement) keeps this security rule local to PropertyOverrider and
     // lets every caller -- REST, embedded, standalone and the test tool -- share it without
     // plumbing an instance through.
-    final DenyListPropertyValidator denyListPropertyValidator = new DenyListPropertyValidator(
-        statement.getSessionConfig()
-            .getConfig(false)
-            .getList(KsqlConfig.KSQL_PROPERTIES_OVERRIDES_DENYLIST));
+    final ConfigOverrideValidator configOverrideValidator = ConfigOverrideValidatorFactory
+        .forMode(statement.getSessionConfig().getConfig(false));
     try {
-      denyListPropertyValidator.validateAll(ImmutableMap.of(
+      configOverrideValidator.validateAll(ImmutableMap.of(
           setProperty.getPropertyName(),
           setProperty.getPropertyValue()
       ));

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -50,6 +50,8 @@ import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.logging.processing.ProcessingLogServerUtils;
 import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.properties.ConfigOverrideValidator;
+import io.confluent.ksql.properties.ConfigOverrideValidatorFactory;
 import io.confluent.ksql.properties.DenyListPropertyValidator;
 import io.confluent.ksql.properties.PropertiesUtil;
 import io.confluent.ksql.query.id.SpecificQueryIdGenerator;
@@ -206,7 +208,7 @@ public final class KsqlRestApplication implements Executable {
   private final Vertx vertx;
   private Server apiServer = null;
   private final CompletableFuture<Void> terminatedFuture = new CompletableFuture<>();
-  private final DenyListPropertyValidator denyListPropertyValidator;
+  private final ConfigOverrideValidator configOverrideValidator;
   private final Optional<PullQueryExecutorMetrics> pullQueryMetrics;
   private final Optional<ScalablePushQueryMetrics> scalablePushQueryMetrics;
   private final Optional<LocalCommands> localCommands;
@@ -247,7 +249,7 @@ public final class KsqlRestApplication implements Executable {
       final Optional<HeartbeatAgent> heartbeatAgent,
       final Optional<LagReportingAgent> lagReportingAgent,
       final Vertx vertx,
-      final DenyListPropertyValidator denyListPropertyValidator,
+      final ConfigOverrideValidator configOverrideValidator,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
       final Optional<ScalablePushQueryMetrics> scalablePushQueryMetrics,
       final Optional<LocalCommands> localCommands,
@@ -281,8 +283,8 @@ public final class KsqlRestApplication implements Executable {
     this.heartbeatAgent = requireNonNull(heartbeatAgent, "heartbeatAgent");
     this.lagReportingAgent = requireNonNull(lagReportingAgent, "lagReportingAgent");
     this.vertx = requireNonNull(vertx, "vertx");
-    this.denyListPropertyValidator =
-        requireNonNull(denyListPropertyValidator, "denyListPropertyValidator");
+    this.configOverrideValidator =
+        requireNonNull(configOverrideValidator, "configOverrideValidator");
 
     this.serverInfoResource =
         new ServerInfoResource(serviceContext, ksqlConfigNoPort, commandRunner);
@@ -350,12 +352,16 @@ public final class KsqlRestApplication implements Executable {
             KsqlRestConfig.DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT_MS_CONFIG)),
         authorizationValidator,
         errorHandler,
-        denyListPropertyValidator,
+        configOverrideValidator,
         queryExecutor
     );
 
     startAsyncThreadRef.set(Thread.currentThread());
     try {
+      // The Vert.x HTTP/2 endpoints (/query-stream, /inserts-stream) stay on the denylist for
+      // now; allowlist enforcement for those is handled in a separate change.
+      final DenyListPropertyValidator denyListPropertyValidator = new DenyListPropertyValidator(
+          ksqlConfigNoPort.getList(KsqlConfig.KSQL_PROPERTIES_OVERRIDES_DENYLIST));
       final Endpoints endpoints = new KsqlServerEndpoints(
           ksqlEngine,
           ksqlConfigNoPort,
@@ -875,8 +881,8 @@ public final class KsqlRestApplication implements Executable {
             metricCollectors.getMetrics(),
             metricsTags
         );
-    final DenyListPropertyValidator denyListPropertyValidator = new DenyListPropertyValidator(
-        ksqlConfig.getList(KsqlConfig.KSQL_PROPERTIES_OVERRIDES_DENYLIST));
+    final ConfigOverrideValidator configOverrideValidator =
+        ConfigOverrideValidatorFactory.forMode(ksqlConfig);
 
     final Optional<PullQueryExecutorMetrics> pullQueryMetrics = ksqlConfig.getBoolean(
         KsqlConfig.KSQL_QUERY_PULL_METRICS_ENABLED)
@@ -925,7 +931,7 @@ public final class KsqlRestApplication implements Executable {
         versionChecker::updateLastRequestTime,
         authorizationValidator,
         errorHandler,
-        denyListPropertyValidator,
+        configOverrideValidator,
         queryExecutor
     );
 
@@ -959,7 +965,7 @@ public final class KsqlRestApplication implements Executable {
         versionChecker::updateLastRequestTime,
         authorizationValidator,
         errorHandler,
-        denyListPropertyValidator
+        configOverrideValidator
     );
 
     final List<KsqlConfigurable> configurables = ImmutableList.of(
@@ -992,7 +998,7 @@ public final class KsqlRestApplication implements Executable {
         heartbeatAgent,
         lagReportingAgent,
         vertx,
-        denyListPropertyValidator,
+        configOverrideValidator,
         pullQueryMetrics,
         scalablePushQueryMetrics,
         localCommands,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -52,7 +52,6 @@ import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.properties.ConfigOverrideValidator;
 import io.confluent.ksql.properties.ConfigOverrideValidatorFactory;
-import io.confluent.ksql.properties.DenyListPropertyValidator;
 import io.confluent.ksql.properties.PropertiesUtil;
 import io.confluent.ksql.query.id.SpecificQueryIdGenerator;
 import io.confluent.ksql.rest.ErrorMessages;
@@ -358,10 +357,6 @@ public final class KsqlRestApplication implements Executable {
 
     startAsyncThreadRef.set(Thread.currentThread());
     try {
-      // The Vert.x HTTP/2 endpoints (/query-stream, /inserts-stream) stay on the denylist for
-      // now; allowlist enforcement for those is handled in a separate change.
-      final DenyListPropertyValidator denyListPropertyValidator = new DenyListPropertyValidator(
-          ksqlConfigNoPort.getList(KsqlConfig.KSQL_PROPERTIES_OVERRIDES_DENYLIST));
       final Endpoints endpoints = new KsqlServerEndpoints(
           ksqlEngine,
           ksqlConfigNoPort,
@@ -379,7 +374,7 @@ public final class KsqlRestApplication implements Executable {
           pullQueryMetrics,
           queryExecutor,
           securityExtension.getAuthTokenProvider(),
-          denyListPropertyValidator
+          configOverrideValidator
       );
       apiServer = new Server(vertx, ksqlRestConfig, endpoints, securityExtension,
           authenticationPlugin, serverState, pullQueryMetrics);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
@@ -30,7 +30,7 @@ import io.confluent.ksql.api.server.MetricsCallbackHolder;
 import io.confluent.ksql.api.spi.Endpoints;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.internal.PullQueryExecutorMetrics;
-import io.confluent.ksql.properties.DenyListPropertyValidator;
+import io.confluent.ksql.properties.ConfigOverrideValidator;
 import io.confluent.ksql.rest.EndpointResponse;
 import io.confluent.ksql.rest.entity.ClusterTerminateRequest;
 import io.confluent.ksql.rest.entity.HeartbeatMessage;
@@ -91,7 +91,7 @@ public class KsqlServerEndpoints implements Endpoints {
   private final Optional<PullQueryExecutorMetrics> pullQueryMetrics;
   private final QueryExecutor queryExecutor;
   private final Optional<KsqlAuthTokenProvider> authTokenProvider;
-  private final DenyListPropertyValidator denyListPropertyValidator;
+  private final ConfigOverrideValidator configOverrideValidator;
 
   // CHECKSTYLE_RULES.OFF: ParameterNumber
   @SuppressFBWarnings(value = "EI_EXPOSE_REP2")
@@ -112,7 +112,7 @@ public class KsqlServerEndpoints implements Endpoints {
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
       final QueryExecutor queryExecutor,
       final Optional<KsqlAuthTokenProvider> authTokenProvider,
-      final DenyListPropertyValidator denyListPropertyValidator
+      final ConfigOverrideValidator configOverrideValidator
   ) {
 
     // CHECKSTYLE_RULES.ON: ParameterNumber
@@ -133,8 +133,8 @@ public class KsqlServerEndpoints implements Endpoints {
     this.pullQueryMetrics = Objects.requireNonNull(pullQueryMetrics);
     this.queryExecutor = queryExecutor;
     this.authTokenProvider = authTokenProvider;
-    this.denyListPropertyValidator =
-        Objects.requireNonNull(denyListPropertyValidator, "denyListPropertyValidator");
+    this.configOverrideValidator =
+        Objects.requireNonNull(configOverrideValidator, "configOverrideValidator");
   }
 
   @Override
@@ -333,7 +333,7 @@ public class KsqlServerEndpoints implements Endpoints {
 
   private void validateProperties(final Map<String, Object> properties) {
     try {
-      denyListPropertyValidator.validateAll(properties);
+      configOverrideValidator.validateAll(properties);
     } catch (KsqlException e) {
       throw new KsqlApiException(e.getMessage(), ERROR_CODE_BAD_REQUEST);
     }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -35,6 +35,7 @@ import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.UnsetProperty;
 import io.confluent.ksql.properties.ConfigOverrideLogger;
 import io.confluent.ksql.properties.ConfigOverrideValidator;
+import io.confluent.ksql.properties.PropertyNotFoundException;
 import io.confluent.ksql.rest.EndpointResponse;
 import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.SessionProperties;
@@ -248,12 +249,15 @@ public class KsqlResource implements KsqlConfigurable {
       final Map<String, Object> properties = new HashMap<>();
       properties.put(property, "");
       final KsqlConfigResolver resolver = new KsqlConfigResolver();
-      final Optional<ConfigItem> resolvedItem = resolver.resolve(property, false);
+      // Reject unknown property names up front with the same PropertyNotFoundException that the
+      // /ksql, /query and /ws/query paths throw as an "unrecognized property" error
+      // rather than a misleading allow/deny-list rejection.
+      final ConfigItem resolvedItem = resolver.resolve(property, true)
+          .orElseThrow(() -> new PropertyNotFoundException(property));
       ConfigOverrideLogger.logOverrides("SET", properties);
       configOverrideValidator.validateAll(properties);
-      if (ksqlEngine.getKsqlConfig().getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)
-          && resolvedItem.isPresent()) {
-        if (!PropertiesList.QueryLevelProperties.contains(resolvedItem.get().getPropertyName())) {
+      if (ksqlEngine.getKsqlConfig().getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)) {
+        if (!PropertiesList.QueryLevelProperties.contains(resolvedItem.getPropertyName())) {
           throw new KsqlException(String.format("When shared runtimes are enabled, the"
               + " config %s can only be set for the entire cluster and all queries currently"
               + " running in it, and not configurable for individual queries."
@@ -262,7 +266,10 @@ public class KsqlResource implements KsqlConfigurable {
         }
       }
       return EndpointResponse.ok(true);
-    } catch (final KsqlException e) {
+    } catch (final PropertyNotFoundException | KsqlException e) {
+      // Unknown property name (PropertyNotFoundException) and denylist/allowlist rejections
+      // (KsqlException) both map to 400 per the documented /is_valid_property contract
+      // ({"@type":"generic_error","error_code":40000}).
       LOG.info("Processed unsuccessfully, reason: ", e);
       return errorHandler.generateResponse(e, Errors.badRequest(e));
     } catch (final Exception e) {
@@ -422,3 +429,4 @@ public class KsqlResource implements KsqlConfigurable {
     }
   }
 }
+

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -34,7 +34,7 @@ import io.confluent.ksql.parser.tree.SetProperty;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.UnsetProperty;
 import io.confluent.ksql.properties.ConfigOverrideLogger;
-import io.confluent.ksql.properties.DenyListPropertyValidator;
+import io.confluent.ksql.properties.ConfigOverrideValidator;
 import io.confluent.ksql.rest.EndpointResponse;
 import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.SessionProperties;
@@ -110,7 +110,7 @@ public class KsqlResource implements KsqlConfigurable {
   private final ActivenessRegistrar activenessRegistrar;
   private final BiFunction<KsqlExecutionContext, ServiceContext, Injector> injectorFactory;
   private final Optional<KsqlAuthorizationValidator> authorizationValidator;
-  private final DenyListPropertyValidator denyListPropertyValidator;
+  private final ConfigOverrideValidator configOverrideValidator;
   private final Supplier<String> commandRunnerWarning;
   private RequestValidator validator;
   private RequestHandler handler;
@@ -125,7 +125,7 @@ public class KsqlResource implements KsqlConfigurable {
       final ActivenessRegistrar activenessRegistrar,
       final Optional<KsqlAuthorizationValidator> authorizationValidator,
       final Errors errorHandler,
-      final DenyListPropertyValidator denyListPropertyValidator
+      final ConfigOverrideValidator configOverrideValidator
   ) {
     this(
         ksqlEngine,
@@ -135,7 +135,7 @@ public class KsqlResource implements KsqlConfigurable {
         Injectors.DEFAULT,
         authorizationValidator,
         errorHandler,
-        denyListPropertyValidator,
+        configOverrideValidator,
         commandRunner::getCommandRunnerDegradedWarning
     );
   }
@@ -148,7 +148,7 @@ public class KsqlResource implements KsqlConfigurable {
       final BiFunction<KsqlExecutionContext, ServiceContext, Injector> injectorFactory,
       final Optional<KsqlAuthorizationValidator> authorizationValidator,
       final Errors errorHandler,
-      final DenyListPropertyValidator denyListPropertyValidator,
+      final ConfigOverrideValidator configOverrideValidator,
       final Supplier<String> commandRunnerWarning
   ) {
     this.ksqlEngine = Objects.requireNonNull(ksqlEngine, "ksqlEngine");
@@ -161,8 +161,8 @@ public class KsqlResource implements KsqlConfigurable {
     this.authorizationValidator = Objects
         .requireNonNull(authorizationValidator, "authorizationValidator");
     this.errorHandler = Objects.requireNonNull(errorHandler, "errorHandler");
-    this.denyListPropertyValidator =
-        Objects.requireNonNull(denyListPropertyValidator, "denyListPropertyValidator");
+    this.configOverrideValidator =
+        Objects.requireNonNull(configOverrideValidator, "configOverrideValidator");
     this.commandRunnerWarning =
         Objects.requireNonNull(commandRunnerWarning, "commandRunnerWarning");
   }
@@ -224,7 +224,7 @@ public class KsqlResource implements KsqlConfigurable {
     ensureValidPatterns(request.getDeleteTopicList());
     try {
       final Map<String, Object> streamsProperties = request.getStreamsProperties();
-      denyListPropertyValidator.validateAll(streamsProperties);
+      configOverrideValidator.validateAll(streamsProperties);
 
       final KsqlEntityList entities = handler.execute(
           securityContext,
@@ -250,7 +250,7 @@ public class KsqlResource implements KsqlConfigurable {
       final KsqlConfigResolver resolver = new KsqlConfigResolver();
       final Optional<ConfigItem> resolvedItem = resolver.resolve(property, false);
       ConfigOverrideLogger.logOverrides("SET", properties);
-      denyListPropertyValidator.validateAll(properties);
+      configOverrideValidator.validateAll(properties);
       if (ksqlEngine.getKsqlConfig().getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)
           && resolvedItem.isPresent()) {
         if (!PropertiesList.QueryLevelProperties.contains(resolvedItem.get().getPropertyName())) {
@@ -295,7 +295,7 @@ public class KsqlResource implements KsqlConfigurable {
 
       final Map<String, Object> configProperties = request.getConfigOverrides();
       ConfigOverrideLogger.logOverrides("/ksql", configProperties);
-      denyListPropertyValidator.validateAll(configProperties);
+      configOverrideValidator.validateAll(configProperties);
 
       final KsqlRequestConfig requestConfig =
           new KsqlRequestConfig(request.getRequestProperties());

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -225,7 +225,6 @@ public class KsqlResource implements KsqlConfigurable {
     ensureValidPatterns(request.getDeleteTopicList());
     try {
       final Map<String, Object> streamsProperties = request.getStreamsProperties();
-      configOverrideValidator.validateAll(streamsProperties);
 
       final KsqlEntityList entities = handler.execute(
           securityContext,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -25,7 +25,7 @@ import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.PrintTopic;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.properties.ConfigOverrideLogger;
-import io.confluent.ksql.properties.DenyListPropertyValidator;
+import io.confluent.ksql.properties.ConfigOverrideValidator;
 import io.confluent.ksql.rest.ApiJsonMapper;
 import io.confluent.ksql.rest.EndpointResponse;
 import io.confluent.ksql.rest.Errors;
@@ -75,7 +75,7 @@ public class StreamedQueryResource {
   private final ActivenessRegistrar activenessRegistrar;
   private final Optional<KsqlAuthorizationValidator> authorizationValidator;
   private final Errors errorHandler;
-  private final DenyListPropertyValidator denyListPropertyValidator;
+  private final ConfigOverrideValidator configOverrideValidator;
   private final QueryExecutor queryExecutor;
 
   private KsqlRestConfig ksqlRestConfig;
@@ -90,7 +90,7 @@ public class StreamedQueryResource {
       final ActivenessRegistrar activenessRegistrar,
       final Optional<KsqlAuthorizationValidator> authorizationValidator,
       final Errors errorHandler,
-      final DenyListPropertyValidator denyListPropertyValidator,
+      final ConfigOverrideValidator configOverrideValidator,
       final QueryExecutor queryExecutor
   ) {
     this(
@@ -103,7 +103,7 @@ public class StreamedQueryResource {
         activenessRegistrar,
         authorizationValidator,
         errorHandler,
-        denyListPropertyValidator,
+        configOverrideValidator,
         queryExecutor
     );
   }
@@ -121,7 +121,7 @@ public class StreamedQueryResource {
       final ActivenessRegistrar activenessRegistrar,
       final Optional<KsqlAuthorizationValidator> authorizationValidator,
       final Errors errorHandler,
-      final DenyListPropertyValidator denyListPropertyValidator,
+      final ConfigOverrideValidator configOverrideValidator,
       final QueryExecutor queryExecutor
   ) {
     this.ksqlEngine = Objects.requireNonNull(ksqlEngine, "ksqlEngine");
@@ -136,8 +136,8 @@ public class StreamedQueryResource {
         Objects.requireNonNull(activenessRegistrar, "activenessRegistrar");
     this.authorizationValidator = authorizationValidator;
     this.errorHandler = Objects.requireNonNull(errorHandler, "errorHandler");
-    this.denyListPropertyValidator =
-        Objects.requireNonNull(denyListPropertyValidator, "denyListPropertyValidator");
+    this.configOverrideValidator =
+        Objects.requireNonNull(configOverrideValidator, "configOverrideValidator");
     this.queryExecutor = queryExecutor;
   }
 
@@ -201,7 +201,7 @@ public class StreamedQueryResource {
 
       final Map<String, Object> configProperties = request.getConfigOverrides();
       ConfigOverrideLogger.logOverrides("/query", configProperties);
-      denyListPropertyValidator.validateAll(configProperties);
+      configOverrideValidator.validateAll(configProperties);
 
       if (statement.getStatement() instanceof Query) {
         if (shouldMigrateToQueryStream(request.getConfigOverrides())) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
@@ -27,7 +27,7 @@ import io.confluent.ksql.parser.tree.PrintTopic;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.properties.ConfigOverrideLogger;
-import io.confluent.ksql.properties.DenyListPropertyValidator;
+import io.confluent.ksql.properties.ConfigOverrideValidator;
 import io.confluent.ksql.rest.ApiJsonMapper;
 import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.entity.KsqlMediaType;
@@ -71,7 +71,7 @@ public class WSQueryEndpoint {
   private final Duration commandQueueCatchupTimeout;
   private final Optional<KsqlAuthorizationValidator> authorizationValidator;
   private final Errors errorHandler;
-  private final DenyListPropertyValidator denyListPropertyValidator;
+  private final ConfigOverrideValidator configOverrideValidator;
   private final QueryExecutor queryExecutor;
 
   // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
@@ -86,7 +86,7 @@ public class WSQueryEndpoint {
       final Duration commandQueueCatchupTimeout,
       final Optional<KsqlAuthorizationValidator> authorizationValidator,
       final Errors errorHandler,
-      final DenyListPropertyValidator denyListPropertyValidator,
+      final ConfigOverrideValidator configOverrideValidator,
       final QueryExecutor queryExecutor
   ) {
     this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
@@ -102,8 +102,8 @@ public class WSQueryEndpoint {
     this.authorizationValidator =
         Objects.requireNonNull(authorizationValidator, "authorizationValidator");
     this.errorHandler = Objects.requireNonNull(errorHandler, "errorHandler");
-    this.denyListPropertyValidator =
-        Objects.requireNonNull(denyListPropertyValidator, "denyListPropertyValidator");
+    this.configOverrideValidator =
+        Objects.requireNonNull(configOverrideValidator, "configOverrideValidator");
     this.queryExecutor = queryExecutor;
   }
 
@@ -206,7 +206,7 @@ public class WSQueryEndpoint {
       // To validate props:
       final Map<String, Object> configProperties = request.getConfigOverrides();
       ConfigOverrideLogger.logOverrides("/ws/query", configProperties);
-      denyListPropertyValidator.validateAll(configProperties);
+      configOverrideValidator.validateAll(configProperties);
       return request;
     } catch (final Exception e) {
       throw new IllegalArgumentException("Error parsing request: " + e.getMessage(), e);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -41,7 +41,7 @@ import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.logging.processing.ProcessingLogServerUtils;
 import io.confluent.ksql.metrics.MetricCollectors;
-import io.confluent.ksql.properties.DenyListPropertyValidator;
+import io.confluent.ksql.properties.ConfigOverrideValidator;
 import io.confluent.ksql.rest.EndpointResponse;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlRequest;
@@ -131,7 +131,7 @@ public class KsqlRestApplicationTest {
   @Mock
   private EndpointResponse response;
   @Mock
-  private DenyListPropertyValidator denyListPropertyValidator;
+  private ConfigOverrideValidator configOverrideValidator;
   @Mock
   private QueryExecutor queryExecutor;
   @Mock
@@ -460,7 +460,7 @@ public class KsqlRestApplicationTest {
         Optional.of(heartbeatAgent),
         Optional.of(lagReportingAgent),
         vertx,
-        denyListPropertyValidator,
+        configOverrideValidator,
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -102,6 +102,7 @@ import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.TableElements;
 import io.confluent.ksql.planner.plan.ConfiguredKsqlPlan;
+import io.confluent.ksql.properties.AllowListPropertyValidator;
 import io.confluent.ksql.properties.ConfigOverrideLogger;
 import io.confluent.ksql.properties.DenyListPropertyValidator;
 import io.confluent.ksql.query.id.SequentialQueryIdGenerator;
@@ -2620,13 +2621,22 @@ public class KsqlResourceTest {
 
   @Test
   public void shouldReturnBadRequestWhenIsValidatorIsCalledWithProhibitedProps() {
-    final Map<String, Object> properties = new HashMap<>();
-    properties.put("ksql.service.id", "");
-
-    // Given:
-    doThrow(new KsqlException("deny override")).when(denyListPropertyValidator).validateAll(
-        properties
+    // Given: a real DenyListPropertyValidator; ksql.service.id is always denied.
+    ksqlResource = new KsqlResource(
+        ksqlEngine,
+        commandRunner,
+        DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT,
+        activenessRegistrar,
+        (ec, sc) -> InjectorChain.of(
+            schemaInjectorFactory.apply(sc),
+            topicInjectorFactory.apply(ec),
+            new TopicDeleteInjector(ec, sc)),
+        Optional.of(authorizationValidator),
+        errorsHandler,
+        new DenyListPropertyValidator(ImmutableList.of()),
+        commandRunnerWarning
     );
+    ksqlResource.configure(ksqlConfig);
 
     // When:
     final EndpointResponse response;
@@ -2639,10 +2649,47 @@ public class KsqlResourceTest {
           "SET", ImmutableMap.of("ksql.service.id", "")));
     }
     assertThat(response.getStatus(), equalTo(400));
+    assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(),
+        containsString("prohibited by the KSQL server denylist"));
   }
 
   @Test
-  public void shouldReturnBadRequestWhenIsValidatorIsCalledWithNonQueryLevelProps() {
+  public void shouldReturnBadRequestWhenIsValidatorIsCalledWithPropertyNotOnAllowlist() {
+    // Given: a real AllowListPropertyValidator; ksql.service.id is always denied via the
+    // ALWAYS_DENIED floor, even with an empty configured allowlist.
+    ksqlResource = new KsqlResource(
+        ksqlEngine,
+        commandRunner,
+        DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT,
+        activenessRegistrar,
+        (ec, sc) -> InjectorChain.of(
+            schemaInjectorFactory.apply(sc),
+            topicInjectorFactory.apply(ec),
+            new TopicDeleteInjector(ec, sc)),
+        Optional.of(authorizationValidator),
+        errorsHandler,
+        new AllowListPropertyValidator(ImmutableList.of()),
+        commandRunnerWarning
+    );
+    ksqlResource.configure(ksqlConfig);
+
+    // When:
+    final EndpointResponse response;
+    try (MockedStatic<ConfigOverrideLogger> configOverrideLogger =
+        Mockito.mockStatic(ConfigOverrideLogger.class)) {
+      response = ksqlResource.isValidProperty("ksql.service.id");
+
+      // Then: log fires BEFORE allowlist throws
+      configOverrideLogger.verify(() -> ConfigOverrideLogger.logOverrides(
+          "SET", ImmutableMap.of("ksql.service.id", "")));
+    }
+    assertThat(response.getStatus(), equalTo(400));
+    assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(),
+        containsString("not permitted by the KSQL server allowlist"));
+  }
+
+  @Test
+  public void shouldRejectIsValidPropertyForNonQueryLevelPropertyWhenSharedRuntimeEnabled() {
     final Map<String, Object> properties = new HashMap<>();
     properties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "");
     givenKsqlConfigWith(ImmutableMap.of(
@@ -2657,7 +2704,7 @@ public class KsqlResourceTest {
   }
 
   @Test
-  public void shouldNotBadRequestWhenIsValidatorIsCalledWithNonQueryLevelProps() {
+  public void shouldAllowIsValidPropertyForQueryLevelPropertyWhenSharedRuntimeEnabled() {
     final Map<String, Object> properties = new HashMap<>();
     properties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "");
     givenKsqlConfigWith(ImmutableMap.of(
@@ -2672,14 +2719,51 @@ public class KsqlResourceTest {
   }
 
   @Test
-  public void shouldThrowOnDenyListValidatorWhenTerminateCluster() {
-    final Map<String, Object> terminateStreamProperties =
-        ImmutableMap.of(DELETE_TOPIC_LIST_PROP, Collections.singletonList("Foo"));
+  public void shouldAllowIsValidPropertyForKnownProperty() {
+    // Given: mocked denyListPropertyValidator never throws.
 
-    // Given:
-    doThrow(new KsqlException("deny override")).when(denyListPropertyValidator).validateAll(
-        terminateStreamProperties
+    // When:
+    final EndpointResponse response =
+        ksqlResource.isValidProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG);
+
+    // Then:
+    assertThat(response.getStatus(), equalTo(200));
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenIsValidatorIsCalledWithUnknownProperty() {
+    // Given: default ksqlResource; "totally.unknown.property" resolves to no ksql/streams/
+    // consumer/producer config, so PropertyNotFoundException fires before the allow/deny
+    // validator.
+
+    // When:
+    final EndpointResponse response = ksqlResource.isValidProperty("totally.unknown.property");
+
+    // Then:
+    assertThat(response.getStatus(), equalTo(400));
+    assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(),
+        containsString("Not recognizable as ksql, streams, consumer, or producer property"));
+  }
+
+  @Test
+  public void shouldThrowOnDenyListValidatorWhenTerminateCluster() {
+    // Given: a real DenyListPropertyValidator that denies the delete-topic-list
+    // property terminateCluster always sends.
+    ksqlResource = new KsqlResource(
+        ksqlEngine,
+        commandRunner,
+        DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT,
+        activenessRegistrar,
+        (ec, sc) -> InjectorChain.of(
+            schemaInjectorFactory.apply(sc),
+            topicInjectorFactory.apply(ec),
+            new TopicDeleteInjector(ec, sc)),
+        Optional.of(authorizationValidator),
+        errorsHandler,
+        new DenyListPropertyValidator(ImmutableList.of(DELETE_TOPIC_LIST_PROP)),
+        commandRunnerWarning
     );
+    ksqlResource.configure(ksqlConfig);
 
     // When:
     final EndpointResponse response = ksqlResource.terminateCluster(
@@ -2687,12 +2771,44 @@ public class KsqlResourceTest {
         VALID_TERMINATE_REQUEST
     );
 
-    // Then:
-    verify(denyListPropertyValidator).validateAll(terminateStreamProperties);
+    // Then: the denylist check rejects the request as server error (500), not a 400.
     assertThat(response.getStatus(), equalTo(INTERNAL_SERVER_ERROR.code()));
     assertThat(response.getEntity(), instanceOf(KsqlStatementErrorMessage.class));
     assertThat(((KsqlStatementErrorMessage) response.getEntity()).getMessage(),
-        containsString("deny override"));
+        containsString("prohibited by the KSQL server denylist"));
+  }
+
+  @Test
+  public void shouldThrowOnAllowListValidatorWhenTerminateCluster() {
+    // Given: a real AllowListPropertyValidator that does not permit the delete-topic-list
+    // property terminateCluster always sends.
+    ksqlResource = new KsqlResource(
+        ksqlEngine,
+        commandRunner,
+        DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT,
+        activenessRegistrar,
+        (ec, sc) -> InjectorChain.of(
+            schemaInjectorFactory.apply(sc),
+            topicInjectorFactory.apply(ec),
+            new TopicDeleteInjector(ec, sc)),
+        Optional.of(authorizationValidator),
+        errorsHandler,
+        new AllowListPropertyValidator(ImmutableList.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)),
+        commandRunnerWarning
+    );
+    ksqlResource.configure(ksqlConfig);
+
+    // When:
+    final EndpointResponse response = ksqlResource.terminateCluster(
+        securityContext,
+        VALID_TERMINATE_REQUEST
+    );
+
+    // Then: the allowlist check rejects the request as server error (500), not a 400.
+    assertThat(response.getStatus(), equalTo(INTERNAL_SERVER_ERROR.code()));
+    assertThat(response.getEntity(), instanceOf(KsqlStatementErrorMessage.class));
+    assertThat(((KsqlStatementErrorMessage) response.getEntity()).getMessage(),
+        containsString("not permitted by the KSQL server allowlist"));
   }
 
   @Test
@@ -2729,7 +2845,7 @@ public class KsqlResourceTest {
 
   @Test
   public void shouldThrowOnDenyListValidatorWhenHandleKsqlStatement() {
-    // Given:
+    // Given: a real DenyListPropertyValidator that denies the override.
     ksqlResource = new KsqlResource(
         ksqlEngine,
         commandRunner,
@@ -2741,17 +2857,12 @@ public class KsqlResourceTest {
             new TopicDeleteInjector(ec, sc)),
         Optional.of(authorizationValidator),
         errorsHandler,
-        denyListPropertyValidator,
+        new DenyListPropertyValidator(ImmutableList.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG)),
         commandRunnerWarning
     );
-    final Map<String, Object> props = new HashMap<>(ksqlRestConfig.getKsqlConfigProperties());
-    props.put(KsqlConfig.KSQL_PROPERTIES_OVERRIDES_DENYLIST,
-        StreamsConfig.NUM_STREAM_THREADS_CONFIG);
-    ksqlResource.configure(new KsqlConfig(props));
+    ksqlResource.configure(ksqlConfig);
     final Map<String, Object> overrides =
         ImmutableMap.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
-    doThrow(new KsqlException("deny override")).when(denyListPropertyValidator)
-        .validateAll(overrides);
 
     // When:
     final EndpointResponse response;
@@ -2769,10 +2880,53 @@ public class KsqlResourceTest {
 
       // Then: Config Override Logger fires, and the denylist check rejects the request.
       configOverrideLogger.verify(() -> ConfigOverrideLogger.logOverrides("/ksql", overrides));
-      verify(denyListPropertyValidator).validateAll(overrides);
     }
     assertThat(response.getStatus(), CoreMatchers.is(BAD_REQUEST.code()));
-    assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(), is("deny override"));
+    assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(),
+        containsString("prohibited by the KSQL server denylist"));
+  }
+
+  @Test
+  public void shouldThrowOnAllowListValidatorWhenHandleKsqlStatement() {
+    // Given: a real AllowListPropertyValidator that does not permit the override.
+    ksqlResource = new KsqlResource(
+        ksqlEngine,
+        commandRunner,
+        DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT,
+        activenessRegistrar,
+        (ec, sc) -> InjectorChain.of(
+            schemaInjectorFactory.apply(sc),
+            topicInjectorFactory.apply(ec),
+            new TopicDeleteInjector(ec, sc)),
+        Optional.of(authorizationValidator),
+        errorsHandler,
+        new AllowListPropertyValidator(ImmutableList.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)),
+        commandRunnerWarning
+    );
+    ksqlResource.configure(ksqlConfig);
+    final Map<String, Object> overrides =
+        ImmutableMap.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
+
+    // When:
+    final EndpointResponse response;
+    try (MockedStatic<ConfigOverrideLogger> configOverrideLogger =
+        Mockito.mockStatic(ConfigOverrideLogger.class)) {
+      response = ksqlResource.handleKsqlStatements(
+          securityContext,
+          new KsqlRequest(
+              "query",
+              overrides,  // stream properties
+              emptyMap(),
+              null
+          )
+      );
+
+      // Then: Config Override Logger fires, and the allowlist check rejects the request.
+      configOverrideLogger.verify(() -> ConfigOverrideLogger.logOverrides("/ksql", overrides));
+    }
+    assertThat(response.getStatus(), CoreMatchers.is(BAD_REQUEST.code()));
+    assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(),
+        containsString("not permitted by the KSQL server allowlist"));
   }
 
   private void givenKsqlConfigWith(final Map<String, Object> additionalConfig) {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.rest.server.resources;
 import static io.confluent.ksql.parser.ParserMatchers.configured;
 import static io.confluent.ksql.parser.ParserMatchers.preparedStatementText;
 import static io.confluent.ksql.rest.Errors.ERROR_CODE_FORBIDDEN_KAFKA_ACCESS;
-import static io.confluent.ksql.rest.entity.ClusterTerminateRequest.DELETE_TOPIC_LIST_PROP;
 import static io.confluent.ksql.rest.entity.CommandId.Action.CREATE;
 import static io.confluent.ksql.rest.entity.CommandId.Action.DROP;
 import static io.confluent.ksql.rest.entity.CommandId.Action.EXECUTE;
@@ -2699,32 +2698,6 @@ public class KsqlResourceTest {
     assertThat(response.getStatus(), equalTo(400));
     assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(),
         containsString("Not recognizable as ksql, streams, consumer, or producer property"));
-  }
-
-  @Test
-  public void shouldThrowOnConfigOverrideValidatorWhenTerminateCluster() {
-    final Map<String, Object> terminateStreamProperties =
-        ImmutableMap.of(DELETE_TOPIC_LIST_PROP, Collections.singletonList("Foo"));
-
-    // Given: mocked configOverrideValidator throws the same message a real
-    // AllowlistPropertyValidator would for the delete-topic-list property.
-    doThrow(new KsqlException("One or more properties overrides set locally are not permitted "
-        + "by the KSQL server allowlist (use UNSET to reset their default value): "
-        + "[deleteTopicList]")).when(configOverrideValidator)
-        .validateAll(terminateStreamProperties);
-
-    // When:
-    final EndpointResponse response = ksqlResource.terminateCluster(
-        securityContext,
-        VALID_TERMINATE_REQUEST
-    );
-
-    // Then: the validator's real message survives, mapped to a server error (500), not a 400.
-    verify(configOverrideValidator).validateAll(terminateStreamProperties);
-    assertThat(response.getStatus(), equalTo(INTERNAL_SERVER_ERROR.code()));
-    assertThat(response.getEntity(), instanceOf(KsqlStatementErrorMessage.class));
-    assertThat(((KsqlStatementErrorMessage) response.getEntity()).getMessage(),
-        containsString("not permitted by the KSQL server allowlist"));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -102,9 +102,8 @@ import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.TableElements;
 import io.confluent.ksql.planner.plan.ConfiguredKsqlPlan;
-import io.confluent.ksql.properties.AllowListPropertyValidator;
 import io.confluent.ksql.properties.ConfigOverrideLogger;
-import io.confluent.ksql.properties.DenyListPropertyValidator;
+import io.confluent.ksql.properties.ConfigOverrideValidator;
 import io.confluent.ksql.query.id.SequentialQueryIdGenerator;
 import io.confluent.ksql.rest.DefaultErrorMessages;
 import io.confluent.ksql.rest.EndpointResponse;
@@ -320,7 +319,7 @@ public class KsqlResourceTest {
   @Mock
   private Errors errorsHandler;
   @Mock
-  private DenyListPropertyValidator denyListPropertyValidator;
+  private ConfigOverrideValidator configOverrideValidator;
   @Mock
   private Supplier<String> commandRunnerWarning;
   @Mock
@@ -456,7 +455,7 @@ public class KsqlResourceTest {
             new TopicDeleteInjector(ec, sc)),
         Optional.of(authorizationValidator),
         errorsHandler,
-        denyListPropertyValidator,
+        configOverrideValidator,
         commandRunnerWarning
     );
 
@@ -488,7 +487,7 @@ public class KsqlResourceTest {
             new TopicDeleteInjector(ec, sc)),
         Optional.of(authorizationValidator),
         errorsHandler,
-        denyListPropertyValidator,
+        configOverrideValidator,
         commandRunnerWarning
     );
 
@@ -2612,7 +2611,7 @@ public class KsqlResourceTest {
             new TopicDeleteInjector(ec, sc)),
         Optional.of(authorizationValidator),
         errorsHandler,
-        denyListPropertyValidator,
+        configOverrideValidator,
         commandRunnerWarning
     );
 
@@ -2621,22 +2620,14 @@ public class KsqlResourceTest {
 
   @Test
   public void shouldReturnBadRequestWhenIsValidatorIsCalledWithProhibitedProps() {
-    // Given: a real DenyListPropertyValidator; ksql.service.id is always denied.
-    ksqlResource = new KsqlResource(
-        ksqlEngine,
-        commandRunner,
-        DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT,
-        activenessRegistrar,
-        (ec, sc) -> InjectorChain.of(
-            schemaInjectorFactory.apply(sc),
-            topicInjectorFactory.apply(ec),
-            new TopicDeleteInjector(ec, sc)),
-        Optional.of(authorizationValidator),
-        errorsHandler,
-        new DenyListPropertyValidator(ImmutableList.of()),
-        commandRunnerWarning
-    );
-    ksqlResource.configure(ksqlConfig);
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("ksql.service.id", "");
+
+    // Given: mocked configOverrideValidator throws the same message a real
+    // DenyListPropertyValidator would for ksql.service.id.
+    doThrow(new KsqlException("One or more properties overrides set locally are prohibited "
+        + "by the KSQL server denylist (use UNSET to reset their default value): "
+        + "[ksql.service.id]")).when(configOverrideValidator).validateAll(properties);
 
     // When:
     final EndpointResponse response;
@@ -2644,48 +2635,13 @@ public class KsqlResourceTest {
         Mockito.mockStatic(ConfigOverrideLogger.class)) {
       response = ksqlResource.isValidProperty("ksql.service.id");
 
-      // Then: log fires BEFORE denylist throws
+      // Then: log fires BEFORE the validator throws
       configOverrideLogger.verify(() -> ConfigOverrideLogger.logOverrides(
           "SET", ImmutableMap.of("ksql.service.id", "")));
     }
     assertThat(response.getStatus(), equalTo(400));
     assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(),
         containsString("prohibited by the KSQL server denylist"));
-  }
-
-  @Test
-  public void shouldReturnBadRequestWhenIsValidatorIsCalledWithPropertyNotOnAllowlist() {
-    // Given: a real AllowListPropertyValidator; ksql.service.id is always denied via the
-    // ALWAYS_DENIED floor, even with an empty configured allowlist.
-    ksqlResource = new KsqlResource(
-        ksqlEngine,
-        commandRunner,
-        DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT,
-        activenessRegistrar,
-        (ec, sc) -> InjectorChain.of(
-            schemaInjectorFactory.apply(sc),
-            topicInjectorFactory.apply(ec),
-            new TopicDeleteInjector(ec, sc)),
-        Optional.of(authorizationValidator),
-        errorsHandler,
-        new AllowListPropertyValidator(ImmutableList.of()),
-        commandRunnerWarning
-    );
-    ksqlResource.configure(ksqlConfig);
-
-    // When:
-    final EndpointResponse response;
-    try (MockedStatic<ConfigOverrideLogger> configOverrideLogger =
-        Mockito.mockStatic(ConfigOverrideLogger.class)) {
-      response = ksqlResource.isValidProperty("ksql.service.id");
-
-      // Then: log fires BEFORE allowlist throws
-      configOverrideLogger.verify(() -> ConfigOverrideLogger.logOverrides(
-          "SET", ImmutableMap.of("ksql.service.id", "")));
-    }
-    assertThat(response.getStatus(), equalTo(400));
-    assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(),
-        containsString("not permitted by the KSQL server allowlist"));
   }
 
   @Test
@@ -2720,7 +2676,7 @@ public class KsqlResourceTest {
 
   @Test
   public void shouldAllowIsValidPropertyForKnownProperty() {
-    // Given: mocked denyListPropertyValidator never throws.
+    // Given: mocked configOverrideValidator never throws.
 
     // When:
     final EndpointResponse response =
@@ -2746,24 +2702,16 @@ public class KsqlResourceTest {
   }
 
   @Test
-  public void shouldThrowOnDenyListValidatorWhenTerminateCluster() {
-    // Given: a real DenyListPropertyValidator that denies the delete-topic-list
-    // property terminateCluster always sends.
-    ksqlResource = new KsqlResource(
-        ksqlEngine,
-        commandRunner,
-        DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT,
-        activenessRegistrar,
-        (ec, sc) -> InjectorChain.of(
-            schemaInjectorFactory.apply(sc),
-            topicInjectorFactory.apply(ec),
-            new TopicDeleteInjector(ec, sc)),
-        Optional.of(authorizationValidator),
-        errorsHandler,
-        new DenyListPropertyValidator(ImmutableList.of(DELETE_TOPIC_LIST_PROP)),
-        commandRunnerWarning
-    );
-    ksqlResource.configure(ksqlConfig);
+  public void shouldThrowOnConfigOverrideValidatorWhenTerminateCluster() {
+    final Map<String, Object> terminateStreamProperties =
+        ImmutableMap.of(DELETE_TOPIC_LIST_PROP, Collections.singletonList("Foo"));
+
+    // Given: mocked configOverrideValidator throws the same message a real
+    // AllowlistPropertyValidator would for the delete-topic-list property.
+    doThrow(new KsqlException("One or more properties overrides set locally are not permitted "
+        + "by the KSQL server allowlist (use UNSET to reset their default value): "
+        + "[deleteTopicList]")).when(configOverrideValidator)
+        .validateAll(terminateStreamProperties);
 
     // When:
     final EndpointResponse response = ksqlResource.terminateCluster(
@@ -2771,40 +2719,8 @@ public class KsqlResourceTest {
         VALID_TERMINATE_REQUEST
     );
 
-    // Then: the denylist check rejects the request as server error (500), not a 400.
-    assertThat(response.getStatus(), equalTo(INTERNAL_SERVER_ERROR.code()));
-    assertThat(response.getEntity(), instanceOf(KsqlStatementErrorMessage.class));
-    assertThat(((KsqlStatementErrorMessage) response.getEntity()).getMessage(),
-        containsString("prohibited by the KSQL server denylist"));
-  }
-
-  @Test
-  public void shouldThrowOnAllowListValidatorWhenTerminateCluster() {
-    // Given: a real AllowListPropertyValidator that does not permit the delete-topic-list
-    // property terminateCluster always sends.
-    ksqlResource = new KsqlResource(
-        ksqlEngine,
-        commandRunner,
-        DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT,
-        activenessRegistrar,
-        (ec, sc) -> InjectorChain.of(
-            schemaInjectorFactory.apply(sc),
-            topicInjectorFactory.apply(ec),
-            new TopicDeleteInjector(ec, sc)),
-        Optional.of(authorizationValidator),
-        errorsHandler,
-        new AllowListPropertyValidator(ImmutableList.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)),
-        commandRunnerWarning
-    );
-    ksqlResource.configure(ksqlConfig);
-
-    // When:
-    final EndpointResponse response = ksqlResource.terminateCluster(
-        securityContext,
-        VALID_TERMINATE_REQUEST
-    );
-
-    // Then: the allowlist check rejects the request as server error (500), not a 400.
+    // Then: the validator's real message survives, mapped to a server error (500), not a 400.
+    verify(configOverrideValidator).validateAll(terminateStreamProperties);
     assertThat(response.getStatus(), equalTo(INTERNAL_SERVER_ERROR.code()));
     assertThat(response.getEntity(), instanceOf(KsqlStatementErrorMessage.class));
     assertThat(((KsqlStatementErrorMessage) response.getEntity()).getMessage(),
@@ -2845,24 +2761,14 @@ public class KsqlResourceTest {
 
   @Test
   public void shouldThrowOnDenyListValidatorWhenHandleKsqlStatement() {
-    // Given: a real DenyListPropertyValidator that denies the override.
-    ksqlResource = new KsqlResource(
-        ksqlEngine,
-        commandRunner,
-        DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT,
-        activenessRegistrar,
-        (ec, sc) -> InjectorChain.of(
-            schemaInjectorFactory.apply(sc),
-            topicInjectorFactory.apply(ec),
-            new TopicDeleteInjector(ec, sc)),
-        Optional.of(authorizationValidator),
-        errorsHandler,
-        new DenyListPropertyValidator(ImmutableList.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG)),
-        commandRunnerWarning
-    );
-    ksqlResource.configure(ksqlConfig);
     final Map<String, Object> overrides =
         ImmutableMap.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
+
+    // Given: mocked configOverrideValidator throws the same message a real
+    // AllowlistListPropertyValidator would for num.stream.threads.
+    doThrow(new KsqlException("One or more properties overrides set locally are not permitted "
+        + "by the KSQL server denylist (use UNSET to reset their default value): "
+        + "[num.stream.threads]")).when(configOverrideValidator).validateAll(overrides);
 
     // When:
     final EndpointResponse response;
@@ -2880,53 +2786,11 @@ public class KsqlResourceTest {
 
       // Then: Config Override Logger fires, and the denylist check rejects the request.
       configOverrideLogger.verify(() -> ConfigOverrideLogger.logOverrides("/ksql", overrides));
+      verify(configOverrideValidator).validateAll(overrides);
     }
     assertThat(response.getStatus(), CoreMatchers.is(BAD_REQUEST.code()));
     assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(),
-        containsString("prohibited by the KSQL server denylist"));
-  }
-
-  @Test
-  public void shouldThrowOnAllowListValidatorWhenHandleKsqlStatement() {
-    // Given: a real AllowListPropertyValidator that does not permit the override.
-    ksqlResource = new KsqlResource(
-        ksqlEngine,
-        commandRunner,
-        DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT,
-        activenessRegistrar,
-        (ec, sc) -> InjectorChain.of(
-            schemaInjectorFactory.apply(sc),
-            topicInjectorFactory.apply(ec),
-            new TopicDeleteInjector(ec, sc)),
-        Optional.of(authorizationValidator),
-        errorsHandler,
-        new AllowListPropertyValidator(ImmutableList.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)),
-        commandRunnerWarning
-    );
-    ksqlResource.configure(ksqlConfig);
-    final Map<String, Object> overrides =
-        ImmutableMap.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
-
-    // When:
-    final EndpointResponse response;
-    try (MockedStatic<ConfigOverrideLogger> configOverrideLogger =
-        Mockito.mockStatic(ConfigOverrideLogger.class)) {
-      response = ksqlResource.handleKsqlStatements(
-          securityContext,
-          new KsqlRequest(
-              "query",
-              overrides,  // stream properties
-              emptyMap(),
-              null
-          )
-      );
-
-      // Then: Config Override Logger fires, and the allowlist check rejects the request.
-      configOverrideLogger.verify(() -> ConfigOverrideLogger.logOverrides("/ksql", overrides));
-    }
-    assertThat(response.getStatus(), CoreMatchers.is(BAD_REQUEST.code()));
-    assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(),
-        containsString("not permitted by the KSQL server allowlist"));
+        containsString("not permitted by the KSQL server denylist"));
   }
 
   private void givenKsqlConfigWith(final Map<String, Object> additionalConfig) {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/WSQueryEndpointTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/WSQueryEndpointTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -27,13 +28,11 @@ import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import io.confluent.ksql.engine.KsqlEngine;
-import io.confluent.ksql.properties.AllowListPropertyValidator;
 import io.confluent.ksql.properties.ConfigOverrideLogger;
-import io.confluent.ksql.properties.DenyListPropertyValidator;
+import io.confluent.ksql.properties.ConfigOverrideValidator;
 import io.confluent.ksql.rest.ApiJsonMapper;
 import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.entity.KsqlRequest;
@@ -43,6 +42,7 @@ import io.confluent.ksql.rest.server.query.QueryExecutor;
 import io.confluent.ksql.rest.server.resources.streaming.WSQueryEndpoint;
 import io.confluent.ksql.security.KsqlSecurityContext;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.version.metrics.ActivenessRegistrar;
 import io.vertx.core.Context;
 import io.vertx.core.MultiMap;
@@ -52,7 +52,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.Before;
 import org.junit.Test;
@@ -71,7 +70,7 @@ public class WSQueryEndpointTest {
   @Mock
   private KsqlSecurityContext ksqlSecurityContext;
   @Mock
-  private DenyListPropertyValidator denyListPropertyValidator;
+  private ConfigOverrideValidator configOverrideValidator;
   @Mock
   private KsqlConfig ksqlConfig;
   @Mock
@@ -95,31 +94,22 @@ public class WSQueryEndpointTest {
         mock(Duration.class),
         Optional.empty(),
         mock(Errors.class),
-        denyListPropertyValidator,
+        configOverrideValidator,
         queryExecutor
     );
   }
 
   @Test
   public void shouldCallPropertyValidatorOnExecuteStream() throws JsonProcessingException {
-    // Given: a real DenyListPropertyValidator that denies the override.
-    wsQueryEndpoint = new WSQueryEndpoint(
-        ksqlConfig,
-        mock(StatementParser.class),
-        mock(KsqlEngine.class),
-        mock(CommandQueue.class),
-        exec,
-        mock(ActivenessRegistrar.class),
-        mock(Duration.class),
-        Optional.empty(),
-        mock(Errors.class),
-        new DenyListPropertyValidator(ImmutableList.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG)),
-        queryExecutor
-    );
+    // Given: mocked configOverrideValidator throws the same message a real
+    // DenyListPropertyValidator would for num.stream.threads.
     final Map<String, Object> overrides =
         ImmutableMap.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
     final MultiMap params = buildRequestParams("show streams;", overrides);
     final ArgumentCaptor<String> jsonCaptor = ArgumentCaptor.forClass(String.class);
+    doThrow(new KsqlException("One or more properties overrides set locally are prohibited "
+        + "by the KSQL server denylist (use UNSET to reset their default value): "
+        + "[num.stream.threads]")).when(configOverrideValidator).validateAll(overrides);
 
     // When
     try (MockedStatic<ConfigOverrideLogger> configOverrideLogger =
@@ -127,43 +117,12 @@ public class WSQueryEndpointTest {
       executeStreamQuery(params, Optional.empty());
 
       // Then: WS sockets do not throw any exception (closes silently). Config Override Logger
-      // fires first, and then the denylist check rejects the request.
+      // fires first, and then the validator's real message survives to the socket's error frame.
       configOverrideLogger.verify(() -> ConfigOverrideLogger.logOverrides("/ws/query", overrides));
+      verify(configOverrideValidator).validateAll(overrides);
     }
     verify(serverWebSocket).writeFinalTextFrame(jsonCaptor.capture(), any());
     assertThat(jsonCaptor.getValue(), containsString("prohibited by the KSQL server denylist"));
-  }
-
-  @Test
-  public void shouldCloseSocketWhenPropertyNotOnAllowlist() throws JsonProcessingException {
-    // Given: a real AllowListPropertyValidator that does not permit the override.
-    wsQueryEndpoint = new WSQueryEndpoint(
-        ksqlConfig,
-        mock(StatementParser.class),
-        mock(KsqlEngine.class),
-        mock(CommandQueue.class),
-        exec,
-        mock(ActivenessRegistrar.class),
-        mock(Duration.class),
-        Optional.empty(),
-        mock(Errors.class),
-        new AllowListPropertyValidator(ImmutableList.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)),
-        queryExecutor
-    );
-    final Map<String, Object> overrides =
-        ImmutableMap.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
-    final MultiMap params = buildRequestParams("show streams;", overrides);
-    final ArgumentCaptor<String> jsonCaptor = ArgumentCaptor.forClass(String.class);
-
-    // When
-    try (MockedStatic<ConfigOverrideLogger> configOverrideLogger =
-        mockStatic(ConfigOverrideLogger.class)) {
-      executeStreamQuery(params, Optional.empty());
-
-      configOverrideLogger.verify(() -> ConfigOverrideLogger.logOverrides("/ws/query", overrides));
-    }
-    verify(serverWebSocket).writeFinalTextFrame(jsonCaptor.capture(), any());
-    assertThat(jsonCaptor.getValue(), containsString("not permitted by the KSQL server allowlist"));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/WSQueryEndpointTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/WSQueryEndpointTest.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.rest.server.resources;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -25,9 +27,11 @@ import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import io.confluent.ksql.engine.KsqlEngine;
+import io.confluent.ksql.properties.AllowListPropertyValidator;
 import io.confluent.ksql.properties.ConfigOverrideLogger;
 import io.confluent.ksql.properties.DenyListPropertyValidator;
 import io.confluent.ksql.rest.ApiJsonMapper;
@@ -48,10 +52,12 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -95,23 +101,69 @@ public class WSQueryEndpointTest {
   }
 
   @Test
-  public void shouldCallPropertyValidatorOnExecuteStream()
-      throws JsonProcessingException {
-    // Given
+  public void shouldCallPropertyValidatorOnExecuteStream() throws JsonProcessingException {
+    // Given: a real DenyListPropertyValidator that denies the override.
+    wsQueryEndpoint = new WSQueryEndpoint(
+        ksqlConfig,
+        mock(StatementParser.class),
+        mock(KsqlEngine.class),
+        mock(CommandQueue.class),
+        exec,
+        mock(ActivenessRegistrar.class),
+        mock(Duration.class),
+        Optional.empty(),
+        mock(Errors.class),
+        new DenyListPropertyValidator(ImmutableList.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG)),
+        queryExecutor
+    );
     final Map<String, Object> overrides =
         ImmutableMap.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
     final MultiMap params = buildRequestParams("show streams;", overrides);
+    final ArgumentCaptor<String> jsonCaptor = ArgumentCaptor.forClass(String.class);
 
     // When
     try (MockedStatic<ConfigOverrideLogger> configOverrideLogger =
         mockStatic(ConfigOverrideLogger.class)) {
       executeStreamQuery(params, Optional.empty());
 
-      // Then: WS sockets do not throw any exception (closes silently). We can only verify that validator
-      // was called.Config Override Logger fires first, and then validator fires.
+      // Then: WS sockets do not throw any exception (closes silently). Config Override Logger
+      // fires first, and then the denylist check rejects the request.
       configOverrideLogger.verify(() -> ConfigOverrideLogger.logOverrides("/ws/query", overrides));
-      verify(denyListPropertyValidator).validateAll(overrides);
     }
+    verify(serverWebSocket).writeFinalTextFrame(jsonCaptor.capture(), any());
+    assertThat(jsonCaptor.getValue(), containsString("prohibited by the KSQL server denylist"));
+  }
+
+  @Test
+  public void shouldCloseSocketWhenPropertyNotOnAllowlist() throws JsonProcessingException {
+    // Given: a real AllowListPropertyValidator that does not permit the override.
+    wsQueryEndpoint = new WSQueryEndpoint(
+        ksqlConfig,
+        mock(StatementParser.class),
+        mock(KsqlEngine.class),
+        mock(CommandQueue.class),
+        exec,
+        mock(ActivenessRegistrar.class),
+        mock(Duration.class),
+        Optional.empty(),
+        mock(Errors.class),
+        new AllowListPropertyValidator(ImmutableList.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)),
+        queryExecutor
+    );
+    final Map<String, Object> overrides =
+        ImmutableMap.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
+    final MultiMap params = buildRequestParams("show streams;", overrides);
+    final ArgumentCaptor<String> jsonCaptor = ArgumentCaptor.forClass(String.class);
+
+    // When
+    try (MockedStatic<ConfigOverrideLogger> configOverrideLogger =
+        mockStatic(ConfigOverrideLogger.class)) {
+      executeStreamQuery(params, Optional.empty());
+
+      configOverrideLogger.verify(() -> ConfigOverrideLogger.logOverrides("/ws/query", overrides));
+    }
+    verify(serverWebSocket).writeFinalTextFrame(jsonCaptor.capture(), any());
+    assertThat(jsonCaptor.getValue(), containsString("not permitted by the KSQL server allowlist"));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -46,7 +46,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.GenericRow;
@@ -61,9 +60,8 @@ import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.PrintTopic;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Statement;
-import io.confluent.ksql.properties.AllowListPropertyValidator;
 import io.confluent.ksql.properties.ConfigOverrideLogger;
-import io.confluent.ksql.properties.DenyListPropertyValidator;
+import io.confluent.ksql.properties.ConfigOverrideValidator;
 import io.confluent.ksql.query.BlockingRowQueue;
 import io.confluent.ksql.query.CompletionHandler;
 import io.confluent.ksql.query.KafkaStreamsBuilder;
@@ -121,7 +119,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
@@ -187,7 +184,7 @@ public class StreamedQueryResourceTest {
   @Mock
   private Errors errorsHandler;
   @Mock
-  private DenyListPropertyValidator denyListPropertyValidator;
+  private ConfigOverrideValidator configOverrideValidator;
   @Mock
   private QueryId queryId;
   @Mock
@@ -245,7 +242,7 @@ public class StreamedQueryResourceTest {
         activenessRegistrar,
         Optional.of(authorizationValidator),
         errorsHandler,
-        denyListPropertyValidator,
+        configOverrideValidator,
         queryExecutor
     );
   }
@@ -290,7 +287,7 @@ public class StreamedQueryResourceTest {
         activenessRegistrar,
         Optional.of(authorizationValidator),
         errorsHandler,
-        denyListPropertyValidator,
+        configOverrideValidator,
         queryExecutor
     );
     when(mockKsqlEngine.getKsqlConfig()).thenReturn(KsqlConfig.empty());
@@ -448,7 +445,8 @@ public class StreamedQueryResourceTest {
 
   @Test
   public void shouldThrowOnDenyListedStreamProperty() {
-    // Given: a real DenyListPropertyValidator that denies the override.
+    // Given: mocked configOverrideValidator throws the same message a real
+    // DenyListPropertyValidator would for num.stream.threads.
     when(mockStatementParser.<Query>parseSingleStatement(PULL_QUERY_STRING)).thenReturn(query);
     testResource = new StreamedQueryResource(
         mockKsqlEngine,
@@ -460,14 +458,20 @@ public class StreamedQueryResourceTest {
         activenessRegistrar,
         Optional.of(authorizationValidator),
         errorsHandler,
-        new DenyListPropertyValidator(ImmutableList.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG)),
+        configOverrideValidator,
         queryExecutor
       );
-    when(mockKsqlEngine.getKsqlConfig()).thenReturn(new KsqlConfig(ImmutableMap.of(
+    final Map<String, Object> props = new HashMap<>(ImmutableMap.of(
         StreamsConfig.APPLICATION_SERVER_CONFIG, "something:1"
-    )));
+    ));
+    props.put(KsqlConfig.KSQL_PROPERTIES_OVERRIDES_DENYLIST,
+        StreamsConfig.NUM_STREAM_THREADS_CONFIG);
+    when(mockKsqlEngine.getKsqlConfig()).thenReturn(new KsqlConfig(props));
     final Map<String, Object> overrides =
         ImmutableMap.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
+    doThrow(new KsqlException("One or more properties overrides set locally are prohibited "
+        + "by the KSQL server denylist (use UNSET to reset their default value): "
+        + "[num.stream.threads]")).when(configOverrideValidator).validateAll(overrides);
     when(errorsHandler.generateResponse(any(), any()))
         .thenAnswer(inv -> inv.getArgument(1));
 
@@ -491,61 +495,13 @@ public class StreamedQueryResourceTest {
 
       // Then: Config Override Logger fires, and the denylist check rejects the request.
       configOverrideLogger.verify(() -> ConfigOverrideLogger.logOverrides("/query", overrides));
+      verify(configOverrideValidator).validateAll(overrides);
     }
     assertThat(response.getStatus(), CoreMatchers.is(BAD_REQUEST.code()));
     assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(),
         containsString("prohibited by the KSQL server denylist"));
-  }
-
-  @Test
-  public void shouldThrowOnPropertyNotOnAllowlist() {
-    // Given: a real AllowListPropertyValidator that does not permit the override.
-    when(mockStatementParser.<Query>parseSingleStatement(PULL_QUERY_STRING)).thenReturn(query);
-    testResource = new StreamedQueryResource(
-        mockKsqlEngine,
-        ksqlRestConfig,
-        mockStatementParser,
-        commandQueue,
-        DISCONNECT_CHECK_INTERVAL,
-        COMMAND_QUEUE_CATCHUP_TIMOEUT,
-        activenessRegistrar,
-        Optional.of(authorizationValidator),
-        errorsHandler,
-        new AllowListPropertyValidator(ImmutableList.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)),
-        queryExecutor
-      );
-    when(mockKsqlEngine.getKsqlConfig()).thenReturn(new KsqlConfig(ImmutableMap.of(
-        StreamsConfig.APPLICATION_SERVER_CONFIG, "something:1"
-    )));
-    final Map<String, Object> overrides =
-        ImmutableMap.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
-    when(errorsHandler.generateResponse(any(), any()))
-        .thenAnswer(inv -> inv.getArgument(1));
-
-    // When:
-    final EndpointResponse response;
-    try (MockedStatic<ConfigOverrideLogger> configOverrideLogger =
-        mockStatic(ConfigOverrideLogger.class)) {
-      response = testResource.streamQuery(
-          securityContext,
-          new KsqlRequest(
-              PULL_QUERY_STRING,
-              overrides, // stream properties
-              Collections.emptyMap(),
-              null
-          ),
-          new CompletableFuture<>(),
-          Optional.empty(),
-          new MetricsCallbackHolder(),
-          context
-      );
-
-      // Then: Config Override Logger fires, and the allowlist check rejects the request.
-      configOverrideLogger.verify(() -> ConfigOverrideLogger.logOverrides("/query", overrides));
-    }
-    assertThat(response.getStatus(), CoreMatchers.is(BAD_REQUEST.code()));
     assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(),
-        containsString("not permitted by the KSQL server allowlist"));
+            containsString(StreamsConfig.NUM_STREAM_THREADS_CONFIG));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -46,6 +46,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.GenericRow;
@@ -60,6 +61,7 @@ import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.PrintTopic;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.properties.AllowListPropertyValidator;
 import io.confluent.ksql.properties.ConfigOverrideLogger;
 import io.confluent.ksql.properties.DenyListPropertyValidator;
 import io.confluent.ksql.query.BlockingRowQueue;
@@ -119,6 +121,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
@@ -445,7 +448,7 @@ public class StreamedQueryResourceTest {
 
   @Test
   public void shouldThrowOnDenyListedStreamProperty() {
-    // Given:
+    // Given: a real DenyListPropertyValidator that denies the override.
     when(mockStatementParser.<Query>parseSingleStatement(PULL_QUERY_STRING)).thenReturn(query);
     testResource = new StreamedQueryResource(
         mockKsqlEngine,
@@ -457,22 +460,16 @@ public class StreamedQueryResourceTest {
         activenessRegistrar,
         Optional.of(authorizationValidator),
         errorsHandler,
-        denyListPropertyValidator,
+        new DenyListPropertyValidator(ImmutableList.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG)),
         queryExecutor
       );
-    final Map<String, Object> props = new HashMap<>(ImmutableMap.of(
+    when(mockKsqlEngine.getKsqlConfig()).thenReturn(new KsqlConfig(ImmutableMap.of(
         StreamsConfig.APPLICATION_SERVER_CONFIG, "something:1"
-    ));
-    props.put(KsqlConfig.KSQL_PROPERTIES_OVERRIDES_DENYLIST,
-        StreamsConfig.NUM_STREAM_THREADS_CONFIG);
-    when(mockKsqlEngine.getKsqlConfig()).thenReturn(new KsqlConfig(props));
+    )));
     final Map<String, Object> overrides =
         ImmutableMap.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
-    doThrow(new KsqlException("deny override")).when(denyListPropertyValidator)
-        .validateAll(overrides);
     when(errorsHandler.generateResponse(any(), any()))
-        .thenReturn(badRequest("A property override was set locally for a property that the "
-            + "server prohibits overrides for: 'num.stream.threads'"));
+        .thenAnswer(inv -> inv.getArgument(1));
 
     // When:
     final EndpointResponse response;
@@ -494,12 +491,61 @@ public class StreamedQueryResourceTest {
 
       // Then: Config Override Logger fires, and the denylist check rejects the request.
       configOverrideLogger.verify(() -> ConfigOverrideLogger.logOverrides("/query", overrides));
-      verify(denyListPropertyValidator).validateAll(overrides);
     }
     assertThat(response.getStatus(), CoreMatchers.is(BAD_REQUEST.code()));
     assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(),
-        is("A property override was set locally for a property that the server prohibits "
-            + "overrides for: '" + StreamsConfig.NUM_STREAM_THREADS_CONFIG + "'"));
+        containsString("prohibited by the KSQL server denylist"));
+  }
+
+  @Test
+  public void shouldThrowOnPropertyNotOnAllowlist() {
+    // Given: a real AllowListPropertyValidator that does not permit the override.
+    when(mockStatementParser.<Query>parseSingleStatement(PULL_QUERY_STRING)).thenReturn(query);
+    testResource = new StreamedQueryResource(
+        mockKsqlEngine,
+        ksqlRestConfig,
+        mockStatementParser,
+        commandQueue,
+        DISCONNECT_CHECK_INTERVAL,
+        COMMAND_QUEUE_CATCHUP_TIMOEUT,
+        activenessRegistrar,
+        Optional.of(authorizationValidator),
+        errorsHandler,
+        new AllowListPropertyValidator(ImmutableList.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)),
+        queryExecutor
+      );
+    when(mockKsqlEngine.getKsqlConfig()).thenReturn(new KsqlConfig(ImmutableMap.of(
+        StreamsConfig.APPLICATION_SERVER_CONFIG, "something:1"
+    )));
+    final Map<String, Object> overrides =
+        ImmutableMap.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
+    when(errorsHandler.generateResponse(any(), any()))
+        .thenAnswer(inv -> inv.getArgument(1));
+
+    // When:
+    final EndpointResponse response;
+    try (MockedStatic<ConfigOverrideLogger> configOverrideLogger =
+        mockStatic(ConfigOverrideLogger.class)) {
+      response = testResource.streamQuery(
+          securityContext,
+          new KsqlRequest(
+              PULL_QUERY_STRING,
+              overrides, // stream properties
+              Collections.emptyMap(),
+              null
+          ),
+          new CompletableFuture<>(),
+          Optional.empty(),
+          new MetricsCallbackHolder(),
+          context
+      );
+
+      // Then: Config Override Logger fires, and the allowlist check rejects the request.
+      configOverrideLogger.verify(() -> ConfigOverrideLogger.logOverrides("/query", overrides));
+    }
+    assertThat(response.getStatus(), CoreMatchers.is(BAD_REQUEST.code()));
+    assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(),
+        containsString("not permitted by the KSQL server allowlist"));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/PropertyOverriderTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/PropertyOverriderTest.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.collections4.map.HashedMap;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.streams.StreamsConfig;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -173,12 +174,52 @@ public class PropertyOverriderTest {
       );
 
       // Then: log fires for the known property BEFORE denylist throws
-      assertThat(e.getMessage(), containsString("prohibited by the KSQL server"));
       configOverrideLogger.verify(() -> ConfigOverrideLogger.logOverrides(
-          "SET", ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "")));
-    }
+              "SET", ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "")));
+      assertThat(e.getMessage(), containsString("prohibited by the KSQL server"));
+       }
+
     assertThat(sessionProperties.getMutableScopedProperties(),
         not(hasKey(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)));
+  }
+
+  @Test
+  public void shouldRejectSetOfPropertyNotOnAllowlist() {
+    // Given: allowlist contains AUTO_OFFSET_RESET_CONFIG, but not the property about to be SET.
+    final String propertyNotOnAllowlist =
+        KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STREAM_THREADS_CONFIG;
+    final KsqlConfig configWithAllowlist = engine.getKsqlConfig().cloneWithPropertyOverwrite(
+        ImmutableMap.of(
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE_ALLOWLIST,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_ALLOWLIST,
+            ConsumerConfig.AUTO_OFFSET_RESET_CONFIG));
+    final SessionProperties sessionProperties =
+        new SessionProperties(new HashedMap<>(), mock(KsqlHostInfo.class), mock(URL.class), false);
+
+    // When:
+    try (MockedStatic<ConfigOverrideLogger> configOverrideLogger =
+        mockStatic(ConfigOverrideLogger.class)) {
+      final Exception e = assertThrows(
+          KsqlStatementException.class,
+          () -> CustomValidators.SET_PROPERTY.validate(
+              ConfiguredStatement.of(PreparedStatement.of(
+                  "SET '" + propertyNotOnAllowlist + "' = '4';",
+                  new SetProperty(Optional.empty(), propertyNotOnAllowlist, "4")),
+                  SessionConfig.of(configWithAllowlist, ImmutableMap.of())),
+              sessionProperties,
+              engine.getEngine(),
+              engine.getServiceContext()
+          )
+      );
+
+      // Then: log fires for the known property BEFORE allowlist throws
+      configOverrideLogger.verify(() -> ConfigOverrideLogger.logOverrides(
+          "SET", ImmutableMap.of(propertyNotOnAllowlist, "")));
+      assertThat(e.getMessage(), containsString("not permitted by the KSQL server allowlist"));
+    }
+    assertThat(sessionProperties.getMutableScopedProperties(),
+        not(hasKey(propertyNotOnAllowlist)));
   }
 
   @Test
@@ -203,6 +244,40 @@ public class PropertyOverriderTest {
     );
 
     assertThat(e.getMessage(), containsString("prohibited by the KSQL server"));
+    assertThat(e.getMessage(), containsString(KsqlConfig.KSQL_SERVICE_ID_CONFIG));
+    assertThat(sessionProperties.getMutableScopedProperties(),
+        not(hasKey(KsqlConfig.KSQL_SERVICE_ID_CONFIG)));
+  }
+
+  @Test
+  public void shouldRejectSetOfServiceIdEvenWhenAllowlisted() {
+    // ksql.service.id is always removed from the effective allowlist by
+    // AllowListPropertyValidator's ALWAYS_DENIED floor, even when an admin mistakenly
+    // allowlists it explicitly.
+    final KsqlConfig configWithAllowlist = engine.getKsqlConfig().cloneWithPropertyOverwrite(
+        ImmutableMap.of(
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE_ALLOWLIST,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_ALLOWLIST,
+            KsqlConfig.KSQL_SERVICE_ID_CONFIG));
+    final SessionProperties sessionProperties =
+        new SessionProperties(new HashedMap<>(), mock(KsqlHostInfo.class), mock(URL.class), false);
+
+    final Exception e = assertThrows(
+        KsqlStatementException.class,
+        () -> CustomValidators.SET_PROPERTY.validate(
+            ConfiguredStatement.of(PreparedStatement.of(
+                "SET '" + KsqlConfig.KSQL_SERVICE_ID_CONFIG + "' = 'hacked';",
+                new SetProperty(Optional.empty(),
+                    KsqlConfig.KSQL_SERVICE_ID_CONFIG, "hacked")),
+                SessionConfig.of(configWithAllowlist, ImmutableMap.of())),
+            sessionProperties,
+            engine.getEngine(),
+            engine.getServiceContext()
+        )
+    );
+
+    assertThat(e.getMessage(), containsString("not permitted by the KSQL server allowlist"));
     assertThat(e.getMessage(), containsString(KsqlConfig.KSQL_SERVICE_ID_CONFIG));
     assertThat(sessionProperties.getMutableScopedProperties(),
         not(hasKey(KsqlConfig.KSQL_SERVICE_ID_CONFIG)));
@@ -234,6 +309,33 @@ public class PropertyOverriderTest {
   }
 
   @Test
+  public void shouldAllowSetWhenPropertyIsOnAllowlist() {
+    // Allowlist mode is on and contains the property being SET.
+    final KsqlConfig configWithAllowlist =
+        engine.getKsqlConfig().cloneWithPropertyOverwrite(ImmutableMap.of(
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE_ALLOWLIST,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_ALLOWLIST,
+            ConsumerConfig.AUTO_OFFSET_RESET_CONFIG));
+    final SessionProperties sessionProperties =
+        new SessionProperties(new HashedMap<>(), mock(KsqlHostInfo.class), mock(URL.class), false);
+
+    CustomValidators.SET_PROPERTY.validate(
+        ConfiguredStatement.of(PreparedStatement.of(
+            "SET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "' = 'earliest';",
+            new SetProperty(Optional.empty(),
+                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")),
+            SessionConfig.of(configWithAllowlist, ImmutableMap.of())),
+        sessionProperties,
+        engine.getEngine(),
+        engine.getServiceContext()
+    );
+
+    assertThat(sessionProperties.getMutableScopedProperties(),
+        hasEntry(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"));
+  }
+
+  @Test
   public void shouldRejectSetWhenPropertyIsOneOfMultipleInDenylist() {
     // Denylist contains several entries; the SET property matches one of them.
     final KsqlConfig configWithDenylist = engine.getKsqlConfig().cloneWithPropertyOverwrite(
@@ -252,6 +354,38 @@ public class PropertyOverriderTest {
                 new SetProperty(Optional.empty(),
                     ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")),
                 SessionConfig.of(configWithDenylist, ImmutableMap.of())),
+            sessionProperties,
+            engine.getEngine(),
+            engine.getServiceContext()
+        )
+    );
+
+    assertThat(e.getMessage(), containsString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG));
+    assertThat(sessionProperties.getMutableScopedProperties(),
+        not(hasKey(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)));
+  }
+
+  @Test
+  public void shouldRejectSetWhenPropertyIsNotOneOfMultipleOnAllowlist() {
+    // Allowlist contains several entries; none of them is the SET property.
+    final KsqlConfig configWithAllowlist = engine.getKsqlConfig().cloneWithPropertyOverwrite(
+        ImmutableMap.of(
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE_ALLOWLIST,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_ALLOWLIST,
+            KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STREAM_THREADS_CONFIG + ","
+                + KsqlConfig.KSQL_STREAMS_PREFIX + ConsumerConfig.MAX_POLL_RECORDS_CONFIG));
+    final SessionProperties sessionProperties =
+        new SessionProperties(new HashedMap<>(), mock(KsqlHostInfo.class), mock(URL.class), false);
+
+    final Exception e = assertThrows(
+        KsqlStatementException.class,
+        () -> CustomValidators.SET_PROPERTY.validate(
+            ConfiguredStatement.of(PreparedStatement.of(
+                "SET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "' = 'earliest';",
+                new SetProperty(Optional.empty(),
+                    ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")),
+                SessionConfig.of(configWithAllowlist, ImmutableMap.of())),
             sessionProperties,
             engine.getEngine(),
             engine.getServiceContext()
@@ -296,6 +430,40 @@ public class PropertyOverriderTest {
   }
 
   @Test
+  public void shouldNotBeBypassableViaSessionOverrideOfAllowlistConfig() {
+    // Verifies the security invariant: an attacker submitting a request whose `streamsProperties`
+    // tries to widen the allowlist cannot use that override to escape the in-SQL SET check.
+    // PropertyOverrider.set must read the allowlist from the system config (getConfig(false)),
+    // not the override-applied config.
+    final KsqlConfig systemConfigWithAllowlist =
+        engine.getKsqlConfig().cloneWithPropertyOverwrite(ImmutableMap.of(
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE_ALLOWLIST,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_ALLOWLIST,
+            KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STREAM_THREADS_CONFIG));
+    final Map<String, Object> overridesTryingToWidenAllowlist = ImmutableMap.of(
+        KsqlConfig.KSQL_PROPERTIES_OVERRIDES_ALLOWLIST, ConsumerConfig.AUTO_OFFSET_RESET_CONFIG);
+    final SessionProperties sessionProperties =
+        new SessionProperties(new HashedMap<>(), mock(KsqlHostInfo.class), mock(URL.class), false);
+
+    final Exception e = assertThrows(
+        KsqlStatementException.class,
+        () -> CustomValidators.SET_PROPERTY.validate(
+            ConfiguredStatement.of(PreparedStatement.of(
+                "SET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "' = 'earliest';",
+                new SetProperty(Optional.empty(),
+                    ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")),
+                SessionConfig.of(systemConfigWithAllowlist, overridesTryingToWidenAllowlist)),
+            sessionProperties,
+            engine.getEngine(),
+            engine.getServiceContext()
+        )
+    );
+
+    assertThat(e.getMessage(), containsString("not permitted by the KSQL server allowlist"));
+  }
+
+  @Test
   public void shouldIncludeStatementTextOnDeniedSet() {
     final String statementText = "SET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "' = 'earliest';";
     final KsqlConfig configWithDenylist = engine.getKsqlConfig().cloneWithPropertyOverwrite(
@@ -313,6 +481,35 @@ public class PropertyOverriderTest {
                 new SetProperty(Optional.empty(),
                     ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")),
                 SessionConfig.of(configWithDenylist, ImmutableMap.of())),
+            sessionProperties,
+            engine.getEngine(),
+            engine.getServiceContext()
+        )
+    );
+
+    assertThat(e.getSqlStatement(), is(statementText));
+  }
+
+  @Test
+  public void shouldIncludeStatementTextOnDeniedSetInAllowlistMode() {
+    final String statementText = "SET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "' = 'earliest';";
+    final KsqlConfig configWithAllowlist = engine.getKsqlConfig().cloneWithPropertyOverwrite(
+        ImmutableMap.of(
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE_ALLOWLIST,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_ALLOWLIST,
+            KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STREAM_THREADS_CONFIG));
+    final SessionProperties sessionProperties =
+        new SessionProperties(new HashedMap<>(), mock(KsqlHostInfo.class), mock(URL.class), false);
+
+    final KsqlStatementException e = assertThrows(
+        KsqlStatementException.class,
+        () -> CustomValidators.SET_PROPERTY.validate(
+            ConfiguredStatement.of(PreparedStatement.of(
+                statementText,
+                new SetProperty(Optional.empty(),
+                    ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")),
+                SessionConfig.of(configWithAllowlist, ImmutableMap.of())),
             sessionProperties,
             engine.getEngine(),
             engine.getServiceContext()


### PR DESCRIPTION
### Description 
Support allowlist for all KSQL endpoints that allows user overrides:
1. /ksql
2. /query
3. /ws/query
4. /query-stream
5. /inserts-stream
6. SET

Remove the config validation from below endpoint:
/terminate - This validation is a no-op.


### Testing done 
Unit tests and local testing using CP 8.1.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

