### PR TITLE
KSQL-15614: bump httpclient5 to 5.6.3 to fix CVE-2026-64607

### DIFF
--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/JLineReaderTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/JLineReaderTest.java
@@ -283,6 +283,10 @@ public class JLineReaderTest {
     final Terminal terminal = TerminalBuilder.builder()
         .streams(inputStream, outputStream)
         .system(false)
+        // Force the exec provider: jline bundles native libs since 3.30.x (absent in 3.25.0),
+        // so the jni provider now succeeds and opens a real OS pty even for explicit streams(),
+        // which hangs reading past the end of these finite, synthetic test streams.
+        .provider(TerminalBuilder.PROP_PROVIDER_EXEC)
         .build();
     final File tempHistoryFile = tempFolder.newFile("ksql-history.txt");
     final Path historyFilePath = Paths.get(tempHistoryFile.getAbsolutePath());

--- a/ksqldb-engine/pom.xml
+++ b/ksqldb-engine/pom.xml
@@ -81,6 +81,11 @@
         </dependency>
 
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
@@ -189,12 +194,6 @@
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock-jetty12</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>${commons-codec.version}</version>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/ksqldb-engine/pom.xml
+++ b/ksqldb-engine/pom.xml
@@ -193,7 +193,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.17.1</version>
+            <version>${commons-codec.version}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,11 @@
         <java.version>17</java.version>
         <apache.directory.server.version>2.0.0-M22</apache.directory.server.version>
         <apache.directory.api.version>1.0.0-M33</apache.directory.api.version>
-        <apache.httpcomponents.version>5.4.3</apache.httpcomponents.version>
+        <apache.httpcomponents.version>5.6.3</apache.httpcomponents.version>
+        <!-- httpclient5 5.4.3 pulled this in transitively; 5.6.3 no longer does,
+             and ksqldb-engine's Encode/MD5 UDFs use it directly, so it must be
+             declared explicitly now. -->
+        <commons-codec.version>1.22.1</commons-codec.version>
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <exec-maven-plugin.version>1.2.1</exec-maven-plugin.version>
         <podam.version>6.0.2.RELEASE</podam.version>
@@ -162,6 +166,11 @@
     <dependencyManagement>
         <dependencies>
             <!-- Cross-submodule dependencies -->
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${commons-codec.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <apache.directory.server.version>2.0.0-M22</apache.directory.server.version>
         <apache.directory.api.version>1.0.0-M33</apache.directory.api.version>
         <apache.httpcomponents.version>5.6.3</apache.httpcomponents.version>
-        <!-- httpclient5 5.4.3 pulled this in transitively; 5.6.3 no longer does,
+        <!-- httpclient5 5.4.3 pulled this in transitively, but 5.6.3 no longer does,
              and ksqldb-engine's Encode/MD5 UDFs use it directly, so it must be
              declared explicitly now. -->
         <commons-codec.version>1.22.1</commons-codec.version>
@@ -147,15 +147,15 @@
         <apache.io.version>2.11.0</apache.io.version>
         <io.confluent.ksql.version>8.0.2</io.confluent.ksql.version>
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
-        <netty-tcnative-version>2.0.78.Final</netty-tcnative-version>
+        <netty-tcnative-version>2.0.81.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`
              we might need to bump `tcnative`, too.
              Please check top level `pom.xml` at https://github.com/netty/netty
              for the netty version we bump to (ie, corresponding git tag),
              to find the correct `tcnative` version. -->
-        <netty.version>4.1.136.Final</netty.version>
-        <netty-codec-http2-version>4.1.136.Final</netty-codec-http2-version>
+        <netty.version>4.1.137.Final</netty.version>
+        <netty-codec-http2-version>4.1.137.Final</netty-codec-http2-version>
         <jersey-common>3.1.10</jersey-common>
         <multi-threaded-testing.forkCount>3</multi-threaded-testing.forkCount>
         <kafka.version>${ce.kafka.version}</kafka.version>


### PR DESCRIPTION
## Summary

- Fixes [KSQL-15614](https://confluentinc.atlassian.net/browse/KSQL-15614): CVE-2026-64607 in `org.apache.httpcomponents.client5:httpclient5`, by bumping `apache.httpcomponents.version` 5.4.3 -> 5.6.3 in `pom.xml`.
- httpclient5 5.6.3 no longer pulls in `commons-codec` transitively, and `ksqldb-engine`'s Encode/MD5 UDFs use it directly, so `commons-codec` is now centralized via a new `commons-codec.version` property (1.22.1) and root `pom.xml` `dependencyManagement` entry; `ksqldb-engine/pom.xml`'s dependency is relocated/updated to match the layout used in #11156 (the 7.9.x -> 8.0.x merge-conflict resolution carrying the original combined fix).
- Also includes the Netty bump for CVE-2026-59903 (`netty.version`/`netty-codec-http2-version` 4.1.136.Final -> 4.1.137.Final, `netty-tcnative-version` 2.0.78.Final -> 2.0.81.Final), matching #11156's diff shape exactly for full parity with how this was applied elsewhere.
- Cherry-picks the `JLineReaderTest` exec-provider fix from #11121: `jline.version` on this branch was already at 3.30.14 (via the earlier KSQL-15404/KSQL-15280 CVE fixes), but the accompanying test fix for the native-provider hang introduced by that version hadn't been ported here yet.

## Test plan
- [ ] CI build passes
- [ ] Verify the fix in the final artifact: `mvn dependency:tree -Dincludes=org.apache.httpcomponents.client5:httpclient5` shows `5.6.3` (could not be run locally in this environment due to missing CodeArtifact credentials)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

[KSQL-15614]: https://confluentinc.atlassian.net/browse/KSQL-15614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ