### PR TITLE
chore: suppress EI_EXPOSE_REP2 on ScalablePushConsumer constructor

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/execution/scalablepush/consumer/ScalablePushConsumer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/execution/scalablepush/consumer/ScalablePushConsumer.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.execution.scalablepush.consumer;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.common.OffsetsRow;
 import io.confluent.ksql.execution.common.QueryRow;
@@ -69,6 +70,12 @@ public abstract class ScalablePushConsumer implements AutoCloseable {
 
   protected AtomicReference<Set<TopicPartition>> topicPartitions = new AtomicReference<>();
 
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "The KafkaConsumer is a live client intentionally shared with this "
+          + "consumer, which owns its lifecycle (poll/commit/close); it is not defensively "
+          + "copyable."
+  )
   public ScalablePushConsumer(
       final String topicName,
       final boolean windowed,


### PR DESCRIPTION
**Jira:** [KSQL-15567](https://confluentinc.atlassian.net/browse/KSQL-15567)

## What
Add `@SuppressFBWarnings("EI_EXPOSE_REP2")` to the `ScalablePushConsumer` constructor, which stores the injected `KafkaConsumer` into a field.

## Why
The nightly `confluent-snapshots` **master** build has failed the SpotBugs `check` on `ksqldb-engine` since 2026-08-07 with `EI_EXPOSE_REP2` at `ScalablePushConsumer.java:82`.

Root cause is upstream, not a ksql change (the built commit was frozen throughout): **KAFKA-20385** added `Consumer#setRebalanceListener`. That `set*` method makes SpotBugs classify `KafkaConsumer` as mutable, so storing the injected consumer now trips `EI_EXPOSE_REP2`. The same frozen commit passed on 2026-08-05 (before the change) and has failed since 08-07.

## Why this is safe
- The `EI_EXPOSE_REP2` remedy is a defensive copy, but a `KafkaConsumer` is a live client with an open connection, background threads, and a lifecycle owned by this class (`poll`/`commit`/`close`) — it cannot be copied.
- The consumer is deliberately injected (`KafkaConsumerFactory` → `ScalablePushRegistry` → `LatestConsumer`/`CatchupConsumer`, and mocked in tests). The exposure is intentional shared state, so the finding is a false positive here.
- Matches the established pattern in `ksqldb-engine` (`ScalablePushQueryMetadata`, `StreamPullQueryMetadata`, `KsqlEngineMetrics`, …).
- Annotation-only: **no runtime behavior change.**

## Testing
Annotation-only change; no logic affected. The full `confluent-snapshots` Maven/SpotBugs build needs internal snapshot deps and wasn't run locally, so this relies on convention-match with the existing suppressions.


[KSQL-15567]: https://confluentinc.atlassian.net/browse/KSQL-15567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ