### PR TITLE
KSQL-15279: gate debug.request behind the internal-listener check

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/query/QueryExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/query/QueryExecutor.java
@@ -244,6 +244,7 @@ public class QueryExecutor {
           statement,
           configOverrides,
           requestProperties,
+          isInternalRequest,
           context,
           scalablePushBandRateLimiter,
           resultForMetrics
@@ -273,7 +274,8 @@ public class QueryExecutor {
     final RoutingOptions routingOptions = new PullQueryConfigRoutingOptions(
         configured.getSessionConfig().getConfig(false),
         configured.getSessionConfig().getOverrides(),
-        requestProperties
+        requestProperties,
+        isInternalRequest.orElse(false)
     );
 
     final PullQueryConfigPlannerOptions plannerOptions = new PullQueryConfigPlannerOptions(
@@ -332,6 +334,7 @@ public class QueryExecutor {
       final PreparedStatement<Query> statement,
       final Map<String, Object> configOverrides,
       final Map<String, Object> requestProperties,
+      final Optional<Boolean> isInternalRequest,
       final Context context,
       final SlidingWindowRateLimiter scalablePushBandRateLimiter,
       final AtomicReference<ScalablePushQueryMetadata> resultForMetrics
@@ -342,7 +345,8 @@ public class QueryExecutor {
     final PushQueryConfigRoutingOptions routingOptions = new PushQueryConfigRoutingOptions(
         ksqlEngine.getKsqlConfig(),
         configOverrides,
-        requestProperties
+        requestProperties,
+        isInternalRequest.orElse(false)
     );
 
     final PushQueryConfigPlannerOptions plannerOptions =

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryConfigRoutingOptions.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryConfigRoutingOptions.java
@@ -32,17 +32,20 @@ public class PullQueryConfigRoutingOptions implements RoutingOptions {
   private final KsqlConfig ksqlConfig;
   private final ImmutableMap<String, ?> configOverrides;
   private final ImmutableMap<String, ?> requestProperties;
+  private final boolean isInternalRequest;
 
   public PullQueryConfigRoutingOptions(
       final KsqlConfig ksqlConfig,
       final Map<String, ?> configOverrides,
-      final Map<String, ?> requestProperties
+      final Map<String, ?> requestProperties,
+      final boolean isInternalRequest
   ) {
     this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
     this.configOverrides = ImmutableMap.copyOf(configOverrides);
     this.requestProperties = ImmutableMap.copyOf(
         Objects.requireNonNull(requestProperties, "requestProperties")
     );
+    this.isInternalRequest = isInternalRequest;
   }
 
   private long getLong() {
@@ -58,6 +61,9 @@ public class PullQueryConfigRoutingOptions implements RoutingOptions {
   }
 
   public boolean getIsDebugRequest() {
+    if (!isInternalRequest) {
+      return false;
+    }
     return Optional.ofNullable(
         (Boolean) requestProperties.get(KsqlRequestConfig.KSQL_DEBUG_REQUEST)
     ).orElse(KsqlRequestConfig.KSQL_DEBUG_REQUEST_DEFAULT);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryConfigRoutingOptions.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryConfigRoutingOptions.java
@@ -27,15 +27,18 @@ public class PushQueryConfigRoutingOptions implements PushRoutingOptions {
   private final KsqlConfig ksqlConfig;
   private final Map<String, ?> configOverrides;
   private final Map<String, ?> requestProperties;
+  private final boolean isInternalRequest;
 
   public PushQueryConfigRoutingOptions(
       final KsqlConfig ksqlConfig,
       final Map<String, ?> configOverrides,
-      final Map<String, ?> requestProperties
+      final Map<String, ?> requestProperties,
+      final boolean isInternalRequest
   ) {
     this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
     this.configOverrides = Objects.requireNonNull(configOverrides, "configOverrides");
     this.requestProperties = Objects.requireNonNull(requestProperties, "requestProperties");
+    this.isInternalRequest = isInternalRequest;
   }
 
   @Override
@@ -49,6 +52,9 @@ public class PushQueryConfigRoutingOptions implements PushRoutingOptions {
 
   @Override
   public boolean getIsDebugRequest() {
+    if (!isInternalRequest) {
+      return false;
+    }
     if (requestProperties.containsKey(KsqlRequestConfig.KSQL_DEBUG_REQUEST)) {
       return (Boolean) requestProperties.get(KsqlRequestConfig.KSQL_DEBUG_REQUEST);
     }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
@@ -207,7 +207,13 @@ public final class RestIntegrationTestUtil {
       final Map<String, ?> properties,
       final Map<String, Object> requestProperties
   ) {
-    try (final KsqlRestClient restClient = restApp.buildKsqlClient(userCreds)) {
+    // debug.request is now only honored on the internal listener (KSQL-15279), so tests
+    // that request debug info (e.g. to inspect sourceHost) must route through it too.
+    final boolean isDebugRequest = requestProperties != null
+        && Boolean.TRUE.equals(requestProperties.get(KsqlRequestConfig.KSQL_DEBUG_REQUEST));
+    try (final KsqlRestClient restClient = isDebugRequest
+        ? restApp.buildInternalKsqlClient(userCreds)
+        : restApp.buildKsqlClient(userCreds)) {
 
       final RestResponse<List<StreamedRow>> res =
           restClient.makeQueryRequest(sql, null, properties, requestProperties);


### PR DESCRIPTION
The `debug.request` query property is read directly from client-supplied request properties in `PullQueryConfigRoutingOptions` and `PushQueryConfigRoutingOptions`, with no check on whether the request actually arrived on the internal listener.

Threads the existing `isInternalRequest` flag (already computed in `QueryExecutor` and already used to gate the forwarded-request flag) into both routing-options classes, so `debug.request` is only honored on the internal listener -- the same trust pattern already used elsewhere in this code path.

## Verification

Existing `QueryExecutorTest` and routing-options unit tests pass; no behavior change for internal/forwarded requests, since `isInternalRequest` is already threaded through those paths today.