### PR TITLE
KSQL-15274: bump Netty version to 4.1.135.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,8 +148,8 @@
              Please check top level `pom.xml` at https://github.com/netty/netty
              for the netty version we bump to (ie, corresponding git tag),
              to find the correct `tcnative` version. -->
-        <netty.version>4.1.133.Final</netty.version>
-        <netty-codec-http2-version>4.1.133.Final</netty-codec-http2-version>
+        <netty.version>4.1.135.Final</netty.version>
+        <netty-codec-http2-version>4.1.135.Final</netty-codec-http2-version>
         <jersey-common>3.1.10</jersey-common>
         <multi-threaded-testing.forkCount>3</multi-threaded-testing.forkCount>
         <kafka.version>${ce.kafka.version}</kafka.version>


### PR DESCRIPTION
KSQL-15274

### Description
Bump Netty version from 4.1.133.Final to 4.1.135.Final on the 8.1.5 patch branch.

### Testing done
Version bump only; relies on existing CI.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.