### PR TITLE
fix(build): suppress SpotBugs EI_EXPOSE_REP2 finding in ScalablePushConsumer

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/execution/scalablepush/consumer/ScalablePushConsumer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/execution/scalablepush/consumer/ScalablePushConsumer.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.execution.scalablepush.consumer;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.common.OffsetsRow;
 import io.confluent.ksql.execution.common.QueryRow;
@@ -69,6 +70,7 @@ public abstract class ScalablePushConsumer implements AutoCloseable {
 
   protected AtomicReference<Set<TopicPartition>> topicPartitions = new AtomicReference<>();
 
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   public ScalablePushConsumer(
       final String topicName,
       final boolean windowed,


### PR DESCRIPTION
### Description
`ScalablePushConsumer`'s constructor stores a `KafkaConsumer` reference passed in from the caller. SpotBugs flags this as `EI_EXPOSE_REP2` (medium severity), which fails the `ksqldb-engine` module build.

This adds the same `@SuppressFBWarnings("EI_EXPOSE_REP2")` annotation already used for this exact finding in `UserRepartitionNode`, `QueryProjectNode`, and `QueryExecutor` — a `KafkaConsumer` should not be defensively copied, so suppression is the correct fix here too, consistent with existing precedent in this codebase.

### Testing done
No behavior change — this only adds a SpotBugs suppression annotation matching existing precedent for the same finding elsewhere in this codebase. CI will confirm the SpotBugs `check` goal passes for `ksqldb-engine`.

### Reviewer checklist
- [x] Docs update — N/A, no user-visible change.
- [x] Relevant issues linked — N/A.
- [x] Rollback compatibility — None; annotation-only change, no behavior change.

---
Generated by `ksqldb-pipe-triage`.
