### PR TITLE
fix(test): use valid host:port in KsqlEngineTest.shouldConfigure

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -2844,7 +2844,7 @@ public class KsqlEngineTest {
     // Given:
     setupKsqlEngineWithSharedRuntimeEnabled();
     final KsqlConfig config
-        = new KsqlConfig(ImmutableMap.of(StreamsConfig.APPLICATION_SERVER_CONFIG, "foo:bar//"));
+        = new KsqlConfig(ImmutableMap.of(StreamsConfig.APPLICATION_SERVER_CONFIG, "foo:1234"));
 
     // When:
     ksqlEngine.configure(config);


### PR DESCRIPTION
## Pipe Triage Fix

**Failure class:** unit-test-regression
**Root cause:** Upstream Kafka Streams `ApplicationServerConfigValidator` (org.apache.kafka.streams.internals) now rejects any `application.server` value that doesn't parse as `host:port`. `KsqlEngineTest.shouldConfigure` at line 2847 was passing the literal `"foo:bar//"`, which the older Streams version accepted but the current one rejects — throwing `ConfigException` via `KsqlConfig.resolveStreamsConfig` → `ConfigItem$Resolved.parseValue`.
**Upstream trigger:** Kafka Streams version bump on the 8.4-line (`io.confluent:common` `[8.4.0-0, 8.4.1-0)`) that pulls in the stricter validator. Master has been red on SHA `a9d028313ef` since ≈2026-06-23 across 30+ auto-retriggered pipelines.
**Confidence:** HIGH
**Files changed:** 1

The test's assertion — `assertThat(ksqlEngine.getKsqlConfig(), is(config))` — verifies the `KsqlConfig` round-trips the `application.server` value. It doesn't care what the value is, only that a valid config accepted at construction survives round-tripping through `configure()`. Substituting `"foo:1234"` restores green while preserving the intent of the test.

**Verification (local):**
- `./mvnw clean install -DskipTests -T 4 -pl ksqldb-engine -am -Dmaven.gitcommitid.skip=true` → passed (13 modules, 3 min)
- `./mvnw test -T 4 -pl ksqldb-engine -Dtest=KsqlEngineTest#shouldConfigure -Dmaven.gitcommitid.skip=true` → `Tests run: 1, Failures: 0, Errors: 0, Skipped: 0`

---
Generated by \`/ksqldb-pipe-triage\`.