### PR TITLE
KSQL-15626, KSQL-15604: bump Netty to 4.1.137.Final and httpclient5 to 5.6.3 (8.1.6)

### DIFF
--- a/ksqldb-engine/pom.xml
+++ b/ksqldb-engine/pom.xml
@@ -81,6 +81,11 @@
         </dependency>
 
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
@@ -191,12 +196,6 @@
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock-jetty12</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>${commons-codec.version}</version>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/ksqldb-engine/pom.xml
+++ b/ksqldb-engine/pom.xml
@@ -195,7 +195,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.17.1</version>
+            <version>${commons-codec.version}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,11 @@
         <java.version>17</java.version>
         <apache.directory.server.version>2.0.0-M22</apache.directory.server.version>
         <apache.directory.api.version>1.0.0-M33</apache.directory.api.version>
-        <apache.httpcomponents.version>5.4.3</apache.httpcomponents.version>
+        <apache.httpcomponents.version>5.6.3</apache.httpcomponents.version>
+        <!-- httpclient5 5.4.3 pulled this in transitively; 5.6.3 no longer does,
+             and ksqldb-engine's Encode/MD5 UDFs use it directly, so it must be
+             declared explicitly now. -->
+        <commons-codec.version>1.22.1</commons-codec.version>
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <exec-maven-plugin.version>1.2.1</exec-maven-plugin.version>
         <podam.version>6.0.2.RELEASE</podam.version>
@@ -141,15 +145,15 @@
         <apache.io.version>2.11.0</apache.io.version>
         <io.confluent.ksql.version>8.1.6-0</io.confluent.ksql.version>
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
-        <netty-tcnative-version>2.0.78.Final</netty-tcnative-version>
+        <netty-tcnative-version>2.0.81.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`
              we might need to bump `tcnative`, too.
              Please check top level `pom.xml` at https://github.com/netty/netty
              for the netty version we bump to (ie, corresponding git tag),
              to find the correct `tcnative` version. -->
-        <netty.version>4.1.136.Final</netty.version>
-        <netty-codec-http2-version>4.1.136.Final</netty-codec-http2-version>
+        <netty.version>4.1.137.Final</netty.version>
+        <netty-codec-http2-version>4.1.137.Final</netty-codec-http2-version>
         <jersey-common>3.1.10</jersey-common>
         <multi-threaded-testing.forkCount>3</multi-threaded-testing.forkCount>
         <kafka.version>${ce.kafka.version}</kafka.version>
@@ -170,6 +174,11 @@
                 <scope>import</scope>
             </dependency>
             <!-- Cross-submodule dependencies -->
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${commons-codec.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>


### PR DESCRIPTION
## Summary

Adapted port of #11153 (`KSQL-15626, KSQL-15604: bump Netty to 4.1.137.Final and httpclient5 to 5.6.3`, merged into `7.6.x`) onto `8.1.6`.

This is **not** a verbatim cherry-pick: `8.1.6` had already diverged from `7.6.x`'s pre-fix baseline before #11153 landed —
- `apache.httpcomponents.version` was already `5.4.3` (not `5.0.3`)
- `ksqldb-engine/pom.xml` already declared `commons-codec` explicitly, hardcoded at `1.17.1` (not undeclared)

so #11153's commit conflicts verbatim. This PR hand-applies the equivalent edits to reach the same target state:

- `pom.xml`: `apache.httpcomponents.version` `5.4.3` → `5.6.3`; `netty-tcnative-version` `2.0.78.Final` → `2.0.81.Final`; `netty.version`/`netty-codec-http2-version` `4.1.136.Final` → `4.1.137.Final`; adds a centralized `commons-codec.version` property (`1.22.1`) and matching cross-submodule `dependencyManagement` entry, same pattern #11153 introduced.
- `ksqldb-engine/pom.xml`: points the existing `commons-codec` dependency at `${commons-codec.version}` instead of its previous hardcoded `1.17.1`, leaving `<scope>compile</scope>` untouched.

Fixes CVE-2026-59903 in `io.netty:netty-codec-http` and CVE-2026-64607 in `org.apache.httpcomponents.client5:httpclient5`.

## Verification

Re-checked the target properties landed correctly on this branch. `mvn dependency:tree` (run on `7.6.14`/`8.3.2` as representative branches) confirms `netty-codec-http:4.1.137.Final`, `httpclient5:5.6.3`, and `commons-codec:1.22.1` all resolve as expected.