### PR TITLE
KSQL-15302: add ksql.kafka.client.additional.config.prefixes

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -494,6 +494,17 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_AUTH_CACHE_MAX_ENTRIES_DOC = "Controls the size of the cache "
       + "to a maximum number of KSQL authorization responses entries.";
 
+  public static final String KSQL_KAFKA_CLIENT_ADDITIONAL_CONFIG_PREFIXES_CONFIG =
+      "ksql.kafka.client.additional.config.prefixes";
+  public static final String KSQL_KAFKA_CLIENT_ADDITIONAL_CONFIG_PREFIXES_DEFAULT = "";
+  public static final String KSQL_KAFKA_CLIENT_ADDITIONAL_CONFIG_PREFIXES_DOC =
+      "Comma-separated list of configuration key prefixes that ksqlDB forwards to the "
+      + "internal Kafka clients (admin, producer and consumer) it builds. By default those "
+      + "clients receive only recognized Kafka client configurations; use this to also pass "
+      + "configurations required by custom client plugins whose keys are not registered Kafka "
+      + "client configs. Any configuration whose "
+      + "key starts with one of these prefixes is forwarded. Empty by default.";
+
   public static final String KSQL_HIDDEN_TOPICS_CONFIG = "ksql.hidden.topics";
   public static final String KSQL_HIDDEN_TOPICS_DEFAULT = "_confluent.*,__confluent.*"
       + ",_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,"
@@ -1231,6 +1242,13 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_READONLY_TOPICS_DOC
         )
         .define(
+            KSQL_KAFKA_CLIENT_ADDITIONAL_CONFIG_PREFIXES_CONFIG,
+            Type.LIST,
+            KSQL_KAFKA_CLIENT_ADDITIONAL_CONFIG_PREFIXES_DEFAULT,
+            Importance.LOW,
+            KSQL_KAFKA_CLIENT_ADDITIONAL_CONFIG_PREFIXES_DOC
+        )
+        .define(
             KSQL_TIMESTAMP_THROW_ON_INVALID,
             Type.BOOLEAN,
             KSQL_TIMESTAMP_THROW_ON_INVALID_DEFAULT,
@@ -1859,6 +1877,7 @@ public class KsqlConfig extends AbstractConfig {
   public Map<String, Object> getKsqlAdminClientConfigProps() {
     final Map<String, Object> map = new HashMap<>();
     map.putAll(getConfigsFor(AdminClientConfig.configNames()));
+    map.putAll(getAdditionalKafkaClientConfigs());
     // admin client metrics aren't used in Confluent deployment
     possiblyConfigureConfluentTelemetry(map);
     return Collections.unmodifiableMap(map);
@@ -1867,6 +1886,7 @@ public class KsqlConfig extends AbstractConfig {
   public Map<String, Object> getProducerClientConfigProps() {
     final Map<String, Object> map = new HashMap<>();
     map.putAll(getConfigsFor(ProducerConfig.configNames()));
+    map.putAll(getAdditionalKafkaClientConfigs());
     // producer client metrics aren't used in Confluent deployment
     possiblyConfigureConfluentTelemetry(map);
     return Collections.unmodifiableMap(map);
@@ -1875,9 +1895,25 @@ public class KsqlConfig extends AbstractConfig {
   public Map<String, Object> getConsumerClientConfigProps() {
     final Map<String, Object> map = new HashMap<>();
     map.putAll(getConfigsFor(ConsumerConfig.configNames()));
+    map.putAll(getAdditionalKafkaClientConfigs());
     // consumer client metrics aren't used in Confluent deployment
     possiblyConfigureConfluentTelemetry(map);
     return Collections.unmodifiableMap(map);
+  }
+
+  // Forwards any config whose key starts with one of the operator-supplied prefixes
+  // (KSQL_KAFKA_CLIENT_ADDITIONAL_CONFIG_PREFIXES_CONFIG) to the internal Kafka clients.
+  // getConfigsFor(...configNames()) keeps only recognized client configs, which drops any
+  // extra configs a custom client plugin may require; this lets a deployment opt those in
+  // without ksqlDB needing to know their concrete keys. Blank prefixes
+  // are ignored so an empty/unset value forwards nothing (byte-identical to prior behavior).
+  private Map<String, Object> getAdditionalKafkaClientConfigs() {
+    final Set<String> prefixes =
+        getList(KSQL_KAFKA_CLIENT_ADDITIONAL_CONFIG_PREFIXES_CONFIG).stream()
+            .map(String::trim)
+            .filter(prefix -> !prefix.isEmpty())
+            .collect(Collectors.toSet());
+    return prefixes.isEmpty() ? Collections.emptyMap() : getConfigsForPrefix(prefixes);
   }
 
   public Map<String, Object> addConfluentMetricsContextConfigsKafka(

--- a/ksqldb-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler;
 import io.confluent.ksql.errors.ProductionExceptionHandlerUtil.LogAndContinueProductionExceptionHandler;
@@ -603,6 +604,41 @@ public class KsqlConfigTest {
     assertThat(ksqlConfig.getProducerClientConfigProps(), hasEntry(ProducerConfig.ACKS_CONFIG, "all"));
     assertThat(ksqlConfig.getProducerClientConfigProps(), hasEntry(ProducerConfig.CLIENT_ID_CONFIG, null));
     assertThat(ksqlConfig.getProducerClientConfigProps(), not(hasKey("not.a.config")));
+  }
+
+  @Test
+  public void shouldForwardConfiguredPrefixesToClients() {
+    // Given: two prefixes are configured, plus a config that matches neither.
+    final Map<String, Object> configs = new HashMap<>();
+    configs.put(KsqlConfig.KSQL_KAFKA_CLIENT_ADDITIONAL_CONFIG_PREFIXES_CONFIG,
+        "some.prefix., another.prefix.");
+    configs.put("some.prefix.a", "value1");
+    configs.put("another.prefix.b", "value2");
+    configs.put("unrelated.c", "value3");
+
+    final KsqlConfig ksqlConfig = new KsqlConfig(configs);
+
+    // Then: configs under a configured prefix reach every client config map; others do not.
+    for (final Map<String, Object> clientConfigs : ImmutableList.of(
+        ksqlConfig.getKsqlAdminClientConfigProps(),
+        ksqlConfig.getProducerClientConfigProps(),
+        ksqlConfig.getConsumerClientConfigProps())) {
+      assertThat(clientConfigs, hasEntry("some.prefix.a", "value1"));
+      assertThat(clientConfigs, hasEntry("another.prefix.b", "value2"));
+      assertThat(clientConfigs, not(hasKey("unrelated.c")));
+    }
+  }
+
+  @Test
+  public void shouldForwardNothingExtraToClientsByDefault() {
+    // Given: no prefixes configured.
+    final KsqlConfig ksqlConfig =
+        new KsqlConfig(Collections.singletonMap("some.prefix.a", "value1"));
+
+    // Then: nothing extra is forwarded.
+    assertThat(ksqlConfig.getKsqlAdminClientConfigProps(), not(hasKey("some.prefix.a")));
+    assertThat(ksqlConfig.getProducerClientConfigProps(), not(hasKey("some.prefix.a")));
+    assertThat(ksqlConfig.getConsumerClientConfigProps(), not(hasKey("some.prefix.a")));
   }
 
   @Test


### PR DESCRIPTION
## Description

The internal Kafka clients (admin/producer/consumer) built by `KsqlConfig` are
configured via `getConfigsFor(<Client>Config.configNames())`, which keeps only
recognized Kafka client configs. Custom client plugins can require additional
configs whose keys are not registered client config names; those get dropped, so
a client that depends on them fails to build.

Add a config, **`ksql.kafka.client.additional.config.prefixes`** (LIST, empty by
default), listing config-key prefixes that ksqlDB forwards to those internal
clients, so a deployment can opt in the extra configs its plugins need without
ksqlDB hard-coding their keys. Blank prefixes are ignored, so an empty/unset
value forwards nothing — byte-identical to prior behavior.

## Testing

Added `KsqlConfigTest` cases: (1) configs under a configured prefix reach all
three internal clients while unrelated configs stay filtered; (2) nothing extra
is forwarded when the config is unset. `KsqlConfigTest` passes; checkstyle clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
