### PR TITLE
Revert jline version to 3.25.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <inject.version>1</inject.version>
         <janino.version>3.1.10</janino.version>
         <javax-validation.version>2.0.1.Final</javax-validation.version>
-        <jline.version>3.30.14</jline.version>
+        <jline.version>3.25.0</jline.version>
         <jna.version>4.4.0</jna.version>
         <jsr305.version>3.0.2</jsr305.version>
         <maven.plugins.version>3.0.0-M1</maven.plugins.version>


### PR DESCRIPTION
## Summary
- Revert `jline.version` from 3.30.14 to 3.25.0 in pom.xml on the 7.5.x branch

## Test plan
- [ ] CI build passes