### PR TITLE
reverting jersey comman version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
              to find the correct `tcnative` version. -->
         <netty.version>4.1.136.Final</netty.version>
         <netty-codec-http2-version>4.1.136.Final</netty-codec-http2-version>
-        <jersey-common>2.46</jersey-common>
+        <jersey-common>3.1.10</jersey-common>
         <multi-threaded-testing.forkCount>3</multi-threaded-testing.forkCount>
         <kafka.version>${ce.kafka.version}</kafka.version>
     </properties>


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_
jersey common version unintentionally changed in this pr : https://github.com/confluentinc/ksql/pull/11114/changes , reverting it.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

