### PR TITLE
fix(rest server): stop heartbeat/lag agents before vertx close to avoid shutdown hang

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -170,6 +170,8 @@ public final class KsqlRestApplication implements Executable {
 
   private static final int NUM_MILLISECONDS_IN_HOUR = 3600 * 1000;
 
+  private static final long VERTX_CLOSE_TIMEOUT_SEC = 30;
+
   private static final SourceName COMMANDS_STREAM_NAME = SourceName.of("KSQL_COMMANDS");
 
   private final KsqlConfig ksqlConfigNoPort;
@@ -534,6 +536,10 @@ public final class KsqlRestApplication implements Executable {
       log.error("Exception while closing security extension", e);
     }
 
+    // Stop before vertx.close(): otherwise their scheduled sends race the close and can
+    // orphan Netty channel-close futures, hanging shutdown.
+    shutdownAdditionalAgents();
+
     if (apiServer != null) {
       apiServer.stop();
       apiServer = null;
@@ -543,7 +549,9 @@ public final class KsqlRestApplication implements Executable {
       try {
         final CountDownLatch latch = new CountDownLatch(1);
         vertx.close(ar -> latch.countDown());
-        latch.await();
+        if (!latch.await(VERTX_CLOSE_TIMEOUT_SEC, TimeUnit.SECONDS)) {
+          log.error("Timed out after {}s waiting for vertx to close", VERTX_CLOSE_TIMEOUT_SEC);
+        }
       } catch (InterruptedException e) {
         log.error("Exception while closing vertx", e);
       }
@@ -552,8 +560,6 @@ public final class KsqlRestApplication implements Executable {
     if (oldApiWebsocketExecutor != null) {
       oldApiWebsocketExecutor.shutdown();
     }
-
-    shutdownAdditionalAgents();
 
     log.info("ksqlDB shutdown complete");
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -220,6 +220,18 @@ public class KsqlRestApplicationTest {
   }
 
   @Test
+  public void shouldStopHeartbeatAndLagReportingAgentsBeforeClosingVertx() {
+    // When:
+    app.shutdown();
+
+    // Then:
+    final InOrder inOrder = Mockito.inOrder(heartbeatAgent, lagReportingAgent, vertx);
+    inOrder.verify(heartbeatAgent).stopAgent();
+    inOrder.verify(lagReportingAgent).stopAgent();
+    inOrder.verify(vertx).close(any());
+  }
+
+  @Test
   public void shouldCloseSecurityExtensionOnClose() {
     // When:
     app.shutdown();


### PR DESCRIPTION
Jira: https://confluentinc.atlassian.net/browse/CPTF-1641

### Description

`KsqlRestApplication.shutdown()` could hang indefinitely because `vertx.close()`'s completion callback is not guaranteed to fire. Root cause: `HeartbeatAgent` and `LagReportingAgent` each run their own `ScheduledExecutorService`-backed loop that issues requests through `serviceContext.getKsqlClient()`, and `shutdownAdditionalAgents()` (which stops both agents) was called *after* `vertx.close()`'s blocking, unbounded `latch.await()` — so nothing stopped that concurrent activity before the close began.

We root-caused this via heap dump: 6 of 31 Netty `AbstractChannel$CloseFuture`s were stuck with `result == null`, so the aggregate future backing `vertx.close()`'s callback never completed. All sockets were already closed at the OS level and the JVM was idle — no CPU/memory/network pressure, nothing visible via `jcmd`. This is a lost in-JVM completion notification, not resource contention or a deadlock, and it surfaces specifically where a large core count inflates the Vert.x event-loop group size without a matching CPU limit (e.g. a Kubernetes pod with a CPU *request* but no CPU *limit* on a 16-core node — `Runtime.availableProcessors()` returns 16, so Vert.x sizes the event-loop group at 2×16=32 threads). On a 1-vCPU host (2 event loops) the identical shutdown path completes in ~11ms.

This change:
1. Moves `shutdownAdditionalAgents()` to run *before* `apiServer.stop()`/`vertx.close()`, so `HeartbeatAgent`/`LagReportingAgent` are fully stopped (both use a bounded, `awaitStopped`-backed `stopAgent()`) before Vert.x begins tearing down its event-loop group. This removes the concurrency that orphaned the `CloseFuture`s.
2. Bounds the `vertx.close()` `latch.await()` with a 30s timeout as a defense-in-depth backstop, logging on timeout instead of blocking forever, so shutdown can never hang indefinitely even if some other, currently-unknown lost-completion case exists.

Neither `apiServer.stop()`, `vertx.close()`, `HeartbeatResource`, nor `LivenessFilter` depend on the agents still running (they only read/write plain `ConcurrentHashMap`s), so stopping them earlier introduces no new failure path.

### Testing done

- Added `KsqlRestApplicationTest#shouldStopHeartbeatAndLagReportingAgentsBeforeClosingVertx`, asserting via `Mockito.inOrder` that `heartbeatAgent.stopAgent()` and `lagReportingAgent.stopAgent()` both run before `vertx.close()`.
- Full `KsqlRestApplicationTest` suite passes on 7.5.x (16/16, clean compile + clean build).
- Reproduced and verified the original hang via heap-dump analysis on a CP build under a Kubernetes-pod deployment (CPU request, no CPU limit); confirmed the fix's ordering removes the concurrent heartbeat/lag activity during `vertx.close()`.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.