### PR TITLE
KSQL-15395: bump Netty version to 4.1.136.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,15 +139,15 @@
         <apache.io.version>2.11.0</apache.io.version>
         <io.confluent.ksql.version>7.5.16-0</io.confluent.ksql.version>
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
-        <netty-tcnative-version>2.0.77.Final</netty-tcnative-version>
+        <netty-tcnative-version>2.0.78.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`
              we might need to bump `tcnative`, too.
              Please check top level `pom.xml` at https://github.com/netty/netty
              for the netty version we bump to (ie, corresponding git tag),
              to find the correct `tcnative` version. -->
-        <netty.version>4.1.135.Final</netty.version>
-        <netty-codec-http2-version>4.1.135.Final</netty-codec-http2-version>
+        <netty.version>4.1.136.Final</netty.version>
+        <netty-codec-http2-version>4.1.136.Final</netty-codec-http2-version>
         <jersey-common>2.46</jersey-common>
         <multi-threaded-testing.forkCount>3</multi-threaded-testing.forkCount>
         <kafka.version>${ce.kafka.version}</kafka.version>


### PR DESCRIPTION
## Summary
- Fixes [CVE-2026-59919](https://confluentinc.atlassian.net/browse/KSQL-15395) in `io.netty:netty-codec-haproxy` by bumping `netty.version` / `netty-codec-http2-version` from `4.1.135.Final` to `4.1.136.Final`.
- Bumps `netty-tcnative-version` from `2.0.77.Final` to `2.0.78.Final` to stay in sync with the tcnative version Netty's own bom pins for `4.1.136.Final`, per the existing comment in `pom.xml`.

## Test plan
- [x] `mvn dependency:tree -Dincludes=io.netty:netty-codec-haproxy` confirms `ksqldb-rest-app` (and all other modules) resolve `netty-codec-haproxy:4.1.136.Final`
- [x] Full reactor build succeeds (`mvn dependency:tree` across all modules)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)