### PR TITLE
KSQL-15212: bound the pull query queues and make saturation observable

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -319,41 +319,25 @@ public class KsqlConfig extends AbstractConfig {
 
   // --- KSQL-15212: pull-query queue bounding, cancellation and rejection semantics ---
 
-  /**
-   * Queue capacity meaning "however many threads the pool has". Measured behaviour at 100
-   * threads: bound 50 returned 39,423 rows, bound 100 returned 51,231 with 91% of failures
-   * clean 429s, bound 200 returned 8,700 with only 6% clean. A queue longer than the pool
-   * admits work the pool cannot reach in time, so the ratio is what matters rather than the
-   * absolute number, and deriving it keeps the ratio at 1 when the pool size is changed.
-   */
-  public static final int KSQL_QUERY_PULL_QUEUE_CAPACITY_MATCH_POOL = -1;
-
-  /** Accepts the sentinel or a real capacity, but not 0, which would admit nothing. */
-  private static final ConfigDef.Validator QUEUE_CAPACITY_VALIDATOR = (name, value) -> {
-    final int capacity = value == null ? 0 : ((Number) value).intValue();
-    if (capacity != KSQL_QUERY_PULL_QUEUE_CAPACITY_MATCH_POOL && capacity < 1) {
-      throw new ConfigException(
-          name, value, "must be at least 1, or -1 to track the size of the pool it feeds");
-    }
-  };
-
   public static final String KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_CONFIG
       = "ksql.query.pull.coordinator.queue.capacity";
   public static final Integer KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_DEFAULT
-      = KSQL_QUERY_PULL_QUEUE_CAPACITY_MATCH_POOL;
+      = Integer.MAX_VALUE;
   public static final String KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_DOC
       = "Maximum number of pull queries that may queue waiting for a coordinator thread. "
-      + "Requests arriving when the queue is full are rejected with a retriable error rather "
-      + "than queued. -1, the default, tracks ksql.query.pull.thread.pool.size.";
+      + "The default, Integer.MAX_VALUE, is effectively unbounded and preserves the previous "
+      + "behaviour of Executors.newFixedThreadPool. Set a positive value to bound the queue; "
+      + "requests arriving when a bounded queue is full are then rejected with a retriable error "
+      + "rather than queued.";
 
   public static final String KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_CONFIG
       = "ksql.query.pull.router.queue.capacity";
   public static final Integer KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_DEFAULT
-      = KSQL_QUERY_PULL_QUEUE_CAPACITY_MATCH_POOL;
+      = Integer.MAX_VALUE;
   public static final String KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_DOC
       = "Maximum number of per-host fetches that may queue waiting for a router thread. "
-      + "-1, the default, tracks ksql.query.pull.router.thread.pool.size. "
-      + "See ksql.query.pull.coordinator.queue.capacity.";
+      + "The default, Integer.MAX_VALUE, is effectively unbounded. Set a positive value to bound "
+      + "the queue. See ksql.query.pull.coordinator.queue.capacity.";
 
 
   public static final String KSQL_QUERY_PULL_MAX_HOURLY_BANDWIDTH_MEGABYTES_CONFIG
@@ -374,7 +358,7 @@ public class KsqlConfig extends AbstractConfig {
 
   public static final String KSQL_QUERY_PULL_THREAD_POOL_SIZE_CONFIG
       = "ksql.query.pull.thread.pool.size";
-  public static final Integer KSQL_QUERY_PULL_THREAD_POOL_SIZE_DEFAULT = 100;
+  public static final Integer KSQL_QUERY_PULL_THREAD_POOL_SIZE_DEFAULT = 50;
   public static final String KSQL_QUERY_PULL_THREAD_POOL_SIZE_DOC =
       "Size of thread pool used for coordinating pull queries. A query that fetches from a "
       + "remote host occupies a coordinator thread for the whole fetch, so this bounds "
@@ -382,7 +366,7 @@ public class KsqlConfig extends AbstractConfig {
 
   public static final String KSQL_QUERY_PULL_ROUTER_THREAD_POOL_SIZE_CONFIG
       = "ksql.query.pull.router.thread.pool.size";
-  public static final Integer KSQL_QUERY_PULL_ROUTER_THREAD_POOL_SIZE_DEFAULT = 100;
+  public static final Integer KSQL_QUERY_PULL_ROUTER_THREAD_POOL_SIZE_DEFAULT = 50;
   public static final String KSQL_QUERY_PULL_ROUTER_THREAD_POOL_SIZE_DOC =
       "Size of thread pool used for routing pull queries. One thread is taken per host a "
       + "query fetches from, so a query that fans out needs more of these than of "
@@ -1283,14 +1267,14 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_CONFIG,
             Type.INT,
             KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_DEFAULT,
-            QUEUE_CAPACITY_VALIDATOR,
+            ConfigDef.Range.atLeast(1),
             Importance.MEDIUM,
             KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_DOC
         ).define(
             KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_CONFIG,
             Type.INT,
             KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_DEFAULT,
-            QUEUE_CAPACITY_VALIDATOR,
+            ConfigDef.Range.atLeast(1),
             Importance.MEDIUM,
             KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_DOC
         )

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -338,17 +338,6 @@ public class KsqlConfig extends AbstractConfig {
       = "Maximum number of per-host fetches that may queue waiting for a router thread. "
       + "See ksql.query.pull.coordinator.queue.capacity.";
 
-  public static final String KSQL_QUERY_PULL_LIMIT_REJECTION_RETRIABLE_CONFIG
-      = "ksql.query.pull.limit.rejection.retriable";
-  public static final boolean KSQL_QUERY_PULL_LIMIT_REJECTION_RETRIABLE_DEFAULT = false;
-  public static final String KSQL_QUERY_PULL_LIMIT_REJECTION_RETRIABLE_DOC
-      = "Whether a rejected pull query is reported as a retriable condition (HTTP 429) rather "
-      + "than an internal server error (HTTP 500). Applies both to exceeding "
-      + "ksql.query.pull.max.concurrent.requests and to a full coordinator or router queue "
-      + "(see ksql.query.pull.coordinator.queue.capacity). 500 is the historical behaviour and "
-      + "is the default, but it is indistinguishable from a server fault and is a status most "
-      + "clients retry immediately.";
-
   public static final String KSQL_QUERY_PULL_LIMIT_FORWARDED_REQUESTS_CONFIG
       = "ksql.query.pull.limit.forwarded.requests";
   public static final boolean KSQL_QUERY_PULL_LIMIT_FORWARDED_REQUESTS_DEFAULT = false;
@@ -1291,12 +1280,6 @@ public class KsqlConfig extends AbstractConfig {
             ConfigDef.Range.atLeast(1),
             Importance.MEDIUM,
             KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_DOC
-        ).define(
-            KSQL_QUERY_PULL_LIMIT_REJECTION_RETRIABLE_CONFIG,
-            Type.BOOLEAN,
-            KSQL_QUERY_PULL_LIMIT_REJECTION_RETRIABLE_DEFAULT,
-            Importance.MEDIUM,
-            KSQL_QUERY_PULL_LIMIT_REJECTION_RETRIABLE_DOC
         ).define(
             KSQL_QUERY_PULL_LIMIT_FORWARDED_REQUESTS_CONFIG,
             Type.BOOLEAN,

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -317,6 +317,45 @@ public class KsqlConfig extends AbstractConfig {
       "The maximum number of concurrent requests allowed for pull "
       + "queries on this host. Once the limit is hit, queries will fail immediately";
 
+  // --- KSQL-15212: pull-query queue bounding, cancellation and rejection semantics ---
+  // Every config below defaults to the pre-existing behaviour, so enabling any of them is an
+  // explicit opt-in and the same build can be A/B tested by configuration alone.
+
+  public static final String KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_CONFIG
+      = "ksql.query.pull.coordinator.queue.capacity";
+  public static final Integer KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_DEFAULT
+      = Integer.MAX_VALUE;
+  public static final String KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_DOC
+      = "Maximum number of pull queries that may queue waiting for a coordinator thread. "
+      + "Requests arriving when the queue is full are rejected immediately rather than "
+      + "queued. The default is effectively unbounded, which matches the previous behaviour "
+      + "of Executors.newFixedThreadPool.";
+
+  public static final String KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_CONFIG
+      = "ksql.query.pull.router.queue.capacity";
+  public static final Integer KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_DEFAULT = Integer.MAX_VALUE;
+  public static final String KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_DOC
+      = "Maximum number of per-host fetches that may queue waiting for a router thread. "
+      + "See ksql.query.pull.coordinator.queue.capacity.";
+
+  public static final String KSQL_QUERY_PULL_LIMIT_REJECTION_RETRIABLE_CONFIG
+      = "ksql.query.pull.limit.rejection.retriable";
+  public static final boolean KSQL_QUERY_PULL_LIMIT_REJECTION_RETRIABLE_DEFAULT = false;
+  public static final String KSQL_QUERY_PULL_LIMIT_REJECTION_RETRIABLE_DOC
+      = "Whether exceeding ksql.query.pull.max.concurrent.requests is reported as a retriable "
+      + "condition (HTTP 429) rather than an internal server error (HTTP 500). 500 is the "
+      + "historical behaviour and is the default, but it is indistinguishable from a server "
+      + "fault and is a status most clients retry immediately.";
+
+  public static final String KSQL_QUERY_PULL_LIMIT_FORWARDED_REQUESTS_CONFIG
+      = "ksql.query.pull.limit.forwarded.requests";
+  public static final boolean KSQL_QUERY_PULL_LIMIT_FORWARDED_REQUESTS_DEFAULT = false;
+  public static final String KSQL_QUERY_PULL_LIMIT_FORWARDED_REQUESTS_DOC
+      = "Whether the rate and concurrency limits also apply to pull query requests forwarded "
+      + "from a peer node. Historically only the request's entry host applies the limits, so "
+      + "forwarded traffic is unlimited and a saturated peer can drive this node's thread "
+      + "pools to exhaustion regardless of the configured limits.";
+
   public static final String KSQL_QUERY_PULL_MAX_HOURLY_BANDWIDTH_MEGABYTES_CONFIG
       = "ksql.query.pull.max.hourly.bandwidth.megabytes";
   public static final Integer KSQL_QUERY_PULL_MAX_HOURLY_BANDWIDTH_MEGABYTES_DEFAULT
@@ -1236,6 +1275,32 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_QUERY_PULL_MAX_CONCURRENT_REQUESTS_DEFAULT,
             Importance.LOW,
             KSQL_QUERY_PULL_MAX_CONCURRENT_REQUESTS_DOC
+        ).define(
+            KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_CONFIG,
+            Type.INT,
+            KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_DEFAULT,
+            ConfigDef.Range.atLeast(1),
+            Importance.MEDIUM,
+            KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_DOC
+        ).define(
+            KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_CONFIG,
+            Type.INT,
+            KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_DEFAULT,
+            ConfigDef.Range.atLeast(1),
+            Importance.MEDIUM,
+            KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_DOC
+        ).define(
+            KSQL_QUERY_PULL_LIMIT_REJECTION_RETRIABLE_CONFIG,
+            Type.BOOLEAN,
+            KSQL_QUERY_PULL_LIMIT_REJECTION_RETRIABLE_DEFAULT,
+            Importance.MEDIUM,
+            KSQL_QUERY_PULL_LIMIT_REJECTION_RETRIABLE_DOC
+        ).define(
+            KSQL_QUERY_PULL_LIMIT_FORWARDED_REQUESTS_CONFIG,
+            Type.BOOLEAN,
+            KSQL_QUERY_PULL_LIMIT_FORWARDED_REQUESTS_DEFAULT,
+            Importance.MEDIUM,
+            KSQL_QUERY_PULL_LIMIT_FORWARDED_REQUESTS_DOC
         )
         .define(
             KSQL_QUERY_PULL_MAX_HOURLY_BANDWIDTH_MEGABYTES_CONFIG,

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -342,10 +342,12 @@ public class KsqlConfig extends AbstractConfig {
       = "ksql.query.pull.limit.rejection.retriable";
   public static final boolean KSQL_QUERY_PULL_LIMIT_REJECTION_RETRIABLE_DEFAULT = false;
   public static final String KSQL_QUERY_PULL_LIMIT_REJECTION_RETRIABLE_DOC
-      = "Whether exceeding ksql.query.pull.max.concurrent.requests is reported as a retriable "
-      + "condition (HTTP 429) rather than an internal server error (HTTP 500). 500 is the "
-      + "historical behaviour and is the default, but it is indistinguishable from a server "
-      + "fault and is a status most clients retry immediately.";
+      = "Whether a rejected pull query is reported as a retriable condition (HTTP 429) rather "
+      + "than an internal server error (HTTP 500). Applies both to exceeding "
+      + "ksql.query.pull.max.concurrent.requests and to a full coordinator or router queue "
+      + "(see ksql.query.pull.coordinator.queue.capacity). 500 is the historical behaviour and "
+      + "is the default, but it is indistinguishable from a server fault and is a status most "
+      + "clients retry immediately.";
 
   public static final String KSQL_QUERY_PULL_LIMIT_FORWARDED_REQUESTS_CONFIG
       = "ksql.query.pull.limit.forwarded.requests";

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -338,14 +338,6 @@ public class KsqlConfig extends AbstractConfig {
       = "Maximum number of per-host fetches that may queue waiting for a router thread. "
       + "See ksql.query.pull.coordinator.queue.capacity.";
 
-  public static final String KSQL_QUERY_PULL_LIMIT_FORWARDED_REQUESTS_CONFIG
-      = "ksql.query.pull.limit.forwarded.requests";
-  public static final boolean KSQL_QUERY_PULL_LIMIT_FORWARDED_REQUESTS_DEFAULT = false;
-  public static final String KSQL_QUERY_PULL_LIMIT_FORWARDED_REQUESTS_DOC
-      = "Whether the rate and concurrency limits also apply to pull query requests forwarded "
-      + "from a peer node. Historically only the request's entry host applies the limits, so "
-      + "forwarded traffic is unlimited and a saturated peer can drive this node's thread "
-      + "pools to exhaustion regardless of the configured limits.";
 
   public static final String KSQL_QUERY_PULL_MAX_HOURLY_BANDWIDTH_MEGABYTES_CONFIG
       = "ksql.query.pull.max.hourly.bandwidth.megabytes";
@@ -1280,12 +1272,6 @@ public class KsqlConfig extends AbstractConfig {
             ConfigDef.Range.atLeast(1),
             Importance.MEDIUM,
             KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_DOC
-        ).define(
-            KSQL_QUERY_PULL_LIMIT_FORWARDED_REQUESTS_CONFIG,
-            Type.BOOLEAN,
-            KSQL_QUERY_PULL_LIMIT_FORWARDED_REQUESTS_DEFAULT,
-            Importance.MEDIUM,
-            KSQL_QUERY_PULL_LIMIT_FORWARDED_REQUESTS_DOC
         )
         .define(
             KSQL_QUERY_PULL_MAX_HOURLY_BANDWIDTH_MEGABYTES_CONFIG,

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -318,24 +318,41 @@ public class KsqlConfig extends AbstractConfig {
       + "queries on this host. Once the limit is hit, queries will fail immediately";
 
   // --- KSQL-15212: pull-query queue bounding, cancellation and rejection semantics ---
-  // Every config below defaults to the pre-existing behaviour, so enabling any of them is an
-  // explicit opt-in and the same build can be A/B tested by configuration alone.
+
+  /**
+   * Queue capacity meaning "however many threads the pool has". Measured behaviour at 100
+   * threads: bound 50 returned 39,423 rows, bound 100 returned 51,231 with 91% of failures
+   * clean 429s, bound 200 returned 8,700 with only 6% clean. A queue longer than the pool
+   * admits work the pool cannot reach in time, so the ratio is what matters rather than the
+   * absolute number, and deriving it keeps the ratio at 1 when the pool size is changed.
+   */
+  public static final int KSQL_QUERY_PULL_QUEUE_CAPACITY_MATCH_POOL = -1;
+
+  /** Accepts the sentinel or a real capacity, but not 0, which would admit nothing. */
+  private static final ConfigDef.Validator QUEUE_CAPACITY_VALIDATOR = (name, value) -> {
+    final int capacity = value == null ? 0 : ((Number) value).intValue();
+    if (capacity != KSQL_QUERY_PULL_QUEUE_CAPACITY_MATCH_POOL && capacity < 1) {
+      throw new ConfigException(
+          name, value, "must be at least 1, or -1 to track the size of the pool it feeds");
+    }
+  };
 
   public static final String KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_CONFIG
       = "ksql.query.pull.coordinator.queue.capacity";
   public static final Integer KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_DEFAULT
-      = Integer.MAX_VALUE;
+      = KSQL_QUERY_PULL_QUEUE_CAPACITY_MATCH_POOL;
   public static final String KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_DOC
       = "Maximum number of pull queries that may queue waiting for a coordinator thread. "
-      + "Requests arriving when the queue is full are rejected immediately rather than "
-      + "queued. The default is effectively unbounded, which matches the previous behaviour "
-      + "of Executors.newFixedThreadPool.";
+      + "Requests arriving when the queue is full are rejected with a retriable error rather "
+      + "than queued. -1, the default, tracks ksql.query.pull.thread.pool.size.";
 
   public static final String KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_CONFIG
       = "ksql.query.pull.router.queue.capacity";
-  public static final Integer KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_DEFAULT = Integer.MAX_VALUE;
+  public static final Integer KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_DEFAULT
+      = KSQL_QUERY_PULL_QUEUE_CAPACITY_MATCH_POOL;
   public static final String KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_DOC
       = "Maximum number of per-host fetches that may queue waiting for a router thread. "
+      + "-1, the default, tracks ksql.query.pull.router.thread.pool.size. "
       + "See ksql.query.pull.coordinator.queue.capacity.";
 
 
@@ -357,15 +374,19 @@ public class KsqlConfig extends AbstractConfig {
 
   public static final String KSQL_QUERY_PULL_THREAD_POOL_SIZE_CONFIG
       = "ksql.query.pull.thread.pool.size";
-  public static final Integer KSQL_QUERY_PULL_THREAD_POOL_SIZE_DEFAULT = 50;
+  public static final Integer KSQL_QUERY_PULL_THREAD_POOL_SIZE_DEFAULT = 100;
   public static final String KSQL_QUERY_PULL_THREAD_POOL_SIZE_DOC =
-      "Size of thread pool used for coordinating pull queries";
+      "Size of thread pool used for coordinating pull queries. A query that fetches from a "
+      + "remote host occupies a coordinator thread for the whole fetch, so this bounds "
+      + "concurrent queries rather than concurrent work.";
 
   public static final String KSQL_QUERY_PULL_ROUTER_THREAD_POOL_SIZE_CONFIG
       = "ksql.query.pull.router.thread.pool.size";
-  public static final Integer KSQL_QUERY_PULL_ROUTER_THREAD_POOL_SIZE_DEFAULT = 50;
+  public static final Integer KSQL_QUERY_PULL_ROUTER_THREAD_POOL_SIZE_DEFAULT = 100;
   public static final String KSQL_QUERY_PULL_ROUTER_THREAD_POOL_SIZE_DOC =
-      "Size of thread pool used for routing pull queries";
+      "Size of thread pool used for routing pull queries. One thread is taken per host a "
+      + "query fetches from, so a query that fans out needs more of these than of "
+      + "ksql.query.pull.thread.pool.size.";
 
   public static final String KSQL_QUERY_PULL_TABLE_SCAN_ENABLED
       = "ksql.query.pull.table.scan.enabled";
@@ -1262,14 +1283,14 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_CONFIG,
             Type.INT,
             KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_DEFAULT,
-            ConfigDef.Range.atLeast(1),
+            QUEUE_CAPACITY_VALIDATOR,
             Importance.MEDIUM,
             KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_DOC
         ).define(
             KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_CONFIG,
             Type.INT,
             KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_DEFAULT,
-            ConfigDef.Range.atLeast(1),
+            QUEUE_CAPACITY_VALIDATOR,
             Importance.MEDIUM,
             KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_DOC
         )

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/HARouting.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/HARouting.java
@@ -484,12 +484,10 @@ public final class HARouting implements AutoCloseable {
    * tells the client its request was malformed and must not be retried. KsqlRateLimitException is
    * already mapped to 429 by ServerUtils, so the client backs off and retries instead.
    */
-  private KsqlException queueFull(final String pool) {
-    final String msg = "Pull query rejected: the " + pool
-        + " queue is full. The server is at capacity; retry after a backoff.";
-    return ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_LIMIT_REJECTION_RETRIABLE_CONFIG)
-        ? new KsqlRateLimitException(msg)
-        : new KsqlException(msg);
+  private KsqlRateLimitException queueFull(final String pool) {
+    pullQueryMetrics.ifPresent(PullQueryExecutorMetrics::recordQueueRejected);
+    return new KsqlRateLimitException("Pull query rejected: the " + pool
+        + " queue is full. The server is at capacity; retry after a backoff.");
   }
 
   private static KsqlException causedByKsqlException(final Exception e) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/HARouting.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/HARouting.java
@@ -197,6 +197,16 @@ public final class HARouting implements AutoCloseable {
       final PullQueryWriteStream pullQueryQueue,
       final CompletableFuture<Void> shouldCancelRequests
   ) {
+    // Checked on dequeue, not just on submit: a query queued while the client was still
+    // connected can be picked up long after it left, and would otherwise run to completion for
+    // nobody. An in-flight scan already stops on its own, because PullPhysicalPlan polls
+    // pullQueryQueue.isDone() between rows; this covers the window before it starts.
+    if (shouldCancelRequests.isDone()) {
+      LOG.debug("Pull query was cancelled before a coordinator thread picked it up; skipping.");
+      pullQueryQueue.close();
+      return;
+    }
+
     // The remaining partition locations to retrieve without error
     List<KsqlPartitionLocation> remainingLocations = ImmutableList.copyOf(locations);
     final Map<KsqlNode, List<Exception>> exceptionsPerNode = new HashMap<>();
@@ -329,6 +339,14 @@ public final class HARouting implements AutoCloseable {
   ) {
     final Function<StreamedRow, StreamedRow> addHostInfo
         = sr -> sr.withSourceHost(routingOptions.getIsDebugRequest() ? toKsqlHostInfo(node) : null);
+    // Same check for the router pool. Reported as SUCCESS rather than an error so the round loop
+    // does not retry these partitions on a standby: the request is going nowhere either way, and
+    // retrying would spend more threads on it.
+    if (shouldCancelRequests.isDone()) {
+      LOG.debug("Pull query to node {} was cancelled before a router thread picked it up; "
+          + "skipping.", node.location());
+      return new NodeFetchResult(RoutingResult.SUCCESS, node, Optional.empty());
+    }
     if (node.isLocal()) {
       try {
         LOG.debug("Query {} partitions {} executed locally at host {} at timestamp {}.",

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/HARouting.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/HARouting.java
@@ -469,20 +469,6 @@ public final class HARouting implements AutoCloseable {
         : new KsqlException(msg);
   }
 
-  /**
-   * A full queue means the server is at capacity, not that the statement was bad. Left uncaught,
-   * RejectedExecutionException surfaces as HTTP 400 carrying the rejected task's toString, which
-   * tells the client its request was malformed and must not be retried. KsqlRateLimitException is
-   * already mapped to 429 by ServerUtils, so the client backs off and retries instead.
-   */
-  private KsqlException queueFull(final String pool) {
-    final String msg = "Pull query rejected: the " + pool
-        + " queue is full. The server is at capacity; retry after a backoff.";
-    return ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_LIMIT_REJECTION_RETRIABLE_CONFIG)
-        ? new KsqlRateLimitException(msg)
-        : new KsqlException(msg);
-  }
-
   private static KsqlException causedByKsqlException(final Exception e) {
     Throwable throwable = e;
     while (throwable != null) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/HARouting.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/HARouting.java
@@ -66,15 +66,6 @@ public final class HARouting implements AutoCloseable {
 
   private static final int TOO_MANY_REQUESTS = 429;
 
-  /** Resolves the queue bound, which by default tracks the size of the pool it feeds. */
-  private static int queueCapacity(
-      final KsqlConfig ksqlConfig, final String config, final int poolSize) {
-    final int configured = ksqlConfig.getInt(config);
-    return configured == KsqlConfig.KSQL_QUERY_PULL_QUEUE_CAPACITY_MATCH_POOL
-        ? poolSize
-        : configured;
-  }
-
   private final ExecutorService coordinatorExecutorService;
   private final ExecutorService routerExecutorService;
   private final RoutingFilterFactory routingFilterFactory;
@@ -100,18 +91,16 @@ public final class HARouting implements AutoCloseable {
         coordinatorPoolSize,
         0L,
         TimeUnit.MILLISECONDS,
-        new LinkedBlockingQueue<>(queueCapacity(
-            ksqlConfig, KsqlConfig.KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_CONFIG,
-            coordinatorPoolSize)),
+        new LinkedBlockingQueue<>(ksqlConfig.getInt(
+            KsqlConfig.KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_CONFIG)),
         new ThreadFactoryBuilder().setNameFormat("pull-query-coordinator-%d").build());
     final ThreadPoolExecutor routerPool = new ThreadPoolExecutor(
         routerPoolSize,
         routerPoolSize,
         0L,
         TimeUnit.MILLISECONDS,
-        new LinkedBlockingQueue<>(queueCapacity(
-            ksqlConfig, KsqlConfig.KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_CONFIG,
-            routerPoolSize)),
+        new LinkedBlockingQueue<>(ksqlConfig.getInt(
+            KsqlConfig.KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_CONFIG)),
         new ThreadFactoryBuilder().setNameFormat("pull-query-router-%d").build());
     this.coordinatorExecutorService = coordinatorPool;
     this.routerExecutorService = routerPool;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/HARouting.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/HARouting.java
@@ -298,12 +298,11 @@ public final class HARouting implements AutoCloseable {
       // becomes a MaterializationException, which reads as a server fault and hides the one
       // thing the caller can act on: the server is at capacity, so retry after a backoff.
       final KsqlRateLimitException rateLimit = causedByRateLimit(e);
-      if (rateLimit != null) {
-        throw rateLimit;
-      }
-      final MaterializationException exception =
-          new MaterializationException(
-              "Unable to execute pull query: " + e.getMessage());
+      final RuntimeException exception = rateLimit != null
+          ? rateLimit
+          : new MaterializationException("Unable to execute pull query: " + e.getMessage());
+      // Earlier rounds may have failed for unrelated reasons before capacity ran out. Those are
+      // attached either way, so a rejection does not arrive with the history stripped off it.
       for (Entry<KsqlNode, List<Exception>> entry : exceptionsPerNode.entrySet()) {
         for (Exception excp : entry.getValue()) {
           exception.addSuppressed(excp);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/HARouting.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/HARouting.java
@@ -284,6 +284,11 @@ public final class HARouting implements AutoCloseable {
           return;
         }
       }
+    } catch (final KsqlRateLimitException e) {
+      // Must escape unwrapped. The handler below turns everything into a MaterializationException,
+      // which the API layer reports as a 500 - losing the retriable 429 that a full router queue
+      // is supposed to produce.
+      throw e;
     } catch (final Exception e) {
       final MaterializationException exception =
           new MaterializationException(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/HARouting.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/HARouting.java
@@ -66,6 +66,15 @@ public final class HARouting implements AutoCloseable {
 
   private static final int TOO_MANY_REQUESTS = 429;
 
+  /** Resolves the queue bound, which by default tracks the size of the pool it feeds. */
+  private static int queueCapacity(
+      final KsqlConfig ksqlConfig, final String config, final int poolSize) {
+    final int configured = ksqlConfig.getInt(config);
+    return configured == KsqlConfig.KSQL_QUERY_PULL_QUEUE_CAPACITY_MATCH_POOL
+        ? poolSize
+        : configured;
+  }
+
   private final ExecutorService coordinatorExecutorService;
   private final ExecutorService routerExecutorService;
   private final RoutingFilterFactory routingFilterFactory;
@@ -91,16 +100,18 @@ public final class HARouting implements AutoCloseable {
         coordinatorPoolSize,
         0L,
         TimeUnit.MILLISECONDS,
-        new LinkedBlockingQueue<>(ksqlConfig.getInt(
-            KsqlConfig.KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_CONFIG)),
+        new LinkedBlockingQueue<>(queueCapacity(
+            ksqlConfig, KsqlConfig.KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_CONFIG,
+            coordinatorPoolSize)),
         new ThreadFactoryBuilder().setNameFormat("pull-query-coordinator-%d").build());
     final ThreadPoolExecutor routerPool = new ThreadPoolExecutor(
         routerPoolSize,
         routerPoolSize,
         0L,
         TimeUnit.MILLISECONDS,
-        new LinkedBlockingQueue<>(ksqlConfig.getInt(
-            KsqlConfig.KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_CONFIG)),
+        new LinkedBlockingQueue<>(queueCapacity(
+            ksqlConfig, KsqlConfig.KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_CONFIG,
+            routerPoolSize)),
         new ThreadFactoryBuilder().setNameFormat("pull-query-router-%d").build());
     this.coordinatorExecutorService = coordinatorPool;
     this.routerExecutorService = routerPool;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/HARouting.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/HARouting.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.KsqlRateLimitException;
 import io.confluent.ksql.util.KsqlRequestConfig;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -48,9 +49,11 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -81,18 +84,35 @@ public final class HARouting implements AutoCloseable {
         KsqlConfig.KSQL_QUERY_PULL_THREAD_POOL_SIZE_CONFIG);
     this.routerPoolSize = ksqlConfig.getInt(
         KsqlConfig.KSQL_QUERY_PULL_ROUTER_THREAD_POOL_SIZE_CONFIG);
-    this.coordinatorExecutorService = Executors.newFixedThreadPool(
+    final ThreadPoolExecutor coordinatorPool = new ThreadPoolExecutor(
         coordinatorPoolSize,
+        coordinatorPoolSize,
+        0L,
+        TimeUnit.MILLISECONDS,
+        new LinkedBlockingQueue<>(ksqlConfig.getInt(
+            KsqlConfig.KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_CONFIG)),
         new ThreadFactoryBuilder().setNameFormat("pull-query-coordinator-%d").build());
-    this.routerExecutorService = Executors.newFixedThreadPool(
+    final ThreadPoolExecutor routerPool = new ThreadPoolExecutor(
         routerPoolSize,
+        routerPoolSize,
+        0L,
+        TimeUnit.MILLISECONDS,
+        new LinkedBlockingQueue<>(ksqlConfig.getInt(
+            KsqlConfig.KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_CONFIG)),
         new ThreadFactoryBuilder().setNameFormat("pull-query-router-%d").build());
+    this.coordinatorExecutorService = coordinatorPool;
+    this.routerExecutorService = routerPool;
     this.pullQueryMetrics = Objects.requireNonNull(pullQueryMetrics, "pullQueryMetrics");
-    this.pullQueryMetrics.ifPresent(pm -> pm.registerCoordinatorThreadPoolSupplier(
-        () -> coordinatorPoolSize
-            - ((ThreadPoolExecutor) coordinatorExecutorService).getActiveCount()));
-    this.pullQueryMetrics.ifPresent(pm -> pm.registerRouterThreadPoolSupplier(
-        () -> routerPoolSize - ((ThreadPoolExecutor) routerExecutorService).getActiveCount()));
+    this.pullQueryMetrics.ifPresent(pm -> {
+      pm.registerCoordinatorThreadPoolSupplier(
+          () -> coordinatorPoolSize - coordinatorPool.getActiveCount());
+      pm.registerRouterThreadPoolSupplier(
+          () -> routerPoolSize - routerPool.getActiveCount());
+      // Free-thread count alone cannot distinguish a momentary spike from a long backlog:
+      // both report zero. Queue depth is the missing signal.
+      pm.registerCoordinatorQueueSizeSupplier(() -> coordinatorPool.getQueue().size());
+      pm.registerRouterQueueSizeSupplier(() -> routerPool.getQueue().size());
+    });
   }
 
   @Override
@@ -144,15 +164,27 @@ public final class HARouting implements AutoCloseable {
         .collect(Collectors.toList());
 
     final CompletableFuture<Void> completableFuture = new CompletableFuture<>();
-    coordinatorExecutorService.submit(() -> {
-      try {
-        executeRounds(serviceContext, pullPhysicalPlan, statement, routingOptions,
-            locations, pullQueryQueue, shouldCancelRequests);
-        completableFuture.complete(null);
-      } catch (Throwable t) {
-        completableFuture.completeExceptionally(t);
-      }
-    });
+    // Timed around the submit: the existing latency metric sums queue wait and execution.
+    final long submittedNanos = System.nanoTime();
+    try {
+      coordinatorExecutorService.submit(() -> {
+        final long startedNanos = System.nanoTime();
+        pullQueryMetrics.ifPresent(
+            pm -> pm.recordCoordinatorQueueWait(startedNanos - submittedNanos));
+        try {
+          executeRounds(serviceContext, pullPhysicalPlan, statement, routingOptions,
+              locations, pullQueryQueue, shouldCancelRequests);
+          completableFuture.complete(null);
+        } catch (Throwable t) {
+          completableFuture.completeExceptionally(t);
+        } finally {
+          pullQueryMetrics.ifPresent(
+              pm -> pm.recordCoordinatorServiceTime(System.nanoTime() - startedNanos));
+        }
+      });
+    } catch (final RejectedExecutionException e) {
+      throw queueFull("coordinator");
+    }
     return completableFuture;
   }
 
@@ -191,12 +223,29 @@ public final class HARouting implements AutoCloseable {
         final Map<KsqlNode, Future<NodeFetchResult>> futures = new LinkedHashMap<>();
         for (Map.Entry<KsqlNode, List<KsqlPartitionLocation>> entry : groupedByHost.entrySet()) {
           final KsqlNode node = entry.getKey();
-          futures.put(node, routerExecutorService.submit(
-              () -> executeOrRouteQuery(
-                  node, entry.getValue(), statement, serviceContext, routingOptions,
-                  pullQueryMetrics, pullPhysicalPlan, pullQueryQueue,
-                  shouldCancelRequests)
-          ));
+          final long routerSubmittedNanos = System.nanoTime();
+          try {
+            futures.put(node, routerExecutorService.submit(
+                () -> {
+                  final long routerStartedNanos = System.nanoTime();
+                  pullQueryMetrics.ifPresent(
+                      pm -> pm.recordRouterQueueWait(routerStartedNanos - routerSubmittedNanos));
+                  try {
+                    return executeOrRouteQuery(
+                        node, entry.getValue(), statement, serviceContext, routingOptions,
+                        pullQueryMetrics, pullPhysicalPlan, pullQueryQueue,
+                        shouldCancelRequests);
+                  } finally {
+                    // A forward to a saturated peer holds this thread for the full forwarding
+                    // timeout, so router service time is where that cost is visible.
+                    pullQueryMetrics.ifPresent(
+                        pm -> pm.recordRouterServiceTime(System.nanoTime() - routerStartedNanos));
+                  }
+                }
+            ));
+          } catch (final RejectedExecutionException e) {
+            throw queueFull("router");
+          }
         }
 
         // Go through all of the results of the requests, either aggregating rows or adding
@@ -404,6 +453,34 @@ public final class HARouting implements AutoCloseable {
               + "empty response from forwarding call, expected a header row.",
           statement.getSessionConfig().getOverrides(), requestProperties));
     }
+  }
+
+  /**
+   * A full queue means the server is at capacity, not that the statement was bad. Left uncaught,
+   * RejectedExecutionException surfaces as HTTP 400 carrying the rejected task's toString, which
+   * tells the client its request was malformed and must not be retried. KsqlRateLimitException is
+   * already mapped to 429 by ServerUtils, so the client backs off and retries instead.
+   */
+  private KsqlException queueFull(final String pool) {
+    final String msg = "Pull query rejected: the " + pool
+        + " queue is full. The server is at capacity; retry after a backoff.";
+    return ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_LIMIT_REJECTION_RETRIABLE_CONFIG)
+        ? new KsqlRateLimitException(msg)
+        : new KsqlException(msg);
+  }
+
+  /**
+   * A full queue means the server is at capacity, not that the statement was bad. Left uncaught,
+   * RejectedExecutionException surfaces as HTTP 400 carrying the rejected task's toString, which
+   * tells the client its request was malformed and must not be retried. KsqlRateLimitException is
+   * already mapped to 429 by ServerUtils, so the client backs off and retries instead.
+   */
+  private KsqlException queueFull(final String pool) {
+    final String msg = "Pull query rejected: the " + pool
+        + " queue is full. The server is at capacity; retry after a backoff.";
+    return ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_LIMIT_REJECTION_RETRIABLE_CONFIG)
+        ? new KsqlRateLimitException(msg)
+        : new KsqlException(msg);
   }
 
   private static KsqlException causedByKsqlException(final Exception e) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/HARouting.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/HARouting.java
@@ -64,6 +64,8 @@ public final class HARouting implements AutoCloseable {
 
   private static final Logger LOG = LoggerFactory.getLogger(HARouting.class);
 
+  private static final int TOO_MANY_REQUESTS = 429;
+
   private final ExecutorService coordinatorExecutorService;
   private final ExecutorService routerExecutorService;
   private final RoutingFilterFactory routingFilterFactory;
@@ -254,6 +256,12 @@ public final class HARouting implements AutoCloseable {
                 }
             ));
           } catch (final RejectedExecutionException e) {
+            // This round is being given up on, so drop the hosts already submitted for it. One
+            // still queued never starts; one already running is interrupted out of its forward
+            // rather than holding a router thread until the forwarding timeout, writing into a
+            // stream the finally block below is about to close. Only reachable now that the
+            // queue is bounded - submit could not fail when the pool queue was unbounded.
+            futures.values().forEach(f -> f.cancel(true));
             throw queueFull("router");
           }
         }
@@ -284,12 +292,15 @@ public final class HARouting implements AutoCloseable {
           return;
         }
       }
-    } catch (final KsqlRateLimitException e) {
-      // Must escape unwrapped. The handler below turns everything into a MaterializationException,
-      // which the API layer reports as a 500 - losing the retriable 429 that a full router queue
-      // is supposed to produce.
-      throw e;
     } catch (final Exception e) {
+      // A rate limit escapes unwrapped, whether it was thrown here on a full router queue or
+      // carried back from a router task inside an ExecutionException. Everything else below
+      // becomes a MaterializationException, which reads as a server fault and hides the one
+      // thing the caller can act on: the server is at capacity, so retry after a backoff.
+      final KsqlRateLimitException rateLimit = causedByRateLimit(e);
+      if (rateLimit != null) {
+        throw rateLimit;
+      }
       final MaterializationException exception =
           new MaterializationException(
               "Unable to execute pull query: " + e.getMessage());
@@ -392,6 +403,9 @@ public final class HARouting implements AutoCloseable {
         LOG.warn("Error forwarding query to node {}. Falling back to standby state which may "
             + "return stale results", node.location(), e.getCause());
         return new NodeFetchResult(RoutingResult.STANDBY_FALLBACK, node, Optional.of(e));
+      } catch (KsqlRateLimitException e) {
+        // Escapes unwrapped so the peer's 429 keeps its identity on the way back to the caller.
+        throw e;
       } catch (Exception e) {
         throw new KsqlException(
           String.format("Error forwarding query to node %s: %s", node.location(), e.getMessage()),
@@ -463,10 +477,18 @@ public final class HARouting implements AutoCloseable {
     }
 
     if (response.isErroneous()) {
-      throw new KsqlException(String.format(
+      final String message = String.format(
           "Forwarding pull query request [%s, %s] failed with error %s ",
           statement.getSessionConfig().getOverrides(), requestProperties,
-          response.getErrorMessage()));
+          response.getErrorMessage());
+      // A saturated peer answers 429. Kept as a rate limit rather than a generic failure so the
+      // client is told to back off instead of being handed an opaque server error. Deliberately
+      // not a StandbyFallbackException: re-sending to another node while the cluster is already
+      // refusing work adds load to the thing that is short of capacity.
+      if (response.getStatusCode() == TOO_MANY_REQUESTS) {
+        throw new KsqlRateLimitException(message);
+      }
+      throw new KsqlException(message);
     }
 
     final int numRows = response.getResponse();
@@ -483,11 +505,30 @@ public final class HARouting implements AutoCloseable {
    * RejectedExecutionException surfaces as HTTP 400 carrying the rejected task's toString, which
    * tells the client its request was malformed and must not be retried. KsqlRateLimitException is
    * already mapped to 429 by ServerUtils, so the client backs off and retries instead.
+   *
+   * <p>Which of those two the client actually sees depends on the pool. A coordinator rejection
+   * happens on the worker thread inside {@code startFromWorkerThread()}, before any response
+   * metadata is written, so it becomes a real HTTP 429. A router rejection happens later, on a
+   * coordinator thread, by which point the 200 and the metadata row have already gone out; it
+   * reaches the client as an error row in the open stream instead. Both carry the same message
+   * and both increment the same rejection metric, so the two are told apart on the server by
+   * which pool's queue-depth gauge is at its bound, not by the status code.
    */
   private KsqlRateLimitException queueFull(final String pool) {
     pullQueryMetrics.ifPresent(PullQueryExecutorMetrics::recordQueueRejected);
     return new KsqlRateLimitException("Pull query rejected: the " + pool
         + " queue is full. The server is at capacity; retry after a backoff.");
+  }
+
+  private static KsqlRateLimitException causedByRateLimit(final Throwable e) {
+    Throwable throwable = e;
+    while (throwable != null) {
+      if (throwable instanceof KsqlRateLimitException) {
+        return (KsqlRateLimitException) throwable;
+      }
+      throwable = throwable.getCause();
+    }
+    return null;
   }
 
   private static KsqlException causedByKsqlException(final Exception e) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/PullQueryResult.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/PullQueryResult.java
@@ -25,6 +25,7 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.util.ConsistencyOffsetVector;
 import io.confluent.ksql.util.KsqlConstants.QuerySourceType;
 import io.confluent.ksql.util.KsqlConstants.RoutingNodeType;
+import io.confluent.ksql.util.KsqlRateLimitException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -115,11 +116,25 @@ public class PullQueryResult {
       future.completeExceptionally(t);
       throw t;
     }
-    // Register the error metric
-    onException(t ->
-        pullQueryMetrics.ifPresent(metrics ->
-            metrics.recordErrorRate(1, sourceType, planType, routingNodeType))
-    );
+    // Register the error metric. A rate-limit rejection (a full router queue, which reaches here
+    // on this async path) is left out: it is load shed, not a query failure, and is already
+    // counted by queue-rejected.
+    onException(t -> {
+      if (causedByRateLimit(t)) {
+        return;
+      }
+      pullQueryMetrics.ifPresent(metrics ->
+          metrics.recordErrorRate(1, sourceType, planType, routingNodeType));
+    });
+  }
+
+  private static boolean causedByRateLimit(final Throwable t) {
+    for (Throwable c = t; c != null; c = c.getCause()) {
+      if (c instanceof KsqlRateLimitException) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public void stop() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/PullQueryExecutorMetrics.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/PullQueryExecutorMetrics.java
@@ -222,7 +222,10 @@ public class PullQueryExecutorMetrics implements Closeable {
     this.routerServiceTimeSensor.record(TimeUnit.NANOSECONDS.toMicros(serviceNanos));
   }
 
-  /** A client disconnected before its response completed; the query still runs to completion. */
+  /**
+   * A client disconnected before its response completed. Whether the query is then cancelled or
+   * left to run to completion depends on ksql.query.pull.cancel.on.disconnect.enabled.
+   */
   public void recordClientDisconnected() {
     this.clientDisconnectedSensor.record(1);
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/PullQueryExecutorMetrics.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/PullQueryExecutorMetrics.java
@@ -87,10 +87,13 @@ public class PullQueryExecutorMetrics implements Closeable {
   private final String ksqlServicePrefix;
   private final Time time;
 
-  private Supplier<Integer> coordinatorThreadPoolSupplier;
-  private Supplier<Integer> routerThreadPoolSupplier;
-  private Supplier<Integer> coordinatorQueueSizeSupplier;
-  private Supplier<Integer> routerQueueSizeSupplier;
+  // Defaulted rather than left null: the gauges are registered in the constructor but the
+  // suppliers are only wired when HARouting is built, so a metrics scrape in between would
+  // otherwise NPE.
+  private Supplier<Integer> coordinatorThreadPoolSupplier = () -> 0;
+  private Supplier<Integer> routerThreadPoolSupplier = () -> 0;
+  private Supplier<Integer> coordinatorQueueSizeSupplier = () -> 0;
+  private Supplier<Integer> routerQueueSizeSupplier = () -> 0;
 
 
   @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "metrics")

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/PullQueryExecutorMetrics.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/PullQueryExecutorMetrics.java
@@ -507,8 +507,8 @@ public class PullQueryExecutorMetrics implements Closeable {
         sensor,
         PULL_REQUESTS + "-forwarded-in-rate",
         ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
-        "Rate of per-host fetches arriving from a peer node. These bypass admission limits "
-            + "unless ksql.query.pull.limit.forwarded.requests is set.",
+        "Rate of per-host fetches arriving from a peer node. These bypass the rate and "
+            + "concurrency limits, which are applied only at the host the client connected to.",
         customMetricsTags,
         new Rate()
     );

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/PullQueryExecutorMetrics.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/PullQueryExecutorMetrics.java
@@ -55,6 +55,8 @@ public class PullQueryExecutorMetrics implements Closeable {
   private static final String PULL_REQUESTS = "pull-query-requests";
   private static final long MAX_LATENCY_BUCKET_VALUE_MICROS = TimeUnit.SECONDS.toMicros(10);
   private static final int NUM_LATENCY_BUCKETS = 1000;
+  // Queue waits reach minutes, so these percentiles need a wider range than latency's 10s.
+  private static final long MAX_WAIT_BUCKET_VALUE_MICROS = TimeUnit.SECONDS.toMicros(120);
 
   private final List<Sensor> sensors;
   private final Sensor localRequestsSensor;
@@ -62,6 +64,11 @@ public class PullQueryExecutorMetrics implements Closeable {
   private final Sensor latencySensor;
   private final Map<MetricsKey, Sensor> latencySensorMap;
   private final Sensor requestRateSensor;
+  private final Sensor requestsOfferedSensor;
+  private final Sensor coordinatorQueueWaitSensor;
+  private final Sensor routerQueueWaitSensor;
+  private final Sensor coordinatorServiceTimeSensor;
+  private final Sensor routerServiceTimeSensor;
   private final Sensor errorRateSensor;
   private final Map<MetricsKey, Sensor> errorRateSensorMap;
   private final Sensor requestSizeSensor;
@@ -82,6 +89,8 @@ public class PullQueryExecutorMetrics implements Closeable {
 
   private Supplier<Integer> coordinatorThreadPoolSupplier;
   private Supplier<Integer> routerThreadPoolSupplier;
+  private Supplier<Integer> coordinatorQueueSizeSupplier;
+  private Supplier<Integer> routerQueueSizeSupplier;
 
 
   @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "metrics")
@@ -107,6 +116,19 @@ public class PullQueryExecutorMetrics implements Closeable {
     this.latencySensor = configureLatencySensor();
     this.latencySensorMap = configureLatencySensorMap();
     this.requestRateSensor = configureRateSensor();
+    this.requestsOfferedSensor = configureRequestsOfferedSensor();
+    this.coordinatorQueueWaitSensor = configureDurationSensor(
+        "coordinator-queue-wait",
+        "queued waiting for a coordinator thread");
+    this.routerQueueWaitSensor = configureDurationSensor(
+        "router-queue-wait",
+        "queued waiting for a router thread");
+    this.coordinatorServiceTimeSensor = configureDurationSensor(
+        "coordinator-service-time",
+        "executing on a coordinator thread, excluding time queued");
+    this.routerServiceTimeSensor = configureDurationSensor(
+        "router-service-time",
+        "executing on a router thread, excluding time queued");
     this.errorRateSensor = configureErrorRateSensor();
     this.errorRateSensorMap = configureErrorSensorMap();
     this.requestSizeSensor = configureRequestSizeSensor();
@@ -133,6 +155,50 @@ public class PullQueryExecutorMetrics implements Closeable {
   public void registerRouterThreadPoolSupplier(final Supplier<Integer> supplier) {
     routerThreadPoolSupplier = supplier;
   }
+
+  public void registerCoordinatorQueueSizeSupplier(final Supplier<Integer> supplier) {
+    coordinatorQueueSizeSupplier = supplier;
+  }
+
+  public void registerRouterQueueSizeSupplier(final Supplier<Integer> supplier) {
+    routerQueueSizeSupplier = supplier;
+  }
+
+  /**
+   * Records a pull query as it arrives, before any admission decision is made.
+   *
+   * <p>This is deliberately distinct from {@code pull-query-requests-rate}, which is recorded
+   * from {@code recordLatency} once a query has finished and therefore measures the rate of
+   * <em>completions</em>. Under saturation nothing completes, so that metric falls towards zero
+   * exactly when load is highest. This one measures offered load.
+   */
+  public void recordRequestOffered() {
+    this.requestsOfferedSensor.record(1);
+  }
+
+  /** Time queued before a coordinator thread picked the query up. */
+  public void recordCoordinatorQueueWait(final long waitNanos) {
+    this.coordinatorQueueWaitSensor.record(TimeUnit.NANOSECONDS.toMicros(waitNanos));
+  }
+
+  /** Time queued before a router thread picked the host fetch up. */
+  public void recordRouterQueueWait(final long waitNanos) {
+    this.routerQueueWaitSensor.record(TimeUnit.NANOSECONDS.toMicros(waitNanos));
+  }
+
+  /** Time the query held a coordinator thread, excluding time queued. */
+  public void recordCoordinatorServiceTime(final long serviceNanos) {
+    this.coordinatorServiceTimeSensor.record(TimeUnit.NANOSECONDS.toMicros(serviceNanos));
+  }
+
+  /**
+   * Time the host fetch held a router thread, excluding time queued. A forward to a saturated
+   * peer holds its thread for the full forwarding timeout, so this is where that cost shows up.
+   */
+  public void recordRouterServiceTime(final long serviceNanos) {
+    this.routerServiceTimeSensor.record(TimeUnit.NANOSECONDS.toMicros(serviceNanos));
+  }
+
 
   public void recordLocalRequests(final double value) {
     this.localRequestsSensor.record(value);
@@ -378,6 +444,87 @@ public class PullQueryExecutorMetrics implements Closeable {
     return sensor;
   }
 
+  private Sensor configureRequestsOfferedSensor() {
+    final Sensor sensor = metrics.sensor(
+        PULL_QUERY_METRIC_GROUP + "-" + PULL_REQUESTS + "-offered");
+
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-offered-rate",
+        ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
+        "Rate of pull query requests arriving, counted before any rate, concurrency or "
+            + "queue-capacity check. Unlike -rate this does not require the query to complete, "
+            + "so it still reports load when the cluster is saturated.",
+        customMetricsTags,
+        new Rate()
+    );
+
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-offered-total",
+        ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
+        "Total pull query requests arriving, counted before any admission check",
+        customMetricsTags,
+        new CumulativeCount()
+    );
+
+    sensors.add(sensor);
+    return sensor;
+  }
+
+  private Sensor configureDurationSensor(final String nameSuffix, final String description) {
+    final Sensor sensor = metrics.sensor(
+        PULL_QUERY_METRIC_GROUP + "-" + PULL_REQUESTS + "-" + nameSuffix);
+    final String name = PULL_REQUESTS + "-" + nameSuffix;
+    final String group = ksqlServicePrefix + PULL_QUERY_METRIC_GROUP;
+
+    addSensor(
+        sensor,
+        name + "-avg",
+        group,
+        "Average microseconds a pull query spent " + description,
+        customMetricsTags,
+        new Avg()
+    );
+
+    addSensor(
+        sensor,
+        name + "-max",
+        group,
+        "Max microseconds a pull query spent " + description,
+        customMetricsTags,
+        new Max()
+    );
+
+    sensor.add(new Percentiles(
+        4 * NUM_LATENCY_BUCKETS,
+        MAX_WAIT_BUCKET_VALUE_MICROS,
+        BucketSizing.LINEAR,
+        new Percentile(metrics.metricName(
+            name + "-p50",
+            group,
+            "Distribution of microseconds spent " + description,
+            customMetricsTags
+        ), 50.0),
+        new Percentile(metrics.metricName(
+            name + "-p90",
+            group,
+            "Distribution of microseconds spent " + description,
+            customMetricsTags
+        ), 90.0),
+        new Percentile(metrics.metricName(
+            name + "-p99",
+            group,
+            "Distribution of microseconds spent " + description,
+            customMetricsTags
+        ), 99.0)
+    ));
+
+    sensors.add(sensor);
+    return sensor;
+  }
+
+
   private Sensor configureRateSensor() {
     final Sensor sensor = metrics.sensor(
         PULL_QUERY_METRIC_GROUP + "-" + PULL_REQUESTS + "-rate");
@@ -518,6 +665,27 @@ public class PullQueryExecutorMetrics implements Closeable {
     );
     metrics.addMetric(routerThreadsAvailable,
                       (Gauge<Integer>) (config, now) -> routerThreadPoolSupplier.get());
+
+    // The free-size gauges above saturate at zero: a pool with one queued request and a pool
+    // with tens of thousands both report zero available threads. Queue depth is what separates
+    // a momentary spike from a backlog that will take an hour to drain.
+    final MetricName coordinatorQueueSize = metrics.metricName(
+        PULL_REQUESTS + "-coordinator-queue-size",
+        ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
+        "Number of pull queries queued waiting for a coordinator thread",
+        customMetricsTags
+    );
+    metrics.addMetric(coordinatorQueueSize,
+                      (Gauge<Integer>) (config, now) -> coordinatorQueueSizeSupplier.get());
+
+    final MetricName routerQueueSize = metrics.metricName(
+        PULL_REQUESTS + "-router-queue-size",
+        ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
+        "Number of pull query host fetches queued waiting for a router thread",
+        customMetricsTags
+    );
+    metrics.addMetric(routerQueueSize,
+                      (Gauge<Integer>) (config, now) -> routerQueueSizeSupplier.get());
   }
 
   private void addRequestMetricsToSensor(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/PullQueryExecutorMetrics.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/PullQueryExecutorMetrics.java
@@ -65,10 +65,13 @@ public class PullQueryExecutorMetrics implements Closeable {
   private final Map<MetricsKey, Sensor> latencySensorMap;
   private final Sensor requestRateSensor;
   private final Sensor requestsOfferedSensor;
+  private final Sensor requestsForwardedInSensor;
+  private final Sensor queueRejectedSensor;
   private final Sensor coordinatorQueueWaitSensor;
   private final Sensor routerQueueWaitSensor;
   private final Sensor coordinatorServiceTimeSensor;
   private final Sensor routerServiceTimeSensor;
+  private final Sensor clientDisconnectedSensor;
   private final Sensor errorRateSensor;
   private final Map<MetricsKey, Sensor> errorRateSensorMap;
   private final Sensor requestSizeSensor;
@@ -120,6 +123,8 @@ public class PullQueryExecutorMetrics implements Closeable {
     this.latencySensorMap = configureLatencySensorMap();
     this.requestRateSensor = configureRateSensor();
     this.requestsOfferedSensor = configureRequestsOfferedSensor();
+    this.requestsForwardedInSensor = configureRequestsForwardedInSensor();
+    this.queueRejectedSensor = configureQueueRejectedSensor();
     this.coordinatorQueueWaitSensor = configureDurationSensor(
         "coordinator-queue-wait",
         "queued waiting for a coordinator thread");
@@ -132,6 +137,7 @@ public class PullQueryExecutorMetrics implements Closeable {
     this.routerServiceTimeSensor = configureDurationSensor(
         "router-service-time",
         "executing on a router thread, excluding time queued");
+    this.clientDisconnectedSensor = configureClientDisconnectedSensor();
     this.errorRateSensor = configureErrorRateSensor();
     this.errorRateSensorMap = configureErrorSensorMap();
     this.requestSizeSensor = configureRequestSizeSensor();
@@ -170,13 +176,27 @@ public class PullQueryExecutorMetrics implements Closeable {
   /**
    * Records a pull query as it arrives, before any admission decision is made.
    *
-   * <p>This is deliberately distinct from {@code pull-query-requests-rate}, which is recorded
-   * from {@code recordLatency} once a query has finished and therefore measures the rate of
-   * <em>completions</em>. Under saturation nothing completes, so that metric falls towards zero
-   * exactly when load is highest. This one measures offered load.
+   * <p>Client requests and peer-forwarded fetches are counted separately: one client query fans
+   * out to every node holding a relevant partition, so counting them together overstates client
+   * demand by the fan-out factor.
+   *
+   * <p>Distinct from {@code pull-query-requests-rate}, which is recorded once a query finishes
+   * and so measures completions. Under saturation nothing completes.
    */
-  public void recordRequestOffered() {
-    this.requestsOfferedSensor.record(1);
+  public void recordRequestOffered(final boolean forwardedFromPeer) {
+    if (forwardedFromPeer) {
+      this.requestsForwardedInSensor.record(1);
+    } else {
+      this.requestsOfferedSensor.record(1);
+    }
+  }
+
+  /**
+   * A query turned away because a queue was full. The rate and concurrency limiters count their
+   * own rejections separately, so this is not a total of all rejections.
+   */
+  public void recordQueueRejected() {
+    this.queueRejectedSensor.record(1);
   }
 
   /** Time queued before a coordinator thread picked the query up. */
@@ -202,6 +222,10 @@ public class PullQueryExecutorMetrics implements Closeable {
     this.routerServiceTimeSensor.record(TimeUnit.NANOSECONDS.toMicros(serviceNanos));
   }
 
+  /** A client disconnected before its response completed; the query still runs to completion. */
+  public void recordClientDisconnected() {
+    this.clientDisconnectedSensor.record(1);
+  }
 
   public void recordLocalRequests(final double value) {
     this.localRequestsSensor.record(value);
@@ -466,7 +490,62 @@ public class PullQueryExecutorMetrics implements Closeable {
         sensor,
         PULL_REQUESTS + "-offered-total",
         ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
-        "Total pull query requests arriving, counted before any admission check",
+        "Total pull query requests arriving from clients, counted before any admission check",
+        customMetricsTags,
+        new CumulativeCount()
+    );
+
+    sensors.add(sensor);
+    return sensor;
+  }
+
+  private Sensor configureRequestsForwardedInSensor() {
+    final Sensor sensor = metrics.sensor(
+        PULL_QUERY_METRIC_GROUP + "-" + PULL_REQUESTS + "-forwarded-in");
+
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-forwarded-in-rate",
+        ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
+        "Rate of per-host fetches arriving from a peer node. These bypass admission limits "
+            + "unless ksql.query.pull.limit.forwarded.requests is set.",
+        customMetricsTags,
+        new Rate()
+    );
+
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-forwarded-in-total",
+        ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
+        "Total per-host fetches arriving from a peer node",
+        customMetricsTags,
+        new CumulativeCount()
+    );
+
+    sensors.add(sensor);
+    return sensor;
+  }
+
+  private Sensor configureQueueRejectedSensor() {
+    final Sensor sensor = metrics.sensor(
+        PULL_QUERY_METRIC_GROUP + "-" + PULL_REQUESTS + "-queue-rejected");
+
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-queue-rejected-rate",
+        ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
+        "Rate of pull queries turned away because a queue was full. Not counted by the "
+            + "latency, error or status-code metrics. The rate and concurrency limiters count "
+            + "their own rejections separately.",
+        customMetricsTags,
+        new Rate()
+    );
+
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-queue-rejected-total",
+        ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
+        "Total pull queries turned away because a queue was full",
         customMetricsTags,
         new CumulativeCount()
     );
@@ -527,6 +606,32 @@ public class PullQueryExecutorMetrics implements Closeable {
     return sensor;
   }
 
+  private Sensor configureClientDisconnectedSensor() {
+    final Sensor sensor = metrics.sensor(
+        PULL_QUERY_METRIC_GROUP + "-" + PULL_REQUESTS + "-client-disconnected");
+
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-client-disconnected-rate",
+        ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
+        "Rate of pull queries whose client disconnected before the response completed. "
+            + "Counts the disconnect regardless of whether the query is then cancelled.",
+        customMetricsTags,
+        new Rate()
+    );
+
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-client-disconnected-total",
+        ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
+        "Total pull queries whose client disconnected before the response completed",
+        customMetricsTags,
+        new CumulativeCount()
+    );
+
+    sensors.add(sensor);
+    return sensor;
+  }
 
   private Sensor configureRateSensor() {
     final Sensor sensor = metrics.sensor(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/execution/pull/HARoutingTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/execution/pull/HARoutingTest.java
@@ -503,6 +503,43 @@ public class HARoutingTest {
   }
 
   @Test
+  public void shouldSizeTheQueueFromThePoolByDefault() throws Exception {
+    // Given: the shipped defaults, where neither capacity is set explicitly.
+    final KsqlConfig defaults = new KsqlConfig(ImmutableMap.of());
+    assertThat(defaults.getInt(KsqlConfig.KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_CONFIG),
+        is(KsqlConfig.KSQL_QUERY_PULL_QUEUE_CAPACITY_MATCH_POOL));
+
+    // When: two coordinator threads, so a bound that tracked the pool admits exactly two more
+    when(ksqlConfig.getInt(KsqlConfig.KSQL_QUERY_PULL_THREAD_POOL_SIZE_CONFIG)).thenReturn(2);
+    when(ksqlConfig.getInt(KsqlConfig.KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_CONFIG))
+        .thenReturn(KsqlConfig.KSQL_QUERY_PULL_QUEUE_CAPACITY_MATCH_POOL);
+    locate(location1, location2, location3, location4);
+    final CountDownLatch release = new CountDownLatch(1);
+    lenient().doAnswer(a -> {
+      release.await(10, TimeUnit.SECONDS);
+      return null;
+    }).when(pullPhysicalPlan).execute(any(), any(), any());
+
+    try (HARouting routing = new HARouting(
+        routingFilterFactory, Optional.of(pullMetrics), ksqlConfig)) {
+      // occupy both threads, then both queue slots
+      for (int i = 0; i < 4; i++) {
+        routing.handlePullQuery(serviceContext, pullPhysicalPlan, statement, routingOptions,
+            pullQueryQueue, disconnect);
+      }
+
+      // Then: the fifth is refused, so the bound resolved to the pool size rather than staying
+      // unbounded. A ratio other than 1 is what the queue-bound testing showed to be wrong.
+      final Exception e = assertThrows(KsqlRateLimitException.class, () ->
+          routing.handlePullQuery(serviceContext, pullPhysicalPlan, statement, routingOptions,
+              pullQueryQueue, disconnect));
+      assertThat(e.getMessage(), containsString("queue is full"));
+    } finally {
+      release.countDown();
+    }
+  }
+
+  @Test
   public void shouldDropHostsAlreadySubmittedWhenTheRouterQueueFillsMidRound() throws Exception {
     // Given: one router thread and room for one queued host, and a round that fans out to three.
     // The third submit is refused, which could not happen before the queue was bounded.

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/execution/pull/HARoutingTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/execution/pull/HARoutingTest.java
@@ -53,8 +53,11 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.SimpleKsqlClient;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlConstants;
+import io.confluent.ksql.util.KsqlRateLimitException;
 import io.confluent.ksql.util.KsqlHostInfo;
 import io.confluent.ksql.util.KsqlRequestConfig;
+import io.confluent.ksql.util.ReservedInternalTopics;
 import io.vertx.core.streams.WriteStream;
 import java.net.URI;
 import java.util.Collections;
@@ -63,6 +66,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -491,6 +495,54 @@ public class HARoutingTest {
     assertThat(pullQueryQueue.size(), is(0));
     assertThat(Throwables.getRootCause(e).getMessage(),
         containsString("Exhausted standby hosts to try."));
+  }
+
+  @Test
+  public void shouldReportAFullCoordinatorQueueAsRetriable() throws Exception {
+    // Given: one coordinator thread and room for one queued query. Without a retriable
+    // rejection the client is told its request was malformed rather than that the server
+    // is at capacity.
+    when(ksqlConfig.getInt(KsqlConfig.KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_CONFIG))
+        .thenReturn(1);
+    final CountDownLatch occupied = new CountDownLatch(1);
+    final CountDownLatch release = new CountDownLatch(1);
+    locate(location1, location2, location3, location4);
+    doAnswer(a -> {
+      occupied.countDown();
+      release.await(10, TimeUnit.SECONDS);
+      return null;
+    }).when(pullPhysicalPlan).execute(any(), any(), any());
+
+    try (HARouting routing = new HARouting(
+        routingFilterFactory, Optional.of(pullMetrics), ksqlConfig)) {
+      // occupy the only thread, then fill the only queue slot
+      routing.handlePullQuery(serviceContext, pullPhysicalPlan, statement, routingOptions,
+          pullQueryQueue, disconnect);
+      assertThat("first query should have started", occupied.await(10, TimeUnit.SECONDS), is(true));
+      routing.handlePullQuery(serviceContext, pullPhysicalPlan, statement, routingOptions,
+          pullQueryQueue, disconnect);
+
+      // When: one more arrives with nowhere to go
+      final Exception e = assertThrows(KsqlRateLimitException.class, () ->
+          routing.handlePullQuery(serviceContext, pullPhysicalPlan, statement, routingOptions,
+              pullQueryQueue, disconnect));
+
+      // Then: it says the server is at capacity, not that the statement was bad
+      assertThat(e.getMessage(), containsString("queue is full"));
+      // and the rejection is counted; no other metric counts it.
+      assertThat(queueRejectedTotal(), is(1.0));
+    } finally {
+      release.countDown();
+    }
+  }
+
+  private double queueRejectedTotal() {
+    final Metrics metrics = pullMetrics.getMetrics();
+    return (Double) metrics.metric(metrics.metricName(
+        "pull-query-requests-queue-rejected-total",
+        ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX + "pull-query",
+        ImmutableMap.of(KsqlConstants.KSQL_SERVICE_ID_METRICS_TAG, KSQL_SERVICE_ID)))
+        .metricValue();
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/execution/pull/HARoutingTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/execution/pull/HARoutingTest.java
@@ -65,6 +65,7 @@ import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.Time;
 import org.junit.After;
@@ -493,8 +494,32 @@ public class HARoutingTest {
   }
 
   @Test
+  public void shouldSkipQueryAlreadyCancelledBeforeItRuns()
+      throws ExecutionException, InterruptedException {
+    // Given: the client went away while the query sat in the pool queue
+    locate(location1, location2, location3, location4);
+    when(disconnect.isDone()).thenReturn(true);
+
+    // When:
+    final CompletableFuture<Void> future = haRouting.handlePullQuery(
+        serviceContext, pullPhysicalPlan, statement, routingOptions,
+        pullQueryQueue, disconnect);
+    future.get();
+
+    // Then: no work is done for a query nobody is waiting for
+    verify(pullPhysicalPlan, never()).execute(any(), any(), any());
+    verify(ksqlClient, never())
+        .makeQueryRequest(any(), any(), any(), any(), any(), any(), any());
+    assertThat(pullQueryQueue.size(), is(0));
+    assertThat(pullQueryQueue.isDone(), is(true));
+  }
+
+  @Test
   public void forwardingError_cancelled() throws ExecutionException, InterruptedException {
-    // Given:
+    // Given: the client disconnects while the request is in flight, not before it starts -
+    // a request already known to be cancelled is now skipped on dequeue, so stubbing isDone()
+    // true up front would test that skip rather than the error suppression this covers.
+    final AtomicBoolean cancelled = new AtomicBoolean(false);
     locate(location5);
     when(ksqlClient.makeQueryRequest(eq(node2.location()), any(), any(), any(), any(), any(), any()))
         .thenAnswer(a -> {
@@ -504,9 +529,10 @@ public class HARoutingTest {
                   StreamedRow.header(queryId, logicalSchema),
                   StreamedRow.pullRow(GenericRow.fromList(ROW2), Optional.empty())));
 
+          cancelled.set(true);
           throw new RuntimeException("Cancelled");
         });
-    when(disconnect.isDone()).thenReturn(true);
+    when(disconnect.isDone()).thenAnswer(a -> cancelled.get());
 
     // When:
     CompletableFuture<Void> future = haRouting.handlePullQuery(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/execution/pull/HARoutingTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/execution/pull/HARoutingTest.java
@@ -503,16 +503,17 @@ public class HARoutingTest {
   }
 
   @Test
-  public void shouldSizeTheQueueFromThePoolByDefault() throws Exception {
-    // Given: the shipped defaults, where neither capacity is set explicitly.
+  public void shouldDefaultToUnboundedAndBoundOnlyWhenConfigured() throws Exception {
+    // Given: the default capacity is unbounded, preserving pre-existing behaviour — a binary
+    // upgrade must not start rejecting. Bounding is opt-in via an explicit positive value.
     final KsqlConfig defaults = new KsqlConfig(ImmutableMap.of());
     assertThat(defaults.getInt(KsqlConfig.KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_CONFIG),
-        is(KsqlConfig.KSQL_QUERY_PULL_QUEUE_CAPACITY_MATCH_POOL));
+        is(Integer.MAX_VALUE));
 
-    // When: two coordinator threads, so a bound that tracked the pool admits exactly two more
+    // When: two coordinator threads and an explicit bound of 2, so it admits exactly two more
     when(ksqlConfig.getInt(KsqlConfig.KSQL_QUERY_PULL_THREAD_POOL_SIZE_CONFIG)).thenReturn(2);
     when(ksqlConfig.getInt(KsqlConfig.KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_CONFIG))
-        .thenReturn(KsqlConfig.KSQL_QUERY_PULL_QUEUE_CAPACITY_MATCH_POOL);
+        .thenReturn(2);
     locate(location1, location2, location3, location4);
     final CountDownLatch release = new CountDownLatch(1);
     lenient().doAnswer(a -> {
@@ -528,8 +529,7 @@ public class HARoutingTest {
             pullQueryQueue, disconnect);
       }
 
-      // Then: the fifth is refused, so the bound resolved to the pool size rather than staying
-      // unbounded. A ratio other than 1 is what the queue-bound testing showed to be wrong.
+      // Then: the fifth is refused — the explicit bound engaged.
       final Exception e = assertThrows(KsqlRateLimitException.class, () ->
           routing.handlePullQuery(serviceContext, pullPhysicalPlan, statement, routingOptions,
               pullQueryQueue, disconnect));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/execution/pull/HARoutingTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/execution/pull/HARoutingTest.java
@@ -17,11 +17,14 @@ package io.confluent.ksql.execution.pull;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -100,6 +103,8 @@ public class HARoutingTest {
   private KsqlNode node1;
   @Mock
   private KsqlNode node2;
+  @Mock
+  private KsqlNode node3;
   @Mock
   private KsqlNode badNode;
   @Mock
@@ -495,6 +500,98 @@ public class HARoutingTest {
     assertThat(pullQueryQueue.size(), is(0));
     assertThat(Throwables.getRootCause(e).getMessage(),
         containsString("Exhausted standby hosts to try."));
+  }
+
+  @Test
+  public void shouldDropHostsAlreadySubmittedWhenTheRouterQueueFillsMidRound() throws Exception {
+    // Given: one router thread and room for one queued host, and a round that fans out to three.
+    // The third submit is refused, which could not happen before the queue was bounded.
+    when(ksqlConfig.getInt(KsqlConfig.KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_CONFIG))
+        .thenReturn(1);
+    // Only getHost is stubbed: node3 is refused at submit, so its task never runs and never
+    // asks whether it is local or where it lives.
+    when(node3.getHost()).thenReturn(Host.include(new KsqlHostInfo("node3", 8090)));
+    final PartitionLocation onNode1 =
+        new PartitionLocation(Optional.empty(), 1, ImmutableList.of(node1));
+    final PartitionLocation onNode2 =
+        new PartitionLocation(Optional.empty(), 2, ImmutableList.of(node2));
+    final PartitionLocation onNode3 =
+        new PartitionLocation(Optional.empty(), 3, ImmutableList.of(node3));
+    locate(onNode1, onNode2, onNode3);
+
+    // node1 holds the single router thread so node2 is still sitting in the queue, unstarted,
+    // at the moment node3 is refused.
+    // Lenient because node1 need not get as far as running: if it is still queued when node3 is
+    // refused it is dropped too, which is equally the behaviour under test.
+    final CountDownLatch release = new CountDownLatch(1);
+    lenient().doAnswer(a -> {
+      release.await(10, TimeUnit.SECONDS);
+      return null;
+    }).when(pullPhysicalPlan).execute(any(), any(), any());
+
+    try (HARouting routing = new HARouting(
+        routingFilterFactory, Optional.of(pullMetrics), ksqlConfig)) {
+      // When: node1 takes the only router thread, node2 fills the only queue slot, node3 is refused
+      final CompletableFuture<Void> future = routing.handlePullQuery(
+          serviceContext, pullPhysicalPlan, statement, routingOptions, pullQueryQueue, disconnect);
+
+      final Exception e = assertThrows(ExecutionException.class, future::get);
+
+      // Then: the round is refused as a rate limit
+      assertThat(Throwables.getRootCause(e), instanceOf(KsqlRateLimitException.class));
+      assertThat(Throwables.getRootCause(e).getMessage(), containsString("queue is full"));
+    } finally {
+      release.countDown();
+    }
+
+    // and node2, which was still queued when the round was given up on, never runs. Left
+    // submitted it would take a router thread to forward a result nothing is waiting for.
+    verify(ksqlClient, after(500).never())
+        .makeQueryRequest(eq(node2.location()), any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void shouldKeepARemoteRejectionRetriable() {
+    // Given: the node holding the data is at capacity and answers 429. Every other erroneous
+    // status becomes a MaterializationException, which reads as a server fault.
+    locate(location2);
+    when(ksqlClient.makeQueryRequest(eq(node2.location()), any(), any(), any(), any(), any(), any()))
+        .thenAnswer(i -> {
+          final WriteStream<List<StreamedRow>> rowConsumer = i.getArgument(4);
+          rowConsumer.write(ImmutableList.of());
+          return RestResponse.erroneous(429, "Pull query rejected: the coordinator queue is full.");
+        });
+
+    // When:
+    final CompletableFuture<Void> future = haRouting.handlePullQuery(
+        serviceContext, pullPhysicalPlan, statement, routingOptions, pullQueryQueue, disconnect);
+    final Exception e = assertThrows(ExecutionException.class, future::get);
+
+    // Then: the peer's rejection arrives as a rate limit rather than a generic failure, so the
+    // caller is told to back off instead of being handed an opaque error.
+    assertThat(Throwables.getRootCause(e), instanceOf(KsqlRateLimitException.class));
+    assertThat(Throwables.getRootCause(e).getMessage(), containsString("queue is full"));
+    assertThat(pullQueryQueue.size(), is(0));
+  }
+
+  @Test
+  public void shouldNotRetryARemoteRejectionOnAStandby() throws Exception {
+    // Given: two nodes hold the partition and the first is at capacity.
+    locate(location4);
+    when(ksqlClient.makeQueryRequest(any(), any(), any(), any(), any(), any(), any()))
+        .thenAnswer(i -> RestResponse.erroneous(429, "at capacity"));
+
+    // When:
+    final CompletableFuture<Void> future = haRouting.handlePullQuery(
+        serviceContext, pullPhysicalPlan, statement, routingOptions, pullQueryQueue, disconnect);
+    assertThrows(ExecutionException.class, future::get);
+
+    // Then: the standby is not tried. Re-sending to another node while the cluster is already
+    // refusing work adds load to the thing that is short of capacity. location4's standby is
+    // the local node, so a fallback would show up as a local execute rather than a second call.
+    verify(ksqlClient, times(1))
+        .makeQueryRequest(any(), any(), any(), any(), any(), any(), any());
+    verify(pullPhysicalPlan, never()).execute(any(), any(), any());
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/execution/pull/HARoutingTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/execution/pull/HARoutingTest.java
@@ -158,6 +158,10 @@ public class HARoutingTest {
         .thenReturn(1);
     when(ksqlConfig.getInt(KsqlConfig.KSQL_QUERY_PULL_ROUTER_THREAD_POOL_SIZE_CONFIG))
         .thenReturn(1);
+    when(ksqlConfig.getInt(KsqlConfig.KSQL_QUERY_PULL_COORDINATOR_QUEUE_CAPACITY_CONFIG))
+        .thenReturn(Integer.MAX_VALUE);
+    when(ksqlConfig.getInt(KsqlConfig.KSQL_QUERY_PULL_ROUTER_QUEUE_CAPACITY_CONFIG))
+        .thenReturn(Integer.MAX_VALUE);
 
     when(serviceContext.getKsqlClient()).thenReturn(ksqlClient);
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/BlockingQueryPublisher.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/BlockingQueryPublisher.java
@@ -66,6 +66,9 @@ public class BlockingQueryPublisher extends BasePublisher<KeyValueMetadata<List<
   private boolean hitLimit;
   private volatile boolean closed;
   private volatile boolean started;
+  // Holds a pull-query failure that arrived before a subscriber attached, so it can be replayed
+  // on subscribe rather than lost to the subscribe race. Only touched on the Vert.x context.
+  private Throwable pendingError;
 
   public BlockingQueryPublisher(final Context ctx,
       final WorkerExecutor workerExecutor) {
@@ -114,7 +117,7 @@ public class BlockingQueryPublisher extends BasePublisher<KeyValueMetadata<List<
       }
     });
     this.queryHandle = queryHandle;
-    queryHandle.onException(t -> ctx.runOnContext(v -> sendError(t)));
+    queryHandle.onException(t -> ctx.runOnContext(v -> deliverError(t)));
   }
 
   @Override
@@ -180,6 +183,25 @@ public class BlockingQueryPublisher extends BasePublisher<KeyValueMetadata<List<
     if (!started) {
       started = true;
       executeOnWorker(queryHandle::start);
+    }
+    // A pull-query failure that raced ahead of this subscriber was held back (see deliverError);
+    // now that the subscriber is attached, deliver it so it reaches the subscriber's onError.
+    if (pendingError != null) {
+      final Throwable e = pendingError;
+      pendingError = null;
+      sendError(e);
+    }
+  }
+
+  // A pull query's result can fail asynchronously (e.g. a router-queue rejection) before the
+  // client's subscriber has attached. Calling sendError then would drop it (no subscriber) and
+  // mark the publisher failed, so the later subscribe would not deliver it. For pull queries we
+  // hold it until afterSubscribe; push queries keep the immediate behaviour.
+  private void deliverError(final Throwable t) {
+    if (isPullQuery && getSubscriber() == null) {
+      pendingError = t;
+    } else {
+      sendError(t);
     }
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
@@ -290,8 +290,8 @@ public class QueryEndpoint {
       } catch (KsqlRateLimitException e) {
         // Rethrown unwrapped: wrapping it as a statement exception below would report a server
         // at capacity as a malformed statement (HTTP 400), telling the client not to retry.
-        pullQueryMetrics.ifPresent(metrics -> metrics.recordErrorRate(1, result.getSourceType(),
-            result.getPlanType(), result.getRoutingNodeType()));
+        // Deliberately left out of the error metric: a retriable rejection is load shed, not a
+        // query failure, and a full queue is already counted by queue-rejected.
         throw e;
       } catch (Exception e) {
         pullQueryMetrics.ifPresent(metrics -> metrics.recordErrorRate(1, result.getSourceType(),

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
@@ -40,6 +40,7 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.ConsistencyOffsetVector;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlRateLimitException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PushQueryMetadata;
 import io.confluent.ksql.util.PushQueryMetadata.ResultType;
@@ -286,6 +287,12 @@ public class QueryEndpoint {
         result.onException(future::completeExceptionally);
         result.onCompletion(future::complete);
         result.start();
+      } catch (KsqlRateLimitException e) {
+        // Rethrown unwrapped: wrapping it as a statement exception below would report a server
+        // at capacity as a malformed statement (HTTP 400), telling the client not to retry.
+        pullQueryMetrics.ifPresent(metrics -> metrics.recordErrorRate(1, result.getSourceType(),
+            result.getPlanType(), result.getRoutingNodeType()));
+        throw e;
       } catch (Exception e) {
         pullQueryMetrics.ifPresent(metrics -> metrics.recordErrorRate(1, result.getSourceType(),
             result.getPlanType(), result.getRoutingNodeType()));

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QueryStreamHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QueryStreamHandler.java
@@ -27,11 +27,13 @@ import io.confluent.ksql.api.server.JsonStreamedRowResponseWriter.RowFormat;
 import io.confluent.ksql.api.spi.Endpoints;
 import io.confluent.ksql.api.spi.QueryPublisher;
 import io.confluent.ksql.api.util.ApiServerUtils;
+import io.confluent.ksql.internal.PullQueryExecutorMetrics;
 import io.confluent.ksql.properties.ConfigOverrideLogger;
 import io.confluent.ksql.rest.entity.KsqlMediaType;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.entity.QueryResponseMetadata;
 import io.confluent.ksql.rest.entity.QueryStreamArgs;
+import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.LogicalSchema.Builder;
 import io.vertx.core.Context;
@@ -64,6 +66,7 @@ public class QueryStreamHandler implements Handler<RoutingContext> {
   private final Context context;
   private final Server server;
   private final boolean queryCompatibilityMode;
+  private final boolean cancelOnDisconnect;
 
   @SuppressFBWarnings(value = "EI_EXPOSE_REP2")
   public QueryStreamHandler(final Endpoints endpoints,
@@ -77,6 +80,9 @@ public class QueryStreamHandler implements Handler<RoutingContext> {
     this.context = Objects.requireNonNull(context);
     this.server = Objects.requireNonNull(server);
     this.queryCompatibilityMode = queryCompatibilityMode;
+    // Read once: the value cannot change after startup, and this is on the per-query path.
+    this.cancelOnDisconnect = server.getConfig()
+        .getBoolean(KsqlRestConfig.KSQL_QUERY_PULL_CANCEL_ON_DISCONNECT_ENABLED_CONFIG);
   }
 
   @Override
@@ -220,6 +226,10 @@ public class QueryStreamHandler implements Handler<RoutingContext> {
     // call to the end handler, which will mess up metrics, so we ensure that this called just
     // once by keeping track of the calls.
     final AtomicBoolean endedResponse = new AtomicBoolean(false);
+    // Set by QuerySubscriber once the query has produced its last row. Neither endedResponse nor
+    // response().ended() can stand in for this: both also become true when the client aborts, so
+    // they cannot say whether the server got to finish.
+    final AtomicBoolean serverCompleted = new AtomicBoolean(false);
 
     if (queryPublisher.isPullQuery()) {
       metadata = new QueryResponseMetadata(
@@ -231,7 +241,7 @@ public class QueryStreamHandler implements Handler<RoutingContext> {
       bufferOutput = true;
 
       // When response is complete, publisher should be closed
-      routingContext.response().endHandler(v -> {
+      final Handler<Void> pullQueryCleanup = v -> {
         if (endedResponse.getAndSet(true)) {
           log.warn("Connection already closed so just returning");
           return;
@@ -242,6 +252,40 @@ public class QueryStreamHandler implements Handler<RoutingContext> {
             routingContext.request().bytesRead(),
             routingContext.response().bytesWritten(),
             startTimeNanos);
+      };
+      routingContext.response().endHandler(pullQueryCleanup);
+
+      // The end handler above only runs once the response has been ended by the server. If the
+      // client goes away mid-response it never fires, so the publisher is never closed and the
+      // query keeps executing with nothing waiting for its result. Closing the publisher
+      // completes the query's cancellation future, which the scan operators poll between rows,
+      // so the query stops promptly instead of running to completion.
+      //
+      // The /query endpoint has always done this (OldApiUtils installs a connection close
+      // handler) and scalable push queries are covered by ConnectionQueryManager; pull queries on
+      // this endpoint are the gap. Behind a flag because running to completion is the existing
+      // behaviour and we want to be able to measure both.
+      // response(), not request().connection(): the handler must be per-response, not
+      // per-connection. HTTP/2 multiplexes many queries onto one connection, so abandoning a
+      // single query resets its stream and leaves the connection open - a connection-level
+      // handler would never fire. HttpConnection.closeHandler is also a setter, so one handler
+      // per connection: registering per request would have each query silently overwrite the
+      // previous one's. HttpServerResponse.closeHandler is documented as always called on
+      // HTTP/2 stream close, and on HTTP/1.x when the connection closes before end().
+      //
+      // Registered unconditionally so disconnects are counted even when cancellation is off.
+      routingContext.response().closeHandler(v -> {
+        // On HTTP/2 this fires for every stream close, including normal ones, so it has to be
+        // filtered. serverCompleted is the only signal that separates the two: the query
+        // produced its last row before the stream closed.
+        if (serverCompleted.get()) {
+          return;
+        }
+        server.getPullQueryMetrics()
+            .ifPresent(PullQueryExecutorMetrics::recordClientDisconnected);
+        if (cancelOnDisconnect) {
+          pullQueryCleanup.handle(null);
+        }
       });
     } else if (queryPublisher.isScalablePushQuery()) {
       metadata = new QueryResponseMetadata(
@@ -295,7 +339,7 @@ public class QueryStreamHandler implements Handler<RoutingContext> {
 
     final QuerySubscriber querySubscriber = new QuerySubscriber(context,
         routingContext.response(), queryStreamResponseWriter,
-        queryPublisher::hitLimit);
+        queryPublisher::hitLimit, serverCompleted);
 
     queryPublisher.subscribe(querySubscriber);
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QuerySubscriber.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QuerySubscriber.java
@@ -29,6 +29,7 @@ import io.vertx.core.Context;
 import io.vertx.core.http.HttpServerResponse;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
@@ -46,16 +47,19 @@ public class QuerySubscriber extends BaseSubscriber<KeyValueMetadata<List<?>, Ge
   private final HttpServerResponse response;
   private final QueryStreamResponseWriter queryStreamResponseWriter;
   private final Supplier<Boolean> hitLimit;
+  private final AtomicBoolean serverCompleted;
   private int tokens;
 
   @SuppressFBWarnings(value = "EI_EXPOSE_REP2")
   public QuerySubscriber(final Context context, final HttpServerResponse response,
       final QueryStreamResponseWriter queryStreamResponseWriter,
-      final Supplier<Boolean> hitLimit) {
+      final Supplier<Boolean> hitLimit,
+      final AtomicBoolean serverCompleted) {
     super(context);
     this.response = Objects.requireNonNull(response);
     this.queryStreamResponseWriter = Objects.requireNonNull(queryStreamResponseWriter);
     this.hitLimit = hitLimit;
+    this.serverCompleted = Objects.requireNonNull(serverCompleted, "serverCompleted");
   }
 
   @Override
@@ -94,6 +98,9 @@ public class QuerySubscriber extends BaseSubscriber<KeyValueMetadata<List<?>, Ge
 
   @Override
   public void handleError(final Throwable t) {
+    // The server produced this response, even though it is an error. Without this the close
+    // handler cannot tell it from a client that walked away.
+    serverCompleted.set(true);
     final StringBuilder stringBuilder = new StringBuilder();
     stringBuilder.append(t);
     for (Throwable s: t.getSuppressed()) {
@@ -112,6 +119,9 @@ public class QuerySubscriber extends BaseSubscriber<KeyValueMetadata<List<?>, Ge
 
   @Override
   public void handleComplete() {
+    // Set before end(): end() can synchronously close the stream, and the close handler reads
+    // this to tell a server-completed response from one the client walked away from.
+    serverCompleted.set(true);
     if (hitLimit.get()) {
       queryStreamResponseWriter.writeLimitMessage();
     } else {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QuerySubscriber.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QuerySubscriber.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.api.server;
 
 import static io.confluent.ksql.rest.Errors.ERROR_CODE_SERVER_ERROR;
+import static io.confluent.ksql.rest.Errors.ERROR_CODE_TOO_MANY_REQUESTS;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.GenericRow;
@@ -25,6 +26,7 @@ import io.confluent.ksql.rest.entity.ConsistencyToken;
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.entity.PushContinuationToken;
 import io.confluent.ksql.util.KeyValueMetadata;
+import io.confluent.ksql.util.KsqlRateLimitException;
 import io.vertx.core.Context;
 import io.vertx.core.http.HttpServerResponse;
 import java.util.List;
@@ -111,10 +113,24 @@ public class QuerySubscriber extends BaseSubscriber<KeyValueMetadata<List<?>, Ge
         stringBuilder.append(s.getMessage());
       }
     }
+    // A rate-limit rejection reaches here in-stream (the response header is already committed,
+    // so it cannot be a 429 status). Code the frame retriable so a client can tell it apart
+    // from a genuine server fault and back off, rather than string-matching the message.
+    final int errorCode = causedByRateLimit(t) ? ERROR_CODE_TOO_MANY_REQUESTS
+        : ERROR_CODE_SERVER_ERROR;
     final KsqlErrorMessage errorResponse = new KsqlErrorMessage(
-        ERROR_CODE_SERVER_ERROR, stringBuilder.toString());
+        errorCode, stringBuilder.toString());
     log.error("Error in processing query {}", stringBuilder, t);
     queryStreamResponseWriter.writeError(errorResponse).end();
+  }
+
+  private static boolean causedByRateLimit(final Throwable t) {
+    for (Throwable c = t; c != null; c = c.getCause()) {
+      if (c instanceof KsqlRateLimitException) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/Server.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/Server.java
@@ -260,6 +260,10 @@ public class Server {
     return config;
   }
 
+  public Optional<PullQueryExecutorMetrics> getPullQueryMetrics() {
+    return pullQueryMetrics;
+  }
+
   void registerQueryConnection(final HttpConnection connection) {
     this.connections.add(Objects.requireNonNull(connection));
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -845,8 +845,7 @@ public final class KsqlRestApplication implements Executable {
         ksqlConfig.getInt(KsqlConfig.KSQL_QUERY_PULL_MAX_QPS_CONFIG),
         "pull",
         metricCollectors.getMetrics(),
-        metricsTags,
-        ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_LIMIT_REJECTION_RETRIABLE_CONFIG)
+        metricsTags
     );
     final ConcurrencyLimiter pullQueryConcurrencyLimiter = new ConcurrencyLimiter(
         ksqlConfig.getInt(KsqlConfig.KSQL_QUERY_PULL_MAX_CONCURRENT_REQUESTS_CONFIG),

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -845,13 +845,15 @@ public final class KsqlRestApplication implements Executable {
         ksqlConfig.getInt(KsqlConfig.KSQL_QUERY_PULL_MAX_QPS_CONFIG),
         "pull",
         metricCollectors.getMetrics(),
-        metricsTags
+        metricsTags,
+        ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_LIMIT_REJECTION_RETRIABLE_CONFIG)
     );
     final ConcurrencyLimiter pullQueryConcurrencyLimiter = new ConcurrencyLimiter(
         ksqlConfig.getInt(KsqlConfig.KSQL_QUERY_PULL_MAX_CONCURRENT_REQUESTS_CONFIG),
         "pull",
         metricCollectors.getMetrics(),
-        metricsTags
+        metricsTags,
+        ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_LIMIT_REJECTION_RETRIABLE_CONFIG)
     );
     final SlidingWindowRateLimiter pullBandRateLimiter =
         new SlidingWindowRateLimiter(

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -851,8 +851,7 @@ public final class KsqlRestApplication implements Executable {
         ksqlConfig.getInt(KsqlConfig.KSQL_QUERY_PULL_MAX_CONCURRENT_REQUESTS_CONFIG),
         "pull",
         metricCollectors.getMetrics(),
-        metricsTags,
-        ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_LIMIT_REJECTION_RETRIABLE_CONFIG)
+        metricsTags
     );
     final SlidingWindowRateLimiter pullBandRateLimiter =
         new SlidingWindowRateLimiter(

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -372,7 +372,7 @@ public class KsqlRestConfig extends AbstractConfig {
 
   public static final String KSQL_QUERY_PULL_CANCEL_ON_DISCONNECT_ENABLED_CONFIG
       = "ksql.query.pull.cancel.on.disconnect.enabled";
-  private static final boolean KSQL_QUERY_PULL_CANCEL_ON_DISCONNECT_ENABLED_DEFAULT = true;
+  private static final boolean KSQL_QUERY_PULL_CANCEL_ON_DISCONNECT_ENABLED_DEFAULT = false;
   private static final String KSQL_QUERY_PULL_CANCEL_ON_DISCONNECT_ENABLED_DOC
       = "Whether a pull query on the /query-stream endpoint is cancelled when the client closes "
       + "the connection. Cleanup on that endpoint is currently driven by the response end "

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -370,6 +370,17 @@ public class KsqlRestConfig extends AbstractConfig {
   private static final String KSQL_LOGGING_SERVER_RATE_LIMITED_REQUEST_PATHS_DOC =
       "A list of path:rate_limit pairs, to rate limit the server request logging";
 
+  public static final String KSQL_QUERY_PULL_CANCEL_ON_DISCONNECT_ENABLED_CONFIG
+      = "ksql.query.pull.cancel.on.disconnect.enabled";
+  private static final boolean KSQL_QUERY_PULL_CANCEL_ON_DISCONNECT_ENABLED_DEFAULT = false;
+  private static final String KSQL_QUERY_PULL_CANCEL_ON_DISCONNECT_ENABLED_DOC
+      = "Whether a pull query on the /query-stream endpoint is cancelled when the client closes "
+      + "the connection. Cleanup on that endpoint is currently driven by the response end "
+      + "handler, which does not run when the client disconnects mid-response, so the query runs "
+      + "to completion with nothing waiting for the result. The older /query endpoint has always "
+      + "cancelled on disconnect, and scalable push queries are covered by "
+      + "ConnectionQueryManager. Defaults to false to preserve existing behaviour.";
+
   public static final String KSQL_LOCAL_COMMANDS_LOCATION_CONFIG = "ksql.local.commands.location";
   public static final String KSQL_LOCAL_COMMANDS_LOCATION_DEFAULT = "";
   public static final String KSQL_LOCAL_COMMANDS_LOCATION_DOC = "Specify the directory where "
@@ -791,6 +802,12 @@ public class KsqlRestConfig extends AbstractConfig {
             KSQL_ENDPOINT_LOGGING_LOG_QUERIES_DEFAULT,
             Importance.LOW,
             KSQL_ENDPOINT_LOGGING_LOG_QUERIES_DOC
+        ).define(
+            KSQL_QUERY_PULL_CANCEL_ON_DISCONNECT_ENABLED_CONFIG,
+            Type.BOOLEAN,
+            KSQL_QUERY_PULL_CANCEL_ON_DISCONNECT_ENABLED_DEFAULT,
+            Importance.MEDIUM,
+            KSQL_QUERY_PULL_CANCEL_ON_DISCONNECT_ENABLED_DOC
         ).define(
             KSQL_INTERNAL_HTTP2_MAX_POOL_SIZE_CONFIG,
             Type.INT,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -372,7 +372,7 @@ public class KsqlRestConfig extends AbstractConfig {
 
   public static final String KSQL_QUERY_PULL_CANCEL_ON_DISCONNECT_ENABLED_CONFIG
       = "ksql.query.pull.cancel.on.disconnect.enabled";
-  private static final boolean KSQL_QUERY_PULL_CANCEL_ON_DISCONNECT_ENABLED_DEFAULT = false;
+  private static final boolean KSQL_QUERY_PULL_CANCEL_ON_DISCONNECT_ENABLED_DEFAULT = true;
   private static final String KSQL_QUERY_PULL_CANCEL_ON_DISCONNECT_ENABLED_DOC
       = "Whether a pull query on the /query-stream endpoint is cancelled when the client closes "
       + "the connection. Cleanup on that endpoint is currently driven by the response end "

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/query/QueryExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/query/QueryExecutor.java
@@ -281,8 +281,8 @@ public class QueryExecutor {
         configured.getSessionConfig().getOverrides()
     );
 
-    // A request is considered forwarded if the request has the forwarded flag or if the request
-    // is from an internal listener.
+    // A request counts as forwarded only if it carries the forwarded flag AND arrived on the
+    // internal listener, so a client cannot skip the limits below by setting the flag itself.
     final boolean isAlreadyForwarded = routingOptions.getIsSkipForwardRequest()
         // Trust the forward request option if isInternalRequest isn't available.
         && isInternalRequest.orElse(true);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/query/QueryExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/query/QueryExecutor.java
@@ -82,7 +82,6 @@ public class QueryExecutor {
   private final HARouting routing;
   private final PushRouting pushRouting;
   private final Optional<LocalCommands> localCommands;
-  private final boolean limitForwardedRequests;
 
   @SuppressWarnings("ParameterNumber")
   @SuppressFBWarnings("EI_EXPOSE_REP2")
@@ -111,8 +110,6 @@ public class QueryExecutor {
     this.routing = routing;
     this.pushRouting = pushRouting;
     this.localCommands = localCommands;
-    this.limitForwardedRequests = ksqlConfig.getBoolean(
-        KsqlConfig.KSQL_QUERY_PULL_LIMIT_FORWARDED_REQUESTS_CONFIG);
   }
 
   @SuppressWarnings("unchecked")
@@ -294,16 +291,10 @@ public class QueryExecutor {
     // is being admitted or completed. Client and forwarded arrivals are counted separately.
     pullQueryMetrics.ifPresent(m -> m.recordRequestOffered(isAlreadyForwarded));
 
-    // Historically the limits are applied only at the host the client connected to, so traffic
-    // forwarded from a peer is unlimited: a saturated peer can exhaust this node's thread pools
-    // however low the configured limits are. Setting
-    // ksql.query.pull.limit.forwarded.requests=true applies them to forwarded requests too, at
-    // the cost of counting a fanned-out query once per node it touches.
-    final boolean applyLimits = !isAlreadyForwarded || limitForwardedRequests;
-
+    // Only check the rate limit at the forwarding host
     Decrementer decrementer = null;
     try {
-      if (applyLimits) {
+      if (!isAlreadyForwarded) {
         rateLimiter.checkLimit();
         decrementer = concurrencyLimiter.increment();
       }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/query/QueryExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/query/QueryExecutor.java
@@ -288,8 +288,8 @@ public class QueryExecutor {
     // even when nothing is being admitted or completed.
     pullQueryMetrics.ifPresent(PullQueryExecutorMetrics::recordRequestOffered);
 
-    // A request is considered forwarded if the request has the forwarded flag or if the request
-    // is from an internal listener.
+    // A request counts as forwarded only if it carries the forwarded flag AND arrived on the
+    // internal listener, so a client cannot bypass the limits below by setting the flag itself.
     final boolean isAlreadyForwarded = routingOptions.getIsSkipForwardRequest()
         // Trust the forward request option if isInternalRequest isn't available.
         && isInternalRequest.orElse(true);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/query/QueryExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/query/QueryExecutor.java
@@ -284,15 +284,15 @@ public class QueryExecutor {
         configured.getSessionConfig().getOverrides()
     );
 
-    // Count the request before any admission decision, so that offered load stays observable
-    // even when nothing is being admitted or completed.
-    pullQueryMetrics.ifPresent(PullQueryExecutorMetrics::recordRequestOffered);
-
-    // A request counts as forwarded only if it carries the forwarded flag AND arrived on the
-    // internal listener, so a client cannot bypass the limits below by setting the flag itself.
+    // A request is considered forwarded if the request has the forwarded flag or if the request
+    // is from an internal listener.
     final boolean isAlreadyForwarded = routingOptions.getIsSkipForwardRequest()
         // Trust the forward request option if isInternalRequest isn't available.
         && isInternalRequest.orElse(true);
+
+    // Counted before any admission decision, so offered load stays observable even when nothing
+    // is being admitted or completed. Client and forwarded arrivals are counted separately.
+    pullQueryMetrics.ifPresent(m -> m.recordRequestOffered(isAlreadyForwarded));
 
     // Historically the limits are applied only at the host the client connected to, so traffic
     // forwarded from a peer is unlimited: a saturated peer can exhaust this node's thread pools

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/query/QueryExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/query/QueryExecutor.java
@@ -82,6 +82,7 @@ public class QueryExecutor {
   private final HARouting routing;
   private final PushRouting pushRouting;
   private final Optional<LocalCommands> localCommands;
+  private final boolean limitForwardedRequests;
 
   @SuppressWarnings("ParameterNumber")
   @SuppressFBWarnings("EI_EXPOSE_REP2")
@@ -110,6 +111,8 @@ public class QueryExecutor {
     this.routing = routing;
     this.pushRouting = pushRouting;
     this.localCommands = localCommands;
+    this.limitForwardedRequests = ksqlConfig.getBoolean(
+        KsqlConfig.KSQL_QUERY_PULL_LIMIT_FORWARDED_REQUESTS_CONFIG);
   }
 
   @SuppressWarnings("unchecked")
@@ -281,16 +284,26 @@ public class QueryExecutor {
         configured.getSessionConfig().getOverrides()
     );
 
+    // Count the request before any admission decision, so that offered load stays observable
+    // even when nothing is being admitted or completed.
+    pullQueryMetrics.ifPresent(PullQueryExecutorMetrics::recordRequestOffered);
+
     // A request is considered forwarded if the request has the forwarded flag or if the request
     // is from an internal listener.
     final boolean isAlreadyForwarded = routingOptions.getIsSkipForwardRequest()
         // Trust the forward request option if isInternalRequest isn't available.
         && isInternalRequest.orElse(true);
 
-    // Only check the rate limit at the forwarding host
+    // Historically the limits are applied only at the host the client connected to, so traffic
+    // forwarded from a peer is unlimited: a saturated peer can exhaust this node's thread pools
+    // however low the configured limits are. Setting
+    // ksql.query.pull.limit.forwarded.requests=true applies them to forwarded requests too, at
+    // the cost of counting a fanned-out query once per node it touches.
+    final boolean applyLimits = !isAlreadyForwarded || limitForwardedRequests;
+
     Decrementer decrementer = null;
     try {
-      if (!isAlreadyForwarded) {
+      if (applyLimits) {
         rateLimiter.checkLimit();
         decrementer = concurrencyLimiter.increment();
       }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryStreamWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryStreamWriter.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.entity.ConsistencyToken;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.KsqlRateLimitException;
 import io.confluent.ksql.util.KsqlStatementException;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -88,6 +89,11 @@ public class PullQueryStreamWriter implements StreamingOutput {
     });
     try {
       result.start();
+    } catch (KsqlRateLimitException e) {
+      // Escapes unwrapped so the resource can map it to 429. Wrapping it as a statement
+      // exception below would report a server at capacity as a malformed statement (400),
+      // telling the client not to retry.
+      throw e;
     } catch (Exception e) {
       throw new KsqlStatementException(
           e.getMessage() == null

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -42,6 +42,7 @@ import io.confluent.ksql.security.KsqlSecurityContext;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.KsqlRateLimitException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PushQueryMetadata;
 import io.confluent.ksql.version.metrics.ActivenessRegistrar;
@@ -234,6 +235,11 @@ public class StreamedQueryResource {
       }
     } catch (final TopicAuthorizationException e) {
       return errorHandler.accessDeniedFromKafkaResponse(e);
+    } catch (final KsqlRateLimitException e) {
+      // A full pull-query queue means the server is at capacity, not that the statement was
+      // bad. Map to 429 so the client backs off and retries rather than treating it as a
+      // malformed statement (400). Must precede the KsqlException catch below.
+      return Errors.tooManyRequests(e.getMessage());
     } catch (final KsqlStatementException e) {
       return Errors.badStatement(e.getRawMessage(), e.getSqlStatement());
     } catch (final KsqlException e) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/ConcurrencyLimiter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/ConcurrencyLimiter.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.rest.util;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.KsqlRateLimitException;
 import io.confluent.ksql.util.ReservedInternalTopics;
 import java.util.Map;
 import java.util.concurrent.Semaphore;
@@ -39,16 +40,27 @@ public class ConcurrencyLimiter {
   private final int limit;
   private final String operationType;
   private final Sensor rejectSensor;
+  private final boolean retriableRejection;
 
   public ConcurrencyLimiter(
       final int limit,
       final String operationType,
       final Metrics metrics,
       final Map<String, String> metricsTags) {
+    this(limit, operationType, metrics, metricsTags, false);
+  }
+
+  public ConcurrencyLimiter(
+      final int limit,
+      final String operationType,
+      final Metrics metrics,
+      final Map<String, String> metricsTags,
+      final boolean retriableRejection) {
 
     this.semaphore = new Semaphore(limit);
     this.limit = limit;
     this.operationType = operationType;
+    this.retriableRejection = retriableRejection;
 
     metrics.addMetric(
         new MetricName(
@@ -75,9 +87,12 @@ public class ConcurrencyLimiter {
   public Decrementer increment() {
     if (!semaphore.tryAcquire()) {
       rejectSensor.record();
-      throw new KsqlException(
-          String.format("Host is at concurrency limit for %s queries. Currently set to %d maximum "
-              + "concurrent operations.", operationType, limit));
+      final String message = String.format(
+          "Host is at concurrency limit for %s queries. Currently set to %d maximum "
+              + "concurrent operations.", operationType, limit);
+      throw retriableRejection
+          ? new KsqlRateLimitException(message)
+          : new KsqlException(message);
     }
     return new Decrementer();
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/ConcurrencyLimiter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/ConcurrencyLimiter.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.rest.util;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.util.KsqlException;
-import io.confluent.ksql.util.KsqlRateLimitException;
 import io.confluent.ksql.util.ReservedInternalTopics;
 import java.util.Map;
 import java.util.concurrent.Semaphore;
@@ -40,27 +39,16 @@ public class ConcurrencyLimiter {
   private final int limit;
   private final String operationType;
   private final Sensor rejectSensor;
-  private final boolean retriableRejection;
 
   public ConcurrencyLimiter(
       final int limit,
       final String operationType,
       final Metrics metrics,
       final Map<String, String> metricsTags) {
-    this(limit, operationType, metrics, metricsTags, false);
-  }
-
-  public ConcurrencyLimiter(
-      final int limit,
-      final String operationType,
-      final Metrics metrics,
-      final Map<String, String> metricsTags,
-      final boolean retriableRejection) {
 
     this.semaphore = new Semaphore(limit);
     this.limit = limit;
     this.operationType = operationType;
-    this.retriableRejection = retriableRejection;
 
     metrics.addMetric(
         new MetricName(
@@ -87,12 +75,9 @@ public class ConcurrencyLimiter {
   public Decrementer increment() {
     if (!semaphore.tryAcquire()) {
       rejectSensor.record();
-      final String message = String.format(
-          "Host is at concurrency limit for %s queries. Currently set to %d maximum "
-              + "concurrent operations.", operationType, limit);
-      throw retriableRejection
-          ? new KsqlRateLimitException(message)
-          : new KsqlException(message);
+      throw new KsqlException(
+          String.format("Host is at concurrency limit for %s queries. Currently set to %d maximum "
+              + "concurrent operations.", operationType, limit));
     }
     return new Decrementer();
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/impl/BlockingQueryPublisherTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/impl/BlockingQueryPublisherTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.impl;
+
+import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.api.server.QueryHandle;
+import io.confluent.ksql.query.BlockingRowQueue;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.util.KeyValueMetadata;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.core.WorkerExecutor;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class BlockingQueryPublisherTest {
+
+  private Vertx vertx;
+  private Context context;
+  @Mock
+  private WorkerExecutor workerExecutor;
+  @Mock
+  private QueryHandle queryHandle;
+  @Mock
+  private BlockingRowQueue queue;
+  @Mock
+  private LogicalSchema schema;
+
+  @Before
+  public void setUp() {
+    vertx = Vertx.vertx();
+    context = vertx.getOrCreateContext();
+    when(queryHandle.getColumnNames()).thenReturn(ImmutableList.of());
+    when(queryHandle.getColumnTypes()).thenReturn(ImmutableList.of());
+    when(queryHandle.getLogicalSchema()).thenReturn(schema);
+    when(queryHandle.getQueue()).thenReturn(queue);
+    when(queryHandle.getQueryId()).thenReturn(new QueryId("q"));
+    when(queryHandle.getConsistencyOffsetVector()).thenReturn(Optional.empty());
+    // Empty so doSend has nothing to stream (a default mock would report not-empty and spin).
+    when(queue.isEmpty()).thenReturn(true);
+  }
+
+  @After
+  public void tearDown() {
+    vertx.close();
+  }
+
+  // A pull query can fail asynchronously (e.g. a router-queue rejection) before the subscriber
+  // attaches. The failure must still reach the subscriber's onError rather than being dropped.
+  @Test
+  public void shouldReplayPreSubscriptionErrorToPullQuerySubscriber() throws Exception {
+    final BlockingQueryPublisher publisher = new BlockingQueryPublisher(context, workerExecutor);
+    final Consumer<Throwable> onException = captureOnException(publisher, true);
+
+    final RuntimeException boom = new RuntimeException("boom");
+    // Failure arrives before any subscriber has attached.
+    onContext(() -> onException.accept(boom));
+
+    final AtomicReference<Throwable> received = new AtomicReference<>();
+    onContext(() -> publisher.subscribe(recordingSubscriber(received)));
+
+    assertThatEventually(received::get, is(sameInstance(boom)));
+  }
+
+  // The normal path (subscriber attaches first, then the query fails) must still deliver.
+  @Test
+  public void shouldDeliverErrorAfterSubscribeForPullQuery() throws Exception {
+    final BlockingQueryPublisher publisher = new BlockingQueryPublisher(context, workerExecutor);
+    final Consumer<Throwable> onException = captureOnException(publisher, true);
+
+    final AtomicReference<Throwable> received = new AtomicReference<>();
+    onContext(() -> publisher.subscribe(recordingSubscriber(received)));
+
+    final RuntimeException boom = new RuntimeException("boom");
+    onContext(() -> onException.accept(boom));
+
+    assertThatEventually(received::get, is(sameInstance(boom)));
+  }
+
+  private Consumer<Throwable> captureOnException(
+      final BlockingQueryPublisher publisher, final boolean isPullQuery) throws Exception {
+    @SuppressWarnings("unchecked") final ArgumentCaptor<Consumer<Throwable>> captor =
+        ArgumentCaptor.forClass(Consumer.class);
+    onContext(() -> publisher.setQueryHandle(queryHandle, isPullQuery, !isPullQuery));
+    verify(queryHandle).onException(captor.capture());
+    return captor.getValue();
+  }
+
+  private Subscriber<KeyValueMetadata<List<?>, GenericRow>> recordingSubscriber(
+      final AtomicReference<Throwable> received) {
+    return new Subscriber<KeyValueMetadata<List<?>, GenericRow>>() {
+      @Override
+      public void onSubscribe(final Subscription s) {
+        s.request(Long.MAX_VALUE);
+      }
+
+      @Override
+      public void onNext(final KeyValueMetadata<List<?>, GenericRow> item) {
+      }
+
+      @Override
+      public void onError(final Throwable t) {
+        received.set(t);
+      }
+
+      @Override
+      public void onComplete() {
+      }
+    };
+  }
+
+  private void onContext(final Runnable runnable) throws Exception {
+    final CountDownLatch latch = new CountDownLatch(1);
+    context.runOnContext(v -> {
+      try {
+        runnable.run();
+      } finally {
+        latch.countDown();
+      }
+    });
+    assertThat(latch.await(10, TimeUnit.SECONDS), is(true));
+  }
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/QueryStreamHandlerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/QueryStreamHandlerTest.java
@@ -33,6 +33,7 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.properties.ConfigOverrideLogger;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.entity.QueryStreamArgs;
+import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KeyValueMetadata;
@@ -122,6 +123,8 @@ public class QueryStreamHandlerTest {
     when(publisher.geLogicalSchema()).thenReturn(SCHEMA);
     when(publisher.isPullQuery()).thenReturn(true);
     doNothing().when(publisher).subscribe(subscriber.capture());
+    when(server.getConfig()).thenReturn(new KsqlRestConfig(
+        ImmutableMap.of(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:8088")));
     handler = new QueryStreamHandler(endpoints, connectionQueryManager, context, server, false);
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/QueryStreamHandlerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/QueryStreamHandlerTest.java
@@ -117,14 +117,15 @@ public class QueryStreamHandlerTest {
     when(endpoints.createQueryPublisher(any(), any(), any(), any(), any(), any(), any(), any(),
         any())).thenReturn(future);
     when(response.endHandler(endHandler.capture())).thenReturn(response);
+    // The handler reads cancel-on-disconnect from config when constructed.
+    when(server.getConfig()).thenReturn(new KsqlRestConfig(
+        ImmutableMap.of(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:8088")));
     when(publisher.queryId()).thenReturn(new QueryId(QUERY_ID));
     when(publisher.getColumnNames()).thenReturn(COL_NAMES);
     when(publisher.getColumnTypes()).thenReturn(COL_TYPES);
     when(publisher.geLogicalSchema()).thenReturn(SCHEMA);
     when(publisher.isPullQuery()).thenReturn(true);
     doNothing().when(publisher).subscribe(subscriber.capture());
-    when(server.getConfig()).thenReturn(new KsqlRestConfig(
-        ImmutableMap.of(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:8088")));
     handler = new QueryStreamHandler(endpoints, connectionQueryManager, context, server, false);
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/QueryStreamHandlerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/QueryStreamHandlerTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -29,6 +30,7 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.api.spi.Endpoints;
 import io.confluent.ksql.api.spi.QueryPublisher;
+import io.confluent.ksql.internal.PullQueryExecutorMetrics;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.properties.ConfigOverrideLogger;
 import io.confluent.ksql.query.QueryId;
@@ -48,6 +50,7 @@ import io.vertx.ext.web.RoutingContext;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.junit.Before;
 import org.junit.Test;
@@ -96,8 +99,12 @@ public class QueryStreamHandlerTest {
   private PushQueryHolder pushQueryHolder;
   @Mock
   private SocketAddress requestAddress;
+  @Mock
+  private PullQueryExecutorMetrics pullQueryMetrics;
   @Captor
   private ArgumentCaptor<Handler<Void>> endHandler;
+  @Captor
+  private ArgumentCaptor<Handler<Void>> closeHandler;
   @Captor
   private ArgumentCaptor<Subscriber<KeyValueMetadata<List<?>, GenericRow>>> subscriber;
 
@@ -147,6 +154,69 @@ public class QueryStreamHandlerTest {
     // Then:
     assertThat(subscriber.getValue(), notNullValue());
     verify(publisher).close();
+  }
+
+  @Test
+  public void shouldCancelAndCountWhenClientDisconnectsAndCancellationEnabled() {
+    // Given: cancel-on-disconnect on, and a client that disconnects before the server completes.
+    when(server.getConfig()).thenReturn(new KsqlRestConfig(ImmutableMap.of(
+        KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:8088",
+        KsqlRestConfig.KSQL_QUERY_PULL_CANCEL_ON_DISCONNECT_ENABLED_CONFIG, true)));
+    when(server.getPullQueryMetrics()).thenReturn(Optional.of(pullQueryMetrics));
+    when(response.closeHandler(closeHandler.capture())).thenReturn(response);
+    final QueryStreamHandler enabled =
+        new QueryStreamHandler(endpoints, connectionQueryManager, context, server, false);
+    givenRequest(new QueryStreamArgs("select * from foo;",
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap()));
+
+    // When:
+    enabled.handle(routingContext);
+    closeHandler.getValue().handle(null);
+
+    // Then: the disconnect is counted and the query is cancelled (publisher closed).
+    verify(pullQueryMetrics).recordClientDisconnected();
+    verify(publisher).close();
+  }
+
+  @Test
+  public void shouldOnlyCountWhenClientDisconnectsAndCancellationDisabled() {
+    // Given: the setUp handler has cancel-on-disconnect off (the default).
+    when(server.getPullQueryMetrics()).thenReturn(Optional.of(pullQueryMetrics));
+    when(response.closeHandler(closeHandler.capture())).thenReturn(response);
+    givenRequest(new QueryStreamArgs("select * from foo;",
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap()));
+
+    // When: the client disconnects before the server completes.
+    handler.handle(routingContext);
+    closeHandler.getValue().handle(null);
+
+    // Then: the disconnect is counted but the query is NOT cancelled.
+    verify(pullQueryMetrics).recordClientDisconnected();
+    verify(publisher, never()).close();
+  }
+
+  @Test
+  public void shouldNeitherCountNorCancelOnNormalServerCompletion() {
+    // Given: cancel-on-disconnect on, but the server completes the query normally.
+    // getPullQueryMetrics is deliberately not stubbed: the serverCompleted filter must return
+    // before the handler ever reaches it.
+    when(server.getConfig()).thenReturn(new KsqlRestConfig(ImmutableMap.of(
+        KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:8088",
+        KsqlRestConfig.KSQL_QUERY_PULL_CANCEL_ON_DISCONNECT_ENABLED_CONFIG, true)));
+    when(response.closeHandler(closeHandler.capture())).thenReturn(response);
+    final QueryStreamHandler enabled =
+        new QueryStreamHandler(endpoints, connectionQueryManager, context, server, false);
+    givenRequest(new QueryStreamArgs("select * from foo;",
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap()));
+    enabled.handle(routingContext);
+
+    // When: the subscriber marks the query server-completed, then the HTTP/2 stream closes.
+    ((QuerySubscriber) subscriber.getValue()).handleComplete();
+    closeHandler.getValue().handle(null);
+
+    // Then: a normal stream close is neither counted as a disconnect nor cancelled.
+    verify(pullQueryMetrics, never()).recordClientDisconnected();
+    verify(publisher, never()).close();
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/QuerySubscriberTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/QuerySubscriberTest.java
@@ -15,16 +15,21 @@
 
 package io.confluent.ksql.api.server;
 
+import static io.confluent.ksql.rest.Errors.ERROR_CODE_SERVER_ERROR;
+import static io.confluent.ksql.rest.Errors.ERROR_CODE_TOO_MANY_REQUESTS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.when;
 
+import io.confluent.ksql.rest.entity.KsqlErrorMessage;
+import io.confluent.ksql.util.KsqlRateLimitException;
 import io.vertx.core.Context;
 import io.vertx.core.http.HttpServerResponse;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -65,5 +70,29 @@ public class QuerySubscriberTest {
     // Without this the close handler cannot tell a failed query from a client that
     // walked away, and the failure is counted as a client disconnect.
     assertThat(serverCompleted.get(), is(true));
+  }
+
+  @Test
+  public void shouldCodeRateLimitErrorAsRetriable() {
+    final ArgumentCaptor<KsqlErrorMessage> captor =
+        ArgumentCaptor.forClass(KsqlErrorMessage.class);
+    when(writer.writeError(captor.capture())).thenReturn(writer);
+
+    // A router-queue rejection reaches the client in-stream (headers already sent), so it
+    // cannot be a 429 status; the frame must still be coded retriable so a client can tell.
+    subscriber.handleError(new KsqlRateLimitException("the router queue is full"));
+
+    assertThat(captor.getValue().getErrorCode(), is(ERROR_CODE_TOO_MANY_REQUESTS));
+  }
+
+  @Test
+  public void shouldCodeOtherErrorsAsServerError() {
+    final ArgumentCaptor<KsqlErrorMessage> captor =
+        ArgumentCaptor.forClass(KsqlErrorMessage.class);
+    when(writer.writeError(captor.capture())).thenReturn(writer);
+
+    subscriber.handleError(new RuntimeException("boom"));
+
+    assertThat(captor.getValue().getErrorCode(), is(ERROR_CODE_SERVER_ERROR));
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/QuerySubscriberTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/QuerySubscriberTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.server;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+import io.vertx.core.Context;
+import io.vertx.core.http.HttpServerResponse;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class QuerySubscriberTest {
+
+  @Mock
+  private Context context;
+  @Mock
+  private HttpServerResponse response;
+  @Mock
+  private QueryStreamResponseWriter writer;
+
+  private AtomicBoolean serverCompleted;
+  private QuerySubscriber subscriber;
+
+  @Before
+  public void setUp() {
+    serverCompleted = new AtomicBoolean(false);
+    subscriber = new QuerySubscriber(context, response, writer, () -> false, serverCompleted);
+  }
+
+  @Test
+  public void shouldMarkServerCompletedOnSuccess() {
+    when(writer.writeCompletionMessage()).thenReturn(writer);
+
+    subscriber.handleComplete();
+
+    assertThat(serverCompleted.get(), is(true));
+  }
+
+  @Test
+  public void shouldMarkServerCompletedOnError() {
+    when(writer.writeError(org.mockito.ArgumentMatchers.any())).thenReturn(writer);
+
+    subscriber.handleError(new RuntimeException("boom"));
+
+    // Without this the close handler cannot tell a failed query from a client that
+    // walked away, and the failure is counted as a client disconnect.
+    assertThat(serverCompleted.get(), is(true));
+  }
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryMetricsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryMetricsTest.java
@@ -317,6 +317,72 @@ public class PullQueryMetricsTest {
     assertThat(detailedValue, equalTo(5.0));
   }
 
+  @Test
+  public void shouldRecordCoordinatorQueueWait() {
+    // Given: 5 ms expressed in nanos, since the metric records microseconds
+    pullMetrics.recordCoordinatorQueueWait(5_000_000L);
+
+    // Then:
+    assertThat(getMetricValue("-coordinator-queue-wait-avg"), closeTo(5000.0, 0.1));
+    assertThat(getMetricValue("-coordinator-queue-wait-max"), closeTo(5000.0, 0.1));
+    assertThat(getMetricValue("-coordinator-queue-wait-p99"), greaterThan(0.0));
+  }
+
+  @Test
+  public void shouldRecordRouterQueueWait() {
+    // Given:
+    pullMetrics.recordRouterQueueWait(2_000_000L);
+
+    // Then:
+    assertThat(getMetricValue("-router-queue-wait-avg"), closeTo(2000.0, 0.1));
+    assertThat(getMetricValue("-router-queue-wait-max"), closeTo(2000.0, 0.1));
+  }
+
+  @Test
+  public void shouldRecordCoordinatorServiceTimeSeparatelyFromQueueWait() {
+    // Given: a query that queued for 5 ms then executed for 1 ms
+    pullMetrics.recordCoordinatorQueueWait(5_000_000L);
+    pullMetrics.recordCoordinatorServiceTime(1_000_000L);
+
+    // Then: the two are reported independently, which is the point of splitting them
+    assertThat(getMetricValue("-coordinator-queue-wait-avg"), closeTo(5000.0, 0.1));
+    assertThat(getMetricValue("-coordinator-service-time-avg"), closeTo(1000.0, 0.1));
+  }
+
+
+  @Test
+  public void shouldRecordCoordinatorQueueWait() {
+    // Given: 5 ms expressed in nanos, since the metric records microseconds
+    pullMetrics.recordCoordinatorQueueWait(5_000_000L);
+
+    // Then:
+    assertThat(getMetricValue("-coordinator-queue-wait-avg"), closeTo(5000.0, 0.1));
+    assertThat(getMetricValue("-coordinator-queue-wait-max"), closeTo(5000.0, 0.1));
+    assertThat(getMetricValue("-coordinator-queue-wait-p99"), greaterThan(0.0));
+  }
+
+  @Test
+  public void shouldRecordRouterQueueWait() {
+    // Given:
+    pullMetrics.recordRouterQueueWait(2_000_000L);
+
+    // Then:
+    assertThat(getMetricValue("-router-queue-wait-avg"), closeTo(2000.0, 0.1));
+    assertThat(getMetricValue("-router-queue-wait-max"), closeTo(2000.0, 0.1));
+  }
+
+  @Test
+  public void shouldRecordCoordinatorServiceTimeSeparatelyFromQueueWait() {
+    // Given: a query that queued for 5 ms then executed for 1 ms
+    pullMetrics.recordCoordinatorQueueWait(5_000_000L);
+    pullMetrics.recordCoordinatorServiceTime(1_000_000L);
+
+    // Then: the two are reported independently, which is the point of splitting them
+    assertThat(getMetricValue("-coordinator-queue-wait-avg"), closeTo(5000.0, 0.1));
+    assertThat(getMetricValue("-coordinator-service-time-avg"), closeTo(1000.0, 0.1));
+  }
+
+
   private double getMetricValue(final String metricName) {
     final Metrics metrics = pullMetrics.getMetrics();
     return Double.parseDouble(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryMetricsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryMetricsTest.java
@@ -349,6 +349,40 @@ public class PullQueryMetricsTest {
     assertThat(getMetricValue("-coordinator-service-time-avg"), closeTo(1000.0, 0.1));
   }
 
+  @Test
+  public void shouldRecordClientDisconnects() {
+    // Given:
+    pullMetrics.recordClientDisconnected();
+    pullMetrics.recordClientDisconnected();
+
+    // Then:
+    assertThat(getMetricValue("-client-disconnected-total"), equalTo(2.0));
+    assertThat(getMetricValue("-client-disconnected-rate"), greaterThan(0.0));
+  }
+
+  @Test
+  public void shouldRecordQueueRejections() {
+    // Given:
+    pullMetrics.recordQueueRejected();
+    pullMetrics.recordQueueRejected();
+
+    // Then:
+    assertThat(getMetricValue("-queue-rejected-total"), equalTo(2.0));
+    assertThat(getMetricValue("-queue-rejected-rate"), greaterThan(0.0));
+  }
+
+  @Test
+  public void shouldCountClientAndForwardedArrivalsSeparately() {
+    // Given:
+    pullMetrics.recordRequestOffered(false);
+    pullMetrics.recordRequestOffered(false);
+    pullMetrics.recordRequestOffered(true);
+
+    // Then: a fanned-out query must not inflate client demand.
+    assertThat(getMetricValue("-offered-total"), equalTo(2.0));
+    assertThat(getMetricValue("-forwarded-in-total"), equalTo(1.0));
+  }
+
   private double getMetricValue(final String metricName) {
     final Metrics metrics = pullMetrics.getMetrics();
     return Double.parseDouble(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryMetricsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryMetricsTest.java
@@ -350,37 +350,8 @@ public class PullQueryMetricsTest {
   }
 
 
-  @Test
-  public void shouldRecordCoordinatorQueueWait() {
-    // Given: 5 ms expressed in nanos, since the metric records microseconds
-    pullMetrics.recordCoordinatorQueueWait(5_000_000L);
 
-    // Then:
-    assertThat(getMetricValue("-coordinator-queue-wait-avg"), closeTo(5000.0, 0.1));
-    assertThat(getMetricValue("-coordinator-queue-wait-max"), closeTo(5000.0, 0.1));
-    assertThat(getMetricValue("-coordinator-queue-wait-p99"), greaterThan(0.0));
-  }
 
-  @Test
-  public void shouldRecordRouterQueueWait() {
-    // Given:
-    pullMetrics.recordRouterQueueWait(2_000_000L);
-
-    // Then:
-    assertThat(getMetricValue("-router-queue-wait-avg"), closeTo(2000.0, 0.1));
-    assertThat(getMetricValue("-router-queue-wait-max"), closeTo(2000.0, 0.1));
-  }
-
-  @Test
-  public void shouldRecordCoordinatorServiceTimeSeparatelyFromQueueWait() {
-    // Given: a query that queued for 5 ms then executed for 1 ms
-    pullMetrics.recordCoordinatorQueueWait(5_000_000L);
-    pullMetrics.recordCoordinatorServiceTime(1_000_000L);
-
-    // Then: the two are reported independently, which is the point of splitting them
-    assertThat(getMetricValue("-coordinator-queue-wait-avg"), closeTo(5000.0, 0.1));
-    assertThat(getMetricValue("-coordinator-service-time-avg"), closeTo(1000.0, 0.1));
-  }
 
 
   private double getMetricValue(final String metricName) {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryMetricsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryMetricsTest.java
@@ -349,11 +349,6 @@ public class PullQueryMetricsTest {
     assertThat(getMetricValue("-coordinator-service-time-avg"), closeTo(1000.0, 0.1));
   }
 
-
-
-
-
-
   private double getMetricValue(final String metricName) {
     final Metrics metrics = pullMetrics.getMetrics();
     return Double.parseDouble(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -28,6 +28,7 @@ import static io.confluent.ksql.rest.server.resources.KsqlRestExceptionMatchers.
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
 import static io.netty.handler.codec.http.HttpResponseStatus.SERVICE_UNAVAILABLE;
+import static io.netty.handler.codec.http.HttpResponseStatus.TOO_MANY_REQUESTS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -93,6 +94,7 @@ import io.confluent.ksql.util.KeyValue;
 import io.confluent.ksql.util.KeyValueMetadata;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.KsqlRateLimitException;
 import io.confluent.ksql.util.PushQueryMetadata.ResultType;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
@@ -392,6 +394,29 @@ public class StreamedQueryResourceTest {
     assertThat(e, exceptionErrorMessage(errorMessage(
         containsString("Timed out while waiting for a previous command to execute"))));
     assertThat(e, exceptionErrorMessage(errorCode(is(Errors.ERROR_CODE_COMMAND_QUEUE_CATCHUP_TIMEOUT))));
+  }
+
+  @Test
+  public void shouldReturn429WhenPullQueryRateLimited() {
+    // Given: the pull-query path throws a rate limit (a full queue, or the qps/concurrency
+    // limiter, both of which raise KsqlRateLimitException from handleStatement).
+    when(queryExecutor.handleStatement(any(), any(), any(), any(), any(), any(), any(),
+        anyBoolean()))
+        .thenThrow(new KsqlRateLimitException(
+            "Pull query rejected: the coordinator queue is full."));
+
+    // When:
+    final EndpointResponse response = testResource.streamQuery(
+        securityContext,
+        new KsqlRequest(PULL_QUERY_STRING, Collections.emptyMap(), Collections.emptyMap(), null),
+        new CompletableFuture<>(),
+        Optional.empty(),
+        new MetricsCallbackHolder(),
+        context
+    );
+
+    // Then: 429, not a 400 "bad statement" — the client should back off and retry.
+    assertThat(response.getStatus(), CoreMatchers.is(TOO_MANY_REQUESTS.code()));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/ConcurrencyLimiterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/ConcurrencyLimiterTest.java
@@ -135,20 +135,4 @@ public class ConcurrencyLimiterTest {
     assertThat(e.getMessage(), containsString("concurrency limit for pull queries"));
   }
 
-  @Test
-  public void shouldRejectWithRetriableExceptionWhenConfigured() {
-    final Metrics metrics = new Metrics();
-    final Map<String, String> tags = Collections.emptyMap();
-    final ConcurrencyLimiter limiter =
-        new ConcurrencyLimiter(1, "pull", metrics, tags, true);
-    limiter.increment();
-
-    final KsqlRateLimitException e =
-        assertThrows(KsqlRateLimitException.class, limiter::increment);
-    assertThat(e.getMessage(), containsString("concurrency limit for pull queries"));
-    // Rejections are still counted the same way.
-    assertThat(getReject(metrics, tags), is(1.0));
-  }
-
-
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/ConcurrencyLimiterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/ConcurrencyLimiterTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertThrows;
 
 import io.confluent.ksql.rest.util.ConcurrencyLimiter.Decrementer;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.KsqlRateLimitException;
 import java.util.Collections;
 import java.util.Map;
 import org.apache.kafka.common.MetricName;
@@ -119,5 +120,61 @@ public class ConcurrencyLimiterTest {
     );
     final KafkaMetric remainingMetric = metrics.metrics().get(remainingMetricName);
     return (double) remainingMetric.metricValue();
+  }
+
+  @Test
+  public void shouldRejectWithNonRetriableExceptionByDefault() {
+    final Metrics metrics = new Metrics();
+    final ConcurrencyLimiter limiter =
+        new ConcurrencyLimiter(1, "pull", metrics, Collections.emptyMap());
+    limiter.increment();
+
+    final KsqlException e = assertThrows(KsqlException.class, limiter::increment);
+    assertThat(e, is(org.hamcrest.Matchers.not(
+        org.hamcrest.Matchers.instanceOf(KsqlRateLimitException.class))));
+    assertThat(e.getMessage(), containsString("concurrency limit for pull queries"));
+  }
+
+  @Test
+  public void shouldRejectWithRetriableExceptionWhenConfigured() {
+    final Metrics metrics = new Metrics();
+    final Map<String, String> tags = Collections.emptyMap();
+    final ConcurrencyLimiter limiter =
+        new ConcurrencyLimiter(1, "pull", metrics, tags, true);
+    limiter.increment();
+
+    final KsqlRateLimitException e =
+        assertThrows(KsqlRateLimitException.class, limiter::increment);
+    assertThat(e.getMessage(), containsString("concurrency limit for pull queries"));
+    // Rejections are still counted the same way.
+    assertThat(getReject(metrics, tags), is(1.0));
+  }
+
+  @Test
+  public void shouldRejectWithNonRetriableExceptionByDefault() {
+    final Metrics metrics = new Metrics();
+    final ConcurrencyLimiter limiter =
+        new ConcurrencyLimiter(1, "pull", metrics, Collections.emptyMap());
+    limiter.increment();
+
+    final KsqlException e = assertThrows(KsqlException.class, limiter::increment);
+    assertThat(e, is(org.hamcrest.Matchers.not(
+        org.hamcrest.Matchers.instanceOf(KsqlRateLimitException.class))));
+    assertThat(e.getMessage(), containsString("concurrency limit for pull queries"));
+  }
+
+  @Test
+  public void shouldRejectWithRetriableExceptionWhenConfigured() {
+    final Metrics metrics = new Metrics();
+    final Map<String, String> tags = Collections.emptyMap();
+    final ConcurrencyLimiter limiter =
+        new ConcurrencyLimiter(1, "pull", metrics, tags, true);
+    limiter.increment();
+
+    final KsqlRateLimitException e =
+        assertThrows(KsqlRateLimitException.class, limiter::increment);
+    assertThat(e.getMessage(), containsString("concurrency limit for pull queries"));
+    // Rejections are still counted the same way.
+    assertThat(getReject(metrics, tags), is(1.0));
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/ConcurrencyLimiterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/ConcurrencyLimiterTest.java
@@ -150,31 +150,5 @@ public class ConcurrencyLimiterTest {
     assertThat(getReject(metrics, tags), is(1.0));
   }
 
-  @Test
-  public void shouldRejectWithNonRetriableExceptionByDefault() {
-    final Metrics metrics = new Metrics();
-    final ConcurrencyLimiter limiter =
-        new ConcurrencyLimiter(1, "pull", metrics, Collections.emptyMap());
-    limiter.increment();
 
-    final KsqlException e = assertThrows(KsqlException.class, limiter::increment);
-    assertThat(e, is(org.hamcrest.Matchers.not(
-        org.hamcrest.Matchers.instanceOf(KsqlRateLimitException.class))));
-    assertThat(e.getMessage(), containsString("concurrency limit for pull queries"));
-  }
-
-  @Test
-  public void shouldRejectWithRetriableExceptionWhenConfigured() {
-    final Metrics metrics = new Metrics();
-    final Map<String, String> tags = Collections.emptyMap();
-    final ConcurrencyLimiter limiter =
-        new ConcurrencyLimiter(1, "pull", metrics, tags, true);
-    limiter.increment();
-
-    final KsqlRateLimitException e =
-        assertThrows(KsqlRateLimitException.class, limiter::increment);
-    assertThat(e.getMessage(), containsString("concurrency limit for pull queries"));
-    // Rejections are still counted the same way.
-    assertThat(getReject(metrics, tags), is(1.0));
-  }
 }


### PR DESCRIPTION
## Problem

A pull query is served by a coordinator thread plus one router thread per host it fetches from, both from fixed pools whose queues were **unbounded** (`Executors.newFixedThreadPool`). Under load the queues grow without limit, and the only visible symptom is free-thread count hitting zero — which looks identical whether one request is queued or thirty thousand.

## Approach: everything opt-in, defaults unchanged

Every behavioural change below is **off by default** — an OSS/Confluent Platform binary upgrade behaves exactly as before. Bounding, the 429s and cancel-on-disconnect are enabled by config; Confluent Cloud turns them on in its own config layer. Only the new **metrics are always on** (pure observability, no behaviour change, and visible even when unbounded).

## Changes

**Bound the queues (opt-in).** New `coordinator.queue.capacity` / `router.queue.capacity`, default `Integer.MAX_VALUE` (unbounded, exactly as `newFixedThreadPool` was). Set a positive value to bound; a full bounded queue is then a **retriable rejection** (`KsqlRateLimitException`).

**Rate limits are retriable on every path.** A queue-full, or the existing qps limiter (`ksql.query.pull.max.qps`), now surfaces as **HTTP 429** wherever a client can see a status code:

| Path | Client sees |
|---|---|
| Coordinator rejection, `/query-stream` | HTTP **429** |
| Direct `/query`, and every inter-node forward (forwards use `/query`) | HTTP **429** (previously 400 "bad statement", non-retriable) |
| Router rejection, `/query-stream` | 200 + in-stream error frame **coded `TOO_MANY_REQUESTS`** |

The router case can't be a status code — the rejection happens on a coordinator thread after the 200 + metadata are already written — so its in-stream frame is coded retriable instead of generic server-error. A true status-429 there needs a pre-header admission handshake, tracked as a follow-up.

The `ksql.query.pull.max.concurrent.requests` concurrency limiter is a separate, pre-existing mechanism and is left unchanged: it still rejects with a non-retriable **HTTP 400**. Only the queue-full and qps-limit paths are retriable 429s.

A peer's 429 deliberately does **not** trigger standby fallback — re-sending to a node that is already refusing work adds load to what is short of capacity.

**Give up a round cleanly.** If a bounded router queue fills part way through a round, the hosts already submitted for that round are cancelled rather than left running (an abandoned task could otherwise hold a router thread for the whole forwarding timeout, writing into a stream that is about to close). This failure mode is new — `submit()` could not fail while the queue was unbounded.

**Cancel-on-disconnect (opt-in).** `cancel.on.disconnect.enabled`, default false. When on, a pull query on `/query-stream` is cancelled if the client disconnects mid-response.

**Metrics (always on).** Queue depth, queue wait, and service time for both pools; offered-request rate; queue-rejected; client-disconnected; forwarded-in. Offered rate matters because the existing `pull-query-requests-rate` counts *completions*, so it falls towards zero exactly when load is highest.

## Configs (all default to prior behaviour)

| Config | Default |
|---|---|
| `ksql.query.pull.coordinator.queue.capacity` | `2147483647` (unbounded) |
| `ksql.query.pull.router.queue.capacity` | `2147483647` (unbounded) |
| `ksql.query.pull.cancel.on.disconnect.enabled` | `false` |

Thread-pool sizes (`ksql.query.pull.thread.pool.size` / `.router.thread.pool.size`) are unchanged at 50; Cloud already overrides them to 100 in its own config.

