### PR TITLE
KSQL-13769: cleanup JMX configuration defaults (7.5.x)

### DIFF
--- a/bin/ksql-run-class
+++ b/bin/ksql-run-class
@@ -58,31 +58,17 @@ fi
  KSQL_LOG4J_OPTS="-Dksql.log.dir=$LOG_DIR ${KSQL_LOG4J_OPTS}"
 
 # JMX settings.
-# ksqlDB does not enable remote JMX by default. Remote JMX without
-# authentication is a code-execution primitive for any peer on the network,
-# so KSQL_JMX_OPTS must be set explicitly with authentication and TLS.
-# JMX_PORT alone is refused at startup rather than silently opening an
-# unauthenticated listener.
-if [ -n "$JMX_PORT" ] && [ -z "$KSQL_JMX_OPTS" ]; then
-  echo "" >&2
-  echo "ERROR: JMX_PORT is set but KSQL_JMX_OPTS is empty." >&2
-  echo "Remote JMX must be configured explicitly with authentication." >&2
-  echo "Refusing to start with an unauthenticated JMX listener." >&2
-  echo "" >&2
-  echo "To enable remote JMX securely, set KSQL_JMX_OPTS with, for example:" >&2
-  echo "  -Dcom.sun.management.jmxremote" >&2
-  echo "  -Dcom.sun.management.jmxremote.authenticate=true" >&2
-  echo "  -Dcom.sun.management.jmxremote.password.file=<path>" >&2
-  echo "  -Dcom.sun.management.jmxremote.access.file=<path>" >&2
-  echo "  -Dcom.sun.management.jmxremote.ssl=true" >&2
-  echo "" >&2
-  echo "See https://docs.confluent.io/platform/current/ksqldb/operate-and-deploy/monitoring.html" >&2
-  exit 1
+# ksqlDB defaults to loopback-only JMX. Remote JMX without authentication is
+# a code-execution primitive for any peer on the network. Operators who need
+# remote JMX must set KSQL_JMX_OPTS with authentication and TLS explicitly.
+# See docs/operate-and-deploy/monitoring.md for a copy-paste example.
+if [ -z "$KSQL_JMX_OPTS" ]; then
+  KSQL_JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
 fi
 
 # Append the JMX port to operator-supplied options if requested.
 if [ -n "$JMX_PORT" ]; then
-  KSQL_JMX_OPTS="$KSQL_JMX_OPTS -Dcom.sun.management.jmxremote.port=$JMX_PORT "
+  KSQL_JMX_OPTS="$KSQL_JMX_OPTS -Dcom.sun.management.jmxremote.port=$JMX_PORT"
 fi
 
 # Generic jvm settings you want to add

--- a/bin/ksql-run-class
+++ b/bin/ksql-run-class
@@ -57,13 +57,31 @@ fi
 
  KSQL_LOG4J_OPTS="-Dksql.log.dir=$LOG_DIR ${KSQL_LOG4J_OPTS}"
 
-# JMX settings
-if [ -z "$KSQL_JMX_OPTS" ]; then
-  KSQL_JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false "
+# JMX settings.
+# ksqlDB does not enable remote JMX by default. Remote JMX without
+# authentication is a code-execution primitive for any peer on the network,
+# so KSQL_JMX_OPTS must be set explicitly with authentication and TLS.
+# JMX_PORT alone is refused at startup rather than silently opening an
+# unauthenticated listener.
+if [ -n "$JMX_PORT" ] && [ -z "$KSQL_JMX_OPTS" ]; then
+  echo "" >&2
+  echo "ERROR: JMX_PORT is set but KSQL_JMX_OPTS is empty." >&2
+  echo "Remote JMX must be configured explicitly with authentication." >&2
+  echo "Refusing to start with an unauthenticated JMX listener." >&2
+  echo "" >&2
+  echo "To enable remote JMX securely, set KSQL_JMX_OPTS with, for example:" >&2
+  echo "  -Dcom.sun.management.jmxremote" >&2
+  echo "  -Dcom.sun.management.jmxremote.authenticate=true" >&2
+  echo "  -Dcom.sun.management.jmxremote.password.file=<path>" >&2
+  echo "  -Dcom.sun.management.jmxremote.access.file=<path>" >&2
+  echo "  -Dcom.sun.management.jmxremote.ssl=true" >&2
+  echo "" >&2
+  echo "See https://docs.confluent.io/platform/current/ksqldb/operate-and-deploy/monitoring.html" >&2
+  exit 1
 fi
 
-# JMX port to use
-if [ ! -z "$JMX_PORT" ]; then
+# Append the JMX port to operator-supplied options if requested.
+if [ -n "$JMX_PORT" ]; then
   KSQL_JMX_OPTS="$KSQL_JMX_OPTS -Dcom.sun.management.jmxremote.port=$JMX_PORT "
 fi
 

--- a/docs/operate-and-deploy/installation/check-ksqldb-server-health.md
+++ b/docs/operate-and-deploy/installation/check-ksqldb-server-health.md
@@ -96,6 +96,12 @@ An exit code of 0 for an open port tells you that the container and ksqlDB JVM
 are running. This confirmation has a level of confidence that's similar to the
 REST health check.
 
+!!! note
+    This probe requires a remote JMX listener. It succeeds only if the operator
+    has set `KSQL_JMX_OPTS` with a remote-bound listener; the default loopback-only
+    JMX configuration rejects remote connections and this probe will fail from
+    another host.
+
 The general responsiveness on the port should be sufficient as a high-level
 health check. For a list of the available metrics you can collect, see
 [JMX Metrics](/reference/metrics/).

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -119,14 +119,20 @@ KSQL_LOG4J_OPTS
 KSQL_JMX_OPTS
 
 :   Specifies ksqlDB metrics options by using Java Management Extensions
-    (JMX). The following example command sets the default JMX configuration.
+    (JMX). Remote JMX requires `KSQL_JMX_OPTS` to configure authentication
+    and TLS. The following example command enables remote JMX with a
+    password file, an access-control file, and SSL.
 
     ```bash
-    export KSQL_JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false "
+    export KSQL_JMX_OPTS="-Dcom.sun.management.jmxremote \
+      -Dcom.sun.management.jmxremote.authenticate=true \
+      -Dcom.sun.management.jmxremote.password.file=/etc/ksqldb/jmxremote.password \
+      -Dcom.sun.management.jmxremote.access.file=/etc/ksqldb/jmxremote.access \
+      -Dcom.sun.management.jmxremote.ssl=true"
     ```
 
     For more information, see
-    [Monitoring and Management Using JMX Technology](https://docs.oracle.com/en/java/javase/11/management/monitoring-and-management-using-jmx-technology.html).
+    [Monitoring and Management Using JMX Technology](https://docs.oracle.com/en/java/javase/17/management/monitoring-and-management-using-jmx-technology.html).
 
 KSQL_HEAP_OPTS
 
@@ -156,10 +162,12 @@ KSQL_JVM_PERFORMANCE_OPTS
 
 JMX_PORT
 
-:   Specifies the port that JMX uses to report metrics.
+:   Specifies the port that JMX uses to report metrics. `JMX_PORT` has
+    no effect unless `KSQL_JMX_OPTS` is also set. The server refuses to
+    start if `JMX_PORT` is set alone.
 
     ```bash
-    export JMX_PORT=1099 
+    export JMX_PORT=1099
     ```
 
 JAVA_HOME

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -119,9 +119,10 @@ KSQL_LOG4J_OPTS
 KSQL_JMX_OPTS
 
 :   Specifies ksqlDB metrics options by using Java Management Extensions
-    (JMX). Remote JMX requires `KSQL_JMX_OPTS` to configure authentication
-    and TLS. The following example command enables remote JMX with a
-    password file, an access-control file, and SSL.
+    (JMX). Remote JMX requires `KSQL_JMX_OPTS` to be set explicitly; the
+    server refuses to start if `JMX_PORT` is set without `KSQL_JMX_OPTS`.
+    The following example is a secure baseline that enables remote JMX
+    with a password file, an access-control file, and SSL.
 
     ```bash
     export KSQL_JMX_OPTS="-Dcom.sun.management.jmxremote \

--- a/docs/operate-and-deploy/installation/server-config/index.md
+++ b/docs/operate-and-deploy/installation/server-config/index.md
@@ -119,8 +119,8 @@ KSQL_LOG4J_OPTS
 KSQL_JMX_OPTS
 
 :   Specifies ksqlDB metrics options by using Java Management Extensions
-    (JMX). Remote JMX requires `KSQL_JMX_OPTS` to be set explicitly; the
-    server refuses to start if `JMX_PORT` is set without `KSQL_JMX_OPTS`.
+    (JMX). By default, ksqlDB starts with loopback-only JMX and no remote
+    listener. To enable remote JMX, set `KSQL_JMX_OPTS` explicitly.
     The following example is a secure baseline that enables remote JMX
     with a password file, an access-control file, and SSL.
 
@@ -163,9 +163,10 @@ KSQL_JVM_PERFORMANCE_OPTS
 
 JMX_PORT
 
-:   Specifies the port that JMX uses to report metrics. `JMX_PORT` has
-    no effect unless `KSQL_JMX_OPTS` is also set. The server refuses to
-    start if `JMX_PORT` is set alone.
+:   Specifies the port that JMX uses to report metrics. If `JMX_PORT` is
+    set without `KSQL_JMX_OPTS`, ksqlDB binds the port with loopback-only
+    JMX defaults (no remote listener). To expose JMX remotely, set
+    `KSQL_JMX_OPTS` with authentication and TLS as shown above.
 
     ```bash
     export JMX_PORT=1099

--- a/docs/operate-and-deploy/monitoring.md
+++ b/docs/operate-and-deploy/monitoring.md
@@ -22,7 +22,9 @@ it in a Docker-based deployment, export an environment variable named
 `KSQL_JMX_OPTS` with your JMX configuration and expose the port that
 JMX will communicate over.
 
-Remote JMX requires `KSQL_JMX_OPTS` to configure authentication and TLS.
+Remote JMX requires `KSQL_JMX_OPTS` to be set explicitly. Configure
+authentication and TLS in `KSQL_JMX_OPTS`; the server refuses to start
+if `JMX_PORT` is set without `KSQL_JMX_OPTS`.
 
 The following Docker Compose example shows how you can configure
 monitoring for ksqlDB server. The surrounding components, like the
@@ -63,11 +65,11 @@ With respect to monitoring, here it what this does:
 - The environment variable `KSQL_JMX_OPTS` is supplied to the server
   with various arguments. The `>` character lets you write a
   multi-line string in Yaml, which makes this long argument easier to
-  read. The example enables JMX authentication (via a password file),
-  a JMX access-control file, and SSL. JMX has a wide range of
-  [configuration
-  options](https://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html);
-  the flags shown are the minimum required for remote access.
+  read. The example is a secure baseline: JMX authentication (via a
+  password file), a JMX access-control file, and SSL. Adjust the
+  advertised hostname and ports for your environment. JMX has a wide
+  range of [configuration
+  options](https://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html).
 
 - `jmxremote.password.file` and `jmxremote.access.file` must be mounted
   into the container with `chmod 0600` (password file) and `chmod 0644`

--- a/docs/operate-and-deploy/monitoring.md
+++ b/docs/operate-and-deploy/monitoring.md
@@ -22,6 +22,8 @@ it in a Docker-based deployment, export an environment variable named
 `KSQL_JMX_OPTS` with your JMX configuration and expose the port that
 JMX will communicate over.
 
+Remote JMX requires `KSQL_JMX_OPTS` to configure authentication and TLS.
+
 The following Docker Compose example shows how you can configure
 monitoring for ksqlDB server. The surrounding components, like the
 broker and CLI, are omitted for brevity. You can see an example of a
@@ -49,9 +51,11 @@ ksqldb-server:
       -Djava.rmi.server.hostname=localhost
       -Dcom.sun.management.jmxremote
       -Dcom.sun.management.jmxremote.port=1099
-      -Dcom.sun.management.jmxremote.authenticate=false
-      -Dcom.sun.management.jmxremote.ssl=false
       -Dcom.sun.management.jmxremote.rmi.port=1099
+      -Dcom.sun.management.jmxremote.authenticate=true
+      -Dcom.sun.management.jmxremote.password.file=/etc/ksqldb/jmxremote.password
+      -Dcom.sun.management.jmxremote.access.file=/etc/ksqldb/jmxremote.access
+      -Dcom.sun.management.jmxremote.ssl=true
 ```
 
 With respect to monitoring, here it what this does:
@@ -59,10 +63,17 @@ With respect to monitoring, here it what this does:
 - The environment variable `KSQL_JMX_OPTS` is supplied to the server
   with various arguments. The `>` character lets you write a
   multi-line string in Yaml, which makes this long argument easier to
-  read. The advertised hostname, port, and security settings are
-  configured. JMX has a wide range of [configuration
-  options](https://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html),
-  and you can set these however you like.
+  read. The example enables JMX authentication (via a password file),
+  a JMX access-control file, and SSL. JMX has a wide range of
+  [configuration
+  options](https://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html);
+  the flags shown are the minimum required for remote access.
+
+- `jmxremote.password.file` and `jmxremote.access.file` must be mounted
+  into the container with `chmod 0600` (password file) and `chmod 0644`
+  (access file). See the
+  [JMX documentation](https://docs.oracle.com/en/java/javase/17/management/monitoring-and-management-using-jmx-technology.html)
+  for the file format.
 
 - Port `1099` is exposed, which corresponds to the JMX port set in the
   `KSQL_JMX_OPTS` configuration. This enables remote monitoring tools

--- a/docs/operate-and-deploy/monitoring.md
+++ b/docs/operate-and-deploy/monitoring.md
@@ -22,9 +22,9 @@ it in a Docker-based deployment, export an environment variable named
 `KSQL_JMX_OPTS` with your JMX configuration and expose the port that
 JMX will communicate over.
 
-Remote JMX requires `KSQL_JMX_OPTS` to be set explicitly. Configure
-authentication and TLS in `KSQL_JMX_OPTS`; the server refuses to start
-if `JMX_PORT` is set without `KSQL_JMX_OPTS`.
+By default, ksqlDB starts with loopback-only JMX and no remote listener.
+To enable remote JMX, set `KSQL_JMX_OPTS` with authentication and TLS
+configured explicitly, as shown in the example below.
 
 The following Docker Compose example shows how you can configure
 monitoring for ksqlDB server. The surrounding components, like the


### PR DESCRIPTION
## Summary

Default `bin/ksql-run-class` to **loopback-only JMX** (`local.only=true`) when the operator hasn't set `KSQL_JMX_OPTS`. Customers who want authenticated remote JMX continue to use the existing `KSQL_JMX_OPTS` env var

Jira: [KSQL-13769](https://confluentinc.atlassian.net/browse/KSQL-13769) (parent epic [KSQL-15197](https://confluentinc.atlassian.net/browse/KSQL-15197))

Docs page: https://docs.confluent.io/platform/current/ksqldb/operate-and-deploy/monitoring.html

## Vulnerability

- CVSS 6.8 — `CVSS:3.0/AV:A/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:H`
- When an operator set `JMX_PORT` (per the CP monitoring docs), the legacy `bin/ksql-run-class` initialised `KSQL_JMX_OPTS` with `authenticate=false ssl=false` and bound an RMI listener with no `local.only` filter. Any peer with network reach to the port could attach anonymously and — via `javax.management.loading.MLet.getMBeansFromURL` — load an attacker-supplied class into the ksqlDB JVM. Full RCE as the ksqlDB service account.
- End-to-end reproduced against the shipped `confluentinc/cp-ksqldb-server:8.2.1` image`.

## Behavior matrix

| `KSQL_JMX_OPTS` | `JMX_PORT` | Before (legacy defaults) | After (this PR) |
|---|---|---|---|
| unset | unset | JMX flags with `authenticate=false ssl=false local.only=false`; no port bound | JMX flags with `authenticate=false ssl=false local.only=true`; no port bound *(unchanged behavior since no port)* |
| unset | **set** | **unauth remote listener on `:JMX_PORT`** — the CVE recipe | **loopback-only listener on `:JMX_PORT`** — CVE closed |
| set | unset | user's opts | user's opts *(unchanged)* |
| set | set | user's opts + port | user's opts + port *(unchanged)* |

The only row that changes is the row that trips the CVE.

## Docs updates in this PR

- `docs/operate-and-deploy/monitoring.md` — drop the "server refuses to start" prose; keep the secure `authenticate=true ssl=true` example (already correct on disk).
- `docs/operate-and-deploy/installation/server-config/index.md` — same fail-hard prose removal in the `KSQL_JMX_OPTS` and `JMX_PORT` entries.
- `docs/operate-and-deploy/installation/check-ksqldb-server-health.md` — added a note that the `nc -z <ksql-node>:1099` probe now requires the operator to have set `KSQL_JMX_OPTS`; the default loopback-only listener rejects remote probes.

## Test plan / verification

- **Repro (pre-fix):** against unmodified `cp-ksqldb-server:8.2.1`, `KSQL_JMX_PORT=1099` opens `:1099` with `authenticate=false ssl=false local.only=false`. jmxterm attached with no credentials; MLet chain achieved full RCE. Verified via `docker exec`.
- **Post-fix, tarball path, no env vars:** boots; JVM cmdline has `local.only=true`, no port bound.
- **Post-fix, `JMX_PORT=1099`, no `KSQL_JMX_OPTS`:** boots; JVM cmdline has `local.only=true` + `port=1099`. `nc -zv <peer> 1099` from another host: connection refused. `nc -zv 127.0.0.1 1099` locally: succeeds.
- **Post-fix, operator supplies own `KSQL_JMX_OPTS`:** verbatim customer config passed through — no shape change.
- The vulnerable JMX block in `bin/ksql-run-class` has been unchanged across all currently-supported CP minors; backport patch is verbatim per-branch.

## Sibling / related tickets

- [KSQL-13770](https://confluentinc.atlassian.net/browse/KSQL-13770) — cc-ksql-healthchecks sidecar; delete JMX outright ([cc-ksql-healthchecks#457](https://github.com/confluentinc/cc-ksql-healthchecks/pull/457)).
- [KSQL-15367](https://confluentinc.atlassian.net/browse/KSQL-15367) — cc-spec-ksql main pod template; delete JMX block outright.
- [K2-848](https://confluentinc.atlassian.net/browse/K2-848) — Kafka broker (`ce-kafka/bin/kafka-run-class.sh`), same insecure idiom. In Progress, Rodrigo Greselle Hartmann, due 2026-09-30.
- [CPBR-2998](https://confluentinc.atlassian.net/browse/CPBR-2998) — `cp-ksqldb-server-ib-images` mirror. Prince Raheja, blocked on this PR.

## Reviewer checklist

- [ ] Behavior matrix matches expectations for your deployment pattern
- [ ] Docs updates preserve the secure `KSQL_JMX_OPTS` example
- [ ] Attach API residual risk is acceptable
- [ ] Backport plan agreed (point-merge 7.5.x → master, then ib-images)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KSQL-13769]: https://confluentinc.atlassian.net/browse/KSQL-13769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KSQL-15197]: https://confluentinc.atlassian.net/browse/KSQL-15197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KSQL-13770]: https://confluentinc.atlassian.net/browse/KSQL-13770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ