### PR TITLE
Support allowlist for all KSQL endpoints that allows user overrides

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/AllowListPropertyValidator.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/AllowListPropertyValidator.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.properties;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Class that validates if a property, or list of property overrides are part of allowed properties:
+ * any property whose name is not in the configured allowlist is rejected (deny-by-default).
+ * This is the inverse of {@link DenyListPropertyValidator} and the stricter of the two policies.
+ *
+ * <p>Notes on behavior:
+ * <ul>
+ *   <li><b>Exact-name matching only.</b></li>
+ *   <li><b>No wildcards.</b> </li>
+ *   <li><b>Empty allowlist is fail-closed.</b> </li>
+ * </ul>
+ */
+public class AllowListPropertyValidator implements ConfigOverrideValidator {
+
+  /** Server-owned keys that must never be permitted as overrides, even if allowlisted. */
+  private static final Set<String> ALWAYS_DENIED = ImmutableSet.of(
+      KsqlConfig.KSQL_SERVICE_ID_CONFIG,
+      KsqlConfig.KSQL_PROPERTIES_OVERRIDES_DENYLIST,
+      KsqlConfig.KSQL_PROPERTIES_OVERRIDES_ALLOWLIST,
+      KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE,
+      KsqlConfig.KSQL_PROPERTIES_OVERRIDES_LOG
+  );
+
+  private final Set<String> allowedProps;
+
+  public AllowListPropertyValidator(final Collection<String> allowlist) {
+    Objects.requireNonNull(allowlist, "allowlist");
+    rejectWildcards(allowlist);
+    this.allowedProps = Sets.difference(ImmutableSet.copyOf(allowlist), ALWAYS_DENIED)
+                        .immutableCopy();
+  }
+
+  /**
+   * Validates that every property override is present in the allowlist.
+   * @throws KsqlException if at least one property is not on the allowlist.
+   */
+  @Override
+  public void validateAll(final Map<String, Object> properties) {
+    final Set<String> notAllowedProps = Sets.difference(properties.keySet(), allowedProps);
+    if (!notAllowedProps.isEmpty()) {
+      throw new KsqlException(String.format("One or more property overrides set locally are "
+          + "not permitted by the KSQL server allowlist (use UNSET to reset their default "
+          + "value): %s", notAllowedProps));
+    }
+  }
+
+  private static void rejectWildcards(final Collection<String> allowlist) {
+    final List<String> withWildcards = allowlist.stream()
+        .filter(name -> name.indexOf('*') >= 0 || name.indexOf('?') >= 0)
+        .collect(Collectors.toList());
+    if (!withWildcards.isEmpty()) {
+      throw new KsqlException("Allowlist entries must be exact property names; wildcard or glob "
+          + "entries are not permitted: " + withWildcards);
+    }
+  }
+}

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/ConfigOverrideValidator.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/ConfigOverrideValidator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.properties;
+
+import java.util.Map;
+
+/**
+ * Validates the property overrides a user supplies on a request against server policy.
+ *
+ * <p>Two implementations exist and exactly one is active per server, selected at startup by
+ * {@link ConfigOverrideValidatorFactory} from
+ * {@code ksql.properties.overrides.validation.mode}:
+ * <ul>
+ *   <li>{@link DenyListPropertyValidator} &mdash; rejects a fixed set of prohibited names
+ *       (default).</li>
+ *   <li>{@link AllowListPropertyValidator} &mdash; rejects anything not explicitly permitted
+ *       (deny-by-default).</li>
+ * </ul>
+ */
+public interface ConfigOverrideValidator {
+
+  /**
+   * Validates every property override in {@code properties}.
+   *
+   * @param properties the user-supplied overrides (keys are property names)
+   * @throws io.confluent.ksql.util.KsqlException if at least one property is not permitted
+   */
+  void validateAll(Map<String, Object> properties);
+}

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/ConfigOverrideValidatorFactory.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/ConfigOverrideValidatorFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.properties;
+
+import io.confluent.ksql.util.KsqlConfig;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Selects the active {@link ConfigOverrideValidator} for a server from
+ * {@code ksql.properties.overrides.validation.mode}.
+ *
+ * <p>Exactly one validator runs per server. Selection is driven solely by the mode.
+ * Default mode is {@link KsqlConfig#KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE_DENYLIST}, which
+ * uses {@link DenyListPropertyValidator}.
+ * </p>
+ */
+public final class ConfigOverrideValidatorFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ConfigOverrideValidatorFactory.class);
+
+  private ConfigOverrideValidatorFactory() {
+  }
+
+  public static ConfigOverrideValidator forMode(final KsqlConfig config) {
+    final String mode = config.getString(KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE);
+
+    if (KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE_ALLOWLIST.equals(mode)) {
+      final List<String> allowlist =
+          config.getList(KsqlConfig.KSQL_PROPERTIES_OVERRIDES_ALLOWLIST);
+      if (allowlist.isEmpty()) {
+        LOG.warn("Property override validation mode is '{}' but '{}' is empty; all property "
+                + "overrides will be rejected.",
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE_ALLOWLIST,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_ALLOWLIST);
+      }
+      return new AllowListPropertyValidator(allowlist);
+    }
+
+    return new DenyListPropertyValidator(
+        config.getList(KsqlConfig.KSQL_PROPERTIES_OVERRIDES_DENYLIST));
+  }
+}

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/DenyListPropertyValidator.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/DenyListPropertyValidator.java
@@ -28,7 +28,7 @@ import java.util.Set;
  * Class that validates if a property, or list of properties, is part of a list of denied
  * properties.
  */
-public class DenyListPropertyValidator {
+public class DenyListPropertyValidator implements ConfigOverrideValidator {
   private final Set<String> immutableProps;
 
   public DenyListPropertyValidator(final Collection<String> immutableProps) {
@@ -41,11 +41,12 @@ public class DenyListPropertyValidator {
    * Validates if a list of properties are part of the list of denied properties.
    * @throws if at least one property is part of the denied list.
    */
+  @Override
   public void validateAll(final Map<String, Object> properties) {
     final Set<String> propsDenied = Sets.intersection(immutableProps, properties.keySet());
     if (!propsDenied.isEmpty()) {
       throw new KsqlException(String.format("One or more properties overrides set locally are "
-          + "prohibited by the KSQL server (use UNSET to reset their default value): %s",
+          + "prohibited by the KSQL server denylist (use UNSET to reset their default value): %s",
           propsDenied));
     }
   }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/PropertyNotFoundException.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/PropertyNotFoundException.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.properties;
 
 public class PropertyNotFoundException extends IllegalArgumentException {
-  PropertyNotFoundException(final String property) {
+  public PropertyNotFoundException(final String property) {
     super(String.format(
         "Not recognizable as ksql, streams, consumer, or producer property: '%s'",
         property

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -650,14 +650,15 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_PROPERTIES_OVERRIDES_DENYLIST =
       "ksql.properties.overrides.denylist";
   private static final String KSQL_PROPERTIES_OVERRIDES_DENYLIST_DOC = "Comma-separated list of "
-      + "properties that KSQL users cannot override.";
+      + "properties that KSQL users cannot override "
+      + "when ksql.properties.overrides.validation.mode = denylist";
 
   public static final String KSQL_PROPERTIES_OVERRIDES_ALLOWLIST =
       "ksql.properties.overrides.allowlist";
   private static final String KSQL_PROPERTIES_OVERRIDES_ALLOWLIST_DOC = "Comma-separated list of "
-      + "property names permitted as overrides when "
-      + "ksql.properties.overrides.validation.mode = allowlist. "
-      + "Note: this list is not currently consulted; 'allowlist' mode is not enforced.";
+      + "properties permitted as overrides "
+      + "when ksql.properties.overrides.validation.mode = allowlist. "
+      + "Entries must be exact names, wildcard/glob entries are rejected." ;
 
   public static final String KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE =
       "ksql.properties.overrides.validation.mode";
@@ -669,9 +670,7 @@ public class KsqlConfig extends AbstractConfig {
       "Validation mode for property overrides on REST endpoints. Allowed values: 'denylist' "
           + "(default behavior - reject names listed in "
           + KSQL_PROPERTIES_OVERRIDES_DENYLIST + "), 'allowlist' (only permit names listed in "
-          + KSQL_PROPERTIES_OVERRIDES_ALLOWLIST + "). "
-          + "Note: only 'denylist' mode is currently enforced; setting this to 'allowlist' "
-          + "has no effect on validation.";
+          + KSQL_PROPERTIES_OVERRIDES_ALLOWLIST + ").";
 
   public static final String KSQL_PROPERTIES_OVERRIDES_LOG =
       "ksql.properties.overrides.log";

--- a/ksqldb-common/src/test/java/io/confluent/ksql/properties/AllowListPropertyValidatorTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/properties/AllowListPropertyValidatorTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.properties;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import java.util.Arrays;
+import org.junit.Test;
+
+public class AllowListPropertyValidatorTest {
+
+  @Test
+  public void shouldNotThrowWhenAllPropertiesAreAllowlisted() {
+    // Given:
+    final AllowListPropertyValidator validator = new AllowListPropertyValidator(Arrays.asList(
+        "auto.offset.reset",
+        "ksql.streams.num.standby.replicas"
+    ));
+
+    // When/Then (no throw):
+    validator.validateAll(ImmutableMap.of(
+        "auto.offset.reset", "earliest",
+        "ksql.streams.num.standby.replicas", "1"
+    ));
+  }
+
+  @Test
+  public void shouldThrowOnPropertyNotOnAllowlist() {
+    // Given:
+    final AllowListPropertyValidator validator = new AllowListPropertyValidator(Arrays.asList(
+        "auto.offset.reset"
+    ));
+
+    // When:
+    final KsqlException e = assertThrows(
+        KsqlException.class,
+        () -> validator.validateAll(ImmutableMap.of(
+            "auto.offset.reset", "earliest",
+            "sasl.jaas.config", "boom"
+        ))
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString(
+        "One or more property overrides set locally are not permitted by the KSQL server "
+            + "allowlist (use UNSET to reset their default value): [sasl.jaas.config]"));
+  }
+
+  @Test
+  public void shouldRejectEveryPropertyWhenAllowlistEmpty() {
+    // Given:
+    final AllowListPropertyValidator validator =
+        new AllowListPropertyValidator(Arrays.asList());
+
+    // When:
+    final KsqlException e = assertThrows(
+        KsqlException.class,
+        () -> validator.validateAll(ImmutableMap.of("auto.offset.reset", "earliest"))
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString("[auto.offset.reset]"));
+  }
+
+  @Test
+  public void shouldNotThrowOnEmptyOverrides() {
+    // Given:
+    final AllowListPropertyValidator validator =
+        new AllowListPropertyValidator(Arrays.asList());
+
+    // When/Then (no throw):
+    validator.validateAll(ImmutableMap.of());
+  }
+
+  @Test
+  public void shouldRejectAlwaysDeniedFloorKeysEvenWhenAllowlisted() {
+    // Given: an admin mistakenly allowlists the service id and the override policy knobs
+    final AllowListPropertyValidator validator = new AllowListPropertyValidator(Arrays.asList(
+        KsqlConfig.KSQL_SERVICE_ID_CONFIG,
+        KsqlConfig.KSQL_PROPERTIES_OVERRIDES_ALLOWLIST,
+        KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE
+    ));
+
+    // When:
+    final KsqlException e = assertThrows(
+        KsqlException.class,
+        () -> validator.validateAll(ImmutableMap.of(
+            KsqlConfig.KSQL_SERVICE_ID_CONFIG, "x",
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE, "denylist"))
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString(KsqlConfig.KSQL_SERVICE_ID_CONFIG));
+    assertThat(e.getMessage(),
+        containsString(KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE));
+  }
+
+  @Test
+  public void shouldRejectWildcardOrGlobAllowlistEntriesAtConstruction() {
+    // When:
+    final KsqlException e = assertThrows(
+        KsqlException.class,
+        () -> new AllowListPropertyValidator(Arrays.asList(
+            "ksql.functions.*",
+            "auto.offset.rese?"
+        ))
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString("wildcard"));
+    assertThat(e.getMessage(), containsString("ksql.functions.*"));
+    assertThat(e.getMessage(), containsString("auto.offset.rese?"));
+  }
+}

--- a/ksqldb-common/src/test/java/io/confluent/ksql/properties/ConfigOverrideValidatorFactoryTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/properties/ConfigOverrideValidatorFactoryTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.properties;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import java.util.Map;
+import org.junit.Test;
+
+public class ConfigOverrideValidatorFactoryTest {
+
+  private static KsqlConfig config(final Map<String, Object> overrides) {
+    return new KsqlConfig(overrides);
+  }
+
+  @Test
+  public void shouldReturnDenyListValidatorByDefault() {
+    // Given: no mode set (defaults to denylist)
+    final ConfigOverrideValidator validator = ConfigOverrideValidatorFactory.forMode(
+        config(ImmutableMap.of()));
+
+    // Then:
+    assertThat(validator, instanceOf(DenyListPropertyValidator.class));
+  }
+
+  @Test
+  public void shouldReturnDenyListValidatorWhenModeIsDenylist() {
+    // Given:
+    final ConfigOverrideValidator validator = ConfigOverrideValidatorFactory.forMode(config(
+        ImmutableMap.of(
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE, "denylist",
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_DENYLIST, "sasl.jaas.config")));
+
+    // Then:
+    assertThat(validator, instanceOf(DenyListPropertyValidator.class));
+    assertThrows(
+        KsqlException.class,
+        () -> validator.validateAll(ImmutableMap.of("sasl.jaas.config", "x")));
+  }
+
+  @Test
+  public void shouldReturnAllowListValidatorWhenModeIsAllowlist() {
+    // Given:
+    final ConfigOverrideValidator validator = ConfigOverrideValidatorFactory.forMode(config(
+        ImmutableMap.of(
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE, "allowlist",
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_ALLOWLIST, "auto.offset.reset")));
+
+    // Then:
+    assertThat(validator, instanceOf(AllowListPropertyValidator.class));
+    // allowlisted property passes:
+    validator.validateAll(ImmutableMap.of("auto.offset.reset", "earliest"));
+    // non-allowlisted property is rejected:
+    assertThrows(
+        KsqlException.class,
+        () -> validator.validateAll(ImmutableMap.of("sasl.jaas.config", "x")));
+  }
+
+  @Test
+  public void shouldReturnAllowListThatRejectsAllWhenAllowlistEmpty() {
+    // Given: allowlist mode with no allowlist configured (fail-closed)
+    final ConfigOverrideValidator validator = ConfigOverrideValidatorFactory.forMode(config(
+        ImmutableMap.of(
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE, "allowlist")));
+
+    // Then:
+    assertThat(validator, instanceOf(AllowListPropertyValidator.class));
+    assertThrows(
+        KsqlException.class,
+        () -> validator.validateAll(ImmutableMap.of("auto.offset.reset", "earliest")));
+  }
+}

--- a/ksqldb-common/src/test/java/io/confluent/ksql/properties/DenyListPropertyValidatorTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/properties/DenyListPropertyValidatorTest.java
@@ -50,7 +50,7 @@ public class DenyListPropertyValidatorTest {
 
     // Then:
     assertThat(e.getMessage(), containsString(
-        "One or more properties overrides set locally are prohibited by the KSQL server "
+        "One or more properties overrides set locally are prohibited by the KSQL server denylist "
             + "(use UNSET to reset their default value): "
             + "[immutable-property-1, immutable-property-2]"
     ));
@@ -77,7 +77,7 @@ public class DenyListPropertyValidatorTest {
 
     // Then:
     assertThat(e.getMessage(), containsString(
-        "One or more properties overrides set locally are prohibited by the KSQL server "
+        "One or more properties overrides set locally are prohibited by the KSQL server denylist "
             + "(use UNSET to reset their default value): [ksql.service.id]"
     ));
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/properties/PropertyOverrider.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/properties/PropertyOverrider.java
@@ -21,7 +21,6 @@ import io.confluent.ksql.config.KsqlConfigResolver;
 import io.confluent.ksql.parser.tree.SetProperty;
 import io.confluent.ksql.parser.tree.UnsetProperty;
 import io.confluent.ksql.statement.ConfiguredStatement;
-import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
 import java.util.Map;
@@ -39,7 +38,7 @@ public final class PropertyOverrider {
     throwIfInvalidProperty(setProperty.getPropertyName(), statement.getMaskedStatementText());
     ConfigOverrideLogger.logOverrides(
             "SET", ImmutableMap.of(setProperty.getPropertyName(), ""));
-    throwIfDeniedProperty(setProperty, statement);
+    throwIfDisallowedProperty(setProperty, statement);
     throwIfInvalidPropertyValues(setProperty, statement);
     mutableProperties.put(setProperty.getPropertyName(), setProperty.getPropertyValue());
   }
@@ -79,22 +78,21 @@ public final class PropertyOverrider {
         .orElseThrow(() -> new KsqlStatementException("Unknown property: " + propertyName, text));
   }
 
-  private static void throwIfDeniedProperty(
+  private static void throwIfDisallowedProperty(
       final SetProperty setProperty,
       final ConfiguredStatement<SetProperty> statement
   ) {
-    // Build the validator from the system config (getConfig(false)), never the override-applied
-    // config, so that a user-supplied override of the denylist itself cannot unlock a denied
-    // property. The validator is stateless and cheap, so constructing it per SET (a rare,
-    // interactive control statement) keeps this security rule local to PropertyOverrider and
+    // Build the validator (denylist or allowlist, per ksql.properties.overrides.validation.mode)
+    // from the system config (getConfig(false)), never the override-applied config, so that a
+    // user-supplied override of the denylist/allowlist or the validation mode itself cannot unlock
+    // a disallowed property. The validator is stateless and cheap, so constructing it per SET (a
+    // rare, interactive control statement) keeps this security rule local to PropertyOverrider and
     // lets every caller -- REST, embedded, standalone and the test tool -- share it without
     // plumbing an instance through.
-    final DenyListPropertyValidator denyListPropertyValidator = new DenyListPropertyValidator(
-        statement.getSessionConfig()
-            .getConfig(false)
-            .getList(KsqlConfig.KSQL_PROPERTIES_OVERRIDES_DENYLIST));
+    final ConfigOverrideValidator configOverrideValidator = ConfigOverrideValidatorFactory
+        .forMode(statement.getSessionConfig().getConfig(false));
     try {
-      denyListPropertyValidator.validateAll(ImmutableMap.of(
+      configOverrideValidator.validateAll(ImmutableMap.of(
           setProperty.getPropertyName(),
           setProperty.getPropertyValue()
       ));

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -50,7 +50,8 @@ import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.logging.processing.ProcessingLogServerUtils;
 import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.name.SourceName;
-import io.confluent.ksql.properties.DenyListPropertyValidator;
+import io.confluent.ksql.properties.ConfigOverrideValidator;
+import io.confluent.ksql.properties.ConfigOverrideValidatorFactory;
 import io.confluent.ksql.properties.PropertiesUtil;
 import io.confluent.ksql.query.id.SpecificQueryIdGenerator;
 import io.confluent.ksql.rest.ErrorMessages;
@@ -206,7 +207,7 @@ public final class KsqlRestApplication implements Executable {
   private final Vertx vertx;
   private Server apiServer = null;
   private final CompletableFuture<Void> terminatedFuture = new CompletableFuture<>();
-  private final DenyListPropertyValidator denyListPropertyValidator;
+  private final ConfigOverrideValidator configOverrideValidator;
   private final Optional<PullQueryExecutorMetrics> pullQueryMetrics;
   private final Optional<ScalablePushQueryMetrics> scalablePushQueryMetrics;
   private final Optional<LocalCommands> localCommands;
@@ -246,7 +247,7 @@ public final class KsqlRestApplication implements Executable {
       final Optional<HeartbeatAgent> heartbeatAgent,
       final Optional<LagReportingAgent> lagReportingAgent,
       final Vertx vertx,
-      final DenyListPropertyValidator denyListPropertyValidator,
+      final ConfigOverrideValidator configOverrideValidator,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
       final Optional<ScalablePushQueryMetrics> scalablePushQueryMetrics,
       final Optional<LocalCommands> localCommands,
@@ -279,8 +280,8 @@ public final class KsqlRestApplication implements Executable {
     this.heartbeatAgent = requireNonNull(heartbeatAgent, "heartbeatAgent");
     this.lagReportingAgent = requireNonNull(lagReportingAgent, "lagReportingAgent");
     this.vertx = requireNonNull(vertx, "vertx");
-    this.denyListPropertyValidator =
-        requireNonNull(denyListPropertyValidator, "denyListPropertyValidator");
+    this.configOverrideValidator =
+        requireNonNull(configOverrideValidator, "configOverrideValidator");
 
     this.serverInfoResource =
         new ServerInfoResource(serviceContext, ksqlConfigNoPort, commandRunner);
@@ -348,7 +349,7 @@ public final class KsqlRestApplication implements Executable {
             KsqlRestConfig.DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT_MS_CONFIG)),
         authorizationValidator,
         errorHandler,
-        denyListPropertyValidator,
+        configOverrideValidator,
         queryExecutor
     );
 
@@ -371,7 +372,7 @@ public final class KsqlRestApplication implements Executable {
           pullQueryMetrics,
           queryExecutor,
           securityExtension.getAuthTokenProvider(),
-          denyListPropertyValidator
+          configOverrideValidator
       );
       apiServer = new Server(vertx, ksqlRestConfig, endpoints, securityExtension,
           authenticationPlugin, serverState, pullQueryMetrics);
@@ -868,8 +869,8 @@ public final class KsqlRestApplication implements Executable {
             metricCollectors.getMetrics(),
             metricsTags
         );
-    final DenyListPropertyValidator denyListPropertyValidator = new DenyListPropertyValidator(
-        ksqlConfig.getList(KsqlConfig.KSQL_PROPERTIES_OVERRIDES_DENYLIST));
+    final ConfigOverrideValidator configOverrideValidator =
+        ConfigOverrideValidatorFactory.forMode(ksqlConfig);
 
     final Optional<PullQueryExecutorMetrics> pullQueryMetrics = ksqlConfig.getBoolean(
         KsqlConfig.KSQL_QUERY_PULL_METRICS_ENABLED)
@@ -918,7 +919,7 @@ public final class KsqlRestApplication implements Executable {
         versionChecker::updateLastRequestTime,
         authorizationValidator,
         errorHandler,
-        denyListPropertyValidator,
+        configOverrideValidator,
         queryExecutor
     );
 
@@ -952,7 +953,7 @@ public final class KsqlRestApplication implements Executable {
         versionChecker::updateLastRequestTime,
         authorizationValidator,
         errorHandler,
-        denyListPropertyValidator
+        configOverrideValidator
     );
 
     final List<KsqlConfigurable> configurables = ImmutableList.of(
@@ -984,7 +985,7 @@ public final class KsqlRestApplication implements Executable {
         heartbeatAgent,
         lagReportingAgent,
         vertx,
-        denyListPropertyValidator,
+        configOverrideValidator,
         pullQueryMetrics,
         scalablePushQueryMetrics,
         localCommands,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
@@ -30,7 +30,7 @@ import io.confluent.ksql.api.server.MetricsCallbackHolder;
 import io.confluent.ksql.api.spi.Endpoints;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.internal.PullQueryExecutorMetrics;
-import io.confluent.ksql.properties.DenyListPropertyValidator;
+import io.confluent.ksql.properties.ConfigOverrideValidator;
 import io.confluent.ksql.rest.EndpointResponse;
 import io.confluent.ksql.rest.entity.ClusterTerminateRequest;
 import io.confluent.ksql.rest.entity.HeartbeatMessage;
@@ -91,7 +91,7 @@ public class KsqlServerEndpoints implements Endpoints {
   private final Optional<PullQueryExecutorMetrics> pullQueryMetrics;
   private final QueryExecutor queryExecutor;
   private final Optional<KsqlAuthTokenProvider> authTokenProvider;
-  private final DenyListPropertyValidator denyListPropertyValidator;
+  private final ConfigOverrideValidator configOverrideValidator;
 
   // CHECKSTYLE_RULES.OFF: ParameterNumber
   @SuppressFBWarnings(value = "EI_EXPOSE_REP2")
@@ -112,7 +112,7 @@ public class KsqlServerEndpoints implements Endpoints {
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
       final QueryExecutor queryExecutor,
       final Optional<KsqlAuthTokenProvider> authTokenProvider,
-      final DenyListPropertyValidator denyListPropertyValidator
+      final ConfigOverrideValidator configOverrideValidator
   ) {
 
     // CHECKSTYLE_RULES.ON: ParameterNumber
@@ -133,8 +133,8 @@ public class KsqlServerEndpoints implements Endpoints {
     this.pullQueryMetrics = Objects.requireNonNull(pullQueryMetrics);
     this.queryExecutor = queryExecutor;
     this.authTokenProvider = authTokenProvider;
-    this.denyListPropertyValidator =
-        Objects.requireNonNull(denyListPropertyValidator, "denyListPropertyValidator");
+    this.configOverrideValidator =
+        Objects.requireNonNull(configOverrideValidator, "configOverrideValidator");
   }
 
   @Override
@@ -333,7 +333,7 @@ public class KsqlServerEndpoints implements Endpoints {
 
   private void validateProperties(final Map<String, Object> properties) {
     try {
-      denyListPropertyValidator.validateAll(properties);
+      configOverrideValidator.validateAll(properties);
     } catch (KsqlException e) {
       throw new KsqlApiException(e.getMessage(), ERROR_CODE_BAD_REQUEST);
     }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -34,7 +34,8 @@ import io.confluent.ksql.parser.tree.SetProperty;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.UnsetProperty;
 import io.confluent.ksql.properties.ConfigOverrideLogger;
-import io.confluent.ksql.properties.DenyListPropertyValidator;
+import io.confluent.ksql.properties.ConfigOverrideValidator;
+import io.confluent.ksql.properties.PropertyNotFoundException;
 import io.confluent.ksql.rest.EndpointResponse;
 import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.SessionProperties;
@@ -110,7 +111,7 @@ public class KsqlResource implements KsqlConfigurable {
   private final ActivenessRegistrar activenessRegistrar;
   private final BiFunction<KsqlExecutionContext, ServiceContext, Injector> injectorFactory;
   private final Optional<KsqlAuthorizationValidator> authorizationValidator;
-  private final DenyListPropertyValidator denyListPropertyValidator;
+  private final ConfigOverrideValidator configOverrideValidator;
   private final Supplier<String> commandRunnerWarning;
   private RequestValidator validator;
   private RequestHandler handler;
@@ -125,7 +126,7 @@ public class KsqlResource implements KsqlConfigurable {
       final ActivenessRegistrar activenessRegistrar,
       final Optional<KsqlAuthorizationValidator> authorizationValidator,
       final Errors errorHandler,
-      final DenyListPropertyValidator denyListPropertyValidator
+      final ConfigOverrideValidator configOverrideValidator
   ) {
     this(
         ksqlEngine,
@@ -135,7 +136,7 @@ public class KsqlResource implements KsqlConfigurable {
         Injectors.DEFAULT,
         authorizationValidator,
         errorHandler,
-        denyListPropertyValidator,
+        configOverrideValidator,
         commandRunner::getCommandRunnerDegradedWarning
     );
   }
@@ -148,7 +149,7 @@ public class KsqlResource implements KsqlConfigurable {
       final BiFunction<KsqlExecutionContext, ServiceContext, Injector> injectorFactory,
       final Optional<KsqlAuthorizationValidator> authorizationValidator,
       final Errors errorHandler,
-      final DenyListPropertyValidator denyListPropertyValidator,
+      final ConfigOverrideValidator configOverrideValidator,
       final Supplier<String> commandRunnerWarning
   ) {
     this.ksqlEngine = Objects.requireNonNull(ksqlEngine, "ksqlEngine");
@@ -161,8 +162,8 @@ public class KsqlResource implements KsqlConfigurable {
     this.authorizationValidator = Objects
         .requireNonNull(authorizationValidator, "authorizationValidator");
     this.errorHandler = Objects.requireNonNull(errorHandler, "errorHandler");
-    this.denyListPropertyValidator =
-        Objects.requireNonNull(denyListPropertyValidator, "denyListPropertyValidator");
+    this.configOverrideValidator =
+        Objects.requireNonNull(configOverrideValidator, "configOverrideValidator");
     this.commandRunnerWarning =
         Objects.requireNonNull(commandRunnerWarning, "commandRunnerWarning");
   }
@@ -224,7 +225,6 @@ public class KsqlResource implements KsqlConfigurable {
     ensureValidPatterns(request.getDeleteTopicList());
     try {
       final Map<String, Object> streamsProperties = request.getStreamsProperties();
-      denyListPropertyValidator.validateAll(streamsProperties);
 
       final KsqlEntityList entities = handler.execute(
           securityContext,
@@ -248,12 +248,15 @@ public class KsqlResource implements KsqlConfigurable {
       final Map<String, Object> properties = new HashMap<>();
       properties.put(property, "");
       final KsqlConfigResolver resolver = new KsqlConfigResolver();
-      final Optional<ConfigItem> resolvedItem = resolver.resolve(property, false);
+      // Reject unknown property names up front with the same PropertyNotFoundException that the
+      // /ksql, /query and /ws/query paths throw as an "unrecognized property" error
+      // rather than a misleading allow/deny-list rejection.
+      final ConfigItem resolvedItem = resolver.resolve(property, true)
+          .orElseThrow(() -> new PropertyNotFoundException(property));
       ConfigOverrideLogger.logOverrides("SET", properties);
-      denyListPropertyValidator.validateAll(properties);
-      if (ksqlEngine.getKsqlConfig().getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)
-          && resolvedItem.isPresent()) {
-        if (!PropertiesList.QueryLevelProperties.contains(resolvedItem.get().getPropertyName())) {
+      configOverrideValidator.validateAll(properties);
+      if (ksqlEngine.getKsqlConfig().getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)) {
+        if (!PropertiesList.QueryLevelProperties.contains(resolvedItem.getPropertyName())) {
           throw new KsqlException(String.format("When shared runtimes are enabled, the"
               + " config %s can only be set for the entire cluster and all queries currently"
               + " running in it, and not configurable for individual queries."
@@ -262,7 +265,10 @@ public class KsqlResource implements KsqlConfigurable {
         }
       }
       return EndpointResponse.ok(true);
-    } catch (final KsqlException e) {
+    } catch (final PropertyNotFoundException | KsqlException e) {
+      // Unknown property name (PropertyNotFoundException) and denylist/allowlist rejections
+      // (KsqlException) both map to 400 per the documented /is_valid_property contract
+      // ({"@type":"generic_error","error_code":40000}).
       LOG.info("Processed unsuccessfully, reason: ", e);
       return errorHandler.generateResponse(e, Errors.badRequest(e));
     } catch (final Exception e) {
@@ -295,7 +301,7 @@ public class KsqlResource implements KsqlConfigurable {
 
       final Map<String, Object> configProperties = request.getConfigOverrides();
       ConfigOverrideLogger.logOverrides("/ksql", configProperties);
-      denyListPropertyValidator.validateAll(configProperties);
+      configOverrideValidator.validateAll(configProperties);
 
       final KsqlRequestConfig requestConfig =
           new KsqlRequestConfig(request.getRequestProperties());
@@ -422,3 +428,4 @@ public class KsqlResource implements KsqlConfigurable {
     }
   }
 }
+

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -25,7 +25,7 @@ import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.PrintTopic;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.properties.ConfigOverrideLogger;
-import io.confluent.ksql.properties.DenyListPropertyValidator;
+import io.confluent.ksql.properties.ConfigOverrideValidator;
 import io.confluent.ksql.rest.ApiJsonMapper;
 import io.confluent.ksql.rest.EndpointResponse;
 import io.confluent.ksql.rest.Errors;
@@ -75,7 +75,7 @@ public class StreamedQueryResource {
   private final ActivenessRegistrar activenessRegistrar;
   private final Optional<KsqlAuthorizationValidator> authorizationValidator;
   private final Errors errorHandler;
-  private final DenyListPropertyValidator denyListPropertyValidator;
+  private final ConfigOverrideValidator configOverrideValidator;
   private final QueryExecutor queryExecutor;
 
   private KsqlRestConfig ksqlRestConfig;
@@ -90,7 +90,7 @@ public class StreamedQueryResource {
       final ActivenessRegistrar activenessRegistrar,
       final Optional<KsqlAuthorizationValidator> authorizationValidator,
       final Errors errorHandler,
-      final DenyListPropertyValidator denyListPropertyValidator,
+      final ConfigOverrideValidator configOverrideValidator,
       final QueryExecutor queryExecutor
   ) {
     this(
@@ -103,7 +103,7 @@ public class StreamedQueryResource {
         activenessRegistrar,
         authorizationValidator,
         errorHandler,
-        denyListPropertyValidator,
+        configOverrideValidator,
         queryExecutor
     );
   }
@@ -121,7 +121,7 @@ public class StreamedQueryResource {
       final ActivenessRegistrar activenessRegistrar,
       final Optional<KsqlAuthorizationValidator> authorizationValidator,
       final Errors errorHandler,
-      final DenyListPropertyValidator denyListPropertyValidator,
+      final ConfigOverrideValidator configOverrideValidator,
       final QueryExecutor queryExecutor
   ) {
     this.ksqlEngine = Objects.requireNonNull(ksqlEngine, "ksqlEngine");
@@ -136,8 +136,8 @@ public class StreamedQueryResource {
         Objects.requireNonNull(activenessRegistrar, "activenessRegistrar");
     this.authorizationValidator = authorizationValidator;
     this.errorHandler = Objects.requireNonNull(errorHandler, "errorHandler");
-    this.denyListPropertyValidator =
-        Objects.requireNonNull(denyListPropertyValidator, "denyListPropertyValidator");
+    this.configOverrideValidator =
+        Objects.requireNonNull(configOverrideValidator, "configOverrideValidator");
     this.queryExecutor = queryExecutor;
   }
 
@@ -201,7 +201,7 @@ public class StreamedQueryResource {
 
       final Map<String, Object> configProperties = request.getConfigOverrides();
       ConfigOverrideLogger.logOverrides("/query", configProperties);
-      denyListPropertyValidator.validateAll(configProperties);
+      configOverrideValidator.validateAll(configProperties);
 
       if (statement.getStatement() instanceof Query) {
         if (shouldMigrateToQueryStream(request.getConfigOverrides())) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
@@ -27,7 +27,7 @@ import io.confluent.ksql.parser.tree.PrintTopic;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.properties.ConfigOverrideLogger;
-import io.confluent.ksql.properties.DenyListPropertyValidator;
+import io.confluent.ksql.properties.ConfigOverrideValidator;
 import io.confluent.ksql.rest.ApiJsonMapper;
 import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.entity.KsqlMediaType;
@@ -71,7 +71,7 @@ public class WSQueryEndpoint {
   private final Duration commandQueueCatchupTimeout;
   private final Optional<KsqlAuthorizationValidator> authorizationValidator;
   private final Errors errorHandler;
-  private final DenyListPropertyValidator denyListPropertyValidator;
+  private final ConfigOverrideValidator configOverrideValidator;
   private final QueryExecutor queryExecutor;
 
   // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
@@ -86,7 +86,7 @@ public class WSQueryEndpoint {
       final Duration commandQueueCatchupTimeout,
       final Optional<KsqlAuthorizationValidator> authorizationValidator,
       final Errors errorHandler,
-      final DenyListPropertyValidator denyListPropertyValidator,
+      final ConfigOverrideValidator configOverrideValidator,
       final QueryExecutor queryExecutor
   ) {
     this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
@@ -102,8 +102,8 @@ public class WSQueryEndpoint {
     this.authorizationValidator =
         Objects.requireNonNull(authorizationValidator, "authorizationValidator");
     this.errorHandler = Objects.requireNonNull(errorHandler, "errorHandler");
-    this.denyListPropertyValidator =
-        Objects.requireNonNull(denyListPropertyValidator, "denyListPropertyValidator");
+    this.configOverrideValidator =
+        Objects.requireNonNull(configOverrideValidator, "configOverrideValidator");
     this.queryExecutor = queryExecutor;
   }
 
@@ -206,7 +206,7 @@ public class WSQueryEndpoint {
       // To validate props:
       final Map<String, Object> configProperties = request.getConfigOverrides();
       ConfigOverrideLogger.logOverrides("/ws/query", configProperties);
-      denyListPropertyValidator.validateAll(configProperties);
+      configOverrideValidator.validateAll(configProperties);
       return request;
     } catch (final Exception e) {
       throw new IllegalArgumentException("Error parsing request: " + e.getMessage(), e);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -41,7 +41,7 @@ import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.logging.processing.ProcessingLogServerUtils;
 import io.confluent.ksql.metrics.MetricCollectors;
-import io.confluent.ksql.properties.DenyListPropertyValidator;
+import io.confluent.ksql.properties.ConfigOverrideValidator;
 import io.confluent.ksql.rest.EndpointResponse;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlRequest;
@@ -128,7 +128,7 @@ public class KsqlRestApplicationTest {
   @Mock
   private EndpointResponse response;
   @Mock
-  private DenyListPropertyValidator denyListPropertyValidator;
+  private ConfigOverrideValidator configOverrideValidator;
   @Mock
   private QueryExecutor queryExecutor;
   @Mock
@@ -459,7 +459,7 @@ public class KsqlRestApplicationTest {
         Optional.of(heartbeatAgent),
         Optional.of(lagReportingAgent),
         vertx,
-        denyListPropertyValidator,
+        configOverrideValidator,
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.rest.server.resources;
 import static io.confluent.ksql.parser.ParserMatchers.configured;
 import static io.confluent.ksql.parser.ParserMatchers.preparedStatementText;
 import static io.confluent.ksql.rest.Errors.ERROR_CODE_FORBIDDEN_KAFKA_ACCESS;
-import static io.confluent.ksql.rest.entity.ClusterTerminateRequest.DELETE_TOPIC_LIST_PROP;
 import static io.confluent.ksql.rest.entity.CommandId.Action.CREATE;
 import static io.confluent.ksql.rest.entity.CommandId.Action.DROP;
 import static io.confluent.ksql.rest.entity.CommandId.Action.EXECUTE;
@@ -104,7 +103,7 @@ import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.TableElements;
 import io.confluent.ksql.planner.plan.ConfiguredKsqlPlan;
 import io.confluent.ksql.properties.ConfigOverrideLogger;
-import io.confluent.ksql.properties.DenyListPropertyValidator;
+import io.confluent.ksql.properties.ConfigOverrideValidator;
 import io.confluent.ksql.query.id.SequentialQueryIdGenerator;
 import io.confluent.ksql.rest.DefaultErrorMessages;
 import io.confluent.ksql.rest.EndpointResponse;
@@ -319,7 +318,7 @@ public class KsqlResourceTest {
   @Mock
   private Errors errorsHandler;
   @Mock
-  private DenyListPropertyValidator denyListPropertyValidator;
+  private ConfigOverrideValidator configOverrideValidator;
   @Mock
   private Supplier<String> commandRunnerWarning;
   @Mock
@@ -455,7 +454,7 @@ public class KsqlResourceTest {
             new TopicDeleteInjector(ec, sc)),
         Optional.of(authorizationValidator),
         errorsHandler,
-        denyListPropertyValidator,
+        configOverrideValidator,
         commandRunnerWarning
     );
 
@@ -487,7 +486,7 @@ public class KsqlResourceTest {
             new TopicDeleteInjector(ec, sc)),
         Optional.of(authorizationValidator),
         errorsHandler,
-        denyListPropertyValidator,
+        configOverrideValidator,
         commandRunnerWarning
     );
 
@@ -2610,7 +2609,7 @@ public class KsqlResourceTest {
             new TopicDeleteInjector(ec, sc)),
         Optional.of(authorizationValidator),
         errorsHandler,
-        denyListPropertyValidator,
+        configOverrideValidator,
         commandRunnerWarning
     );
 
@@ -2622,10 +2621,11 @@ public class KsqlResourceTest {
     final Map<String, Object> properties = new HashMap<>();
     properties.put("ksql.service.id", "");
 
-    // Given:
-    doThrow(new KsqlException("deny override")).when(denyListPropertyValidator).validateAll(
-        properties
-    );
+    // Given: mocked configOverrideValidator throws the same message a real
+    // DenyListPropertyValidator would for ksql.service.id.
+    doThrow(new KsqlException("One or more properties overrides set locally are prohibited "
+        + "by the KSQL server denylist (use UNSET to reset their default value): "
+        + "[ksql.service.id]")).when(configOverrideValidator).validateAll(properties);
 
     // When:
     final EndpointResponse response;
@@ -2633,15 +2633,17 @@ public class KsqlResourceTest {
         Mockito.mockStatic(ConfigOverrideLogger.class)) {
       response = ksqlResource.isValidProperty("ksql.service.id");
 
-      // Then: log fires BEFORE denylist throws
+      // Then: log fires BEFORE the validator throws
       configOverrideLogger.verify(() -> ConfigOverrideLogger.logOverrides(
           "SET", ImmutableMap.of("ksql.service.id", "")));
     }
     assertThat(response.getStatus(), equalTo(400));
+    assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(),
+        containsString("prohibited by the KSQL server denylist"));
   }
 
   @Test
-  public void shouldReturnBadRequestWhenIsValidatorIsCalledWithNonQueryLevelProps() {
+  public void shouldRejectIsValidPropertyForNonQueryLevelPropertyWhenSharedRuntimeEnabled() {
     final Map<String, Object> properties = new HashMap<>();
     properties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "");
     givenKsqlConfigWith(ImmutableMap.of(
@@ -2656,7 +2658,7 @@ public class KsqlResourceTest {
   }
 
   @Test
-  public void shouldNotBadRequestWhenIsValidatorIsCalledWithNonQueryLevelProps() {
+  public void shouldAllowIsValidPropertyForQueryLevelPropertyWhenSharedRuntimeEnabled() {
     final Map<String, Object> properties = new HashMap<>();
     properties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "");
     givenKsqlConfigWith(ImmutableMap.of(
@@ -2671,27 +2673,30 @@ public class KsqlResourceTest {
   }
 
   @Test
-  public void shouldThrowOnDenyListValidatorWhenTerminateCluster() {
-    final Map<String, Object> terminateStreamProperties =
-        ImmutableMap.of(DELETE_TOPIC_LIST_PROP, Collections.singletonList("Foo"));
-
-    // Given:
-    doThrow(new KsqlException("deny override")).when(denyListPropertyValidator).validateAll(
-        terminateStreamProperties
-    );
+  public void shouldAllowIsValidPropertyForKnownProperty() {
+    // Given: mocked configOverrideValidator never throws.
 
     // When:
-    final EndpointResponse response = ksqlResource.terminateCluster(
-        securityContext,
-        VALID_TERMINATE_REQUEST
-    );
+    final EndpointResponse response =
+        ksqlResource.isValidProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG);
 
     // Then:
-    verify(denyListPropertyValidator).validateAll(terminateStreamProperties);
-    assertThat(response.getStatus(), equalTo(INTERNAL_SERVER_ERROR.code()));
-    assertThat(response.getEntity(), instanceOf(KsqlStatementErrorMessage.class));
-    assertThat(((KsqlStatementErrorMessage) response.getEntity()).getMessage(),
-        containsString("deny override"));
+    assertThat(response.getStatus(), equalTo(200));
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenIsValidatorIsCalledWithUnknownProperty() {
+    // Given: default ksqlResource; "totally.unknown.property" resolves to no ksql/streams/
+    // consumer/producer config, so PropertyNotFoundException fires before the allow/deny
+    // validator.
+
+    // When:
+    final EndpointResponse response = ksqlResource.isValidProperty("totally.unknown.property");
+
+    // Then:
+    assertThat(response.getStatus(), equalTo(400));
+    assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(),
+        containsString("Not recognizable as ksql, streams, consumer, or producer property"));
   }
 
   @Test
@@ -2728,29 +2733,14 @@ public class KsqlResourceTest {
 
   @Test
   public void shouldThrowOnDenyListValidatorWhenHandleKsqlStatement() {
-    // Given:
-    ksqlResource = new KsqlResource(
-        ksqlEngine,
-        commandRunner,
-        DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT,
-        activenessRegistrar,
-        (ec, sc) -> InjectorChain.of(
-            schemaInjectorFactory.apply(sc),
-            topicInjectorFactory.apply(ec),
-            new TopicDeleteInjector(ec, sc)),
-        Optional.of(authorizationValidator),
-        errorsHandler,
-        denyListPropertyValidator,
-        commandRunnerWarning
-    );
-    final Map<String, Object> props = new HashMap<>(ksqlRestConfig.getKsqlConfigProperties());
-    props.put(KsqlConfig.KSQL_PROPERTIES_OVERRIDES_DENYLIST,
-        StreamsConfig.NUM_STREAM_THREADS_CONFIG);
-    ksqlResource.configure(new KsqlConfig(props));
     final Map<String, Object> overrides =
         ImmutableMap.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
-    doThrow(new KsqlException("deny override")).when(denyListPropertyValidator)
-        .validateAll(overrides);
+
+    // Given: mocked configOverrideValidator throws the same message a real
+    // AllowlistListPropertyValidator would for num.stream.threads.
+    doThrow(new KsqlException("One or more properties overrides set locally are not permitted "
+        + "by the KSQL server denylist (use UNSET to reset their default value): "
+        + "[num.stream.threads]")).when(configOverrideValidator).validateAll(overrides);
 
     // When:
     final EndpointResponse response;
@@ -2768,10 +2758,11 @@ public class KsqlResourceTest {
 
       // Then: Config Override Logger fires, and the denylist check rejects the request.
       configOverrideLogger.verify(() -> ConfigOverrideLogger.logOverrides("/ksql", overrides));
-      verify(denyListPropertyValidator).validateAll(overrides);
+      verify(configOverrideValidator).validateAll(overrides);
     }
     assertThat(response.getStatus(), CoreMatchers.is(BAD_REQUEST.code()));
-    assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(), is("deny override"));
+    assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(),
+        containsString("not permitted by the KSQL server denylist"));
   }
 
   private void givenKsqlConfigWith(final Map<String, Object> additionalConfig) {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/WSQueryEndpointTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/WSQueryEndpointTest.java
@@ -15,9 +15,12 @@
 
 package io.confluent.ksql.rest.server.resources;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -29,7 +32,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.properties.ConfigOverrideLogger;
-import io.confluent.ksql.properties.DenyListPropertyValidator;
+import io.confluent.ksql.properties.ConfigOverrideValidator;
 import io.confluent.ksql.rest.ApiJsonMapper;
 import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.entity.KsqlRequest;
@@ -39,6 +42,7 @@ import io.confluent.ksql.rest.server.query.QueryExecutor;
 import io.confluent.ksql.rest.server.resources.streaming.WSQueryEndpoint;
 import io.confluent.ksql.security.KsqlSecurityContext;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.version.metrics.ActivenessRegistrar;
 import io.vertx.core.Context;
 import io.vertx.core.MultiMap;
@@ -52,6 +56,7 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -65,7 +70,7 @@ public class WSQueryEndpointTest {
   @Mock
   private KsqlSecurityContext ksqlSecurityContext;
   @Mock
-  private DenyListPropertyValidator denyListPropertyValidator;
+  private ConfigOverrideValidator configOverrideValidator;
   @Mock
   private KsqlConfig ksqlConfig;
   @Mock
@@ -89,29 +94,35 @@ public class WSQueryEndpointTest {
         mock(Duration.class),
         Optional.empty(),
         mock(Errors.class),
-        denyListPropertyValidator,
+        configOverrideValidator,
         queryExecutor
     );
   }
 
   @Test
-  public void shouldCallPropertyValidatorOnExecuteStream()
-      throws JsonProcessingException {
-    // Given
+  public void shouldCallPropertyValidatorOnExecuteStream() throws JsonProcessingException {
+    // Given: mocked configOverrideValidator throws the same message a real
+    // DenyListPropertyValidator would for num.stream.threads.
     final Map<String, Object> overrides =
         ImmutableMap.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
     final MultiMap params = buildRequestParams("show streams;", overrides);
+    final ArgumentCaptor<String> jsonCaptor = ArgumentCaptor.forClass(String.class);
+    doThrow(new KsqlException("One or more properties overrides set locally are prohibited "
+        + "by the KSQL server denylist (use UNSET to reset their default value): "
+        + "[num.stream.threads]")).when(configOverrideValidator).validateAll(overrides);
 
     // When
     try (MockedStatic<ConfigOverrideLogger> configOverrideLogger =
         mockStatic(ConfigOverrideLogger.class)) {
       executeStreamQuery(params, Optional.empty());
 
-      // Then: WS sockets do not throw any exception (closes silently). We can only verify that validator
-      // was called.Config Override Logger fires first, and then validator fires.
+      // Then: WS sockets do not throw any exception (closes silently). Config Override Logger
+      // fires first, and then the validator's real message survives to the socket's error frame.
       configOverrideLogger.verify(() -> ConfigOverrideLogger.logOverrides("/ws/query", overrides));
-      verify(denyListPropertyValidator).validateAll(overrides);
+      verify(configOverrideValidator).validateAll(overrides);
     }
+    verify(serverWebSocket).writeFinalTextFrame(jsonCaptor.capture(), any());
+    assertThat(jsonCaptor.getValue(), containsString("prohibited by the KSQL server denylist"));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -61,7 +61,7 @@ import io.confluent.ksql.parser.tree.PrintTopic;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.properties.ConfigOverrideLogger;
-import io.confluent.ksql.properties.DenyListPropertyValidator;
+import io.confluent.ksql.properties.ConfigOverrideValidator;
 import io.confluent.ksql.query.BlockingRowQueue;
 import io.confluent.ksql.query.CompletionHandler;
 import io.confluent.ksql.query.KafkaStreamsBuilder;
@@ -184,7 +184,7 @@ public class StreamedQueryResourceTest {
   @Mock
   private Errors errorsHandler;
   @Mock
-  private DenyListPropertyValidator denyListPropertyValidator;
+  private ConfigOverrideValidator configOverrideValidator;
   @Mock
   private QueryId queryId;
   @Mock
@@ -242,7 +242,7 @@ public class StreamedQueryResourceTest {
         activenessRegistrar,
         Optional.of(authorizationValidator),
         errorsHandler,
-        denyListPropertyValidator,
+        configOverrideValidator,
         queryExecutor
     );
   }
@@ -287,7 +287,7 @@ public class StreamedQueryResourceTest {
         activenessRegistrar,
         Optional.of(authorizationValidator),
         errorsHandler,
-        denyListPropertyValidator,
+        configOverrideValidator,
         queryExecutor
     );
     when(mockKsqlEngine.getKsqlConfig()).thenReturn(KsqlConfig.empty());
@@ -445,7 +445,8 @@ public class StreamedQueryResourceTest {
 
   @Test
   public void shouldThrowOnDenyListedStreamProperty() {
-    // Given:
+    // Given: mocked configOverrideValidator throws the same message a real
+    // DenyListPropertyValidator would for num.stream.threads.
     when(mockStatementParser.<Query>parseSingleStatement(PULL_QUERY_STRING)).thenReturn(query);
     testResource = new StreamedQueryResource(
         mockKsqlEngine,
@@ -457,7 +458,7 @@ public class StreamedQueryResourceTest {
         activenessRegistrar,
         Optional.of(authorizationValidator),
         errorsHandler,
-        denyListPropertyValidator,
+        configOverrideValidator,
         queryExecutor
       );
     final Map<String, Object> props = new HashMap<>(ImmutableMap.of(
@@ -468,11 +469,11 @@ public class StreamedQueryResourceTest {
     when(mockKsqlEngine.getKsqlConfig()).thenReturn(new KsqlConfig(props));
     final Map<String, Object> overrides =
         ImmutableMap.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
-    doThrow(new KsqlException("deny override")).when(denyListPropertyValidator)
-        .validateAll(overrides);
+    doThrow(new KsqlException("One or more properties overrides set locally are prohibited "
+        + "by the KSQL server denylist (use UNSET to reset their default value): "
+        + "[num.stream.threads]")).when(configOverrideValidator).validateAll(overrides);
     when(errorsHandler.generateResponse(any(), any()))
-        .thenReturn(badRequest("A property override was set locally for a property that the "
-            + "server prohibits overrides for: 'num.stream.threads'"));
+        .thenAnswer(inv -> inv.getArgument(1));
 
     // When:
     final EndpointResponse response;
@@ -494,12 +495,13 @@ public class StreamedQueryResourceTest {
 
       // Then: Config Override Logger fires, and the denylist check rejects the request.
       configOverrideLogger.verify(() -> ConfigOverrideLogger.logOverrides("/query", overrides));
-      verify(denyListPropertyValidator).validateAll(overrides);
+      verify(configOverrideValidator).validateAll(overrides);
     }
     assertThat(response.getStatus(), CoreMatchers.is(BAD_REQUEST.code()));
     assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(),
-        is("A property override was set locally for a property that the server prohibits "
-            + "overrides for: '" + StreamsConfig.NUM_STREAM_THREADS_CONFIG + "'"));
+        containsString("prohibited by the KSQL server denylist"));
+    assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(),
+            containsString(StreamsConfig.NUM_STREAM_THREADS_CONFIG));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/PropertyOverriderTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/PropertyOverriderTest.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.collections4.map.HashedMap;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.streams.StreamsConfig;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -173,12 +174,52 @@ public class PropertyOverriderTest {
       );
 
       // Then: log fires for the known property BEFORE denylist throws
-      assertThat(e.getMessage(), containsString("prohibited by the KSQL server"));
       configOverrideLogger.verify(() -> ConfigOverrideLogger.logOverrides(
-          "SET", ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "")));
-    }
+              "SET", ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "")));
+      assertThat(e.getMessage(), containsString("prohibited by the KSQL server"));
+       }
+
     assertThat(sessionProperties.getMutableScopedProperties(),
         not(hasKey(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)));
+  }
+
+  @Test
+  public void shouldRejectSetOfPropertyNotOnAllowlist() {
+    // Given: allowlist contains AUTO_OFFSET_RESET_CONFIG, but not the property about to be SET.
+    final String propertyNotOnAllowlist =
+        KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STREAM_THREADS_CONFIG;
+    final KsqlConfig configWithAllowlist = engine.getKsqlConfig().cloneWithPropertyOverwrite(
+        ImmutableMap.of(
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE_ALLOWLIST,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_ALLOWLIST,
+            ConsumerConfig.AUTO_OFFSET_RESET_CONFIG));
+    final SessionProperties sessionProperties =
+        new SessionProperties(new HashedMap<>(), mock(KsqlHostInfo.class), mock(URL.class), false);
+
+    // When:
+    try (MockedStatic<ConfigOverrideLogger> configOverrideLogger =
+        mockStatic(ConfigOverrideLogger.class)) {
+      final Exception e = assertThrows(
+          KsqlStatementException.class,
+          () -> CustomValidators.SET_PROPERTY.validate(
+              ConfiguredStatement.of(PreparedStatement.of(
+                  "SET '" + propertyNotOnAllowlist + "' = '4';",
+                  new SetProperty(Optional.empty(), propertyNotOnAllowlist, "4")),
+                  SessionConfig.of(configWithAllowlist, ImmutableMap.of())),
+              sessionProperties,
+              engine.getEngine(),
+              engine.getServiceContext()
+          )
+      );
+
+      // Then: log fires for the known property BEFORE allowlist throws
+      configOverrideLogger.verify(() -> ConfigOverrideLogger.logOverrides(
+          "SET", ImmutableMap.of(propertyNotOnAllowlist, "")));
+      assertThat(e.getMessage(), containsString("not permitted by the KSQL server allowlist"));
+    }
+    assertThat(sessionProperties.getMutableScopedProperties(),
+        not(hasKey(propertyNotOnAllowlist)));
   }
 
   @Test
@@ -203,6 +244,40 @@ public class PropertyOverriderTest {
     );
 
     assertThat(e.getMessage(), containsString("prohibited by the KSQL server"));
+    assertThat(e.getMessage(), containsString(KsqlConfig.KSQL_SERVICE_ID_CONFIG));
+    assertThat(sessionProperties.getMutableScopedProperties(),
+        not(hasKey(KsqlConfig.KSQL_SERVICE_ID_CONFIG)));
+  }
+
+  @Test
+  public void shouldRejectSetOfServiceIdEvenWhenAllowlisted() {
+    // ksql.service.id is always removed from the effective allowlist by
+    // AllowListPropertyValidator's ALWAYS_DENIED floor, even when an admin mistakenly
+    // allowlists it explicitly.
+    final KsqlConfig configWithAllowlist = engine.getKsqlConfig().cloneWithPropertyOverwrite(
+        ImmutableMap.of(
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE_ALLOWLIST,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_ALLOWLIST,
+            KsqlConfig.KSQL_SERVICE_ID_CONFIG));
+    final SessionProperties sessionProperties =
+        new SessionProperties(new HashedMap<>(), mock(KsqlHostInfo.class), mock(URL.class), false);
+
+    final Exception e = assertThrows(
+        KsqlStatementException.class,
+        () -> CustomValidators.SET_PROPERTY.validate(
+            ConfiguredStatement.of(PreparedStatement.of(
+                "SET '" + KsqlConfig.KSQL_SERVICE_ID_CONFIG + "' = 'hacked';",
+                new SetProperty(Optional.empty(),
+                    KsqlConfig.KSQL_SERVICE_ID_CONFIG, "hacked")),
+                SessionConfig.of(configWithAllowlist, ImmutableMap.of())),
+            sessionProperties,
+            engine.getEngine(),
+            engine.getServiceContext()
+        )
+    );
+
+    assertThat(e.getMessage(), containsString("not permitted by the KSQL server allowlist"));
     assertThat(e.getMessage(), containsString(KsqlConfig.KSQL_SERVICE_ID_CONFIG));
     assertThat(sessionProperties.getMutableScopedProperties(),
         not(hasKey(KsqlConfig.KSQL_SERVICE_ID_CONFIG)));
@@ -234,6 +309,33 @@ public class PropertyOverriderTest {
   }
 
   @Test
+  public void shouldAllowSetWhenPropertyIsOnAllowlist() {
+    // Allowlist mode is on and contains the property being SET.
+    final KsqlConfig configWithAllowlist =
+        engine.getKsqlConfig().cloneWithPropertyOverwrite(ImmutableMap.of(
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE_ALLOWLIST,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_ALLOWLIST,
+            ConsumerConfig.AUTO_OFFSET_RESET_CONFIG));
+    final SessionProperties sessionProperties =
+        new SessionProperties(new HashedMap<>(), mock(KsqlHostInfo.class), mock(URL.class), false);
+
+    CustomValidators.SET_PROPERTY.validate(
+        ConfiguredStatement.of(PreparedStatement.of(
+            "SET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "' = 'earliest';",
+            new SetProperty(Optional.empty(),
+                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")),
+            SessionConfig.of(configWithAllowlist, ImmutableMap.of())),
+        sessionProperties,
+        engine.getEngine(),
+        engine.getServiceContext()
+    );
+
+    assertThat(sessionProperties.getMutableScopedProperties(),
+        hasEntry(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"));
+  }
+
+  @Test
   public void shouldRejectSetWhenPropertyIsOneOfMultipleInDenylist() {
     // Denylist contains several entries; the SET property matches one of them.
     final KsqlConfig configWithDenylist = engine.getKsqlConfig().cloneWithPropertyOverwrite(
@@ -252,6 +354,38 @@ public class PropertyOverriderTest {
                 new SetProperty(Optional.empty(),
                     ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")),
                 SessionConfig.of(configWithDenylist, ImmutableMap.of())),
+            sessionProperties,
+            engine.getEngine(),
+            engine.getServiceContext()
+        )
+    );
+
+    assertThat(e.getMessage(), containsString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG));
+    assertThat(sessionProperties.getMutableScopedProperties(),
+        not(hasKey(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)));
+  }
+
+  @Test
+  public void shouldRejectSetWhenPropertyIsNotOneOfMultipleOnAllowlist() {
+    // Allowlist contains several entries; none of them is the SET property.
+    final KsqlConfig configWithAllowlist = engine.getKsqlConfig().cloneWithPropertyOverwrite(
+        ImmutableMap.of(
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE_ALLOWLIST,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_ALLOWLIST,
+            KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STREAM_THREADS_CONFIG + ","
+                + KsqlConfig.KSQL_STREAMS_PREFIX + ConsumerConfig.MAX_POLL_RECORDS_CONFIG));
+    final SessionProperties sessionProperties =
+        new SessionProperties(new HashedMap<>(), mock(KsqlHostInfo.class), mock(URL.class), false);
+
+    final Exception e = assertThrows(
+        KsqlStatementException.class,
+        () -> CustomValidators.SET_PROPERTY.validate(
+            ConfiguredStatement.of(PreparedStatement.of(
+                "SET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "' = 'earliest';",
+                new SetProperty(Optional.empty(),
+                    ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")),
+                SessionConfig.of(configWithAllowlist, ImmutableMap.of())),
             sessionProperties,
             engine.getEngine(),
             engine.getServiceContext()
@@ -296,6 +430,40 @@ public class PropertyOverriderTest {
   }
 
   @Test
+  public void shouldNotBeBypassableViaSessionOverrideOfAllowlistConfig() {
+    // Verifies the security invariant: an attacker submitting a request whose `streamsProperties`
+    // tries to widen the allowlist cannot use that override to escape the in-SQL SET check.
+    // PropertyOverrider.set must read the allowlist from the system config (getConfig(false)),
+    // not the override-applied config.
+    final KsqlConfig systemConfigWithAllowlist =
+        engine.getKsqlConfig().cloneWithPropertyOverwrite(ImmutableMap.of(
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE_ALLOWLIST,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_ALLOWLIST,
+            KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STREAM_THREADS_CONFIG));
+    final Map<String, Object> overridesTryingToWidenAllowlist = ImmutableMap.of(
+        KsqlConfig.KSQL_PROPERTIES_OVERRIDES_ALLOWLIST, ConsumerConfig.AUTO_OFFSET_RESET_CONFIG);
+    final SessionProperties sessionProperties =
+        new SessionProperties(new HashedMap<>(), mock(KsqlHostInfo.class), mock(URL.class), false);
+
+    final Exception e = assertThrows(
+        KsqlStatementException.class,
+        () -> CustomValidators.SET_PROPERTY.validate(
+            ConfiguredStatement.of(PreparedStatement.of(
+                "SET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "' = 'earliest';",
+                new SetProperty(Optional.empty(),
+                    ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")),
+                SessionConfig.of(systemConfigWithAllowlist, overridesTryingToWidenAllowlist)),
+            sessionProperties,
+            engine.getEngine(),
+            engine.getServiceContext()
+        )
+    );
+
+    assertThat(e.getMessage(), containsString("not permitted by the KSQL server allowlist"));
+  }
+
+  @Test
   public void shouldIncludeStatementTextOnDeniedSet() {
     final String statementText = "SET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "' = 'earliest';";
     final KsqlConfig configWithDenylist = engine.getKsqlConfig().cloneWithPropertyOverwrite(
@@ -313,6 +481,35 @@ public class PropertyOverriderTest {
                 new SetProperty(Optional.empty(),
                     ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")),
                 SessionConfig.of(configWithDenylist, ImmutableMap.of())),
+            sessionProperties,
+            engine.getEngine(),
+            engine.getServiceContext()
+        )
+    );
+
+    assertThat(e.getSqlStatement(), is(statementText));
+  }
+
+  @Test
+  public void shouldIncludeStatementTextOnDeniedSetInAllowlistMode() {
+    final String statementText = "SET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "' = 'earliest';";
+    final KsqlConfig configWithAllowlist = engine.getKsqlConfig().cloneWithPropertyOverwrite(
+        ImmutableMap.of(
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_MODE_ALLOWLIST,
+            KsqlConfig.KSQL_PROPERTIES_OVERRIDES_ALLOWLIST,
+            KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STREAM_THREADS_CONFIG));
+    final SessionProperties sessionProperties =
+        new SessionProperties(new HashedMap<>(), mock(KsqlHostInfo.class), mock(URL.class), false);
+
+    final KsqlStatementException e = assertThrows(
+        KsqlStatementException.class,
+        () -> CustomValidators.SET_PROPERTY.validate(
+            ConfiguredStatement.of(PreparedStatement.of(
+                statementText,
+                new SetProperty(Optional.empty(),
+                    ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")),
+                SessionConfig.of(configWithAllowlist, ImmutableMap.of())),
             sessionProperties,
             engine.getEngine(),
             engine.getServiceContext()


### PR DESCRIPTION
Merge pull request #11083 from confluentinc/KSQL-15014

Support allowlist for all KSQL endpoints that allows user overrides:
1. /ksql
2. /query
3. /ws/query
4. /query-stream
5. /inserts-stream
6. SET

Remove the config validation from below endpoint:
/terminate - This validation is a no-op.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

