### PR TITLE
KSQL-15280 | CVE fix for org.jline:jline-remote-telnet (GHSA-2r2c-cx56-8933)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <inject.version>1</inject.version>
         <janino.version>3.1.10</janino.version>
         <javax-validation.version>2.0.1.Final</javax-validation.version>
-        <jline.version>3.25.0</jline.version>
+        <jline.version>4.2.1</jline.version>
         <jna.version>4.4.0</jna.version>
         <jsr305.version>3.0.2</jsr305.version>
         <maven.plugins.version>3.0.0-M1</maven.plugins.version>


### PR DESCRIPTION
## Summary
- Fixes [KSQL-15280](https://confluentinc.atlassian.net/browse/KSQL-15280) — request to fix `GHSA-2r2c-cx56-8933`  in `org.jline:jline-remote-telnet`.
- Bumps `jline.version` from `3.25.0` to `4.2.1` in `pom.xml`. The advisory's patched versions are `4.2.1` (4.x line) and `3.30.14` (3.x line); went with `4.2.1` per the ticket's explicit ask.

## Verification
- Confirmed the resolved `org.jline:jline:4.2.1` jar embeds `jline-remote-telnet:4.2.1`.
- `ksqldb-cli` (the only module depending on jline) compiles, test-compiles, and its unit test suite passes against the new version.


[KSQL-15280]: https://confluentinc.atlassian.net/browse/KSQL-15280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ