### PR TITLE
Bump wire-runtime-jvm/wire-schema-jvm to 6.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,10 @@
              and ksqldb-engine's Encode/MD5 UDFs use it directly, so it must be
              declared explicitly now. -->
         <commons-codec.version>1.22.1</commons-codec.version>
+        <!-- wire-schema-jvm is pulled in transitively (via the protobuf schema
+             parsing path); wire-runtime-jvm rides along with it at the same
+             version. Pinned here to pull in the CVE-2026-45799 fix. -->
+        <wire.version>6.3.0</wire.version>
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <exec-maven-plugin.version>1.2.1</exec-maven-plugin.version>
         <podam.version>6.0.2.RELEASE</podam.version>
@@ -164,6 +168,16 @@
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
                 <version>${commons-codec.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.wire</groupId>
+                <artifactId>wire-runtime-jvm</artifactId>
+                <version>${wire.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.wire</groupId>
+                <artifactId>wire-schema-jvm</artifactId>
+                <version>${wire.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
## What

Overrides the transitively-pulled `com.squareup.wire:wire-runtime-jvm` and `com.squareup.wire:wire-schema-jvm` to 6.3.0 via `dependencyManagement`.

## Why

CVE-2026-45799: fixed upstream in wire 6.3.0.

## Verification

- Confirmed the only Wire API this codebase calls (`ProtoFileElement.getPackageName()/getTypes()`, `TypeElement.getName()` in `AbstractProtobufFormat.java`) has identical method signatures in wire-schema-jvm 5.5.0 vs 6.3.0.
- CI build/test will validate the full build.