### PR TITLE
KSQL-15614: bump httpclient5 to 5.6.3 to fix CVE-2026-64607

### DIFF
--- a/ksqldb-engine/pom.xml
+++ b/ksqldb-engine/pom.xml
@@ -193,7 +193,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.17.1</version>
+            <version>${commons-codec.version}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,11 @@
         <java.version>17</java.version>
         <apache.directory.server.version>2.0.0-M22</apache.directory.server.version>
         <apache.directory.api.version>1.0.0-M33</apache.directory.api.version>
-        <apache.httpcomponents.version>5.4.3</apache.httpcomponents.version>
+        <apache.httpcomponents.version>5.6.3</apache.httpcomponents.version>
+        <!-- httpclient5 5.4.3 pulled this in transitively; 5.6.3 no longer does,
+             and ksqldb-engine's Encode/MD5 UDFs use it directly, so it must be
+             declared explicitly now. -->
+        <commons-codec.version>1.22.1</commons-codec.version>
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <exec-maven-plugin.version>1.2.1</exec-maven-plugin.version>
         <podam.version>6.0.2.RELEASE</podam.version>
@@ -162,6 +166,11 @@
     <dependencyManagement>
         <dependencies>
             <!-- Cross-submodule dependencies -->
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${commons-codec.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>


### PR DESCRIPTION
## Summary
- Fixes [KSQL-15614](https://confluentinc.atlassian.net/browse/KSQL-15614): CVE-2026-64607 in `org.apache.httpcomponents.client5:httpclient5`, by bumping `apache.httpcomponents.version` 5.4.3 -> 5.6.3 in `pom.xml`.
- httpclient5 5.6.3 no longer pulls in `commons-codec` transitively, and `ksqldb-engine`'s Encode/MD5 UDFs use it directly, so `commons-codec` is now centralized via a new `commons-codec.version` property (1.22.1) and root `pom.xml` `dependencyManagement` entry, with `ksqldb-engine/pom.xml`'s existing dependency pointed at it instead of its previous hardcoded `1.17.1`.
- This is the same fix already applied to several other release branches (7.6.x, 7.7.x, 7.8.x, 7.9.x, 8.0.8, 8.1.x, 8.2.x, 8.3.x) via the combined KSQL-15626/KSQL-15604 commits, adapted here for 8.0.2-cp10, which started from the same pre-fix version state as 8.0.8 did. Scoped to httpclient5/commons-codec only — the unrelated Netty CVE-2026-59903 bump for this branch is tracked/handled separately.

## Test plan
- [ ] CI build passes
- [ ] Verify the fix in the final artifact: `mvn dependency:tree -Dincludes=org.apache.httpcomponents.client5:httpclient5` shows `5.6.3` (could not be run locally in this environment due to missing CodeArtifact credentials)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

[KSQL-15614]: https://confluentinc.atlassian.net/browse/KSQL-15614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ