### PR TITLE
Bump Netty to 4.1.137.Final on 8.0.2-cp10 (proactive, ahead of next cycle)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,15 +143,15 @@
         <apache.io.version>2.11.0</apache.io.version>
         <io.confluent.ksql.version>8.0.2</io.confluent.ksql.version>
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
-        <netty-tcnative-version>2.0.78.Final</netty-tcnative-version>
+        <netty-tcnative-version>2.0.81.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`
              we might need to bump `tcnative`, too.
              Please check top level `pom.xml` at https://github.com/netty/netty
              for the netty version we bump to (ie, corresponding git tag),
              to find the correct `tcnative` version. -->
-        <netty.version>4.1.136.Final</netty.version>
-        <netty-codec-http2-version>4.1.136.Final</netty-codec-http2-version>
+        <netty.version>4.1.137.Final</netty.version>
+        <netty-codec-http2-version>4.1.137.Final</netty-codec-http2-version>
         <jersey-common>3.1.10</jersey-common>
         <multi-threaded-testing.forkCount>3</multi-threaded-testing.forkCount>
         <kafka.version>${ce.kafka.version}</kafka.version>


### PR DESCRIPTION
## Summary
- Proactive bump of Netty on the `8.0.2-cp10` FedRAMP branch: `4.1.136.Final` -> `4.1.137.Final`, following up on #11144 (which fixed CVE-2026-55831 by bumping to `4.1.136.Final`).
- Not tied to a specific CVE — getting ahead of the next patch cycle rather than waiting for the next required fix.
- Bumps `netty-codec-http2-version` in lockstep (pinned to the same property).
- Bumps `netty-tcnative-version` from `2.0.78.Final` -> `2.0.81.Final` per netty's own release pom for `4.1.137.Final` (https://github.com/netty/netty/blob/netty-4.1.137.Final/pom.xml), same pattern as the tcnative bump in #11144.
- All `netty-*` submodules in `pom.xml` are pinned to `${netty.version}` in `dependencyManagement`, so this single property bump carries `netty-codec-http` (and its siblings) to the fixed version.

## Test plan
- [ ] CI build/dependency resolution on this PR to confirm `netty-codec-http` resolves to `4.1.137.Final` and `netty-tcnative-boringssl-static` resolves to `2.0.81.Final` (`mvn dependency:tree -Dincludes=io.netty`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)