### PR TITLE
KSQL-15814: Fix flaky RestQueryTranslationTestBatch3 thread-leak cascade

### DIFF
--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
@@ -101,6 +101,10 @@ public class RestTestExecutor implements Closeable {
   private static final String STATEMENT_MACRO = "\\{STATEMENT}";
   private static final Duration MAX_QUERY_RUNNING_CHECK = Duration.ofSeconds(45);
   private static final Duration MAX_TRANSIENT_QUERY_COMPLETION_TIME = Duration.ofSeconds(10);
+  // Bounded well under the outer JUnit test timeout so a hung row publisher fails fast, with a
+  // clear TimeoutException, instead of relying solely on the outer timeout interrupting the test
+  // thread (which doesn't synchronously cancel the publisher's async work and can leak threads).
+  private static final Duration MAX_ROW_PUBLISHER_WAIT = Duration.ofSeconds(60);
   private static final String MATCH_OPERATOR_DELIMITER = "|";
   private static final String QUERY_KEY = "query";
   private static final String ROW_KEY = "row";
@@ -470,10 +474,10 @@ public class RestTestExecutor implements Closeable {
     publisher.subscribe(subscriber);
 
     try {
-      header.get();
+      header.get(MAX_ROW_PUBLISHER_WAIT.toMillis(), TimeUnit.MILLISECONDS);
       inputConditionsParameters.getWaitForInputConditionsToBeMet().run();
       inputConditionsParameters.getAfterInputConditions().run();
-      return Optional.of(future.get());
+      return Optional.of(future.get(MAX_ROW_PUBLISHER_WAIT.toMillis(), TimeUnit.MILLISECONDS));
     } catch (Exception e) {
       LOG.error("Error waiting on header, calling afterHeader, or waiting on rows", e);
       throw new AssertionError(e);

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/ThreadTestUtil.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/ThreadTestUtil.java
@@ -129,7 +129,8 @@ public final class ThreadTestUtil {
           .excludeJmxServerThreads()
           .excludeJdkThreads()
           .excludeSystem()
-          .excludeBrokerTypeCheckThreads();
+          .excludeBrokerTypeCheckThreads()
+          .excludeCommonForkJoinPoolThreads();
     }
 
     public ThreadFilterBuilder excludeSystem() {
@@ -182,6 +183,19 @@ public final class ThreadTestUtil {
 
     public ThreadFilterBuilder excludeBrokerTypeCheckThreads() {
       nameMatches(name -> !name.contains("kafka.brokerTypeTopicClient"));
+      return this;
+    }
+
+    /**
+     * The common {@link java.util.concurrent.ForkJoinPool} is a JVM-wide, shared pool used as
+     * the default executor for parallel streams and unforked {@code CompletableFuture} stages.
+     * Its worker threads are lazily created the first time anything in the JVM uses it, and are
+     * not owned or leaked by any individual test, so they must be excluded from per-test thread
+     * leak detection to avoid false positives.
+     */
+    public ThreadFilterBuilder excludeCommonForkJoinPoolThreads() {
+      nameMatches(name -> !name.matches("ForkJoinPool\\.commonPool-worker-\\d+")
+          && !name.matches("ForkJoinPool-\\d+-worker-\\d+"));
       return this;
     }
   }


### PR DESCRIPTION
Jira: [KSQL-15814](https://confluentinc.atlassian.net/browse/KSQL-15814) (epic: [KSQL-15184](https://confluentinc.atlassian.net/browse/KSQL-15184))

## Summary
Investigated a failed CI run (`logs.txt`, branch `7.9.x`, job `821c9a47-325e-4e50-9f22-5099caf50faf`) where `io.confluent.ksql.test.rest.batches.RestQueryTranslationTestBatch3` reported `Tests run: 104, Failures: 9, Errors: 1`. All 10 failures trace back to a single root cause, not 10 independent bugs:

1. **Trigger (the 1 error):** `RestTestExecutor.handleRowPublisher` blocked on `header.get()`/`future.get()` with no explicit timeout, relying solely on the outer 90s JUnit test timeout. Under CI load one query hung, JUnit interrupted the test thread with a `TestTimedOutException`, but the interrupt didn't synchronously cancel the row publisher's async work (`QueryStreamSubscriber.close()` only *schedules* cancellation via `context.runOnContext`) — leaking a `ForkJoinPool` worker thread.
2. **Cascade (the 9 failures):** That leaked thread then poisoned every subsequent parameterized test case run in the same JVM/batch: `RestQueryTranslationTest.tearDown()` calls `ThreadTestUtil.assertSameThreads()`, which diffs against a baseline thread snapshot and fails when it sees the extra thread — each failure waiting out `AssertEventually`'s 30s default before giving up.

## Changes
- `RestTestExecutor.handleRowPublisher`: bound `header.get()`/`future.get()` to an explicit 60s timeout (`MAX_ROW_PUBLISHER_WAIT`), well under the outer 90s JUnit timeout, so a hang fails fast with a clear `TimeoutException` rather than depending on the outer timeout's less-clean interrupt path.
- `ThreadTestUtil.ThreadFilterBuilder`: added `excludeCommonForkJoinPoolThreads()` (wired into the default filter chain) to exclude the JVM-shared common `ForkJoinPool`'s worker threads from per-test leak detection — these are lazily created once per JVM and aren't owned or leaked by any individual test, so treating them as a leak is a false positive regardless of the timeout fix above.

Together these address both the underlying hang-handling gap and the test-infra behavior that let one flake cascade into 9 more.

## Test plan
- [x] `./mvnw -pl ksqldb-test-util,ksqldb-functional-tests -am test-compile` succeeds
- [x] `./mvnw -pl ksqldb-test-util,ksqldb-functional-tests checkstyle:check` passes
- [ ] CI passes (including the previously-flaky `RestQueryTranslationTestBatch3`)

[KSQL-15814]: https://confluentinc.atlassian.net/browse/KSQL-15814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KSQL-15184]: https://confluentinc.atlassian.net/browse/KSQL-15184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ