### PR TITLE
KSQL-15404 | CVE fix for netty-codec-http dependency (8.0.2-cp10)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,15 +143,15 @@
         <apache.io.version>2.11.0</apache.io.version>
         <io.confluent.ksql.version>8.0.2</io.confluent.ksql.version>
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
-        <netty-tcnative-version>2.0.77.Final</netty-tcnative-version>
+        <netty-tcnative-version>2.0.78.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`
              we might need to bump `tcnative`, too.
              Please check top level `pom.xml` at https://github.com/netty/netty
              for the netty version we bump to (ie, corresponding git tag),
              to find the correct `tcnative` version. -->
-        <netty.version>4.1.135.Final</netty.version>
-        <netty-codec-http2-version>4.1.135.Final</netty-codec-http2-version>
+        <netty.version>4.1.136.Final</netty.version>
+        <netty-codec-http2-version>4.1.136.Final</netty-codec-http2-version>
         <jersey-common>3.1.10</jersey-common>
         <multi-threaded-testing.forkCount>3</multi-threaded-testing.forkCount>
         <kafka.version>${ce.kafka.version}</kafka.version>


### PR DESCRIPTION
## Summary
- [FEDRAMP] Fixes CVE-2026-55831 in `io.netty:netty-codec-http` on the `8.0.2-cp10` CP FedRAMP branch.
- Bumps `netty.version` 4.1.135.Final -> 4.1.136.Final (one of the fixed versions requested: `4.1.136.Final` / `4.2.16.Final`), plus `netty-codec-http2-version` in lockstep and the companion `netty-tcnative-version` 2.0.77.Final -> 2.0.78.Final per netty's own release pom.
- Same fix already applied on `master` (KSQL-15395, commit 73c7104701e) and on the `8.0.x` mainline umbrella ticket KSQL-15404; this backports the equivalent property bump onto the `8.0.2-cp10` branch.
- All `netty-*` submodules in `pom.xml` are pinned to `${netty.version}` in `dependencyManagement`, so this single property bump carries `netty-codec-http` (and its siblings) to the fixed version.

## Test plan
- [x] Confirmed `8.0.2-cp10` pom.xml pinned `netty.version` to the vulnerable `4.1.135.Final` prior to this change.
- [x] Diff mirrors the exact fix already merged to `master` for the same underlying dependency bump.
- [ ] CI build/dependency resolution on this PR to confirm `netty-codec-http` resolves to `4.1.136.Final` in the final artifact (`mvn dependency:tree -Dincludes=io.netty:netty-codec-http`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)