### PR TITLE
KSQL-13769: bind the default JMX listener to loopback

### DIFF
--- a/bin/ksql-run-class
+++ b/bin/ksql-run-class
@@ -57,13 +57,11 @@ fi
 
  KSQL_LOG4J_OPTS="-Dksql.log.dir=$LOG_DIR ${KSQL_LOG4J_OPTS}"
 
-# JMX settings.
-# ksqlDB defaults to loopback-only JMX. Remote JMX without authentication is
-# a code-execution primitive for any peer on the network. Operators who need
-# remote JMX must set KSQL_JMX_OPTS with authentication and TLS explicitly.
-# See docs/operate-and-deploy/monitoring.md for a copy-paste example.
+# JMX binds to loopback unless KSQL_JMX_OPTS is set; see
+# docs/operate-and-deploy/monitoring.md. jmxremote.host does the binding and
+# java.rmi.server.hostname the stub address; local.only is not read here.
 if [ -z "$KSQL_JMX_OPTS" ]; then
-  KSQL_JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
+  KSQL_JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.host=127.0.0.1 -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.local.only=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
 fi
 
 # Append the JMX port to operator-supplied options if requested.

--- a/docs/operate-and-deploy/monitoring.md
+++ b/docs/operate-and-deploy/monitoring.md
@@ -26,6 +26,9 @@ By default, ksqlDB starts with loopback-only JMX and no remote listener.
 To enable remote JMX, set `KSQL_JMX_OPTS` with authentication and TLS
 configured explicitly, as shown in the example below.
 
+In the Docker images, `KSQL_JMX_PORT` sets the JMX port but does not expose it
+remotely; the listener stays on loopback unless `KSQL_JMX_OPTS` is also set.
+
 The following Docker Compose example shows how you can configure
 monitoring for ksqlDB server. The surrounding components, like the
 broker and CLI, are omitted for brevity. You can see an example of a


### PR DESCRIPTION
## Problem

The loopback-only JMX default on this branch does not work. Setting `JMX_PORT` still produces a remotely reachable, unauthenticated JMX listener.

`com.sun.management.jmxremote.local.only` is read only in `ConnectorBootstrap.startLocalConnectorServer`. Setting a JMX port takes the *remote* path through `exportMBeanServer`, whose bind address comes solely from `com.sun.management.jmxremote.host` via `HostAwareSocketFactory` — and with that unset it calls `new ServerSocket(port)`, i.e. wildcard, unfiltered.

Measured on Zulu OpenJDK 11.0.31 with the exact flags this branch produces for `JMX_PORT=1099`, `KSQL_JMX_OPTS` unset:

```
FLAGS: -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=true
       -Dcom.sun.management.jmxremote.authenticate=false
       -Dcom.sun.management.jmxremote.ssl=false
       -Dcom.sun.management.jmxremote.port=1099

bind:   ::  (wildcard)
remote: JMX_RESULT=REACHABLE   ← anonymous client, from a separate container
```

That is the behaviour the default was added to prevent.

## Change

`bin/ksql-run-class` — two flags added to the default, none removed:

| Flag | Role |
| --- | --- |
| `com.sun.management.jmxremote.host=127.0.0.1` | binds the listener to loopback |
| `java.rmi.server.hostname=127.0.0.1` | makes the RMI stub advertise loopback |

The second is not optional. RMI answers the registry lookup, then hands the client a stub whose address comes from `java.rmi.server.hostname`; unset, it defaults to the host's own IP, which nothing is listening on. Binding the registry alone leaves JMX unusable **even over loopback**:

```
host=127.0.0.1                                      -> loopback UNREACHABLE
host=127.0.0.1 + java.rmi.server.hostname=127.0.0.1 -> loopback REACHABLE
```

`local.only=true` is kept — harmless, and consistent with `confluent-operator`'s `jvm.tmpl`, which this now matches flag for flag (CFK-3966).

The literal `127.0.0.1` rather than `localhost` is deliberate: both bind `::ffff:127.0.0.1` by default, but `localhost` depends on `/etc/hosts` and JVM address-preference order — with `-Djava.net.preferIPv6Addresses=true` it resolves to `::1` and refuses IPv4 loopback clients.

## Verification

Against a real JVM, asserting on `/proc/net/tcp6` for the bind address and a real MBean read for reachability:

| Scenario | Bind | Remote | Loopback |
| --- | --- | --- | --- |
| `JMX_PORT=1099`, no `KSQL_JMX_OPTS` | `::ffff:127.0.0.1` | refused | REACHABLE |
| operator sets `KSQL_JMX_OPTS` + port | — | REACHABLE | — |

Operator-supplied options pass through untouched, with no leakage of the loopback default — remote JMX opt-in still works.

## Docs

The existing "loopback-only" statements in `monitoring.md`, `server-config/index.md` and `check-ksqldb-server-health.md` describe exactly this behaviour. They were never wrong, only unimplemented, so they need no correction — this change makes them true.

The second commit adds one sentence for `KSQL_JMX_PORT`, the Docker images' port variable, which appeared nowhere in the docs and whose behaviour changes alongside ksql-images#354.

## Scope

`7.5.x` only. The ineffective default reached every branch from `7.5.x` to `master`, so this needs the same propagation — handled through the normal ping-merge process, not proposed here.

Companion: ksql-images#354 (cp-ksqldb-server `launch`), cc-spec-ksql#1619 (cc-ksql template). The three cover disjoint deployments — the image bypasses `ksql-run-class` by exporting `KSQL_JMX_OPTS`, and cc-ksql bypasses it by setting `KSQL_JMX_OPTS=' '` — so none is redundant.

## Breaking change

Deployments that set `JMX_PORT` to scrape JMX from outside the host now bind loopback-only and must set `KSQL_JMX_OPTS` explicitly with authentication and TLS. Needs a release note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
