### PR TITLE
[Common BOM] Remove avro.version property references

### DIFF
--- a/ksqldb-common/pom.xml
+++ b/ksqldb-common/pom.xml
@@ -76,6 +76,12 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
 

--- a/ksqldb-engine/pom.xml
+++ b/ksqldb-engine/pom.xml
@@ -99,6 +99,12 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/ksqldb-version-metrics-client/pom.xml
+++ b/ksqldb-version-metrics-client/pom.xml
@@ -79,7 +79,7 @@
             <plugin>
                 <groupId>org.apache.avro</groupId>
                 <artifactId>avro-maven-plugin</artifactId>
-                <version>${avro.version}</version>
+                <version>1.12.1</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -572,18 +572,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.apache.avro</groupId>
-                <artifactId>avro</artifactId>
-                <version>${avro.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.google.guava</groupId>
-                        <artifactId>guava</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-csv</artifactId>
                 <version>${csv.version}</version>


### PR DESCRIPTION
## Summary
Three separate GAVs referenced `${avro.version}` across this repo, each requiring a different fix:

- Root `pom.xml`'s `dependencyManagement` entry for `org.apache.avro:avro` had a `guava` exclusion, so it couldn't just be stripped down to a versionless entry (a `dependencyManagement` entry must specify a complete version — confirmed via `mvn help:effective-pom`, which failed with `version ... is missing` when only the version line was removed). Removed the whole entry and moved the `guava` exclusion to the two actual usage sites (`ksqldb-common`, `ksqldb-engine`) so the exclusion behavior is preserved.
- `ksqldb-version-metrics-client`'s `avro-maven-plugin` is a real, executed plugin (`generate-sources`/`schema` goal) with no upstream `pluginManagement` backing it from `common` or `confluent-common-bom` (only the `org.apache.avro:avro` *dependency* is BOM-managed, not this plugin), so the property reference was replaced with the current resolved literal (`1.12.1`) rather than removed outright.

`common` declares `avro.version = 1.12.1`, matching `confluent-common-bom`'s managed value for the `avro` dependency, so this is a no-op version change.

## Tracking
Part of the `common` dependency-property cleanup effort: https://claude.ai/code/artifact/854856e4-47a3-4455-9e22-326715a12c82

## Test plan
- [x] `mvn -N validate` passes
- [x] `mvn help:effective-pom` confirms all `avro` dependency/plugin resolutions are unchanged at `1.12.1`, and the `guava` exclusion survives on exactly the two modules that had it before
- [ ] CI green