### PR TITLE
Bump opentelemetry-api/opentelemetry-context to 1.62.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,10 @@
              parsing path); wire-runtime-jvm rides along with it at the same
              version. Pinned here to pull in the CVE-2026-45799 fix. -->
         <wire.version>6.3.0</wire.version>
+        <!-- opentelemetry-api is pulled in transitively; opentelemetry-context
+             rides along with it at the same version (released in lockstep).
+             Pinned here to pull in the CVE-2026-45292 fix. -->
+        <opentelemetry-api.version>1.62.0</opentelemetry-api.version>
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <exec-maven-plugin.version>1.2.1</exec-maven-plugin.version>
         <podam.version>6.0.2.RELEASE</podam.version>
@@ -178,6 +182,16 @@
                 <groupId>com.squareup.wire</groupId>
                 <artifactId>wire-schema-jvm</artifactId>
                 <version>${wire.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-api</artifactId>
+                <version>${opentelemetry-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-context</artifactId>
+                <version>${opentelemetry-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
## What

Overrides the transitively-pulled `io.opentelemetry:opentelemetry-api` and `io.opentelemetry:opentelemetry-context` to 1.62.0 via `dependencyManagement` (these two are released in lockstep at matching versions).

## Why

CVE-2026-45292: fixed upstream in opentelemetry-api 1.62.0.

## Verification

- This codebase already runs a wide, working spread of OpenTelemetry artifact versions (e.g. opentelemetry-sdk at 1.30.1 alongside opentelemetry-api at 1.42.1 prior to this change), confirming the library's strong cross-version API compatibility guarantees — bumping just api/context is safe without needing to move sdk/instrumentation/semconv artifacts in lockstep.
- CI build/test will validate the full build.