### PR TITLE
Suppress FindBugs NP warning in InListEvaluator.numbersMatch

### DIFF
--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/helpers/InListEvaluator.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/helpers/InListEvaluator.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.execution.codegen.helpers;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.InListExpression;
 import io.confluent.ksql.execution.expression.tree.InPredicate;
@@ -225,6 +226,13 @@ public final class InListEvaluator {
     return requiredValue.equals(parsed);
   }
 
+  @SuppressFBWarnings(
+      value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+      justification = "requiredValue's runtime class is constrained by KSQL's schema to one of"
+          + " the four numeric SqlBaseTypes (INTEGER/BIGINT/DOUBLE/DECIMAL), each of which has a"
+          + " corresponding entry in WIDENERS, so the lookup cannot return null for a"
+          + " well-formed query."
+  )
   private static boolean numbersMatch(
       final Number requiredValue,
       final Number possibleMatch


### PR DESCRIPTION
## Summary
- Adds a `@SuppressFBWarnings` annotation to `InListEvaluator.numbersMatch` to suppress a FindBugs `NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE` warning
- `requiredValue`'s runtime class is constrained by KSQL's schema to one of the four numeric `SqlBaseType`s (INTEGER/BIGINT/DOUBLE/DECIMAL), each of which has a corresponding entry in `WIDENERS`, so the lookup cannot return null for a well-formed query

## Test plan
- [ ] CI passes (build/FindBugs checks)