### PR TITLE
fix: extend ConfigMigrator to migrate legacy OAuth callback handler classes

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ConfigMigrator.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ConfigMigrator.java
@@ -15,26 +15,101 @@
 
 package io.confluent.ksql.rest.server.computation;
 
+import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Handles configuration property migrations for backward compatibility.
- * 
- * <p>This class is responsible for transforming deprecated or legacy configuration
- * values into their modern equivalents when commands are executed. Migrations are
- * applied at runtime (during command execution) but not during serialization, ensuring
- * that original values are preserved in the command topic for backup and restore scenarios.
+ *
+ * <p>This class transforms deprecated configuration values into their modern equivalents
+ * when commands are executed. Migrations are applied at runtime (during command execution)
+ * but not during serialization, preserving original values in the command topic.
+ *
+ * <p>To add a new migration, add an entry to {@link #OVERWRITE_MIGRATIONS} and
+ * {@link #ORIGINAL_MIGRATIONS}.
  */
 public final class ConfigMigrator {
 
+  private static final Logger LOG = LogManager.getLogger(ConfigMigrator.class);
+
   /**
-   * The deprecated legacy value for exactly-once processing guarantee.
-   * This value is no longer supported in newer Kafka Streams versions.
+   * Legacy exactly-once value, deprecated in Kafka Streams 3.0+.
    */
   public static final String LEGACY_EXACTLY_ONCE = "exactly_once";
+
+  /**
+   * Legacy OAuth login callback handler from the "secured" package.
+   * Removed in Kafka 4.0/CP 8.x (deprecated since Kafka 3.4.0).
+   */
+  public static final String LEGACY_OAUTH_LOGIN_CALLBACK_HANDLER =
+      "org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerLoginCallbackHandler";
+
+  /**
+   * Legacy OAuth validator callback handler from the "secured" package.
+   * Removed in Kafka 4.0/CP 8.x (deprecated since Kafka 3.4.0).
+   */
+  public static final String LEGACY_OAUTH_VALIDATOR_CALLBACK_HANDLER =
+      "org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerValidatorCallbackHandler";
+
+  /**
+   * Migrations for overwrite properties (session-level overrides).
+   * Keys are unprefixed.
+   */
+  private static final Map<String, Map<String, String>> OVERWRITE_MIGRATIONS =
+      ImmutableMap.<String, Map<String, String>>builder()
+          .put(
+              StreamsConfig.PROCESSING_GUARANTEE_CONFIG,
+              ImmutableMap.of(LEGACY_EXACTLY_ONCE, StreamsConfig.EXACTLY_ONCE_V2)
+          )
+          .put(
+              SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+              ImmutableMap.of(
+                  LEGACY_OAUTH_LOGIN_CALLBACK_HANDLER,
+                  OAuthBearerLoginCallbackHandler.class.getName()
+              )
+          )
+          .put(
+              SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS,
+              ImmutableMap.of(
+                  LEGACY_OAUTH_VALIDATOR_CALLBACK_HANDLER,
+                  OAuthBearerValidatorCallbackHandler.class.getName()
+              )
+          )
+          .build();
+
+  /**
+   * Migrations for original properties (server configuration).
+   * Keys are prefixed with ksql.streams.
+   */
+  private static final Map<String, Map<String, String>> ORIGINAL_MIGRATIONS =
+      ImmutableMap.<String, Map<String, String>>builder()
+          .put(
+              KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.PROCESSING_GUARANTEE_CONFIG,
+              ImmutableMap.of(LEGACY_EXACTLY_ONCE, StreamsConfig.EXACTLY_ONCE_V2)
+          )
+          .put(
+              KsqlConfig.KSQL_STREAMS_PREFIX + SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+              ImmutableMap.of(
+                  LEGACY_OAUTH_LOGIN_CALLBACK_HANDLER,
+                  OAuthBearerLoginCallbackHandler.class.getName()
+              )
+          )
+          .put(
+              KsqlConfig.KSQL_STREAMS_PREFIX + SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS,
+              ImmutableMap.of(
+                  LEGACY_OAUTH_VALIDATOR_CALLBACK_HANDLER,
+                  OAuthBearerValidatorCallbackHandler.class.getName()
+              )
+          )
+          .build();
 
   private ConfigMigrator() {
     // Utility class
@@ -46,10 +121,7 @@ public final class ConfigMigrator {
   public static <T> Map<String, T> migrateOverwriteProperties(
       final Map<String, T> overwriteProperties
   ) {
-    return migrateProcessingGuarantee(
-        overwriteProperties,
-        StreamsConfig.PROCESSING_GUARANTEE_CONFIG
-    );
+    return applyMigrations(overwriteProperties, OVERWRITE_MIGRATIONS);
   }
 
   /**
@@ -58,34 +130,49 @@ public final class ConfigMigrator {
   public static <T> Map<String, T> migrateOriginalProperties(
       final Map<String, T> originalProperties
   ) {
-    return migrateProcessingGuarantee(
-        originalProperties,
-        KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.PROCESSING_GUARANTEE_CONFIG
-    );
+    return applyMigrations(originalProperties, ORIGINAL_MIGRATIONS);
   }
 
   /**
-   * Migrates the 'processing.guarantee' property from 'exactly_once' to 'exactly_once_v2'.
-   * 
-   * <p>This migration is necessary because Kafka Streams deprecated 'exactly_once' in favor
-   * of 'exactly_once_v2' in newer versions. Commands stored in the command topic may contain
-   * the legacy value, and this method ensures they can be executed on newer Kafka Streams
-   * versions without validation errors.
+   * Applies migrations using O(1) HashMap lookups.
+   *
+   * <p>For each migration, we do a direct lookup in the properties map (O(1)),
+   * then check if the value needs replacement (O(1)). Total: O(M) where M is
+   * the number of migrations (constant).
+   *
+   * @param properties the properties map to migrate
+   * @param migrations the migration definitions
+   * @return the original map if no changes, or a new map with migrations applied
    */
-  private static <T> Map<String, T> migrateProcessingGuarantee(
+  private static <T> Map<String, T> applyMigrations(
       final Map<String, T> properties,
-      final String key
+      final Map<String, Map<String, String>> migrations
   ) {
-    final T value = properties.get(key);
-    if (value != null && LEGACY_EXACTLY_ONCE.equals(value.toString())) {
-      final Map<String, T> migrated = new HashMap<>(properties);
-      @SuppressWarnings("unchecked")
-      final T migratedValue = (T) StreamsConfig.EXACTLY_ONCE_V2;
-      migrated.put(key, migratedValue);
-      return migrated;
+    Map<String, T> result = null;
+
+    for (final Map.Entry<String, Map<String, String>> migration : migrations.entrySet()) {
+      final String key = migration.getKey();
+      final T currentValue = properties.get(key);
+
+      if (currentValue != null) {
+        final String replacement = migration.getValue().get(currentValue.toString());
+
+        if (replacement != null && !replacement.equals(currentValue.toString())) {
+          LOG.info("Migrating deprecated config value for '{}': '{}' -> '{}'",
+              key, currentValue, replacement);
+
+          // Lazy initialization - only create new map when we have a change
+          if (result == null) {
+            result = new HashMap<>(properties);
+          }
+
+          @SuppressWarnings("unchecked")
+          final T typedReplacement = (T) replacement;
+          result.put(key, typedReplacement);
+        }
+      }
     }
-    return properties;
+
+    return result != null ? result : properties;
   }
 }
-
-

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/ConfigMigratorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/ConfigMigratorTest.java
@@ -16,6 +16,8 @@
 package io.confluent.ksql.rest.server.computation;
 
 import static io.confluent.ksql.rest.server.computation.ConfigMigrator.LEGACY_EXACTLY_ONCE;
+import static io.confluent.ksql.rest.server.computation.ConfigMigrator.LEGACY_OAUTH_LOGIN_CALLBACK_HANDLER;
+import static io.confluent.ksql.rest.server.computation.ConfigMigrator.LEGACY_OAUTH_VALIDATOR_CALLBACK_HANDLER;
 import static io.confluent.ksql.util.KsqlConfig.KSQL_STREAMS_PREFIX;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
@@ -25,10 +27,17 @@ import static org.hamcrest.Matchers.sameInstance;
 import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.Test;
 
 public class ConfigMigratorTest {
+
+  // =========================================================================
+  // Processing Guarantee Migration Tests
+  // =========================================================================
 
   @Test
   public void shouldMigrateExactlyOnceInOverwriteProperties() {
@@ -130,6 +139,160 @@ public class ConfigMigratorTest {
     );
   }
 
+  // =========================================================================
+  // OAuth Login Callback Handler Migration Tests
+  // =========================================================================
+
+  @Test
+  public void shouldMigrateOAuthLoginHandlerInOverwriteProperties() {
+    // Given:
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put(
+        SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+        LEGACY_OAUTH_LOGIN_CALLBACK_HANDLER
+    );
+
+    // When:
+    final Map<String, Object> result = ConfigMigrator.migrateOverwriteProperties(properties);
+
+    // Then:
+    assertThat(result, hasEntry(
+        SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+        OAuthBearerLoginCallbackHandler.class.getName()
+    ));
+  }
+
+  @Test
+  public void shouldMigrateOAuthLoginHandlerInOriginalProperties() {
+    // Given:
+    final Map<String, String> properties = new HashMap<>();
+    properties.put(
+        KSQL_STREAMS_PREFIX + SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+        LEGACY_OAUTH_LOGIN_CALLBACK_HANDLER
+    );
+
+    // When:
+    final Map<String, String> result = ConfigMigrator.migrateOriginalProperties(properties);
+
+    // Then:
+    assertThat(result, hasEntry(
+        KSQL_STREAMS_PREFIX + SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+        OAuthBearerLoginCallbackHandler.class.getName()
+    ));
+  }
+
+  @Test
+  public void shouldNotModifyNewOAuthLoginHandler() {
+    // Given:
+    final Map<String, Object> properties = ImmutableMap.of(
+        SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+        OAuthBearerLoginCallbackHandler.class.getName()
+    );
+
+    // When:
+    final Map<String, Object> result = ConfigMigrator.migrateOverwriteProperties(properties);
+
+    // Then:
+    assertThat(result, sameInstance(properties));
+  }
+
+  // =========================================================================
+  // OAuth Validator Callback Handler Migration Tests
+  // =========================================================================
+
+  @Test
+  public void shouldMigrateOAuthValidatorHandlerInOverwriteProperties() {
+    // Given:
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put(
+        SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS,
+        LEGACY_OAUTH_VALIDATOR_CALLBACK_HANDLER
+    );
+
+    // When:
+    final Map<String, Object> result = ConfigMigrator.migrateOverwriteProperties(properties);
+
+    // Then:
+    assertThat(result, hasEntry(
+        SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS,
+        OAuthBearerValidatorCallbackHandler.class.getName()
+    ));
+  }
+
+  @Test
+  public void shouldMigrateOAuthValidatorHandlerInOriginalProperties() {
+    // Given:
+    final Map<String, String> properties = new HashMap<>();
+    properties.put(
+        KSQL_STREAMS_PREFIX + SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS,
+        LEGACY_OAUTH_VALIDATOR_CALLBACK_HANDLER
+    );
+
+    // When:
+    final Map<String, String> result = ConfigMigrator.migrateOriginalProperties(properties);
+
+    // Then:
+    assertThat(result, hasEntry(
+        KSQL_STREAMS_PREFIX + SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS,
+        OAuthBearerValidatorCallbackHandler.class.getName()
+    ));
+  }
+
+  @Test
+  public void shouldNotModifyNewOAuthValidatorHandler() {
+    // Given:
+    final Map<String, Object> properties = ImmutableMap.of(
+        SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS,
+        OAuthBearerValidatorCallbackHandler.class.getName()
+    );
+
+    // When:
+    final Map<String, Object> result = ConfigMigrator.migrateOverwriteProperties(properties);
+
+    // Then:
+    assertThat(result, sameInstance(properties));
+  }
+
+  // =========================================================================
+  // Multiple Migrations Tests
+  // =========================================================================
+
+  @Test
+  public void shouldMigrateMultiplePropertiesInSingleCall() {
+    // Given:
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, LEGACY_EXACTLY_ONCE);
+    properties.put(
+        SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+        LEGACY_OAUTH_LOGIN_CALLBACK_HANDLER
+    );
+    properties.put(
+        SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS,
+        LEGACY_OAUTH_VALIDATOR_CALLBACK_HANDLER
+    );
+
+    // When:
+    final Map<String, Object> result = ConfigMigrator.migrateOverwriteProperties(properties);
+
+    // Then:
+    assertThat(result, hasEntry(
+        StreamsConfig.PROCESSING_GUARANTEE_CONFIG,
+        StreamsConfig.EXACTLY_ONCE_V2
+    ));
+    assertThat(result, hasEntry(
+        SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+        OAuthBearerLoginCallbackHandler.class.getName()
+    ));
+    assertThat(result, hasEntry(
+        SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS,
+        OAuthBearerValidatorCallbackHandler.class.getName()
+    ));
+  }
+
+  // =========================================================================
+  // Edge Case Tests
+  // =========================================================================
+
   @Test
   public void shouldNotModifyWhenKeyNotPresent() {
     // Given:
@@ -190,5 +353,163 @@ public class ConfigMigratorTest {
         is(StreamsConfig.EXACTLY_ONCE_V2)
     );
   }
-}
 
+  // =========================================================================
+  // Mixed Valid and Invalid Values Tests
+  // =========================================================================
+
+  @Test
+  public void shouldMigrateOnlyLegacyValuesWhenMixedWithModernValues() {
+    // Given: processing.guarantee is already modern, but OAuth handlers are legacy
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2);
+    properties.put(
+        SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+        LEGACY_OAUTH_LOGIN_CALLBACK_HANDLER
+    );
+    properties.put(
+        SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS,
+        OAuthBearerValidatorCallbackHandler.class.getName()  // already modern
+    );
+
+    // When:
+    final Map<String, Object> result = ConfigMigrator.migrateOverwriteProperties(properties);
+
+    // Then: Only the legacy OAuth login handler should be migrated
+    assertThat(result, hasEntry(
+        StreamsConfig.PROCESSING_GUARANTEE_CONFIG,
+        StreamsConfig.EXACTLY_ONCE_V2
+    ));
+    assertThat(result, hasEntry(
+        SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+        OAuthBearerLoginCallbackHandler.class.getName()
+    ));
+    assertThat(result, hasEntry(
+        SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS,
+        OAuthBearerValidatorCallbackHandler.class.getName()
+    ));
+  }
+
+  @Test
+  public void shouldNotMigrateCustomCallbackHandler() {
+    // Given: User has a custom callback handler implementation
+    final String customHandler = "com.mycompany.security.CustomOAuthCallbackHandler";
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, customHandler);
+
+    // When:
+    final Map<String, Object> result = ConfigMigrator.migrateOverwriteProperties(properties);
+
+    // Then: Custom handler should NOT be migrated
+    assertThat(result, sameInstance(properties));
+    assertThat(result.get(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS), is(customHandler));
+  }
+
+  @Test
+  public void shouldHandleNullValuesInProperties() {
+    // Given: Properties map contains null values
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, null);
+    properties.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, LEGACY_OAUTH_LOGIN_CALLBACK_HANDLER);
+
+    // When:
+    final Map<String, Object> result = ConfigMigrator.migrateOverwriteProperties(properties);
+
+    // Then: Null value should be preserved, legacy OAuth should be migrated
+    assertThat(result.containsKey(StreamsConfig.PROCESSING_GUARANTEE_CONFIG), is(true));
+    assertThat(result.get(StreamsConfig.PROCESSING_GUARANTEE_CONFIG), is((Object) null));
+    assertThat(result, hasEntry(
+        SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+        OAuthBearerLoginCallbackHandler.class.getName()
+    ));
+  }
+
+  @Test
+  public void shouldMigrateOnlyLoginHandlerWhenValidatorNotConfigured() {
+    // Given: Partial OAuth setup - only login handler configured
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put(
+        SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+        LEGACY_OAUTH_LOGIN_CALLBACK_HANDLER
+    );
+    properties.put("some.other.config", "some-value");
+
+    // When:
+    final Map<String, Object> result = ConfigMigrator.migrateOverwriteProperties(properties);
+
+    // Then:
+    assertThat(result, hasEntry(
+        SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+        OAuthBearerLoginCallbackHandler.class.getName()
+    ));
+    assertThat(result, hasEntry("some.other.config", "some-value"));
+    assertThat(result.containsKey(SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS), is(false));
+  }
+
+  @Test
+  public void shouldNotMigrateLegacyValueInUnrelatedKey() {
+    // Given: Legacy value appears in a different config key (should not be migrated)
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("some.custom.config", LEGACY_EXACTLY_ONCE);
+    properties.put("another.custom.config", LEGACY_OAUTH_LOGIN_CALLBACK_HANDLER);
+
+    // When:
+    final Map<String, Object> result = ConfigMigrator.migrateOverwriteProperties(properties);
+
+    // Then: Values should NOT be migrated because they're in wrong keys
+    assertThat(result, sameInstance(properties));
+    assertThat(result.get("some.custom.config"), is(LEGACY_EXACTLY_ONCE));
+    assertThat(result.get("another.custom.config"), is(LEGACY_OAUTH_LOGIN_CALLBACK_HANDLER));
+  }
+
+  @Test
+  public void shouldPreserveOtherPropertiesWhenMigrating() {
+    // Given: Properties with various unrelated configs mixed with legacy values
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, LEGACY_EXACTLY_ONCE);
+    properties.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 4);
+    properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "my-app");
+    properties.put("custom.setting", "custom-value");
+    properties.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
+
+    // When:
+    final Map<String, Object> result = ConfigMigrator.migrateOverwriteProperties(properties);
+
+    // Then: All properties should be preserved, only legacy value migrated
+    assertThat(result, hasEntry(
+        StreamsConfig.PROCESSING_GUARANTEE_CONFIG,
+        StreamsConfig.EXACTLY_ONCE_V2
+    ));
+    assertThat(result, hasEntry(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 4));
+    assertThat(result, hasEntry(StreamsConfig.APPLICATION_ID_CONFIG, "my-app"));
+    assertThat(result, hasEntry("custom.setting", "custom-value"));
+    assertThat(result, hasEntry(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER"));
+  }
+
+  @Test
+  public void shouldMigrateBothOriginalAndOverwritePropertiesIndependently() {
+    // Given: Different legacy values in overwrite vs original properties
+    final Map<String, Object> overwrite = new HashMap<>();
+    overwrite.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, LEGACY_EXACTLY_ONCE);
+
+    final Map<String, String> original = new HashMap<>();
+    original.put(
+        KSQL_STREAMS_PREFIX + SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+        LEGACY_OAUTH_LOGIN_CALLBACK_HANDLER
+    );
+
+    // When:
+    final Map<String, Object> overwriteResult = ConfigMigrator.migrateOverwriteProperties(overwrite);
+    final Map<String, String> originalResult = ConfigMigrator.migrateOriginalProperties(original);
+
+    // Then: Each should be migrated independently
+    assertThat(overwriteResult, hasEntry(
+        StreamsConfig.PROCESSING_GUARANTEE_CONFIG,
+        StreamsConfig.EXACTLY_ONCE_V2
+    ));
+    assertThat(originalResult, hasEntry(
+        KSQL_STREAMS_PREFIX + SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+        OAuthBearerLoginCallbackHandler.class.getName()
+    ));
+  }
+}


### PR DESCRIPTION
## Summary
- Extend `ConfigMigrator` to also migrate the legacy "secured" package OAuth callback handler classes (`OAuthBearerLoginCallbackHandler`, `OAuthBearerValidatorCallbackHandler`), which were removed in Kafka 4.0/CP 8.x (deprecated since Kafka 3.4.0), in addition to the existing `exactly_once` -> `exactly_once_v2` migration.
- Migrations now apply to both overwrite (session-level) properties and original (server) properties.

## Test plan
- [x] `ConfigMigratorTest` (23 tests) passes covering the new OAuth handler migrations, null-value handling, unrelated-key exclusion, and independent overwrite/original migration behavior.