### PR TITLE
[Common BOM] Remove explicit spotbugs.version override, inherit from common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -776,7 +776,6 @@
             <dependency>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-annotations</artifactId>
-                <version>${spotbugs.version}</version>
                 <scope>provided</scope>
             </dependency>
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -773,11 +773,6 @@
                 <version>2.5.2</version>
             </dependency>
 
-            <dependency>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-annotations</artifactId>
-                <scope>provided</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -824,6 +824,7 @@
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
+            <scope>provided</scope>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
## Summary
- Removes the explicit `<version>${spotbugs.version}</version>` override on `com.github.spotbugs:spotbugs-annotations`, letting it resolve from `common`'s own `dependencyManagement` instead.
- `common`'s own `dependencyManagement` already pins this artifact at `${spotbugs.version}` = `4.10.3`, which matches `confluent-common-bom`'s managed value exactly — this is a no-op version change.
- Part of an effort to stop downstream repos referencing `common`'s property-scoped dependency versions directly, so `common` can eventually drop properties that are fully covered by `confluent-common-bom`.

## Test plan
- [ ] `mvn dependency:tree -Dincludes=com.github.spotbugs` resolves `spotbugs-annotations` to `4.10.3` (unchanged)
- [ ] Standard build/test suite passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Tracking
Part of the `spotbugs.version` cleanup step in the [Common Inheritance Map — Cleanup Plan](https://claude.ai/code/artifact/854856e4-47a3-4455-9e22-326715a12c82) audit.
