### PR TITLE
Bump multi-threaded-testing.forkCount from 3 to 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
         <netty.version>4.1.137.Final</netty.version>
         <netty-codec-http2-version>4.1.137.Final</netty-codec-http2-version>
         <jersey-common>3.1.10</jersey-common>
-        <multi-threaded-testing.forkCount>3</multi-threaded-testing.forkCount>
+        <multi-threaded-testing.forkCount>8</multi-threaded-testing.forkCount>
         <kafka.version>${ce.kafka.version}</kafka.version>
     </properties>
 


### PR DESCRIPTION
## Summary
- The Semaphore CI machine for this build (`s1-prod-ubuntu24-04-amd64-3`, a `c6a.4xlarge`) has 16 vCPUs, but the failsafe `multi-threaded-testing` execution (`RestQueryTranslationTest` and everything under `ksqldb-rest-app/.../rest/integration/**`) was only forking 3 parallel JVMs, leaving most of the machine idle for that portion of the build.
- Raises `multi-threaded-testing.forkCount` to 8 — roughly half the available cores, kept below the full 16 since each fork also spins up an embedded Kafka broker and this failsafe execution has no explicit per-fork heap cap (unlike the regular surefire execution, which sets `-Xmx1g -Xms1g`).

## Test plan
- [x] `pom.xml` parses cleanly (validated with Maven `validate`).
- [ ] Watch the first Semaphore run on this PR for wall-clock improvement and for any OOM/thrashing from running more forks concurrently on the 32GB box. If stable, a further bump (toward ~12) or an explicit per-fork `-Xmx` cap could be considered as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)