### PR TITLE
fix: correct FIPS/non-FIPS netty-tcnative runtime selection

### DIFF
--- a/bin/ksql-run-class
+++ b/bin/ksql-run-class
@@ -64,9 +64,7 @@ should_include_netty_tcnative_jar() {
 
   if [ "$FIPS_ENABLED" = "true" ]; then
     # FIPS mode: exclude non-FIPS BoringSSL, keep FIPS version
-    # Match: netty-tcnative-boringssl-static but NOT netty-tcnative-fips-boringssl-static
-    if echo "$entry" | grep -q "netty-tcnative-boringssl-static" && \
-       ! echo "$entry" | grep -q "netty-tcnative-fips-boringssl-static"; then
+    if echo "$entry" | grep -q "netty-tcnative-boringssl-static"; then
       return 1
     fi
   else
@@ -117,9 +115,7 @@ KSQL_CLASSPATH=$(filter_netty_tcnative_classpath "$KSQL_CLASSPATH")
 if [ "$FIPS_ENABLED" = "true" ]; then
   echo "FIPS Mode: ENABLED (enable.fips=true detected in properties file)"
   echo "  -> Using netty-tcnative-fips-boringssl-static (FIPS 140-3 compliant)"
-  # Add FIPS-specific JVM options for Bouncy Castle FIPS provider
-  # KSQL_OPTS="$KSQL_OPTS -Dorg.bouncycastle.fips.approved_only=true"
-  
+
   # CRITICAL: Explicitly enable Netty OpenSSL support.
   # The Confluent FIPS security providers (BcFipsProviderCreator, BcFipsJsseProviderCreator)
   # set -Dio.netty.handler.ssl.noOpenSsl=true to force JDK SSL for FIPS compliance.
@@ -129,11 +125,11 @@ if [ "$FIPS_ENABLED" = "true" ]; then
   # Netty's BouncyCastleAlpnSslUtils due to reflection access restrictions.
   KSQL_OPTS="$KSQL_OPTS -Dio.netty.handler.ssl.noOpenSsl=false"
   echo "  -> Enabled Netty OpenSSL (FIPS BoringSSL is FIPS 140-3 compliant)"
-  
-  # Add JVM --add-opens flags as fallback for cases where OpenSSL native libraries
-  # are not available for the platform (e.g., ARM64). In these cases, Netty falls back
-  # to JDK SSL with BouncyCastle, and these flags allow the reflection access
-  # that Netty's BouncyCastleAlpnSslUtils needs for ALPN (HTTP/2) support.
+
+  # Add JVM --add-opens flags as fallback for platforms other than linux-x86_64, the
+  # only platform with a published native FIPS BoringSSL build. On those platforms
+  # Netty falls back to JDK SSL with BouncyCastle, and these flags allow the reflection
+  # access that Netty's BouncyCastleAlpnSslUtils needs for ALPN (HTTP/2) support.
   FIPS_JVM_OPTS=""
   FIPS_JVM_OPTS="$FIPS_JVM_OPTS --add-opens java.base/java.lang=ALL-UNNAMED"
   FIPS_JVM_OPTS="$FIPS_JVM_OPTS --add-opens java.base/java.lang.reflect=ALL-UNNAMED"

--- a/bin/ksql-run-class
+++ b/bin/ksql-run-class
@@ -58,40 +58,55 @@ done
 # Use KSQL_FIPS_ENABLED from environment (set by ksql-server-start)
 FIPS_ENABLED="${KSQL_FIPS_ENABLED:-false}"
 
+# Returns 0 (include) or 1 (exclude) for a single jar path/filename, based on FIPS_ENABLED.
+should_include_netty_tcnative_jar() {
+  local entry="$1"
+
+  if [ "$FIPS_ENABLED" = "true" ]; then
+    # FIPS mode: exclude non-FIPS BoringSSL, keep FIPS version
+    # Match: netty-tcnative-boringssl-static but NOT netty-tcnative-fips-boringssl-static
+    if echo "$entry" | grep -q "netty-tcnative-boringssl-static" && \
+       ! echo "$entry" | grep -q "netty-tcnative-fips-boringssl-static"; then
+      return 1
+    fi
+  else
+    # Standard mode: exclude FIPS BoringSSL, keep standard version
+    if echo "$entry" | grep -q "netty-tcnative-fips-boringssl-static"; then
+      return 1
+    fi
+  fi
+  return 0
+}
+
 filter_netty_tcnative_classpath() {
   local input_classpath="$1"
   local filtered_classpath=""
-  
+
   # Save and restore IFS
   local OLD_IFS="$IFS"
   IFS=':'
-  
+
   for entry in $input_classpath; do
-    local should_include=true
-    
-    if [ "$FIPS_ENABLED" = "true" ]; then
-      # FIPS mode: exclude non-FIPS BoringSSL, keep FIPS version
-      # Match: netty-tcnative-boringssl-static but NOT netty-tcnative-fips-boringssl-static
-      if echo "$entry" | grep -q "netty-tcnative-boringssl-static" && \
-         ! echo "$entry" | grep -q "netty-tcnative-fips-boringssl-static"; then
-        should_include=false
+    # KSQL_CLASSPATH entries built above are directory wildcards (e.g. ".../share/java/foo/*"),
+    # which the JVM expands internally at launch. Individual jar filenames never appear in
+    # such an entry, so it must be expanded here in order to filter by jar name at all.
+    if [[ "$entry" == */\* ]]; then
+      local jar_dir="${entry%/*}"
+      if [ -d "$jar_dir" ]; then
+        for jar in "$jar_dir"/*.jar; do
+          [ -e "$jar" ] || continue
+          if should_include_netty_tcnative_jar "$jar"; then
+            filtered_classpath="${filtered_classpath:+$filtered_classpath:}$jar"
+          fi
+        done
       fi
     else
-      # Standard mode: exclude FIPS BoringSSL, keep standard version
-      if echo "$entry" | grep -q "netty-tcnative-fips-boringssl-static"; then
-        should_include=false
-      fi
-    fi
-    
-    if [ "$should_include" = "true" ]; then
-      if [ -z "$filtered_classpath" ]; then
-        filtered_classpath="$entry"
-      else
-        filtered_classpath="$filtered_classpath:$entry"
+      if should_include_netty_tcnative_jar "$entry"; then
+        filtered_classpath="${filtered_classpath:+$filtered_classpath:}$entry"
       fi
     fi
   done
-  
+
   IFS="$OLD_IFS"
   echo "$filtered_classpath"
 }

--- a/ksqldb-rest-app/pom.xml
+++ b/ksqldb-rest-app/pom.xml
@@ -149,6 +149,13 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-fips-boringssl-static</artifactId>
         </dependency>
+        <!-- Only a linux-x86_64 native build of the FIPS artifact is currently published
+             internally; see the FIPS Compliance comment in the root pom.xml. -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-fips-boringssl-static</artifactId>
+            <classifier>linux-x86_64</classifier>
+        </dependency>
 
         <dependency>
             <groupId>io.netty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1248,9 +1248,18 @@
                 <artifactId>netty-transport-native-unix-common</artifactId>
                 <version>${netty.version}</version>
             </dependency>
-            <!-- FIPS Compliance: Block BoringSSL by setting scope to provided
-                 This prevents non-FIPS BoringSSL from being included in runtime classpath.
-                 TLS will use BC-FIPS/BC-JSSE instead. -->
+            <!-- FIPS Compliance: both variants are packaged onto the runtime classpath at
+                 compile scope; bin/ksql-run-class selects the correct one at launch time
+                 based on FIPS_ENABLED. See "FIPS Compliance Notes" at the end of this file.
+
+                 The classifier-less netty-tcnative-fips-boringssl-static artifact carries no
+                 native library and no transitive classifier dependencies of its own (unlike
+                 netty-tcnative-boringssl-static, which pulls in a classifier jar per OS/arch
+                 automatically). Confluent's internal repo currently only publishes a
+                 linux-x86_64 native build of this artifact, so that classifier is depended on
+                 explicitly below. On other platforms Netty finds no matching native library
+                 and falls back to JDK SSL, which ksql-run-class already handles via add-opens
+                 JVM flags for the FIPS_ENABLED case. -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-fips-boringssl-static</artifactId>
@@ -1258,9 +1267,14 @@
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
+                <artifactId>netty-tcnative-fips-boringssl-static</artifactId>
+                <version>${netty-tcnative-fips-version}</version>
+                <classifier>linux-x86_64</classifier>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
                 <version>${netty-tcnative-version}</version>
-                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1701,11 +1701,15 @@
          - netty-tcnative-boringssl-static (standard, CVE-free)
          - netty-tcnative-fips-boringssl-static (FIPS 140-3 compliant)
 
-         Runtime selection is controlled by FIPS_ENABLED environment variable
-         in the ksql-run-class startup script.
+         Runtime selection is controlled by the KSQL_FIPS_ENABLED environment
+         variable in the ksql-run-class startup script. ksql-server-start sets
+         this automatically by checking for 'enable.fips=true' in the server
+         properties file passed to it - it is not read directly from the shell
+         environment.
 
          Usage:
            Standard mode: bin/ksql-server-start config/ksql-server.properties
-           FIPS mode:     FIPS_ENABLED=true bin/ksql-server-start config/ksql-server.properties
+           FIPS mode:     add `enable.fips=true` to the properties file, then run
+                          bin/ksql-server-start config/ksql-server.properties
          =========================================================================== -->
 </project>


### PR DESCRIPTION
## What changed

`netty-tcnative-boringssl-static` was declared with `provided` scope, which
excluded it (and the per-platform native jars it pulls in transitively) from
the packaged runtime distribution. `netty-tcnative-fips-boringssl-static` had
no native classifier declared, so it resolved to a metadata-only artifact
with no native library at all. `bin/ksql-run-class` attempts to select
between the two at runtime via `FIPS_ENABLED`, but its classpath filter
matched against directory-wildcard classpath entries instead of individual
jar paths, so it never actually matched or excluded anything.

This PR:
- Removes the `provided` scope override so `netty-tcnative-boringssl-static`
  is packaged normally.
- Adds an explicit `linux-x86_64` classifier dependency for
  `netty-tcnative-fips-boringssl-static`, the only native classifier
  currently published for that artifact.
- Updates `filter_netty_tcnative_classpath` in `bin/ksql-run-class` to expand
  directory-wildcard classpath entries into individual jar paths before
  filtering, so `FIPS_ENABLED` actually selects the correct jar at launch.
- Removes a redundant/dead check in the classpath filter and a stale,
  unreferenced commented-out JVM option, and corrects two comments/docs
  (in `ksql-run-class` and the `pom.xml` FIPS notes) that no longer matched
  actual behavior.

## Test plan

- [x] `./mvnw package -pl ksqldb-rest-app -am -DskipTests` builds successfully
- [x] Verified `share/java/ksqldb-rest-app/` contains the expected jars for
      both the standard and FIPS variants after packaging
- [x] Verified `filter_netty_tcnative_classpath` selects the correct jar set
      for both `FIPS_ENABLED=true` and `FIPS_ENABLED=false`
- [x] Ran `bin/ksql-run-class` end-to-end against a small probe using
      `io.netty.handler.ssl.OpenSsl`: standard mode loads the native
      BoringSSL library successfully; FIPS mode falls back to JDK SSL on
      platforms without a published native FIPS build, as intended
- [ ] CI