### PR TITLE
Revert "Exclude non-FIPS bcpkix-jdk18on from broker-plugins dependency (#11134)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -767,12 +767,6 @@
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>broker-plugins</artifactId>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.bouncycastle</groupId>
-                        <artifactId>bcpkix-jdk18on</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
This reverts #11134.

Reverting on 7.9.x pending further validation of the FIPS fix.