### PR TITLE
KSQL-15015: log restore range validations regardless of restore.enabled flag in command topic.

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutor.java
@@ -206,16 +206,15 @@ public class InteractiveStatementExecutor {
 
         final KsqlConfig config = ksqlEngine.getKsqlConfig();
         if (config.getBoolean(KsqlConfig.KSQL_PROPERTIES_OVERRIDES_VALIDATION_RESTORE_ENABLED)) {
-
           final Map<String, Object> filteredRawOverrides =
               new RestorePropertyOverrideFilter(config)
               .filter("command_topic_restore", queryId, rawOverrides);
           overwriteProperties = PropertiesUtil.coerceTypes(filteredRawOverrides, true);
-          ConfigOverrideLogger.logRangeViolations(
-                  "command_topic_restore", Optional.of(queryId), overwriteProperties);
         } else {
           overwriteProperties = command.getOverwritePropertiesForExecution();
         }
+        ConfigOverrideLogger.logRangeViolations(
+                "command_topic_restore", Optional.of(queryId), overwriteProperties);
       } else {
         overwriteProperties = command.getOverwritePropertiesForExecution();
       }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -1118,9 +1117,11 @@ public class InteractiveStatementExecutorTest {
       // Then: The audit log still fires - it sits outside the gate.
       configOverrideLogger.verify(() -> ConfigOverrideLogger.logOverrides(
                 eq("command_topic_restore"), any(), any()));
-      // But no filtering and no range check either.
-      configOverrideLogger.verify(
-          () -> ConfigOverrideLogger.logRangeViolations(any(), any(), any()), never());
+      // And: the range check also fires
+      configOverrideLogger.verify(() -> ConfigOverrideLogger.logRangeViolations(
+          eq("command_topic_restore"),
+          eq(Optional.of(COMMAND_ID.toString())),
+          any()), times(1));
     }
 
     // And: every stored override reaches the query untouched.


### PR DESCRIPTION
### Description 
On the command-topic restore path, range-validation logging  (`ConfigOverrideLogger.logRangeViolations`) was nested inside the  `ksql.properties.overrides.validation.restore.enabled` branch in `InteractiveStatementExecutor`. That coupled two independent features: range  violations were only logged when restore *filtering* was enabled, so an  operator who wanted the range-validation log during restore was forced to also turn on override filtering (which drops properties from restored queries).                                                                                                                                                                                                                                                                                                      
This decouples them. `logRangeViolations` now runs on every restore — exactly like the `logOverrides` call that already sits outside the gate:                                                                                                                             
  - validation **on**  → overrides filtered by `RestorePropertyOverrideFilter`, then coerced                                                                                                                     
  - validation **off** → overrides coerced, unfiltered                                                                                                                                                           
                                                                                                                                                                                                               
### Testing done 
Unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Do these changes have compatibility implications for rollback? If so, ensure that the ksql [command version](https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java#L41) is bumped.

