### PR TITLE
Fix compilation error in JsonFormatTest

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
@@ -98,9 +98,7 @@ public class JsonFormatTest {
   public void before() {
     streamName = "STREAM_" + COUNTER.getAndIncrement();
 
-    ksqlConfig = KsqlConfigTestUtil.create(
-        TEST_HARNESS.kafkaBootstrapServers(),
-        Collections.singletonMap(KsqlConfig.KSQL_UDF_SECURITY_MANAGER_ENABLED, false));
+    ksqlConfig = KsqlConfigTestUtil.create(TEST_HARNESS.kafkaBootstrapServers());
     serviceContext = ServiceContextFactory.create(ksqlConfig, DisabledKsqlClient::instance);
     functionRegistry = new InternalFunctionRegistry();
     UserFunctionLoader.newInstance(


### PR DESCRIPTION
## Summary
- `JsonFormatTest` referenced `KsqlConfig.KSQL_UDF_SECURITY_MANAGER_ENABLED`, which no longer exists, breaking test compilation.
- Removed the reference and switched to the `KsqlConfigTestUtil.create(bootstrapServers)` overload that requires no additional config.

## Test plan
- [x] `./mvnw -pl ksqldb-engine -am test-compile` now succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)