### PR TITLE
Exclude non-FIPS bcpkix-jdk18on from broker-plugins dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -755,6 +755,12 @@
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>broker-plugins</artifactId>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcpkix-jdk18on</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
Forward-port of #11134 to `7.5.x`.

- `broker-plugins` is declared unscoped (`compile`) in the root `pom.xml` and inherited by every `ksqldb-*` module. It transitively pulls in non-FIPS `bcpkix-jdk18on` -> `bcutil-jdk18on` -> `bcprov-jdk18on`, which can then coexist on the runtime classpath alongside `bc-fips`. BC's FIPS module intentionally reuses the same package names as the standard provider (`org.bouncycastle.crypto.*`), so the two are never meant to coexist — the JVM's jar-signer/sealing check rejects it, crash-looping ksqlDB at startup under FIPS mode.
- Fix: exclude `org.bouncycastle:bcpkix-jdk18on` from the `broker-plugins` dependency. This leaves `broker-plugins` and its FIPS-only `kafka-client-plugins` dependency (which provides `BcFipsProviderCreator`/`BcFipsJsseProviderCreator`) intact — only the offending non-FIPS transitive artifact is removed.

## Test plan
- [ ] `./mvnw dependency:tree -Dincludes=org.bouncycastle` shows no `bcpkix-jdk18on`/`bcprov-jdk18on`/`bcutil-jdk18on`, and `bc-fips`/`bcpkix-fips`/`bctls-fips` still present
- [ ] Existing ksqlDB test suite still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)