### PR TITLE
limit col size to prevent overflow

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udtf/Cube.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udtf/Cube.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.function.udtf;
 
 import io.confluent.ksql.function.FunctionCategory;
+import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.util.KsqlConstants;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -32,6 +33,11 @@ import java.util.List;
 )
 public class Cube {
 
+  // 2^20 (~1M) output rows already comfortably covers realistic use of this function while
+  // keeping the worst-case allocation below bounded regardless of heap size, well clear of the
+  // 31-column shift-overflow boundary.
+  private static final int MAX_COLUMNS = 20;
+
   @Udtf
   public <T> List<List<T>> cube(final List<T> columns) {
     if (columns == null) {
@@ -42,6 +48,11 @@ public class Cube {
 
 
   private <T> List<List<T>>  createAllCombinations(final List<T> columns) {
+
+    if (columns.size() > MAX_COLUMNS) {
+      throw new KsqlFunctionException(
+          "cube_explode: too many columns (" + columns.size() + "); max is " + MAX_COLUMNS);
+    }
 
     final int combinations = 1 << columns.size();
     // when a column value is null there is only a single possibility for the output

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udtf/CubeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udtf/CubeTest.java
@@ -17,8 +17,10 @@ package io.confluent.ksql.function.udtf;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.Lists;
+import io.confluent.ksql.function.KsqlFunctionException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -96,6 +98,21 @@ public class CubeTest {
     // Then:
     assertThat(result.size(), is(1));
     assertThat(result.get(0), is(Arrays.asList(null, null)));
+  }
+
+  @Test
+  public void shouldThrowOnTooManyColumns() {
+    // Given: one more column than the function's cap, to prevent the 2^N combinations
+    // computed internally from exhausting the heap (see KSQL-15278)
+    final List<Object> tooManyColumns = Collections.nCopies(21, 1);
+
+    // When:
+    final KsqlFunctionException e = assertThrows(
+        KsqlFunctionException.class,
+        () -> cubeUdtf.cube(tooManyColumns));
+
+    // Then:
+    assertThat(e.getMessage(), is("cube_explode: too many columns (21); max is 20"));
   }
 
 }


### PR DESCRIPTION
Adds a bound on the number of columns accepted by the cube_explode table function. Previously the function would allocate a result set sized 2^N for N input columns with no upper limit, which could lead to excessive memory usage for large column counts. This change caps N at 20 and rejects larger inputs with a clear error message, consistent with how other built-in UDFs validate their arguments.

Testing done

Added a unit test verifying that exceeding the column limit throws the expected error. Existing cube_explode tests and functional-test fixtures (which use small column counts) are unaffected.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

