### PR TITLE
Split QueryTranslationTest into parallel batches

### DIFF
--- a/ksqldb-functional-tests/pom.xml
+++ b/ksqldb-functional-tests/pom.xml
@@ -30,6 +30,11 @@
   <properties>
     <air.main.basedir>${project.parent.basedir}</air.main.basedir>
     <main-class>io.confluent.ksql.test.tools.KsqlTestingTool</main-class>
+    <!-- QueryTranslationTest is split into 4 batches (see the `batches` package); using a
+    fork per batch (rather than reusing multi-threaded-testing.forkCount, which is tuned for
+    the RestQueryTranslationTest batches) lets all 4 run concurrently in one round instead of
+    one batch waiting for a fork to free up. -->
+    <query-translation-test.forkCount>4</query-translation-test.forkCount>
   </properties>
 
   <dependencies>
@@ -177,6 +182,45 @@
           <showWarnings>true</showWarnings>
           <showDeprecation>true</showDeprecation>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <!-- Scoped to this module (rather than the root pom) because this is the only module
+        with QueryTranslationTestBatch* classes: giving default-test an <excludes> here, instead
+        of at the root, keeps every other module's default-test execution on Surefire's plain
+        (non-scanning) discovery path, so it doesn't risk double-discovering @Nested test classes
+        whose own name matches the default Test/Tests include globs (e.g. FooTest$BuilderTest). -->
+        <executions>
+          <execution>
+            <!-- No explicit phase/goals here: this merges into the implicit default-test
+            binding this module's jar packaging already provides. -->
+            <id>default-test</id>
+            <configuration>
+              <excludes>
+                <exclude>**/QueryTranslationTestBatch*.java</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <!-- QueryTranslationTest is split into batches (see the `batches` package) so
+            they can run as parallel Maven forks instead of one long, single-threaded run
+            through thousands of parameterized test cases. -->
+            <id>query-translation-test-batches</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <includes>
+                <include>**/QueryTranslationTestBatch*.java</include>
+              </includes>
+              <forkCount>${query-translation-test.forkCount}</forkCount>
+              <reuseForks>false</reuseForks>
+              <parallel>classes</parallel>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/QueryTranslationTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/QueryTranslationTest.java
@@ -35,45 +35,23 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 /**
  * Runs the json functional tests defined under
  * `ksql-functional-tests/src/test/resources/query-validation-tests`.
  *
  * See `ksql-functional-tests/README.md` for more info.
+ *
+ * Note that this test is not directly executable anymore, but has been broken up into batches
+ * under the batches package, so they can run in parallel Maven forks instead of one long,
+ * single-threaded run.
  */
-@RunWith(Parameterized.class)
 public class QueryTranslationTest {
 
   // Define this in the JVM to only test against the latest version, i.e. no historical plans
   //private static final String LATEST_ONLY_SWITCH = "topology.versions.latest-only";
 
   private static final Path QUERY_VALIDATION_TEST_DIR = Paths.get("query-validation-tests");
-
-  @SuppressWarnings("UnstableApiUsage")
-  @Parameterized.Parameters(name = "{0}")
-  public static Collection<Object[]> data() {
-    final boolean latestOnly = true;  //System.getProperties().containsKey(LATEST_ONLY_SWITCH);
-
-    final Stream<TestCase> testCases = latestOnly
-        ? testFileLoader().load()
-        : Streams.concat(
-            testFileLoader().load(),
-            PlannedTestLoader.load()
-        );
-
-    return
-        testCases
-            .map(testCase -> new Object[]{testCase.getName(), testCase})
-            .collect(Collectors.toCollection(ArrayList::new));
-  }
-
-  public static Stream<TestCase> findTestCases() {
-    return testFileLoader().load();
-  }
 
   private final TestCase testCase;
 
@@ -87,8 +65,32 @@ public class QueryTranslationTest {
     this.testCase = requireNonNull(testCase, "testCase");
   }
 
-  @Test
-  public void shouldBuildAndExecuteQueries() {
+  @SuppressWarnings("UnstableApiUsage")
+  protected static Collection<Object[]> data(final int totalSegments, final int segment) {
+    final boolean latestOnly = true;  //System.getProperties().containsKey(LATEST_ONLY_SWITCH);
+
+    final Stream<TestCase> testCases = latestOnly
+        ? testFileLoader().load()
+        : Streams.concat(
+            testFileLoader().load(),
+            PlannedTestLoader.load()
+        );
+
+    final List<Object[]> collection = testCases
+        .map(testCase -> new Object[]{testCase.getName(), testCase})
+        .collect(Collectors.toCollection(ArrayList::new));
+
+    final int testsPerSegment = collection.size() / totalSegments;
+    return collection.subList(
+        testsPerSegment * segment,
+        segment < totalSegments - 1 ? testsPerSegment * (segment + 1) : collection.size());
+  }
+
+  public static Stream<TestCase> findTestCases() {
+    return testFileLoader().load();
+  }
+
+  protected void shouldBuildAndExecuteQueries() {
     EndToEndEngineTestUtil.shouldBuildAndExecuteQuery(testCase);
   }
 

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/batches/QueryTranslationTestBatch0.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/batches/QueryTranslationTestBatch0.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.batches;
+
+import io.confluent.ksql.test.QueryTranslationTest;
+import io.confluent.ksql.test.tools.TestCase;
+import java.util.Collection;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class QueryTranslationTestBatch0 extends QueryTranslationTest {
+
+  public QueryTranslationTestBatch0(final String name, final TestCase testCase) {
+    super(name, testCase);
+  }
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Object[]> data() {
+    return data(4, 0);
+  }
+
+  @Test
+  public void shouldBuildAndExecuteQueries() {
+    super.shouldBuildAndExecuteQueries();
+  }
+}

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/batches/QueryTranslationTestBatch1.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/batches/QueryTranslationTestBatch1.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.batches;
+
+import io.confluent.ksql.test.QueryTranslationTest;
+import io.confluent.ksql.test.tools.TestCase;
+import java.util.Collection;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class QueryTranslationTestBatch1 extends QueryTranslationTest {
+
+  public QueryTranslationTestBatch1(final String name, final TestCase testCase) {
+    super(name, testCase);
+  }
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Object[]> data() {
+    return data(4, 1);
+  }
+
+  @Test
+  public void shouldBuildAndExecuteQueries() {
+    super.shouldBuildAndExecuteQueries();
+  }
+}

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/batches/QueryTranslationTestBatch2.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/batches/QueryTranslationTestBatch2.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.batches;
+
+import io.confluent.ksql.test.QueryTranslationTest;
+import io.confluent.ksql.test.tools.TestCase;
+import java.util.Collection;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class QueryTranslationTestBatch2 extends QueryTranslationTest {
+
+  public QueryTranslationTestBatch2(final String name, final TestCase testCase) {
+    super(name, testCase);
+  }
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Object[]> data() {
+    return data(4, 2);
+  }
+
+  @Test
+  public void shouldBuildAndExecuteQueries() {
+    super.shouldBuildAndExecuteQueries();
+  }
+}

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/batches/QueryTranslationTestBatch3.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/batches/QueryTranslationTestBatch3.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.batches;
+
+import io.confluent.ksql.test.QueryTranslationTest;
+import io.confluent.ksql.test.tools.TestCase;
+import java.util.Collection;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class QueryTranslationTestBatch3 extends QueryTranslationTest {
+
+  public QueryTranslationTestBatch3(final String name, final TestCase testCase) {
+    super(name, testCase);
+  }
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Object[]> data() {
+    return data(4, 3);
+  }
+
+  @Test
+  public void shouldBuildAndExecuteQueries() {
+    super.shouldBuildAndExecuteQueries();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,11 @@
         <netty-codec-http2-version>4.1.137.Final</netty-codec-http2-version>
         <jersey-common>2.46</jersey-common>
         <multi-threaded-testing.forkCount>3</multi-threaded-testing.forkCount>
+        <!-- QueryTranslationTest is split into 4 batches (see the `batches` package); using a
+        fork per batch (rather than reusing multi-threaded-testing.forkCount, which is tuned for
+        the RestQueryTranslationTest batches) lets all 4 run concurrently in one round instead of
+        one batch waiting for a fork to free up. -->
+        <query-translation-test.forkCount>4</query-translation-test.forkCount>
         <kafka.version>${ce.kafka.version}</kafka.version>
     </properties>
 
@@ -894,7 +899,7 @@
                             <includes>
                                 <include>**/QueryTranslationTestBatch*.java</include>
                             </includes>
-                            <forkCount>${multi-threaded-testing.forkCount}</forkCount>
+                            <forkCount>${query-translation-test.forkCount}</forkCount>
                             <reuseForks>false</reuseForks>
                             <parallel>classes</parallel>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -868,6 +868,38 @@
                     <excludedGroups>io.confluent.common.utils.IntegrationTest, IntegrationTest</excludedGroups>
                 </configuration>
                 <version>3.2.5</version>
+                <executions>
+                    <execution>
+                        <!-- No explicit phase/goals here: this merges into whichever implicit
+                        default-test binding (if any) a module's packaging already provides,
+                        rather than forcing surefire:test to run in modules that otherwise never
+                        would (e.g. the pom-packaged parent). -->
+                        <id>default-test</id>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/QueryTranslationTestBatch*.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!-- QueryTranslationTest is split into batches (see the `batches`
+                        package) so they can run as parallel Maven forks instead of one long,
+                        single-threaded run through thousands of parameterized test cases. -->
+                        <id>query-translation-test-batches</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/QueryTranslationTestBatch*.java</include>
+                            </includes>
+                            <forkCount>${multi-threaded-testing.forkCount}</forkCount>
+                            <reuseForks>false</reuseForks>
+                            <parallel>classes</parallel>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -158,11 +158,6 @@
         <netty-codec-http2-version>4.1.137.Final</netty-codec-http2-version>
         <jersey-common>2.46</jersey-common>
         <multi-threaded-testing.forkCount>3</multi-threaded-testing.forkCount>
-        <!-- QueryTranslationTest is split into 4 batches (see the `batches` package); using a
-        fork per batch (rather than reusing multi-threaded-testing.forkCount, which is tuned for
-        the RestQueryTranslationTest batches) lets all 4 run concurrently in one round instead of
-        one batch waiting for a fork to free up. -->
-        <query-translation-test.forkCount>4</query-translation-test.forkCount>
         <kafka.version>${ce.kafka.version}</kafka.version>
     </properties>
 
@@ -873,38 +868,6 @@
                     <excludedGroups>io.confluent.common.utils.IntegrationTest, IntegrationTest</excludedGroups>
                 </configuration>
                 <version>3.2.5</version>
-                <executions>
-                    <execution>
-                        <!-- No explicit phase/goals here: this merges into whichever implicit
-                        default-test binding (if any) a module's packaging already provides,
-                        rather than forcing surefire:test to run in modules that otherwise never
-                        would (e.g. the pom-packaged parent). -->
-                        <id>default-test</id>
-                        <configuration>
-                            <excludes>
-                                <exclude>**/QueryTranslationTestBatch*.java</exclude>
-                            </excludes>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!-- QueryTranslationTest is split into batches (see the `batches`
-                        package) so they can run as parallel Maven forks instead of one long,
-                        single-threaded run through thousands of parameterized test cases. -->
-                        <id>query-translation-test-batches</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <configuration>
-                            <includes>
-                                <include>**/QueryTranslationTestBatch*.java</include>
-                            </includes>
-                            <forkCount>${query-translation-test.forkCount}</forkCount>
-                            <reuseForks>false</reuseForks>
-                            <parallel>classes</parallel>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary
`QueryTranslationTest` (2342 parameterized test cases) was the single longest-running test class in CI (~1804s / ~30 min), because it runs under the default `maven-surefire-plugin` execution, which has no `forkCount`/`parallel` configuration in the root `pom.xml` — all 2342 test methods executed serially in one thread.

This is the same problem `RestQueryTranslationTest` used to have, which was already fixed in this codebase by splitting it into `RestQueryTranslationTestBatch0-3`, each running in its own Maven fork via a dedicated `failsafe` execution (`multi-threaded-testing`, `forkCount=3`, `parallel=classes`). This PR applies the identical pattern to `QueryTranslationTest`.

## Changes
- `QueryTranslationTest` becomes a base class (mirroring `RestQueryTranslationTest`): no longer directly runnable (`@RunWith(Parameterized.class)` and `@Test` removed), exposes a `protected static data(int totalSegments, int segment)` that slices the full test-case set, and `shouldBuildAndExecuteQueries()` is now a plain `protected` method rather than `@Test`-annotated.
- Added `QueryTranslationTestBatch0`-`Batch3` under a new `io.confluent.ksql.test.batches` package, each running one quarter of the data via `data(4, N)`.
- Added a dedicated `maven-surefire-plugin` execution (`query-translation-test-batches`) in the root `pom.xml` that runs `**/QueryTranslationTestBatch*.java` with `parallel=classes`, and excludes those classes from the `default-test` execution so they don't also run serially there.
- Uses its own `query-translation-test.forkCount=4` property (not the shared `multi-threaded-testing.forkCount=3` used by the REST batches) so all 4 batches run concurrently in a single round instead of one batch waiting for a fork to free up — see "Expected speedup" below for why this matters.
- `findTestCases()` and the package-private `QttTestFile` class are unchanged, since `PlannedTestsUpToDateTest`, `PlannedTestGeneratorTest`, and `QueryAnonymizerTest` depend on them.

## Expected speedup
Using the CI baseline (1804s / 2342 tests ≈ 0.77s/test):
- 4 equal batches (~585 tests each) → ~451s per batch.
- With `forkCount=4`, all 4 batches start concurrently in one round → **~1804s (~30 min) → ~450-500s (~7.5-8.5 min)**, roughly a **~4x** speedup.
- (An earlier version of this PR reused `multi-threaded-testing.forkCount=3`, which would only have given ~2x, since 4 batches over 3 forks needs two rounds — `ceil(4/3) = 2` — before the 4th batch gets a fork.)

## Verification
- `mvn test-compile` and `checkstyle:check` pass for `ksqldb-functional-tests`.
- Ran `QueryTranslationTestBatch0` standalone after a clean build: **585 tests executed** (`2342/4`, matching the expected slice size). Only failure: a pre-existing floating-point serialization precision mismatch in `average-udaf - average long` (`4.6116860184273879E+18` vs `4.611686018427388E+18`), unrelated to this change — the batching logic only partitions which test cases run in which JUnit class, it doesn't touch execution/comparison/serialization code.
- Did not run all 4 batches concurrently locally; the real parallel-forks speedup will show up in CI.

## Test plan
- [x] `mvn test-compile` succeeds
- [x] `mvn checkstyle:check` passes
- [x] Ran `QueryTranslationTestBatch0` standalone: 585/585 real test cases attempted, 1 pre-existing unrelated failure
- [ ] CI passes with all 4 batches running in parallel forks