### PR TITLE
Remove redundant commons-io dependencyManagement pin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -602,12 +602,6 @@
             </dependency>
 
             <dependency>
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>${commons-io.version}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
                 <version>${commons-text.version}</version>


### PR DESCRIPTION
## Summary
- Removes the local `commons-io:commons-io` dependencyManagement entry (versioned via `${commons-io.version}`, inherited from `common`).

## Why this is safe
- `confluent-common-bom` already manages `commons-io:commons-io` at the exact same version (`2.20.0`) that `ksql` currently pins via `common`'s inherited property.
- `ksql`'s parent is `common` directly, and `common` imports `confluent-common-bom` into its own dependencyManagement — so this GA is already supplied transitively at the identical version, making the local entry fully redundant.
- Verified with `mvn help:effective-pom` on `ksqldb-testing-tool` (the only module with an actual `commons-io` dependency): resolves to `2.20.0`, `compile` scope, unchanged before/after this removal.

## Context
This is one of 3 repos (`confluent-security-plugins`, `ksql`, `ksql-internal`) that inherit `commons-io.version` from `common` the same way — piloting here on `8.0.x` first before deciding whether to fan out to the others and their other active branches.

## Verification
- `mvn help:effective-pom -pl ksqldb-testing-tool` confirms `commons-io` still resolves to `2.20.0`/`compile` scope.
- Full reactor `mvn validate` hit an unrelated pre-existing 401 fetching a third-party artifact (`fastutil`) for a different module (`ksqldb-stream-lib`) — an environment/credentials issue unrelated to this change, not something this PR introduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)