### PR TITLE
feat: Resolve config overrides before validation

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/PropertyNotFoundException.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/PropertyNotFoundException.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.properties;
 
 public class PropertyNotFoundException extends IllegalArgumentException {
-  PropertyNotFoundException(final String property) {
+  public PropertyNotFoundException(final String property) {
     super(String.format(
         "Not recognizable as ksql, streams, consumer, or producer property: '%s'",
         property

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
@@ -28,9 +28,11 @@ import io.confluent.ksql.api.server.InsertsStreamSubscriber;
 import io.confluent.ksql.api.server.KsqlApiException;
 import io.confluent.ksql.api.server.MetricsCallbackHolder;
 import io.confluent.ksql.api.spi.Endpoints;
+import io.confluent.ksql.config.KsqlConfigResolver;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.internal.PullQueryExecutorMetrics;
 import io.confluent.ksql.properties.DenyListPropertyValidator;
+import io.confluent.ksql.properties.PropertyNotFoundException;
 import io.confluent.ksql.rest.EndpointResponse;
 import io.confluent.ksql.rest.entity.ClusterTerminateRequest;
 import io.confluent.ksql.rest.entity.HeartbeatMessage;
@@ -151,7 +153,7 @@ public class KsqlServerEndpoints implements Endpoints {
         .provide(apiSecurityContext);
     return executeOnWorker(() -> {
       try {
-        validateProperties(properties);
+        resolveAndValidateProperties(properties);
         return new QueryEndpoint(ksqlEngine, ksqlConfig, pullQueryMetrics, queryExecutor)
             .createQueryPublisher(
                 sql,
@@ -177,7 +179,7 @@ public class KsqlServerEndpoints implements Endpoints {
       final WorkerExecutor workerExecutor,
       final ApiSecurityContext apiSecurityContext) {
     return executeOnWorker(() -> {
-      validateProperties(properties.getMap());
+      resolveAndValidateProperties(properties.getMap());
       return new InsertsStreamEndpoint(ksqlEngine, ksqlConfig, reservedInternalTopics)
           .createInsertsSubscriber(target, properties, acksSubscriber, context, workerExecutor,
               ksqlSecurityContextProvider.provide(apiSecurityContext).getServiceContext());
@@ -331,10 +333,14 @@ public class KsqlServerEndpoints implements Endpoints {
     }, workerExecutor);
   }
 
-  private void validateProperties(final Map<String, Object> properties) {
+  private void resolveAndValidateProperties(final Map<String, Object> properties) {
     try {
-      denyListPropertyValidator.validateAll(properties);
-    } catch (KsqlException e) {
+      final KsqlConfigResolver configResolver = new KsqlConfigResolver();
+      properties.keySet().forEach(key ->
+          configResolver.resolve(key, true)
+              .orElseThrow(() -> new PropertyNotFoundException(key)));
+        denyListPropertyValidator.validateAll(properties);
+    } catch (PropertyNotFoundException | KsqlException e) {
       throw new KsqlApiException(e.getMessage(), ERROR_CODE_BAD_REQUEST);
     }
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
@@ -339,7 +339,7 @@ public class KsqlServerEndpoints implements Endpoints {
       properties.keySet().forEach(key ->
           configResolver.resolve(key, true)
               .orElseThrow(() -> new PropertyNotFoundException(key)));
-        denyListPropertyValidator.validateAll(properties);
+      denyListPropertyValidator.validateAll(properties);
     } catch (PropertyNotFoundException | KsqlException e) {
       throw new KsqlApiException(e.getMessage(), ERROR_CODE_BAD_REQUEST);
     }


### PR DESCRIPTION
### Description 
Resolve config overrides before validation for /query-stream and /inserts-stream endpoint.
```
1. /query-stream
curl -s --http2 -X POST http://localhost:8088/query-stream \
    -H "Content-Type: application/vnd.ksqlapi.delimited.v1" \
    -d '{
      "sql": "SELECT * FROM src_orders EMIT CHANGES LIMIT 1;",
      "properties": {
        "auto.offset.resety": "earliest",
        "ksql.streams.num.stream.threadsy": "4",
        "commit.interval.ms": "5000"
      }
    }'
  {"@type":"generic_error","error_code":40000,"message":"Not recognizable as ksql, streams, consumer, or producer property: 'auto.offset.resety'"}%  

2. /inserts-stream
 curl -s --http2 -X POST http://localhost:8088/inserts-stream \
    -H "Content-Type: application/application/vnd.ksql.v1+json" \
    --data-binary $'{"target":"SRC_ORDERS","properties":{"auto.offset.resety":"earliest","ksql.streams.num.stream.threadsy":"4"}}\n{"order_id":42,"customer":"alice","amount":250.0}'
    
 {"@type":"generic_error","error_code":40000,"message":"Not recognizable as ksql, streams, consumer, or producer property: 'auto.offset.resety'"}%  
```

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

