### PR TITLE
KSQL-15185: Add Metrics-bearing register hook to KsqlResourceExtension SPI

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlResourceExtension.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlResourceExtension.java
@@ -19,6 +19,16 @@ public interface KsqlResourceExtension extends AutoCloseable {
   void register(KsqlConfig ksqlConfig);
 
   /**
+   * Registers and initializes the resource extension with additional server context (metrics and
+   * node/cluster identity). The default delegates to {@link #register(KsqlConfig)} so extensions
+   * that do not need the extra context keep working unchanged.
+   * @param context the registration context
+   */
+  default void register(final KsqlResourceExtensionContext context) {
+    register(context.ksqlConfig());
+  }
+
+  /**
    * Closes the resource extension and releases any held resources.
    */
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlResourceExtensionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlResourceExtensionContext.java
@@ -4,9 +4,11 @@
 
 package io.confluent.ksql.security;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Immutable context passed to {@link KsqlResourceExtension#register(KsqlResourceExtensionContext)}.
@@ -19,13 +21,13 @@ public final class KsqlResourceExtensionContext {
 
   private final KsqlConfig ksqlConfig;
   private final MetricCollectors metricCollectors;
-  private final String nodeId;
+  private final Optional<String> nodeId;
   private final String clusterId;
 
   public KsqlResourceExtensionContext(
       final KsqlConfig ksqlConfig,
       final MetricCollectors metricCollectors,
-      final String nodeId,
+      final Optional<String> nodeId,
       final String clusterId
   ) {
     this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
@@ -37,6 +39,8 @@ public final class KsqlResourceExtensionContext {
   /**
    * @return the ksqlDB configuration containing all server settings
    */
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP",
+      justification = "context intentionally shares the live server config")
   public KsqlConfig ksqlConfig() {
     return ksqlConfig;
   }
@@ -45,14 +49,19 @@ public final class KsqlResourceExtensionContext {
    * @return the server metric collectors; {@code metricCollectors().getMetrics()} yields the Kafka
    *     {@code Metrics} instance an extension can register gauges against
    */
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP",
+      justification = "context intentionally shares the live server metrics sink")
   public MetricCollectors metricCollectors() {
     return metricCollectors;
   }
 
   /**
-   * @return a stable identifier unique to this ksqlDB node
+   * @return a stable identifier unique to this ksqlDB node, or empty when the node has no routable
+   *     address configured to derive one from. Consumers must treat an empty id as "attribution not
+   *     available for this node" rather than substituting a placeholder, since a non-unique id
+   *     would collide across nodes.
    */
-  public String nodeId() {
+  public Optional<String> nodeId() {
     return nodeId;
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlResourceExtensionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlResourceExtensionContext.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ */
+
+package io.confluent.ksql.security;
+
+import io.confluent.ksql.metrics.MetricCollectors;
+import io.confluent.ksql.util.KsqlConfig;
+import java.util.Objects;
+
+/**
+ * Immutable context passed to {@link KsqlResourceExtension#register(KsqlResourceExtensionContext)}.
+ *
+ * <p>It carries the server {@link MetricCollectors} and this node's identity, which a resource
+ * extension needs for cross-cutting concerns such as license node attribution that the plain
+ * {@link KsqlResourceExtension#register(KsqlConfig)} overload cannot supply.
+ */
+public final class KsqlResourceExtensionContext {
+
+  private final KsqlConfig ksqlConfig;
+  private final MetricCollectors metricCollectors;
+  private final String nodeId;
+  private final String clusterId;
+
+  public KsqlResourceExtensionContext(
+      final KsqlConfig ksqlConfig,
+      final MetricCollectors metricCollectors,
+      final String nodeId,
+      final String clusterId
+  ) {
+    this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
+    this.metricCollectors = Objects.requireNonNull(metricCollectors, "metricCollectors");
+    this.nodeId = Objects.requireNonNull(nodeId, "nodeId");
+    this.clusterId = Objects.requireNonNull(clusterId, "clusterId");
+  }
+
+  /**
+   * @return the ksqlDB configuration containing all server settings
+   */
+  public KsqlConfig ksqlConfig() {
+    return ksqlConfig;
+  }
+
+  /**
+   * @return the server metric collectors; {@code metricCollectors().getMetrics()} yields the Kafka
+   *     {@code Metrics} instance an extension can register gauges against
+   */
+  public MetricCollectors metricCollectors() {
+    return metricCollectors;
+  }
+
+  /**
+   * @return a stable identifier unique to this ksqlDB node
+   */
+  public String nodeId() {
+    return nodeId;
+  }
+
+  /**
+   * @return the identifier of the ksqlDB cluster this node belongs to
+   */
+  public String clusterId() {
+    return clusterId;
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/security/KsqlResourceExtensionTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/security/KsqlResourceExtensionTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.Matchers.sameInstance;
 
 import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.util.KsqlConfig;
+import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -49,7 +50,8 @@ public class KsqlResourceExtensionTest {
   }
 
   private KsqlResourceExtensionContext context() {
-    return new KsqlResourceExtensionContext(ksqlConfig, metricCollectors, "node-1", "cluster-1");
+    return new KsqlResourceExtensionContext(
+        ksqlConfig, metricCollectors, Optional.of("node-1"), "cluster-1");
   }
 
   private static final class RecordingExtension implements KsqlResourceExtension {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/security/KsqlResourceExtensionTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/security/KsqlResourceExtensionTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ */
+
+package io.confluent.ksql.security;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+
+import io.confluent.ksql.metrics.MetricCollectors;
+import io.confluent.ksql.util.KsqlConfig;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KsqlResourceExtensionTest {
+
+  @Mock
+  private KsqlConfig ksqlConfig;
+  @Mock
+  private MetricCollectors metricCollectors;
+
+  @Test
+  public void shouldDelegateContextRegistrationToKsqlConfigOverloadByDefault() {
+    // Given: an extension that only implements the legacy register(KsqlConfig)
+    final RecordingExtension extension = new RecordingExtension();
+
+    // When: registered with the richer context
+    extension.register(context());
+
+    // Then: the default hook forwards the config to the legacy overload
+    assertThat(extension.registeredConfig, is(sameInstance(ksqlConfig)));
+  }
+
+  @Test
+  public void shouldPassFullContextToContextAwareExtension() {
+    // Given: an extension that overrides the context-aware overload
+    final ContextAwareExtension extension = new ContextAwareExtension();
+    final KsqlResourceExtensionContext context = context();
+
+    // When
+    extension.register(context);
+
+    // Then: the extension receives the context as-is
+    assertThat(extension.registeredContext, is(sameInstance(context)));
+  }
+
+  private KsqlResourceExtensionContext context() {
+    return new KsqlResourceExtensionContext(ksqlConfig, metricCollectors, "node-1", "cluster-1");
+  }
+
+  private static final class RecordingExtension implements KsqlResourceExtension {
+    private KsqlConfig registeredConfig;
+
+    @Override
+    public void register(final KsqlConfig config) {
+      this.registeredConfig = config;
+    }
+
+    @Override
+    public void close() {
+    }
+  }
+
+  private static final class ContextAwareExtension implements KsqlResourceExtension {
+    private KsqlResourceExtensionContext registeredContext;
+
+    @Override
+    public void register(final KsqlConfig config) {
+    }
+
+    @Override
+    public void register(final KsqlResourceExtensionContext context) {
+      this.registeredContext = context;
+    }
+
+    @Override
+    public void close() {
+    }
+  }
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -1222,24 +1222,56 @@ public final class KsqlRestApplication implements Executable {
       return Optional.of(extension);
 
     } catch (final Throwable t) {
-      log.warn(KsqlConstants.KSQL_RESOURCE_EXTENSION_MISCONFIGURED_LOG_MESSAGE);
+      log.warn(KsqlConstants.KSQL_RESOURCE_EXTENSION_MISCONFIGURED_LOG_MESSAGE, t);
       return Optional.empty();
     }
   }
 
   /**
-   * Resolves a stable per-node identifier for license node attribution: a ksqlDB node is identified
-   * by its own address. Prefers the explicitly advertised inter-node listener; otherwise uses the
-   * first configured listener, which {@link KsqlRestConfig} validates to be present. The final
-   * node-id semantics are still being confirmed with the Licensing team (KSQL-15185).
+   * Resolves a stable per-node identifier for license node attribution from this node's own
+   * inter-node address. Prefers the advertised inter-node listener, then the internal listener,
+   * then the first non-wildcard entry in {@code listeners}.
+   *
+   * <p>Wildcard bind addresses (0.0.0.0, [::]) are skipped: they are identical on every node and so
+   * are useless — and explicitly disallowed — as an identity. If no routable address is configured
+   * the id is absent, and callers must leave node attribution disabled rather than emit a colliding
+   * label. The final node-id semantics are still being confirmed with the Licensing team
+   * (KSQL-15185).
    */
-  private static String resolveNodeId(final KsqlRestConfig restConfig) {
-    final String advertisedListener =
-        restConfig.getString(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG);
-    if (advertisedListener != null && !advertisedListener.trim().isEmpty()) {
-      return advertisedListener;
+  @VisibleForTesting
+  static Optional<String> resolveNodeId(final KsqlRestConfig restConfig) {
+    final String advertised = restConfig.getString(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG);
+    if (isRoutableListener(advertised)) {
+      return Optional.of(advertised.trim());
     }
-    return restConfig.getList(KsqlRestConfig.LISTENERS_CONFIG).get(0);
+    final String internal = restConfig.getString(KsqlRestConfig.INTERNAL_LISTENER_CONFIG);
+    if (isRoutableListener(internal)) {
+      return Optional.of(internal.trim());
+    }
+    return restConfig.getList(KsqlRestConfig.LISTENERS_CONFIG).stream()
+        .filter(KsqlRestApplication::isRoutableListener)
+        .map(String::trim)
+        .findFirst();
+  }
+
+  /**
+   * @return true if {@code listener} is a non-blank URL whose host is a routable address, i.e. not
+   *     a wildcard bind address such as {@code 0.0.0.0} or {@code [::]}.
+   */
+  private static boolean isRoutableListener(final String listener) {
+    if (listener == null || listener.trim().isEmpty()) {
+      return false;
+    }
+    final String host;
+    try {
+      host = URI.create(listener.trim()).getHost();
+    } catch (final IllegalArgumentException e) {
+      return false;
+    }
+    if (host == null || host.isEmpty()) {
+      return false;
+    }
+    return !"0.0.0.0".equals(host) && !"::".equals(host) && !"[::]".equals(host);
   }
 
   private static Optional<AuthenticationPlugin> loadAuthenticationPlugin(

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -97,6 +97,7 @@ import io.confluent.ksql.security.KsqlAuthorizationValidator;
 import io.confluent.ksql.security.KsqlAuthorizationValidatorFactory;
 import io.confluent.ksql.security.KsqlDefaultSecurityExtension;
 import io.confluent.ksql.security.KsqlResourceExtension;
+import io.confluent.ksql.security.KsqlResourceExtensionContext;
 import io.confluent.ksql.security.KsqlSecurityContext;
 import io.confluent.ksql.security.KsqlSecurityExtension;
 import io.confluent.ksql.services.ConnectClientFactory;
@@ -837,7 +838,7 @@ public final class KsqlRestApplication implements Executable {
             sharedClient);
 
     final Optional<KsqlResourceExtension> ksqlResourceExtension =
-        loadKsqlResourceExtension(ksqlConfig);
+        loadKsqlResourceExtension(restConfig, ksqlConfig, metricCollectors);
 
     final Optional<AuthenticationPlugin> securityHandlerPlugin = loadAuthenticationPlugin(
         restConfig);
@@ -1179,7 +1180,9 @@ public final class KsqlRestApplication implements Executable {
   }
 
   private static Optional<KsqlResourceExtension> loadKsqlResourceExtension(
-      final KsqlConfig ksqlConfig) {
+      final KsqlRestConfig restConfig,
+      final KsqlConfig ksqlConfig,
+      final MetricCollectors metricCollectors) {
 
     final String extensionClassName =
         ksqlConfig.getString(KsqlConfig.KSQL_RESOURCE_EXTENSION_CLASS);
@@ -1209,7 +1212,11 @@ public final class KsqlRestApplication implements Executable {
         throw new KsqlException(KsqlConstants.KSQL_RESOURCE_EXTENSION_MISCONFIGURED_LOG_MESSAGE);
       }
 
-      extension.register(ksqlConfig);
+      extension.register(new KsqlResourceExtensionContext(
+          ksqlConfig,
+          metricCollectors,
+          resolveNodeId(restConfig),
+          ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)));
       log.info("Successfully loaded and registered KSQL resource extension: {}",
           extensionClassName);
       return Optional.of(extension);
@@ -1218,6 +1225,21 @@ public final class KsqlRestApplication implements Executable {
       log.warn(KsqlConstants.KSQL_RESOURCE_EXTENSION_MISCONFIGURED_LOG_MESSAGE);
       return Optional.empty();
     }
+  }
+
+  /**
+   * Resolves a stable per-node identifier for license node attribution: a ksqlDB node is identified
+   * by its own address. Prefers the explicitly advertised inter-node listener; otherwise uses the
+   * first configured listener, which {@link KsqlRestConfig} validates to be present. The final
+   * node-id semantics are still being confirmed with the Licensing team (KSQL-15185).
+   */
+  private static String resolveNodeId(final KsqlRestConfig restConfig) {
+    final String advertisedListener =
+        restConfig.getString(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG);
+    if (advertisedListener != null && !advertisedListener.trim().isEmpty()) {
+      return advertisedListener;
+    }
+    return restConfig.getList(KsqlRestConfig.LISTENERS_CONFIG).get(0);
   }
 
   private static Optional<AuthenticationPlugin> loadAuthenticationPlugin(

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.hash.Hashing;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -1228,50 +1229,27 @@ public final class KsqlRestApplication implements Executable {
   }
 
   /**
-   * Resolves a stable per-node identifier for license node attribution from this node's own
-   * inter-node address. Prefers the advertised inter-node listener, then the internal listener,
-   * then the first non-wildcard entry in {@code listeners}.
-   *
-   * <p>Wildcard bind addresses (0.0.0.0, [::]) are skipped: they are identical on every node and so
-   * are useless — and explicitly disallowed — as an identity. If no routable address is configured
-   * the id is absent, and callers must leave node attribution disabled rather than emit a colliding
-   * label. The final node-id semantics are still being confirmed with the Licensing team
-   * (KSQL-15185).
+   * Resolves this node's identifier for license node attribution: a short, stable hash of the
+   * host and port of ksqlDB's inter-node listener ({@link KsqlRestConfig#getInterNodeListener}),
+   * the same endpoint ksqlDB advertises to peers as the Streams {@code application.server}. Order
+   * is advertised listener, then internal listener, then the first listener, with wildcard binds
+   * sanitized to the local host. Hashing host:port keeps the id short and display-friendly, while
+   * staying stable across restarts and unique per node (co-located nodes included). If nothing
+   * resolves, the id is absent and node attribution is left disabled.
    */
   @VisibleForTesting
   static Optional<String> resolveNodeId(final KsqlRestConfig restConfig) {
-    final String advertised = restConfig.getString(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG);
-    if (isRoutableListener(advertised)) {
-      return Optional.of(advertised.trim());
-    }
-    final String internal = restConfig.getString(KsqlRestConfig.INTERNAL_LISTENER_CONFIG);
-    if (isRoutableListener(internal)) {
-      return Optional.of(internal.trim());
-    }
-    return restConfig.getList(KsqlRestConfig.LISTENERS_CONFIG).stream()
-        .filter(KsqlRestApplication::isRoutableListener)
-        .map(String::trim)
-        .findFirst();
-  }
-
-  /**
-   * @return true if {@code listener} is a non-blank URL whose host is a routable address, i.e. not
-   *     a wildcard bind address such as {@code 0.0.0.0} or {@code [::]}.
-   */
-  private static boolean isRoutableListener(final String listener) {
-    if (listener == null || listener.trim().isEmpty()) {
-      return false;
-    }
-    final String host;
     try {
-      host = URI.create(listener.trim()).getHost();
-    } catch (final IllegalArgumentException e) {
-      return false;
+      final URL listener = restConfig.getInterNodeListener(URL::getPort);
+      final String hostPort = listener.getHost() + ":" + listener.getPort();
+      // 16 hex chars (64 bits): short enough for a UI, collision-safe for realistic node counts.
+      return Optional.of(
+          Hashing.sha256().hashString(hostPort, StandardCharsets.UTF_8).toString().substring(0, 16));
+    } catch (final RuntimeException e) {
+      log.warn("Could not resolve this node's inter-node listener for license node attribution; "
+          + "node attribution will be disabled", e);
+      return Optional.empty();
     }
-    if (host == null || host.isEmpty()) {
-      return false;
-    }
-    return !"0.0.0.0".equals(host) && !"::".equals(host) && !"[::]".equals(host);
   }
 
   private static Optional<AuthenticationPlugin> loadAuthenticationPlugin(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -490,43 +490,52 @@ public class KsqlRestApplicationTest {
   }
 
   @Test
-  public void shouldResolveNodeIdFromAdvertisedListener() {
-    final KsqlRestConfig config = mock(KsqlRestConfig.class);
-    when(config.getString(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG))
-        .thenReturn("http://host-a:8088");
+  public void shouldResolveStableHashedNodeIdFromAdvertisedInterNodeListener() {
+    final KsqlRestConfig config = new KsqlRestConfig(ImmutableMap.of(
+        KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "http://host-a:8088"));
 
-    assertThat(KsqlRestApplication.resolveNodeId(config), is(Optional.of("http://host-a:8088")));
+    final Optional<String> nodeId = KsqlRestApplication.resolveNodeId(config);
+
+    assertThat(nodeId.isPresent(), is(true));
+    // A short, opaque, lowercase-hex hash of host:port.
+    assertThat(nodeId.get().matches("[0-9a-f]{16}"), is(true));
+    // Deterministic: the same listener hashes to the same id across restarts.
+    assertThat(KsqlRestApplication.resolveNodeId(config), is(nodeId));
   }
 
   @Test
-  public void shouldFallBackToInternalListenerWhenAdvertisedIsWildcard() {
-    final KsqlRestConfig config = mock(KsqlRestConfig.class);
-    when(config.getString(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG))
-        .thenReturn("http://0.0.0.0:8088");
-    when(config.getString(KsqlRestConfig.INTERNAL_LISTENER_CONFIG))
-        .thenReturn("http://host-b:8090");
+  public void shouldResolveHashedNodeIdFromListenerWhenNoInterNodeListenerConfigured() {
+    final KsqlRestConfig config = new KsqlRestConfig(ImmutableMap.of(
+        KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:8088"));
 
-    assertThat(KsqlRestApplication.resolveNodeId(config), is(Optional.of("http://host-b:8090")));
+    assertThat(KsqlRestApplication.resolveNodeId(config).get().matches("[0-9a-f]{16}"), is(true));
   }
 
   @Test
-  public void shouldSkipWildcardListenersAndUseFirstRoutableOne() {
-    final KsqlRestConfig config = mock(KsqlRestConfig.class);
-    when(config.getString(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG)).thenReturn(null);
-    when(config.getString(KsqlRestConfig.INTERNAL_LISTENER_CONFIG)).thenReturn(null);
-    when(config.getList(KsqlRestConfig.LISTENERS_CONFIG))
-        .thenReturn(ImmutableList.of("http://0.0.0.0:8088", "http://host-c:8088"));
+  public void shouldResolveDistinctNodeIdsForDistinctListeners() {
+    final Optional<String> hostA = KsqlRestApplication.resolveNodeId(new KsqlRestConfig(
+        ImmutableMap.of(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "http://host-a:8088")));
+    final Optional<String> hostB = KsqlRestApplication.resolveNodeId(new KsqlRestConfig(
+        ImmutableMap.of(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "http://host-b:8088")));
 
-    assertThat(KsqlRestApplication.resolveNodeId(config), is(Optional.of("http://host-c:8088")));
+    assertThat(hostA, is(not(hostB)));
   }
 
   @Test
-  public void shouldReturnEmptyNodeIdWhenOnlyWildcardAddressesAreConfigured() {
-    final KsqlRestConfig config = mock(KsqlRestConfig.class);
-    when(config.getString(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG)).thenReturn(null);
-    when(config.getString(KsqlRestConfig.INTERNAL_LISTENER_CONFIG)).thenReturn(null);
-    when(config.getList(KsqlRestConfig.LISTENERS_CONFIG))
-        .thenReturn(ImmutableList.of("http://0.0.0.0:8088"));
+  public void shouldResolveNodeIdForWildcardListenerSanitizedToLocalHost() {
+    final KsqlRestConfig config = new KsqlRestConfig(ImmutableMap.of(
+        KsqlRestConfig.LISTENERS_CONFIG, "http://0.0.0.0:8088"));
+
+    final Optional<String> nodeId = KsqlRestApplication.resolveNodeId(config);
+
+    assertThat(nodeId.isPresent(), is(true));
+    assertThat(nodeId.get().matches("[0-9a-f]{16}"), is(true));
+  }
+
+  @Test
+  public void shouldReturnEmptyNodeIdWhenAdvertisedListenerIsWildcard() {
+    final KsqlRestConfig config = new KsqlRestConfig(ImmutableMap.of(
+        KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "http://0.0.0.0:8088"));
 
     assertThat(KsqlRestApplication.resolveNodeId(config), is(Optional.empty()));
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -489,4 +489,46 @@ public class KsqlRestApplicationTest {
     );
   }
 
+  @Test
+  public void shouldResolveNodeIdFromAdvertisedListener() {
+    final KsqlRestConfig config = mock(KsqlRestConfig.class);
+    when(config.getString(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG))
+        .thenReturn("http://host-a:8088");
+
+    assertThat(KsqlRestApplication.resolveNodeId(config), is(Optional.of("http://host-a:8088")));
+  }
+
+  @Test
+  public void shouldFallBackToInternalListenerWhenAdvertisedIsWildcard() {
+    final KsqlRestConfig config = mock(KsqlRestConfig.class);
+    when(config.getString(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG))
+        .thenReturn("http://0.0.0.0:8088");
+    when(config.getString(KsqlRestConfig.INTERNAL_LISTENER_CONFIG))
+        .thenReturn("http://host-b:8090");
+
+    assertThat(KsqlRestApplication.resolveNodeId(config), is(Optional.of("http://host-b:8090")));
+  }
+
+  @Test
+  public void shouldSkipWildcardListenersAndUseFirstRoutableOne() {
+    final KsqlRestConfig config = mock(KsqlRestConfig.class);
+    when(config.getString(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG)).thenReturn(null);
+    when(config.getString(KsqlRestConfig.INTERNAL_LISTENER_CONFIG)).thenReturn(null);
+    when(config.getList(KsqlRestConfig.LISTENERS_CONFIG))
+        .thenReturn(ImmutableList.of("http://0.0.0.0:8088", "http://host-c:8088"));
+
+    assertThat(KsqlRestApplication.resolveNodeId(config), is(Optional.of("http://host-c:8088")));
+  }
+
+  @Test
+  public void shouldReturnEmptyNodeIdWhenOnlyWildcardAddressesAreConfigured() {
+    final KsqlRestConfig config = mock(KsqlRestConfig.class);
+    when(config.getString(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG)).thenReturn(null);
+    when(config.getString(KsqlRestConfig.INTERNAL_LISTENER_CONFIG)).thenReturn(null);
+    when(config.getList(KsqlRestConfig.LISTENERS_CONFIG))
+        .thenReturn(ImmutableList.of("http://0.0.0.0:8088"));
+
+    assertThat(KsqlRestApplication.resolveNodeId(config), is(Optional.empty()));
+  }
+
 }


### PR DESCRIPTION
## What

Adds a `Metrics`-bearing registration hook to the `KsqlResourceExtension` SPI so a resource extension can obtain the server's `MetricCollectors` and this node's identity at registration time.

- **`KsqlResourceExtensionContext`** (new): immutable value type carrying `KsqlConfig`, `MetricCollectors`, `nodeId`, and `clusterId` (all validated non-null).
- **`KsqlResourceExtension.register(KsqlResourceExtensionContext)`** (new): a `default` method that delegates to the existing `register(KsqlConfig)`. **Fully backward compatible** — existing extensions need no change; only extensions that want the richer context override the new overload.
- **`KsqlRestApplication`**: builds the context and passes it through. `nodeId` is resolved from the advertised inter-node listener, falling back to the first configured listener (no DNS lookup); `clusterId` is the ksqlDB service id.

## Why

License node attribution emits a labeled gauge whose labels are `component_type` / `node_id` / `cluster_id` and whose sink is the Kafka `Metrics` object. The Confluent `LicenseManagerConfig` builder throws unless all of `metrics`, `nodeId`, and `clusterId` are supplied when node attribution is enabled. Today the ksqlDB SPI hands an extension only `KsqlConfig`, which exposes none of these — so the license extension in `confluent-security-plugins` (KSQL-15185, PR #1227) keeps node attribution **disabled** behind a seam. This SPI change is what lets that seam be wired up.

## Compatibility / risk

- No signature is removed or changed; the new `register(context)` default preserves existing behavior for every current implementation.
- No new runtime dependency or network call is introduced (`nodeId` resolution reads already-configured listeners; no DNS).

## Test

`KsqlResourceExtensionTest` covers both paths: a legacy extension receives the delegated `KsqlConfig`, and a context-aware extension receives the full context unchanged.

## Open question (for review — rasika / OAAC)

**`nodeId` semantics.** This PR resolves `nodeId` to the advertised inter-node listener (then the first configured listener). Please confirm that's the identity we want as the attribution `node_id`, versus an alternative stable per-node id. The resolution is isolated to `KsqlRestApplication#resolveNodeId`, so changing it is a one-method edit.

---
Paired change: confluent-security-plugins PR #1227 (KSQL-15185).
