### PR TITLE
remove log4jpin in fedramp branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,8 +159,6 @@
         <jersey-common>3.1.10</jersey-common>
         <multi-threaded-testing.forkCount>3</multi-threaded-testing.forkCount>
         <kafka.version>${ce.kafka.version}</kafka.version>
-        <!-- This needs to be removed once the version is populated in common -->
-        <log4j2.version>2.25.4</log4j2.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
### Description 
Remove log4j2 pin. Version needs to come from common.

