### PR TITLE
KSQL-15370: docs: audit remaining community contribution invitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,19 +126,18 @@ The following statement will create a Kafka Connect sink connector that continuo
 For user help, questions or queries about ksqlDB please use our [user Google Group](https://groups.google.com/forum/#!forum/ksql-users)
 or our public Slack channel #ksqldb in [Confluent Community Slack](https://slackpass.io/confluentcommunity). Everyone is welcome!
 
-You can get help, learn how to contribute to ksqlDB, and find the latest news by [connecting with the Confluent community](https://www.confluent.io/contact-us-thank-you/).
+You can get help and find the latest news by [connecting with the Confluent community](https://www.confluent.io/contact-us-thank-you/).
 
 For more general questions about the Confluent Platform please post in the [Confluent Google group](https://groups.google.com/forum/#!forum/confluent-platform).
 
 
 # Contributing and building from source
 
-Contributions to the code, examples, documentation, etc. are very much appreciated.
+**We are no longer accepting contributions from the community.**
 
 - Report issues and bugs directly in [this GitHub project](https://github.com/confluentinc/ksql/issues).
-- Learn how to work with the ksqlDB source code, including building and testing ksqlDB as well as contributing code changes
-  to ksqlDB by reading our [Development and Contribution guidelines](CONTRIBUTING.md).
-- One good way to get started is by tackling a [newbie issue](https://github.com/confluentinc/ksql/labels/good%20first%20issue).
+- Learn how to work with the ksqlDB source code, including building and testing ksqlDB, by reading our
+  [Development and Contribution guidelines](CONTRIBUTING.md).
 
 
 # License

--- a/design-proposals/README.md
+++ b/design-proposals/README.md
@@ -1,6 +1,9 @@
 # KSQL Improvement Proposals
 
-This is a place to collect improvement proposals for KSQL from the community. Please follow the 
+**We are no longer accepting community-submitted KLIPs.**
+The process below is retained for historical/internal reference only.
+
+This is a place to collect improvement proposals for KSQL. Please follow the
 [KLIP Template](klip-template.md) when creating a new KLIP.
 
 We have a two-part process for submitting KLIPs:

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,14 +10,10 @@ contains the markdown files and other source content for the
 Contribute to ksqlDB docs
 =========================
 
-You can help to improve the ksqlDB documentation by contributing to this repo:
+**We are no longer accepting community contributions to the ksqlDB documentation.**
 
-- Open a [GitHub issue](https://github.com/confluentinc/ksql/issues) and give it
-  the `documentation` label.
-- Submit a [pull request](https://github.com/confluentinc/ksql/pulls) with your
-  proposed documentation changes.
-- Get started with
-  [writing and formatting on GitHub](https://help.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github).
+If you find an issue with the docs, please open a [GitHub issue](https://github.com/confluentinc/ksql/issues)
+and give it the `documentation` label.
 
 Build docs locally
 ==================

--- a/docs/developer-guide/ksqldb-clients/index.md
+++ b/docs/developer-guide/ksqldb-clients/index.md
@@ -17,4 +17,5 @@ maintained by community members:
 - [Go client](https://github.com/thmeitz/ksqldb-go)
 - [Python client](https://github.com/bryanyang0528/ksql-python)
 
-To contribute a new client for your favorite language, see our [recommendations](contributing.md).
+We are no longer accepting community contributions of new clients. See the
+[client contribution guide](contributing.md) for historical/internal reference.

--- a/docs/how-to-guides/index.md
+++ b/docs/how-to-guides/index.md
@@ -74,10 +74,4 @@ Follow compact lessons that help you work with common ksqlDB functionality.
     <p class="card-body"><small>Transform columns of structured data without user-defined functions.</small></p>
     <span><a href="/how-to-guides/use-lambda-functions">Learn →</a></span>
   </div>
-  
-  <div class="card how-to-guide contribute">
-    <a href="https://github.com/confluentinc/ksql"><strong>Help us write another?</strong></a>
-    <p class="card-body"><small>We're always looking for more guides. Just send a pull request!</small></p>
-    <span><a href="https://github.com/confluentinc/ksql">Contribute →</a></span>
-  </div>
 </div>


### PR DESCRIPTION
## Summary
- Follow-up to #11103, which added a "no longer accepting community contributions" notice to `CONTRIBUTING.md` and the client contribution guide.
- Audited the rest of the repo's documentation for other places that still invite or describe community code/KLIP/docs/client contributions, and updated them for consistency:
  - `README.md`: dropped the "learn how to contribute" phrasing from the community section, added the no-longer-accepting notice to "Contributing and building from source", removed the "good first issue" invitation.
  - `design-proposals/README.md`: added a notice that community-submitted KLIPs are no longer accepted (process retained for historical/internal reference).
  - `docs/README.md`: replaced the docs contribution invitation (open issue + submit PR) with the notice.
  - `docs/developer-guide/ksqldb-clients/index.md`: reworded the link to the client contribution guide so it no longer invites new contributions.
  - `docs/how-to-guides/index.md`: removed the "Help us write another? Just send a pull request!" card.

## Test plan
- [x] Docs-only change; no code/tests affected.
- [ ] Visual check of rendered `docs/how-to-guides/index.md` cards layout (card removed cleanly, no dangling markup).