### PR TITLE
[Common BOM] Remove redundant junit.version override

### DIFF
--- a/ksqldb-docker/pom.xml
+++ b/ksqldb-docker/pom.xml
@@ -85,6 +85,12 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
   </dependencies>

--- a/ksqldb-functional-tests/pom.xml
+++ b/ksqldb-functional-tests/pom.xml
@@ -52,6 +52,12 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/ksqldb-package/pom.xml
+++ b/ksqldb-package/pom.xml
@@ -101,6 +101,12 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/ksqldb-rocksdb-config-setter/pom.xml
+++ b/ksqldb-rocksdb-config-setter/pom.xml
@@ -37,6 +37,12 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/ksqldb-stream-lib/pom.xml
+++ b/ksqldb-stream-lib/pom.xml
@@ -25,6 +25,12 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/ksqldb-test-util/pom.xml
+++ b/ksqldb-test-util/pom.xml
@@ -88,6 +88,12 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/ksqldb-udf-quickstart/pom.xml
+++ b/ksqldb-udf-quickstart/pom.xml
@@ -48,6 +48,12 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -751,20 +751,6 @@
                 <version>${jersey-common}</version>
             </dependency>
 
-            <!-- Required for running tests -->
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit.version}</version>
-                <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.hamcrest</groupId>
-                        <artifactId>hamcrest-core</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava-testlib</artifactId>


### PR DESCRIPTION
## Summary
- Removes the redundant `junit:junit` `dependencyManagement` entry (pinning `${junit.version}`, plus a `hamcrest-core` exclusion) — already managed at the same version (`4.13.2`) by `confluent-common-bom`'s dependency management, transitively via the `common` parent POM.
- Unlike a plain override, this one carries a real `hamcrest-core` exclusion that's still needed: deleting just `<version>` broke 7 child modules (Maven doesn't merge managed-dependency fields across POM levels), and deleting the whole entry passed POM validation but demonstrably reintroduced `org.hamcrest:hamcrest-core:1.3` transitively (confirmed via `dependency:tree`) — a real conflict risk given `ksqldb-engine` already carries a `hamcrest-core:2.2` + `hamcrest-all:1.3` mix elsewhere.
- So instead: moved the `hamcrest-core` exclusion to each of the 7 modules that actually declare `junit:junit` (`ksqldb-udf-quickstart`, `ksqldb-rocksdb-config-setter`, `ksqldb-docker`, `ksqldb-functional-tests`, `ksqldb-test-util`, `ksqldb-package`, `ksqldb-stream-lib`), then dropped the now-fully-redundant root entry.

## Test plan
- [x] `mvn help:effective-pom` confirms `junit` still resolves to `4.13.2` everywhere, unchanged
- [x] `mvn dependency:tree` confirms `hamcrest-core` does not reappear in any of the 7 modules, and `ksqldb-engine`'s pre-existing hamcrest mix is unchanged
- [ ] CI green