### PR TITLE
KSQL-15626, KSQL-15604: bump Netty to 4.1.137.Final and httpclient5 to 5.6.3 (7.8.11)

### DIFF
--- a/ksqldb-engine/pom.xml
+++ b/ksqldb-engine/pom.xml
@@ -76,6 +76,11 @@
         </dependency>
 
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,11 @@
     <properties>
         <apache.directory.server.version>2.0.0-M22</apache.directory.server.version>
         <apache.directory.api.version>1.0.0-M33</apache.directory.api.version>
-        <apache.httpcomponents.version>5.0.3</apache.httpcomponents.version>
+        <apache.httpcomponents.version>5.6.3</apache.httpcomponents.version>
+        <!-- httpclient5 5.0.3 pulled this in transitively; 5.6.3 no longer does,
+             and ksqldb-engine's Encode/MD5 UDFs use it directly, so it must be
+             declared explicitly now. -->
+        <commons-codec.version>1.22.1</commons-codec.version>
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <exec-maven-plugin.version>1.2.1</exec-maven-plugin.version>
         <podam.version>6.0.2.RELEASE</podam.version>
@@ -139,15 +143,15 @@
         <apache.io.version>2.11.0</apache.io.version>
         <io.confluent.ksql.version>7.8.11-0</io.confluent.ksql.version>
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
-        <netty-tcnative-version>2.0.78.Final</netty-tcnative-version>
+        <netty-tcnative-version>2.0.81.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`
              we might need to bump `tcnative`, too.
              Please check top level `pom.xml` at https://github.com/netty/netty
              for the netty version we bump to (ie, corresponding git tag),
              to find the correct `tcnative` version. -->
-        <netty.version>4.1.136.Final</netty.version>
-        <netty-codec-http2-version>4.1.136.Final</netty-codec-http2-version>
+        <netty.version>4.1.137.Final</netty.version>
+        <netty-codec-http2-version>4.1.137.Final</netty-codec-http2-version>
         <jersey-common>2.46</jersey-common>
         <multi-threaded-testing.forkCount>3</multi-threaded-testing.forkCount>
         <kafka.version>${ce.kafka.version}</kafka.version>
@@ -156,6 +160,11 @@
     <dependencyManagement>
         <dependencies>
             <!-- Cross-submodule dependencies -->
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${commons-codec.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka_${kafka.scala.version}</artifactId>


### PR DESCRIPTION
## Summary

Cherry-picks #11153 (`3e35b81c5e9c7beef94e9ecee3657c746924131b`, merged into `7.6.x`) onto `7.8.11` — exact, unmodified diff. Verified the baseline on `7.8.11` was identical to what #11153 patched (`apache.httpcomponents.version=5.0.3`, `netty.version`/`netty-tcnative-version=4.1.136.Final`/`2.0.78.Final`, `commons-codec` undeclared in `ksqldb-engine/pom.xml`), so the commit applies cleanly with zero conflicts.

Fixes CVE-2026-59903 in `io.netty:netty-codec-http` and CVE-2026-64607 in `org.apache.httpcomponents.client5:httpclient5`. Bumps `netty-tcnative` to `2.0.81.Final` to match, and declares `commons-codec 1.22.1` explicitly now that httpclient5 5.6.3 no longer pulls it in transitively (`ksqldb-engine`'s Encode/MD5 UDFs use it directly).

## Verification

```
mvn dependency:tree -Dincludes=io.netty:netty-codec-http
mvn dependency:tree -Dincludes=org.apache.httpcomponents.client5:httpclient5
mvn dependency:tree -Dincludes=commons-codec:commons-codec
```

all resolve to the expected patched versions on this branch.