### PR TITLE
feat: make Kafka admin request retry timeout configurable

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -480,6 +480,14 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_SHUTDOWN_TIMEOUT_MS_DOC = "Timeout in "
       + "milliseconds to block waiting for the underlying streams instance to exit";
 
+  public static final String KSQL_ADMIN_REQUEST_RETRY_TIMEOUT_MS_CONFIG =
+      "ksql.admin.request.retry.timeout.ms";
+  public static final Long KSQL_ADMIN_REQUEST_RETRY_TIMEOUT_MS_DEFAULT = 2500L;
+  public static final String KSQL_ADMIN_REQUEST_RETRY_TIMEOUT_MS_DOC = "Total time in "
+      + "milliseconds to keep retrying a retryable Kafka admin request (for example, describing a "
+      + "topic that was created moments earlier but whose metadata has not yet propagated) before "
+      + "giving up. The number of attempts is derived from this timeout and a fixed retry backoff.";
+
   public static final String KSQL_AUTH_CACHE_EXPIRY_TIME_SECS =
       "ksql.authorization.cache.expiry.time.secs";
   public static final Long KSQL_AUTH_CACHE_EXPIRY_TIME_SECS_DEFAULT = 30L;
@@ -1203,6 +1211,12 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_SHUTDOWN_TIMEOUT_MS_DEFAULT,
             Importance.MEDIUM,
             KSQL_SHUTDOWN_TIMEOUT_MS_DOC
+        ).define(
+            KSQL_ADMIN_REQUEST_RETRY_TIMEOUT_MS_CONFIG,
+            Type.LONG,
+            KSQL_ADMIN_REQUEST_RETRY_TIMEOUT_MS_DEFAULT,
+            Importance.MEDIUM,
+            KSQL_ADMIN_REQUEST_RETRY_TIMEOUT_MS_DOC
         ).define(
             KSQL_AUTH_CACHE_EXPIRY_TIME_SECS,
             Type.LONG,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterables;
+import io.confluent.ksql.exception.KafkaResponseGetFailedException;
 import io.confluent.ksql.execution.ddl.commands.CreateStreamCommand;
 import io.confluent.ksql.execution.ddl.commands.CreateTableCommand;
 import io.confluent.ksql.execution.plan.Formats;
@@ -293,7 +294,14 @@ public final class CreateSourceFactory {
       final ServiceContext serviceContext
   ) {
     final String kafkaTopicName = properties.getKafkaTopic();
-    if (!serviceContext.getTopicClient().isTopicExists(kafkaTopicName)) {
+    // Wait for the topic's metadata to propagate rather than doing a single fast existence check.
+    // describeTopic retries UNKNOWN_TOPIC_OR_PARTITION within the configurable admin-request retry
+    // window (see KsqlConfig.KSQL_ADMIN_REQUEST_RETRY_TIMEOUT_MS_CONFIG), so a just-created topic
+    // on a backend with slower metadata propagation is waited for instead of failing immediately.
+    // isTopicExists deliberately does NOT retry UNKNOWN_TOPIC_OR_PARTITION, so it is not used here.
+    try {
+      serviceContext.getTopicClient().describeTopic(kafkaTopicName);
+    } catch (final KafkaResponseGetFailedException e) {
       throw new KsqlException("Kafka topic does not exist: " + kafkaTopicName);
     }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
@@ -55,8 +55,12 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class CreateSourceFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CreateSourceFactory.class);
 
   private final ServiceContext serviceContext;
   private final SerdeFeaturessSupplier keySerdeFeaturesSupplier;
@@ -302,6 +306,10 @@ public final class CreateSourceFactory {
     try {
       serviceContext.getTopicClient().describeTopic(kafkaTopicName);
     } catch (final KafkaResponseGetFailedException e) {
+      // describeTopic can fail for reasons other than the topic being absent (e.g. authorization
+      // or an invalid-topic error). Log the underlying cause so it is not masked by the generic
+      // user-facing message below.
+      LOG.warn("Failed to verify existence of Kafka topic '{}'", kafkaTopicName, e);
       throw new KsqlException("Kafka topic does not exist: " + kafkaTopicName);
     }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/ExecutorUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/ExecutorUtil.java
@@ -26,11 +26,35 @@ import org.apache.logging.log4j.Logger;
 
 public final class ExecutorUtil {
 
-  private static final int NUM_RETRIES = 5;
+  // Number of attempts for retryable Kafka admin requests (for example, waiting for a
+  // just-created topic's metadata to become visible, where describeTopics retries
+  // UNKNOWN_TOPIC_OR_PARTITION via RetryBehaviour.ON_RETRYABLE). This is derived from a
+  // configurable timeout (see setRetryTimeoutMs) and the fixed backoff below, and defaults to
+  // DEFAULT_NUM_RETRIES so behaviour is unchanged unless the timeout is configured.
+  static final int DEFAULT_NUM_RETRIES = 5;
   private static final Duration RETRY_BACKOFF_MS = Duration.ofMillis(500);
+  private static volatile int configuredNumRetries = DEFAULT_NUM_RETRIES;
   private static final Logger log = LogManager.getLogger(ExecutorUtil.class);
 
   private ExecutorUtil() {
+  }
+
+  /**
+   * Sets the number of attempts used by the default {@code executeWithRetries} overloads for
+   * retryable Kafka admin requests, derived from the given timeout and the fixed retry backoff.
+   * At least one attempt is always made. Intended to be called once during startup from
+   * configuration.
+   *
+   * @param retryTimeoutMs the total time to keep retrying a request for, in milliseconds
+   */
+  public static void setRetryTimeoutMs(final long retryTimeoutMs) {
+    configuredNumRetries =
+        Math.max(1, (int) Math.ceil((double) retryTimeoutMs / RETRY_BACKOFF_MS.toMillis()));
+  }
+
+  // Visible for testing: the number of attempts derived from the configured retry timeout.
+  static int getConfiguredNumRetries() {
+    return configuredNumRetries;
   }
 
   public enum RetryBehaviour implements Predicate<Throwable> {
@@ -82,7 +106,8 @@ public final class ExecutorUtil {
       final Predicate<Throwable> shouldRetry,
       final Supplier<Duration> retryBackOff
   ) throws Exception {
-    return executeWithRetries(executable, shouldRetry, (retry) -> retryBackOff.get(), NUM_RETRIES);
+    return executeWithRetries(
+        executable, shouldRetry, (retry) -> retryBackOff.get(), configuredNumRetries);
   }
 
   public static <T> T executeWithRetries(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -135,8 +136,7 @@ public class CommandFactoriesTest {
 
   @Before
   public void before() {
-    when(serviceContext.getTopicClient()).thenReturn(topicClient);
-    when(topicClient.isTopicExists(any())).thenReturn(true);
+    lenient().when(serviceContext.getTopicClient()).thenReturn(topicClient);
     when(createSourceFactory.createStreamCommand(any(), any()))
         .thenReturn(createStreamCommand);
     when(createSourceFactory.createTableCommand(any(CreateTable.class), any()))

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
@@ -41,6 +41,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.ddl.commands.CreateSourceFactory.SerdeFeaturessSupplier;
+import io.confluent.ksql.exception.KafkaResponseGetFailedException;
 import io.confluent.ksql.execution.ddl.commands.CreateStreamCommand;
 import io.confluent.ksql.execution.ddl.commands.CreateTableCommand;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
@@ -184,7 +185,6 @@ public class CreateSourceFactoryTest {
   @Before
   public void before() {
     when(serviceContext.getTopicClient()).thenReturn(topicClient);
-    when(topicClient.isTopicExists(any())).thenReturn(true);
     when(keySerdeFactory.create(any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(keySerde);
     when(valueSerdeFactory.create(any(), any(), any(), any(), any(), any(), any()))
@@ -529,7 +529,9 @@ public class CreateSourceFactoryTest {
   @Test
   public void shouldThrowIfTopicDoesNotExistForStream() {
     // Given:
-    when(topicClient.isTopicExists(any())).thenReturn(false);
+    when(topicClient.describeTopic(TOPIC_NAME)).thenThrow(new KafkaResponseGetFailedException(
+        "Failed to Describe Kafka Topic(s): " + TOPIC_NAME,
+        new org.apache.kafka.common.errors.UnknownTopicOrPartitionException("unknown topic")));
     final CreateStream statement =
         new CreateStream(SOME_NAME, ONE_KEY_ONE_VALUE, false, true, withProperties, false);
 
@@ -555,7 +557,7 @@ public class CreateSourceFactoryTest {
     createSourceFactory.createStreamCommand(statement, ksqlConfig);
 
     // Then:
-    verify(topicClient).isTopicExists(TOPIC_NAME);
+    verify(topicClient).describeTopic(TOPIC_NAME);
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/FakeKafkaTopicClient.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/FakeKafkaTopicClient.java
@@ -20,6 +20,7 @@ import static org.apache.kafka.common.config.TopicConfig.CLEANUP_POLICY_CONFIG;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
+import io.confluent.ksql.exception.KafkaResponseGetFailedException;
 import io.confluent.ksql.topic.TopicProperties;
 import java.util.Collection;
 import java.util.Collections;
@@ -177,7 +178,8 @@ public class FakeKafkaTopicClient implements KafkaTopicClient {
   public TopicDescription describeTopic(final String topicName) {
     final FakeTopic fakeTopic = topicMap.get(topicName);
     if (fakeTopic == null) {
-      throw new UnknownTopicOrPartitionException("unknown topic: " + topicName);
+      throw new KafkaResponseGetFailedException("Failed to Describe Kafka Topic(s): " + topicName,
+          new UnknownTopicOrPartitionException("unknown topic: " + topicName));
     }
 
     return fakeTopic.getDescription();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/ExecutorUtilTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/ExecutorUtilTest.java
@@ -28,11 +28,31 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.junit.After;
 import org.junit.Test;
 
 public class ExecutorUtilTest {
 
   private static final Duration SMALL_RETRY_BACKOFF = Duration.ofMillis(1);
+
+  @After
+  public void resetRetryTimeout() {
+    // Reset the global retry count to its default so other tests are unaffected.
+    ExecutorUtil.setRetryTimeoutMs(2500);
+  }
+
+  @Test
+  public void shouldDeriveRetriesFromConfiguredTimeout() {
+    ExecutorUtil.setRetryTimeoutMs(30000);
+    assertThat(ExecutorUtil.getConfiguredNumRetries(), is(60));
+
+    ExecutorUtil.setRetryTimeoutMs(2500);
+    assertThat(ExecutorUtil.getConfiguredNumRetries(), is(5));
+
+    // Always makes at least one attempt, even for a very small timeout.
+    ExecutorUtil.setRetryTimeoutMs(0);
+    assertThat(ExecutorUtil.getConfiguredNumRetries(), is(1));
+  }
 
   @Test
   public void shouldRetryAndEventuallyThrowIfNeverSucceeds() throws Exception {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -108,6 +108,7 @@ import io.confluent.ksql.services.LazyServiceContext;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.SimpleKsqlClient;
 import io.confluent.ksql.util.AppInfo;
+import io.confluent.ksql.util.ExecutorUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConfigurable;
 import io.confluent.ksql.util.KsqlConstants;
@@ -407,6 +408,8 @@ public final class KsqlRestApplication implements Executable {
 
   @VisibleForTesting
   void startKsql(final KsqlConfig ksqlConfigWithPort) {
+    ExecutorUtil.setRetryTimeoutMs(
+        ksqlConfigWithPort.getLong(KsqlConfig.KSQL_ADMIN_REQUEST_RETRY_TIMEOUT_MS_CONFIG));
     cleanupOldState();
     initialize(ksqlConfigWithPort);
   }


### PR DESCRIPTION
## Summary

Introduces `ksql.admin.request.retry.timeout.ms` (default `2500`ms, matching the previous hard-coded behavior). `ExecutorUtil` now derives the number of attempts for retryable Kafka admin requests from this timeout and the fixed retry backoff, and the value is applied once at server startup.

This lets deployments that talk to a Kafka backend with slower topic-metadata propagation extend how long ksqlDB waits for a just-created topic's metadata to become visible, without changing the default.

`ensureTopicExists` (`CreateSourceFactory`) now uses `describeTopic` (which retries `UNKNOWN_TOPIC_OR_PARTITION` within this window) instead of the non-retrying `isTopicExists` check, and logs the underlying cause when the check fails instead of always surfacing a generic message.

## Test plan

- [x] `KsqlConfigTest`, `ExecutorUtilTest`, `CommandFactoriesTest` pass
- [x] `./mvnw install` for the affected modules (`ksqldb-common`, `ksqldb-engine`, `ksqldb-rest-app`) succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)