### PR TITLE
Port: SpotBugs suppression fixes from #11155

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -501,8 +501,7 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable, KsqlConfigur
           // for a partition when the partition is empty, either because it has never had
           // a record (end offset of 0), or because the log cleaner deleted all the records
           // (start offsets == end offsets).
-          .filter(e -> e.getValue().offset() > 0L
-              && e.getValue().offset() > startOffsetsForStreamPullQuery.get(e.getKey()))
+          .filter(e -> isPastStartOffset(e, startOffsetsForStreamPullQuery))
           .collect(toMap(Entry::getKey, e -> e.getValue().offset()));
       return ImmutableMap.copyOf(result);
     } catch (final InterruptedException e) {
@@ -515,6 +514,20 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable, KsqlConfigur
       log.error("Admin#listOffsets(" + topicDescription.name() + ") timed out", e);
       throw new KsqlServerException("Backend timed out");
     }
+  }
+
+  @SuppressFBWarnings(
+      value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+      justification = "startOffsets is built from the same topicDescription.partitions() as the"
+          + " entry set being filtered here, so every key looked up is guaranteed to be present"
+          + " and the map lookup cannot return null."
+  )
+  private boolean isPastStartOffset(
+      final Entry<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> entry,
+      final Map<TopicPartition, Long> startOffsets
+  ) {
+    return entry.getValue().offset() > 0L
+        && entry.getValue().offset() > startOffsets.get(entry.getKey());
   }
 
   private ImmutableMap<TopicPartition, Long> getStartOffsetsForStreamPullQuery(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.engine;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.analyzer.ImmutableAnalysis;
 import io.confluent.ksql.execution.pull.HARouting;
@@ -79,6 +80,13 @@ final class SandboxedExecutionContext implements KsqlExecutionContext {
   }
 
   @Override
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP",
+      justification = "MetricCollectors is a shared, intentionally mutable object used to"
+          + " aggregate metrics across the engine and its sandboxes; returning the same"
+          + " instance rather than a defensive copy is required for metrics to be recorded"
+          + " correctly."
+  )
   public MetricCollectors metricCollectors() {
     return metricCollectors;
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/execution/scalablepush/ScalablePushRegistry.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/execution/scalablepush/ScalablePushRegistry.java
@@ -66,6 +66,12 @@ import org.slf4j.LoggerFactory;
  * reads from the persistent query's output topic, reading rows. These rows are then fed to any
  * registered ProcessingQueues where they are eventually passed on to scalable push queries.
  */
+@SuppressFBWarnings(
+    value = "USO_UNSAFE_METHOD_SYNCHRONIZATION",
+    justification = "This registry is only ever constructed via the static create() factory and"
+        + " handed to internal engine code; it is never exposed to untrusted callers who could"
+        + " lock on its monitor, so synchronizing on 'this' across its instance methods is safe."
+)
 public class ScalablePushRegistry {
 
   private static final Logger LOG = LoggerFactory.getLogger(ScalablePushRegistry.class);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafFactoryInvoker.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafFactoryInvoker.java
@@ -154,11 +154,23 @@ class UdafFactoryInvoker implements FunctionSignature {
   }
 
   @Override
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP",
+      justification = "paramTypes is derived once from the UDAF factory method's signature at"
+          + " construction and is never mutated afterwards, so exposing the same immutable-in-"
+          + "practice list avoids needless defensive copies on every call."
+  )
   public List<ParamType> parameters() {
     return paramTypes;
   }
 
   @Override
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP",
+      justification = "params is derived once from the UDAF factory method's signature at"
+          + " construction and is never mutated afterwards, so exposing the same immutable-in-"
+          + "practice list avoids needless defensive copies on every call."
+  )
   public List<ParameterInfo> parameterInfo() {
     return params;
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
@@ -25,6 +25,7 @@ import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetric
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import java.io.File;
@@ -247,6 +248,12 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
     return queryMetricSum;
   }
   
+  @SuppressFBWarnings(
+      value = "USO_UNSAFE_STATIC_METHOD_SYNCHRONIZATION",
+      justification = "This class is only instantiated internally by the Kafka Streams metrics"
+          + " framework and its class object is never exposed to untrusted code, so"
+          + " synchronizing on the class monitor here is safe."
+  )
   public static synchronized BigInteger getMaxTaskUsage(final Metrics metricRegistry) {
     final Collection<KafkaMetric> taskMetrics = metricRegistry
         .metrics()

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/helpers/InListEvaluator.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/helpers/InListEvaluator.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.execution.codegen.helpers;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.InListExpression;
 import io.confluent.ksql.execution.expression.tree.InPredicate;
@@ -225,6 +226,13 @@ public final class InListEvaluator {
     return requiredValue.equals(parsed);
   }
 
+  @SuppressFBWarnings(
+      value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+      justification = "requiredValue's runtime class is constrained by KSQL's schema to one of"
+          + " the four numeric SqlBaseTypes (INTEGER/BIGINT/DOUBLE/DECIMAL), each of which has a"
+          + " corresponding entry in WIDENERS, so the lookup cannot return null for a"
+          + " well-formed query."
+  )
   private static boolean numbersMatch(
       final Number requiredValue,
       final Number possibleMatch

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/InsertResult.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/InsertResult.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.api.server;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public interface InsertResult {
 
   long sequenceNumber();
@@ -55,6 +57,12 @@ public interface InsertResult {
       }
 
       @Override
+      @SuppressFBWarnings(
+          value = "EI_EXPOSE_REP",
+          justification = "This Exception is captured solely to be surfaced back to the caller"
+              + " of the insert; it is not otherwise held or mutated by ksqlDB, so returning the"
+              + " same instance rather than a defensive copy is intentional."
+      )
       public Exception exception() {
         return exception;
       }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/LocalCommandsFile.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/LocalCommandsFile.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.rest.server;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.util.KsqlException;
 import java.io.Closeable;
 import java.io.File;
@@ -31,6 +32,13 @@ import java.util.Objects;
 /**
  * Represents a single file of commands issued to this node.
  */
+@SuppressFBWarnings(
+    value = "USO_UNSAFE_METHOD_SYNCHRONIZATION",
+    justification = "This file handle is only ever constructed via the static createReadonly()/"
+        + "createWriteable() factories and handed to internal server code; it is never exposed"
+        + " to untrusted callers who could lock on its monitor, so synchronizing on 'this' is"
+        + " safe."
+)
 public final class LocalCommandsFile  implements Closeable {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriter.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.rest.server.resources.streaming;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.api.server.StreamingOutput;
 import io.confluent.ksql.parser.tree.PrintTopic;
@@ -38,6 +39,12 @@ import org.apache.kafka.common.utils.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressFBWarnings(
+    value = "USO_UNSAFE_METHOD_SYNCHRONIZATION",
+    justification = "This writer is only ever constructed via the static create() factory and"
+        + " handed to internal server code; it is never exposed to untrusted callers who could"
+        + " lock on its monitor, so synchronizing on 'this' is safe."
+)
 public class TopicStreamWriter implements StreamingOutput {
 
   private static final Logger log = LoggerFactory.getLogger(TopicStreamWriter.class);


### PR DESCRIPTION
## Summary
Ports all changes from #11155 to the 7.6.x branch:
- Suppresses a SpotBugs `NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE` finding in `InListEvaluator.numbersMatch` (requiredValue's runtime class is always one of the four numeric SqlBaseTypes, each of which has a WIDENERS entry, so the flagged null-return path is unreachable for a well-formed query).
- Extracts `KsqlEngine`'s stream-pull-query offset filter predicate into a named `isPastStartOffset` method and suppresses `NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE` on it (startOffsets is built from the same partition set being filtered, so the lookup cannot return null).
- Suppresses `EI_EXPOSE_REP` in `SandboxedExecutionContext.metricCollectors()`, `UdafFactoryInvoker.parameters()`/`parameterInfo()`, and `InsertResult`'s anonymous `exception()` — each intentionally returns a shared/immutable-in-practice instance rather than a defensive copy.
- Suppresses `USO_UNSAFE_METHOD_SYNCHRONIZATION` in `ScalablePushRegistry`, `LocalCommandsFile`, and `TopicStreamWriter` — each is only ever constructed via a static factory and handed to internal code, never exposed to untrusted callers.
- Suppresses `USO_UNSAFE_STATIC_METHOD_SYNCHRONIZATION` in `StorageUtilizationMetricsReporter.getMaxTaskUsage` — only instantiated internally by the Kafka Streams metrics framework.

`ScalablePushRegistry.java` and `TopicStreamWriter.java` needed manual re-application (rather than a clean `git apply`) since their 7.6.x versions have diverged from master (different logger imports); the resulting changes are otherwise identical in intent to #11155.

## Test plan
- [x] `./mvnw -pl ksqldb-engine,ksqldb-execution,ksqldb-rest-app -am compile` succeeds
- [ ] CI passes