### PR TITLE
Fix JLineReaderTest hang caused by jline 3.30.x native pty provider

### DIFF
--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/JLineReaderTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/JLineReaderTest.java
@@ -283,6 +283,10 @@ public class JLineReaderTest {
     final Terminal terminal = TerminalBuilder.builder()
         .streams(inputStream, outputStream)
         .system(false)
+        // Force the exec provider: jline bundles native libs since 3.30.x (absent in 3.25.0),
+        // so the jni provider now succeeds and opens a real OS pty even for explicit streams(),
+        // which hangs reading past the end of these finite, synthetic test streams.
+        .provider(TerminalBuilder.PROP_PROVIDER_EXEC)
         .build();
     final File tempHistoryFile = tempFolder.newFile("ksql-history.txt");
     final Path historyFilePath = Paths.get(tempHistoryFile.getAbsolutePath());


### PR DESCRIPTION
## Summary
- jline bundles native libs since 3.30.x (absent in 3.25.0), so the jni provider now succeeds and opens a real OS pty even for explicit `streams()`, which hangs reading past the end of these finite, synthetic test streams.
- Force the exec provider in `JLineReaderTest#createReaderForInput` so the terminal keeps using the synthetic streams as before.

## Test plan
- [ ] `JLineReaderTest` passes locally without hanging
- [ ] CI green on 8.0.2-cp9