### PR TITLE
Exclude non-FIPS bcpkix-jdk18on from broker-plugins dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -767,6 +767,12 @@
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>broker-plugins</artifactId>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcpkix-jdk18on</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -766,8 +766,13 @@
         </dependency>
             <dependency>
                 <groupId>io.confluent</groupId>
-                <artifactId>kafka-client-plugins</artifactId>
-                <version>${ce.kafka.version}</version>
+                <artifactId>broker-plugins</artifactId>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -766,13 +766,8 @@
         </dependency>
             <dependency>
                 <groupId>io.confluent</groupId>
-                <artifactId>broker-plugins</artifactId>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.bouncycastle</groupId>
-                        <artifactId>bcpkix-jdk18on</artifactId>
-                    </exclusion>
-                </exclusions>
+                <artifactId>kafka-client-plugins</artifactId>
+                <version>${ce.kafka.version}</version>
             </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -770,7 +770,7 @@
                 <exclusions>
                     <exclusion>
                         <groupId>org.bouncycastle</groupId>
-                        <artifactId>*</artifactId>
+                        <artifactId>bcpkix-jdk18on</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
## Summary
- FIPS mode crash-loops ksqlDB at startup with `java.lang.SecurityException: class "org.bouncycastle.crypto.SecureRandomProvider"'s signer information does not match signer information of other classes in the same package`, thrown from `BcFipsProviderCreator.getProvider` while `KsqlSchemaRegistryClientFactory.newSslContext` builds the Schema Registry client's SSL context.
- Root cause: `broker-plugins` is declared unscoped (`compile`) in the root `pom.xml` and inherited by every `ksqldb-*` module. It transitively pulls in non-FIPS `bcpkix-jdk18on` -> `bcutil-jdk18on` -> `bcprov-jdk18on`, which then coexists on the runtime classpath alongside `bc-fips`. BC's FIPS module intentionally reuses the same package names as the standard provider (`org.bouncycastle.crypto.*`) so the two are never meant to coexist — the JVM's jar-signer/sealing check rejects it.
- Other CP components (Schema Registry, Kafka REST) depend on the same `broker-plugins` artifact but scope it to `test`, so the non-FIPS jars never reach their production classpath. ksqlDB's root pom has no such scoping, so it's the only component that ships the conflicting jar.
- Fix: exclude `org.bouncycastle:bcpkix-jdk18on` from the `broker-plugins` dependency. This leaves `broker-plugins` and its FIPS-only `kafka-client-plugins` dependency (which provides `BcFipsProviderCreator`/`BcFipsJsseProviderCreator`) intact — only the offending non-FIPS transitive artifact is removed.

## Verification
Confirmed via `./mvnw dependency:tree -Dincludes=org.bouncycastle -Dverbose`:
- Before: tree includes `bcpkix-jdk18on:1.84` / `bcutil-jdk18on:1.84` / `bcprov-jdk18on:1.84` at `runtime` scope alongside `bc-fips:2.1.2`.
- After: `bc-fips`, `bcpkix-fips`, and `bctls-fips` all still resolve at real runtime scope via `broker-plugins -> kafka-client-plugins`; no `bcpkix-jdk18on`/`bcutil-jdk18on`/`bcprov-jdk18on` anywhere in the tree; `ksqldb-rest-app` builds successfully.

Surfaced via the CFK e2e test `TestCPFipsZKWithZK` (`enable.fips=true`, RBAC + mTLS to Schema Registry) — every other component (Kafka, ZooKeeper, Connect, Schema Registry, Kafka REST Proxy) starts fine; only ksqlDB crash-loops.

## Test plan
- [ ] Re-run `TestCPFipsZKWithZK` against a ksqlDB image built from this branch and confirm ksqlDB comes up healthy under FIPS mode
- [ ] `./mvnw dependency:tree -Dincludes=org.bouncycastle` shows no `bcpkix-jdk18on`/`bcprov-jdk18on`/`bcutil-jdk18on`, and `bc-fips`/`bcpkix-fips`/`bctls-fips` still present
- [ ] Existing ksqlDB test suite still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)